### PR TITLE
Fix Issue #370: Update text on kage challenge button

### DIFF
--- a/app/src/app/townhall/page.tsx
+++ b/app/src/app/townhall/page.tsx
@@ -519,7 +519,7 @@ const KageChallenge: React.FC<{
           ) : (
             <Lock className="h-6 w-6 mr-2" />
           )}
-          {openForChallenges ? "Open for Challenges" : "Closed for Challenges"}
+          {openForChallenges ? "Accepting Challenges" : "Not Accepting Challenges"}
         </Button>
       </p>
       {requests && requests.length > 0 && openForChallenges && (


### PR DESCRIPTION
# Pull Request

Current button text is "Open for Challenges" and "Closed for Challenges".  Updated to use "Accepting Challenges" and "Not Accepting Challenges"

Fix #370 

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
