### PR TITLE
Allow jutsu reskins and link jutsu to parent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,3 +175,8 @@ git-branch-uncommit: # Undo the last N commits (keeping changes staged), usage: 
 	git reset --hard origin/main
 	git apply --reject --whitespace=fix branch.patch
 	rm -f branch.patch
+
+.PHONY: force-push-staging
+force-push-staging: # Force-push the current branch to the remote staging branch
+	@echo "${YELLOW}Force-pushing current branch to origin/dev${RESET}"
+	git push origin HEAD:staging --force

--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -45,6 +45,7 @@ export const ContentTypes = [
   "ai",
   "badge",
   "bloodline",
+  "bloodline_reskin",
   "item",
   "jutsu",
   "jutsu_reskin",

--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -47,6 +47,7 @@ export const ContentTypes = [
   "bloodline",
   "item",
   "jutsu",
+  "jutsu_reskin",
   "quest",
   "user",
   "skillTree",
@@ -714,6 +715,10 @@ export const JUTSU_TRANSFER_FREE_AMOUNT = 2;
 export const JUTSU_TRANSFER_FREE_NORMAL = 3;
 export const JUTSU_TRANSFER_FREE_SILVER = 4;
 export const JUTSU_TRANSFER_FREE_GOLD = 5;
+
+// Jutsu reskin config
+export const RESKIN_LIMIT = 2;
+export const COST_RESKIN_JUTSU = 60;
 
 // Village config
 export const VILLAGE_LEAVE_REQUIRED_RANK = "CHUNIN";
@@ -1407,6 +1412,8 @@ export const IMG_MANUAL_BLOODLINE =
   "https://utfs.io/f/Hzww9EQvYURJaCMo8gYYfKMcJ2B5EmWt6VsNgqxpG8OSXAQk";
 export const IMG_MANUAL_JUTSU =
   "https://utfs.io/f/Hzww9EQvYURJMI7fE4tsO4cexqW2RDgkE3zZbNXSFGitmnar";
+export const IMG_MANUAL_JUTSU_RESKINS =
+  "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJEOTlPgLfKL5D7TAFe29bymSaPCIQ846MdzGg";
 export const IMG_MANUAL_SKILLTREE =
   "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJQB2gVJjhzBPya1rwfCIqOTU0cV5xgsMeo3u2";
 export const IMG_MANUAL_BALANCE =

--- a/app/drizzle/schema.ts
+++ b/app/drizzle/schema.ts
@@ -420,11 +420,53 @@ export const bloodline = mysqlTable(
 export type Bloodline = InferSelectModel<typeof bloodline>;
 export type BloodlineRank = Bloodline["rank"];
 
+// Bloodline reskins are curated by staff and can be assigned to users
+export const bloodlineReskin = mysqlTable(
+  "BloodlineReskin",
+  {
+    id: varchar("id", { length: 191 }).primaryKey().notNull(),
+    bloodlineId: varchar("bloodlineId", { length: 191 }).notNull(),
+    name: varchar("name", { length: 191 }).notNull(),
+    description: text("description").notNull(),
+    image: varchar("image", { length: 191 }).notNull(),
+    createdBy: varchar("createdBy", { length: 191 }).notNull(),
+    createdAt: datetime("createdAt", { mode: "date", fsp: 3 })
+      .default(sql`(CURRENT_TIMESTAMP(3))`)
+      .notNull(),
+    updatedAt: datetime("updatedAt", { mode: "date", fsp: 3 })
+      .default(sql`(CURRENT_TIMESTAMP(3))`)
+      .notNull(),
+  },
+  (table) => {
+    return {
+      bloodlineIdIdx: index("BloodlineReskin_bloodlineId_idx").on(table.bloodlineId),
+      createdByIdx: index("BloodlineReskin_createdBy_idx").on(table.createdBy),
+      bloodlineNameKey: uniqueIndex("BloodlineReskin_bloodlineId_name_key").on(
+        table.bloodlineId,
+        table.name,
+      ),
+    };
+  },
+);
+export type BloodlineReskin = InferSelectModel<typeof bloodlineReskin>;
+
 export const bloodlineRelations = relations(bloodline, ({ one, many }) => ({
   users: many(userData),
   village: one(village, {
     fields: [bloodline.villageId],
     references: [village.id],
+  }),
+  reskins: many(bloodlineReskin),
+}));
+
+export const bloodlineReskinRelations = relations(bloodlineReskin, ({ one }) => ({
+  bloodline: one(bloodline, {
+    fields: [bloodlineReskin.bloodlineId],
+    references: [bloodline.id],
+  }),
+  creator: one(userData, {
+    fields: [bloodlineReskin.createdBy],
+    references: [userData.userId],
   }),
 }));
 
@@ -1206,15 +1248,59 @@ export const jutsu = mysqlTable(
   },
 );
 
-export const jutsuRelations = relations(jutsu, ({ one }) => ({
+export const jutsuRelations = relations(jutsu, ({ one, many }) => ({
   bloodline: one(bloodline, {
     fields: [jutsu.bloodlineId],
     references: [bloodline.id],
   }),
+  reskins: many(jutsuReskin, { relationName: "jutsuReskins" }),
 }));
 
 export type Jutsu = InferSelectModel<typeof jutsu>;
 export type JutsuRank = Jutsu["jutsuRank"];
+
+export const jutsuReskin = mysqlTable(
+  "JutsuReskin",
+  {
+    id: varchar("id", { length: 191 }).primaryKey().notNull(),
+    userId: varchar("userId", { length: 191 }).notNull(),
+    jutsuId: varchar("jutsuId", { length: 191 }).notNull(),
+    name: varchar("name", { length: 191 }).notNull(),
+    description: text("description").notNull(),
+    battleDescription: text("battleDescription").notNull(),
+    image: varchar("image", { length: 191 }).notNull(),
+    createdAt: datetime("createdAt", { mode: "date", fsp: 3 })
+      .default(sql`(CURRENT_TIMESTAMP(3))`)
+      .notNull(),
+    updatedAt: datetime("updatedAt", { mode: "date", fsp: 3 })
+      .default(sql`(CURRENT_TIMESTAMP(3))`)
+      .notNull(),
+  },
+  (table) => {
+    return {
+      userIdIdx: index("JutsuReskin_userId_idx").on(table.userId),
+      jutsuIdIdx: index("JutsuReskin_jutsuId_idx").on(table.jutsuId),
+      userIdJutsuIdKey: uniqueIndex("JutsuReskin_userId_jutsuId_key").on(
+        table.userId,
+        table.jutsuId,
+      ),
+    };
+  },
+);
+
+export const jutsuReskinRelations = relations(jutsuReskin, ({ one }) => ({
+  user: one(userData, {
+    fields: [jutsuReskin.userId],
+    references: [userData.userId],
+  }),
+  jutsu: one(jutsu, {
+    fields: [jutsuReskin.jutsuId],
+    references: [jutsu.id],
+    relationName: "jutsuReskins",
+  }),
+}));
+
+export type JutsuReskin = InferSelectModel<typeof jutsuReskin>;
 
 export const jutsuLoadout = mysqlTable(
   "JutsuLoadout",
@@ -1755,6 +1841,7 @@ export const userData = mysqlTable(
     level: int("level").default(1).notNull(),
     villageId: varchar("villageId", { length: 191 }),
     bloodlineId: varchar("bloodlineId", { length: 191 }),
+    bloodlineReskinId: varchar("bloodlineReskinId", { length: 191 }),
     status: mysqlEnum("status", consts.UserStatuses).default("AWAKE").notNull(),
     strength: double("strength").default(10).notNull(),
     intelligence: double("intelligence").default(10).notNull(),
@@ -1874,6 +1961,7 @@ export const userData = mysqlTable(
     movedTooFastCount: int("movedTooFastCount").default(0).notNull(),
     extraItemSlots: smallint("extraItemSlots", { unsigned: true }).default(0).notNull(),
     extraJutsuSlots: tinyint("extraJutsuSlots").default(0).notNull(),
+    extraReskinSlots: tinyint("extraReskinSlots").default(2).notNull(),
     customTitle: varchar("customTitle", { length: 191 }).default("").notNull(),
     marriageSlots: int("marriageSlots", { unsigned: true }).default(1).notNull(),
     aiProfileId: varchar("aiProfileId", { length: 191 }),
@@ -1910,6 +1998,9 @@ export const userData = mysqlTable(
       levelIdx: index("UserData_level_idx").on(table.level),
       usernameKey: uniqueIndex("UserData_username_key").on(table.username),
       bloodlineIdIdx: index("UserData_bloodlineId_idx").on(table.bloodlineId),
+      bloodlineReskinIdIdx: index("UserData_bloodlineReskinId_idx").on(
+        table.bloodlineReskinId,
+      ),
       villageIdIdx: index("UserData_villageId_idx").on(table.villageId),
       battleIdIdx: index("UserData_battleId_idx").on(table.battleId),
       statusIdx: index("UserData_status_idx").on(table.status),
@@ -1975,6 +2066,10 @@ export const userDataRelations = relations(userData, ({ one, many }) => ({
   bloodline: one(bloodline, {
     fields: [userData.bloodlineId],
     references: [bloodline.id],
+  }),
+  activeReskin: one(bloodlineReskin, {
+    fields: [userData.bloodlineReskinId],
+    references: [bloodlineReskin.id],
   }),
   village: one(village, {
     fields: [userData.villageId],
@@ -2316,6 +2411,7 @@ export const userJutsu = mysqlTable(
     experience: int("experience").default(0).notNull(),
     equipped: tinyint("equipped").default(0).notNull(),
     finishTraining: datetime("finishTraining", { mode: "date", fsp: 3 }),
+    reskinId: varchar("reskinId", { length: 191 }),
   },
   (table) => {
     return {
@@ -2325,10 +2421,15 @@ export const userJutsu = mysqlTable(
       ),
       jutsuIdIdx: index("UserJutsu_jutsuId_idx").on(table.jutsuId),
       equippedIdx: index("Jutsu_equipped_idx").on(table.equipped),
+      reskinIdIdx: index("UserJutsu_reskinId_idx").on(table.reskinId),
     };
   },
 );
 export type UserJutsu = InferSelectModel<typeof userJutsu>;
+export type UserJutsuWithRelations = UserJutsu & {
+  jutsu: Jutsu;
+  activeReskin: JutsuReskin | null;
+};
 
 export const userJutsuRelations = relations(userJutsu, ({ one }) => ({
   jutsu: one(jutsu, {
@@ -2338,6 +2439,10 @@ export const userJutsuRelations = relations(userJutsu, ({ one }) => ({
   user: one(userData, {
     fields: [userJutsu.userId],
     references: [userData.userId],
+  }),
+  activeReskin: one(jutsuReskin, {
+    fields: [userJutsu.reskinId],
+    references: [jutsuReskin.id],
   }),
 }));
 

--- a/app/src/app/jutsus/page.tsx
+++ b/app/src/app/jutsus/page.tsx
@@ -604,7 +604,7 @@ export default function MyJutsu() {
                   button={
                     <Button id="return" variant="destructive">
                       <Trash2 className="h-6 w-6 sm:mr-2" />
-                      <p className="hidden sm:block">Forget [${forgetRyo} ryo]</p>
+                      <p className="hidden sm:block">{`Forget [${forgetRyo} ryo]`}</p>
                     </Button>
                   }
                   onAccept={(e) => {

--- a/app/src/app/jutsus/page.tsx
+++ b/app/src/app/jutsus/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Trash2, CircleFadingArrowUp, ArrowRightLeft } from "lucide-react";
+import { Trash2, CircleFadingArrowUp, ArrowRightLeft, Palette } from "lucide-react";
 import ItemWithEffects from "@/layout/ItemWithEffects";
 import ContentBox from "@/layout/ContentBox";
 import Modal2 from "@/layout/Modal2";
@@ -37,7 +37,16 @@ import {
 import { getFreeTransfers } from "@/libs/jutsu";
 import JutsuFiltering, { useFiltering, getFilter } from "@/layout/JutsuFiltering";
 import { canTransferJutsu } from "@/utils/permissions";
-import type { Jutsu, UserJutsu } from "@/drizzle/schema";
+
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { COST_RESKIN_JUTSU, RESKIN_LIMIT } from "@/drizzle/constants";
+import { canReskinFreely } from "@/utils/permissions";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { jutsuReskinCreateSchema } from "@/validators/jutsu";
+import type { JutsuReskinCreateSchema } from "@/validators/jutsu";
+import type { UserJutsuWithRelations } from "@/drizzle/schema";
 
 export default function MyJutsu() {
   // tRPC utility
@@ -50,14 +59,31 @@ export default function MyJutsu() {
   const now = new Date();
   const { data: userData, updateUser } = useRequiredUserData();
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const [userjutsu, setUserJutsu] = useState<(Jutsu & UserJutsu) | undefined>(
+  const [isReskinOpen, setIsReskinOpen] = useState<boolean>(false);
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [userjutsu, setUserJutsu] = useState<UserJutsuWithRelations | undefined>(
     undefined,
   );
-  const [transferTarget, setTransferTarget] = useState<(Jutsu & UserJutsu) | undefined>(
-    undefined,
-  );
+  const [transferTarget, setTransferTarget] = useState<
+    UserJutsuWithRelations | undefined
+  >(undefined);
   const transferCost = canTransferJutsu(userData) ? 0 : JUTSU_TRANSFER_COST;
   const [transferValue, setTransferValue] = useState<number>(1);
+  const [modalType, setModalType] = useState<string | null>(null);
+  const [reskinData, setReskinData] = useState<JutsuReskinCreateSchema | null>(null);
+
+  // Reskin form
+  const reskinForm = useForm<JutsuReskinCreateSchema>({
+    mode: "onChange",
+    resolver: zodResolver(jutsuReskinCreateSchema),
+    defaultValues: {
+      jutsuId: "",
+      name: "",
+      description: "",
+      battleDescription: "",
+      image: undefined,
+    },
+  });
 
   // User Jutsus & items
   const { data: userJutsus, isFetching: l1 } = api.jutsu.getUserJutsus.useQuery(
@@ -68,6 +94,9 @@ export default function MyJutsu() {
     undefined,
     { enabled: !!userData },
   );
+  const { data: userReskins } = api.jutsu.getUserReskins.useQuery(undefined, {
+    enabled: !!userData,
+  });
   const { data: recentTransfers } = api.jutsu.getRecentTransfers.useQuery(undefined, {
     enabled: !!userData,
   });
@@ -175,48 +204,82 @@ export default function MyJutsu() {
       onSettled,
     });
 
+  const { mutate: reskin, isPending: isReskinning } =
+    api.jutsu.createReskin.useMutation({
+      onSuccess: async (data) => {
+        showMutationToast(data);
+        if (data.success) {
+          await utils.jutsu.getUserJutsus.invalidate();
+          setIsReskinOpen(false);
+          setUserJutsu(undefined);
+        }
+      },
+    });
+
+  const { mutate: removeReskin, isPending: isRemovingReskin } =
+    api.jutsu.removeReskin.useMutation({
+      onSuccess: async (data) => {
+        showMutationToast(data);
+        if (data.success) {
+          await Promise.all([
+            utils.jutsu.getUserJutsus.invalidate(),
+            utils.jutsu.getUserReskins.invalidate(),
+          ]);
+          setIsOpen(false);
+        }
+      },
+    });
+
   const isPending =
-    isToggling || isForgetting || isUpgrading || isUnequipping || isTransferring;
+    isToggling ||
+    isForgetting ||
+    isUpgrading ||
+    isUnequipping ||
+    isTransferring ||
+    isReskinning ||
+    isRemovingReskin;
   const isFetching = l1 || l2;
 
   // Collapse UserItem and Item
   const userElements = new Set(getUserElements(userData));
-  const allJutsu = userJutsus?.map((userjutsu) => {
+  const actionItems = userJutsus?.map((uj) => {
     let warning = "";
     if (userData) {
-      if (!checkJutsuItems(userjutsu.jutsu, userItems)) {
-        warning = `No ${userjutsu.jutsu.jutsuWeapon.toLowerCase()} weapon equipped.`;
+      if (!checkJutsuItems(uj.jutsu, userItems)) {
+        warning = `No ${uj.jutsu.jutsuWeapon.toLowerCase()} weapon equipped.`;
       }
-      if (!checkJutsuElements(userjutsu.jutsu, userElements)) {
+      if (!checkJutsuElements(uj.jutsu, userElements)) {
         warning = "You do not have the required elements to use this jutsu.";
       }
-      if (!hasRequiredRank(userData.rank, userjutsu.jutsu.requiredRank)) {
+      if (!hasRequiredRank(userData.rank, uj.jutsu.requiredRank)) {
         warning = "You do not have the required rank to use this jutsu.";
       }
-      if (!hasRequiredLevel(userData.level, userjutsu.jutsu.requiredLevel)) {
+      if (!hasRequiredLevel(userData.level, uj.jutsu.requiredLevel)) {
         warning = "You do not have the required level to use this jutsu.";
       }
-      if (!checkJutsuRank(userjutsu.jutsu.jutsuRank, userData.rank)) {
+      if (!checkJutsuRank(uj.jutsu.jutsuRank, userData.rank)) {
         warning = "You do not have the required rank to use this jutsu.";
       }
-      if (!checkJutsuVillage(userjutsu.jutsu, userData)) {
+      if (!checkJutsuVillage(uj.jutsu, userData)) {
         warning = "You do not have the required village to use this jutsu.";
       }
-      if (!checkJutsuBloodline(userjutsu.jutsu, userData)) {
+      if (!checkJutsuBloodline(uj.jutsu, userData)) {
         warning = "You do not have the required bloodline to use this jutsu.";
       }
     }
     return {
-      ...userjutsu.jutsu,
-      ...userjutsu,
-      highlight: userjutsu.equipped ? true : false,
-      warning: warning,
+      ...uj.jutsu,
+      ...uj,
+      type: "jutsu" as const,
+      highlight: !!uj.equipped,
+      warning,
+      isReskinned: !!uj.activeReskin,
     };
   });
 
   // Sort if we have a loadout
-  if (userData?.loadout?.jutsuIds && allJutsu) {
-    allJutsu.sort((a, b) => {
+  if (userData?.loadout?.jutsuIds && userJutsus) {
+    userJutsus.sort((a, b) => {
       const aIndex = userData?.loadout?.jutsuIds.indexOf(a.jutsuId) ?? -1;
       const bIndex = userData?.loadout?.jutsuIds.indexOf(b.jutsuId) ?? -1;
       if (aIndex === -1 && bIndex === -1) return 0;
@@ -234,6 +297,7 @@ export default function MyJutsu() {
     curEquip && maxEquip
       ? `Equipped ${curEquip}/${maxEquip}`
       : "Jutsus you want to use in combat";
+  const activeReskins = userJutsus?.filter((uj) => uj.activeReskin);
 
   // Ryo from forgetting
   const forgetRyo = 0;
@@ -243,6 +307,9 @@ export default function MyJutsu() {
 
   // Can afford removing
   const canUpgrade = userData.reputationPoints >= COST_EXTRA_JUTSU_SLOT;
+
+  // Calculate reskin cost based on permissions
+  const reskinCost = canReskinFreely(userData?.role) ? 0 : COST_RESKIN_JUTSU;
 
   return (
     <ContentBox
@@ -291,11 +358,11 @@ export default function MyJutsu() {
     >
       {isFetching && <Loader explanation="Loading Jutsu" />}
       <ActionSelector
-        items={allJutsu}
+        items={actionItems}
         counts={userJutsuCounts}
         labelSingles={true}
         onClick={(id) => {
-          setUserJutsu(allJutsu?.find((jutsu) => jutsu.id === id));
+          setUserJutsu(userJutsus?.find((uj) => uj.id === id));
           setIsOpen(true);
         }}
         showBgColor={false}
@@ -337,10 +404,21 @@ export default function MyJutsu() {
           {!isPending && (
             <>
               <ItemWithEffects
-                item={userjutsu}
+                item={userjutsu.jutsu}
                 key={userjutsu.id}
                 showStatistic="jutsu"
               />
+              {userReskins?.find((r) => r.jutsuId === userjutsu.jutsuId) &&
+                !userjutsu.activeReskin &&
+                !userjutsu.activeReskin && (
+                  <div className="mt-2 p-2 bg-blue-50 border border-blue-200 rounded-lg">
+                    <p className="text-sm text-blue-700">
+                      <Palette className="h-4 w-4 inline mr-1" />
+                      This jutsu has been previously reskinned. You can create a new
+                      reskin for free.
+                    </p>
+                  </div>
+                )}
               <div className="flex flex-row gap-3 items-center">
                 {userData.loadout?.jutsuIds.includes(userjutsu.jutsuId) && (
                   <>
@@ -375,8 +453,8 @@ export default function MyJutsu() {
                       title="Transfer Level"
                       button={
                         <Button id="transfer" variant="secondary">
-                          <ArrowRightLeft className="h-6 w-6 mr-2" />
-                          Transfer Level
+                          <ArrowRightLeft className="h-6 w-6 sm:mr-2" />
+                          <p className="hidden sm:block">Transfer Level</p>
                         </Button>
                       }
                       proceed_label={transferTarget ? "Confirm Transfer" : null}
@@ -420,14 +498,15 @@ export default function MyJutsu() {
                                 padding: "2px 4px",
                               }}
                             />{" "}
-                            level(s) from {userjutsu.name} to {transferTarget.name}?
+                            level(s) from {userjutsu.jutsu.name} to{" "}
+                            {transferTarget.jutsu.name}?
                           </p>
                           <p>
                             This will subtract {transferValue} level
-                            {transferValue > 1 ? "s" : ""} from {userjutsu.name} (new
-                            level: {userjutsu.level - transferValue}) and add{" "}
+                            {transferValue > 1 ? "s" : ""} from {userjutsu.jutsu.name}{" "}
+                            (new level: {userjutsu.level - transferValue}) and add{" "}
                             {transferValue} level{transferValue > 1 ? "s" : ""} to{" "}
-                            {transferTarget.name} (new level:{" "}
+                            {transferTarget.jutsu.name} (new level:{" "}
                             {transferTarget.level + transferValue}).
                           </p>
                           <p>
@@ -441,32 +520,85 @@ export default function MyJutsu() {
                         <div className="flex flex-col gap-2">
                           <p>Select a jutsu to transfer the level to.</p>
                           <ActionSelector
-                            items={allJutsu?.filter(
-                              (jutsu) =>
-                                jutsu.jutsuType === userjutsu.jutsuType &&
-                                jutsu.jutsuRank === userjutsu.jutsuRank &&
-                                jutsu.id !== userjutsu.id,
-                            )}
+                            items={userJutsus
+                              ?.filter(
+                                (uj) =>
+                                  uj.jutsu.jutsuType === userjutsu.jutsu.jutsuType &&
+                                  uj.jutsu.jutsuRank === userjutsu.jutsu.jutsuRank &&
+                                  uj.id !== userjutsu.id,
+                              )
+                              ?.map((uj) => ({
+                                id: uj.id,
+                                name: uj.jutsu.name,
+                                image: uj.jutsu.image,
+                                effects: uj.jutsu.effects,
+                                type: "jutsu" as const,
+                              }))}
                             counts={userJutsuCounts}
                             labelSingles={true}
                             showBgColor={false}
                             showLabels={true}
                             onClick={(id) => {
-                              setTransferTarget(
-                                allJutsu?.find((jutsu) => jutsu.id === id),
-                              );
+                              setTransferTarget(userJutsus?.find((uj) => uj.id === id));
                             }}
                           />
                         </div>
                       )}
                     </Confirm2>
                   )}
+                {userjutsu.activeReskin ? (
+                  <Confirm2
+                    title="Remove Reskin"
+                    button={
+                      <Button id="remove-reskin" variant="destructive">
+                        <Palette className="h-6 w-6 sm:mr-2" />
+                        <p className="hidden sm:block">Remove Reskin</p>
+                      </Button>
+                    }
+                    onAccept={(e) => {
+                      e.preventDefault();
+                      removeReskin({ userJutsuId: userjutsu.id });
+                    }}
+                  >
+                    <p>
+                      Are you sure you want to remove the reskin for this jutsu? This
+                      will restore the original name and description.
+                    </p>
+                  </Confirm2>
+                ) : (
+                  <Button
+                    id="reskin"
+                    variant="outline"
+                    onClick={() => {
+                      // Pre-fill with current reskin data if it exists
+                      reskinForm.reset({
+                        jutsuId: userjutsu.jutsuId,
+                        name: userjutsu.activeReskin?.name || "",
+                        description: userjutsu.activeReskin?.description || "",
+                        battleDescription:
+                          userjutsu.activeReskin?.battleDescription || "",
+                        image: undefined,
+                      });
+                      setIsOpen(false);
+                      setIsReskinOpen(true);
+                      setModalType("reskin");
+                    }}
+                    disabled={
+                      isPending ||
+                      userjutsu.jutsu.jutsuType === "SPECIAL" ||
+                      userjutsu.jutsu.jutsuType === "BLOODLINE"
+                    }
+                  >
+                    <Palette className="h-6 w-6 sm:mr-2" />
+                    <p className="hidden sm:block">Reskin</p>
+                  </Button>
+                )}
                 <Confirm2
                   title="Forget Jutsu"
                   button={
                     <Button id="return" variant="destructive">
-                      <Trash2 className="h-6 w-6 mr-2" />
-                      Forget [${forgetRyo} ryo]
+                      <Trash2 className="h-6 w-6 sm:mr-2" />
+                      <p className="hidden sm:block">Forget [${forgetRyo} ryo]</p>
                     </Button>
                   }
                   onAccept={(e) => {
@@ -479,10 +611,167 @@ export default function MyJutsu() {
               </div>
             </>
           )}
-          {isPending && <Loader explanation={`Processing ${userjutsu.name}`} />}
+          {isPending && <Loader explanation={`Processing ${userjutsu.jutsu.name}`} />}
         </Modal2>
       )}
-      {isPending && <Loader explanation="Loading Jutsu" />}
+      {modalType === "reskin" && userjutsu && isReskinOpen && (
+        <Modal2
+          title={userjutsu.activeReskin ? "Update Jutsu Reskin" : "Create Jutsu Reskin"}
+          isOpen={isReskinOpen}
+          setIsOpen={setIsReskinOpen}
+          proceed_label={userjutsu.activeReskin ? "Update Reskin" : "Create Reskin"}
+          isValid={reskinForm.formState.isValid}
+          onAccept={() => {
+            if (!isReskinning && userjutsu) {
+              const data = reskinForm.getValues();
+              setReskinData(data);
+              setIsReskinOpen(false);
+              setIsConfirmOpen(true);
+            }
+          }}
+        >
+          <div className="space-y-4">
+            <div
+              className="reskin-rules"
+              style={{
+                maxWidth: "800px",
+                margin: "0 auto",
+                padding: "1rem",
+                fontFamily: "sans-serif",
+                lineHeight: "1.6",
+              }}
+            >
+              <p>
+                <strong className="text-red-500">
+                  {userjutsu.activeReskin
+                    ? "Updating a reskin is free."
+                    : `Creating a reskin costs ${reskinCost} reputation points!`}
+                </strong>
+                <br />
+                <br />
+                <strong>Reskin Usage:</strong>
+                <br />
+                You have used {activeReskins?.length || 0}/
+                {userData.extraReskinSlots + RESKIN_LIMIT} available reskins.
+                <br />
+                <br />
+                Reskins are a way to personalize your jutsu&apos;s name, description,
+                and in-combat flavor text. These are cosmetic only and must follow the
+                rules below (as well as the overall game rules)
+                <br />
+                <br />
+                <strong>What You Can Change:</strong>
+                <br />
+                You are allowed to modify only the following:
+                <br />
+                - Jutsu Name
+                <br />
+                - Jutsu Description (what shows outside of combat)
+                <br />
+                - Battle Description (what appears in combat, e.g., &quot;%user uses
+                %jutsu on %target&quot;)
+                <br />
+                <br />
+                <strong>Tone & Content Restrictions:</strong>
+                <br />
+                - No hostile, mocking, or negative wording toward other players, clans,
+                villages, bloodlines, or jutsu.
+                <br />
+                - No profanity, slurs, or real-world political/religious references.
+                <br />
+                - No inappropriate humor or immersion-breaking language.
+                <br />
+                - No subtle digs or sarcasm aimed at others. If it could be taken
+                negatively, it&apos;s not allowed.
+                <br />
+                <br />
+                <strong>Example:</strong>
+                <br />
+                Original Name: Fireball Jutsu
+                <br />
+                Reskin Name: Blazing Verdict
+                <br />
+                Original Description: A sphere of fire launched at the target.
+                <br />
+                Reskin Description: A judgment cast in searing flame, leaving no room
+                for appeal.
+                <br />
+                Original Battle Description: %user hurls a fireball at %target.
+                <br />
+                Reskin Battle Description: %user delivers the Blazing Verdict to
+                %target, flames roaring with finality.
+                <br />
+                <br />
+                <strong>Note:</strong> Violation of these rules may result in the
+                modification or removal of the reskinned jutsu.
+              </p>
+            </div>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                if (reskinForm.formState.isValid) {
+                  const data = reskinForm.getValues();
+                  setReskinData(data);
+                  setIsReskinOpen(false);
+                  setIsConfirmOpen(true);
+                }
+              }}
+              className="space-y-4"
+            >
+              <div>
+                <Input placeholder="New jutsu name" {...reskinForm.register("name")} />
+              </div>
+
+              <div>
+                <Textarea
+                  placeholder="New jutsu description"
+                  {...reskinForm.register("description")}
+                />
+              </div>
+
+              <div>
+                <Textarea
+                  placeholder="New battle description"
+                  {...reskinForm.register("battleDescription")}
+                />
+              </div>
+            </form>
+          </div>
+        </Modal2>
+      )}
+      {isConfirmOpen && reskinData && userjutsu && (
+        <Modal2
+          isOpen={isConfirmOpen}
+          setIsOpen={setIsConfirmOpen}
+          title={
+            userjutsu.activeReskin
+              ? "Confirm Jutsu Reskin Update"
+              : "Confirm Jutsu Reskin"
+          }
+          proceed_label={"Confirm"}
+          onAccept={() => {
+            if (reskinData && userjutsu) {
+              reskin(reskinData);
+              setIsConfirmOpen(false);
+            }
+          }}
+        >
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              By clicking &quot;Confirm&quot;, you acknowledge that you are{" "}
+              {userjutsu.activeReskin ? "updating" : "creating"} a reskin{" "}
+              {userjutsu.activeReskin
+                ? ""
+                : `that costs ${reskinCost} reputation points`}{" "}
+              and that your reskin follows all the outlined rules.
+              <br />
+              <br />
+              <strong>Note:</strong> Violations may result in the modification or
+              removal of your reskin.
+            </p>
+          </div>
+        </Modal2>
+      )}
     </ContentBox>
   );
 }

--- a/app/src/app/jutsus/page.tsx
+++ b/app/src/app/jutsus/page.tsx
@@ -47,6 +47,9 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { jutsuReskinCreateSchema } from "@/validators/jutsu";
 import type { JutsuReskinCreateSchema } from "@/validators/jutsu";
 import type { UserJutsuWithRelations } from "@/drizzle/schema";
+import { Label } from "@/components/ui/label";
+import { UploadButton } from "@/utils/uploadthing";
+import AvatarImage from "@/layout/Avatar";
 
 export default function MyJutsu() {
   // tRPC utility
@@ -573,10 +576,13 @@ export default function MyJutsu() {
                       // Pre-fill with current reskin data if it exists
                       reskinForm.reset({
                         jutsuId: userjutsu.jutsuId,
-                        name: userjutsu.activeReskin?.name || "",
-                        description: userjutsu.activeReskin?.description || "",
+                        name: userjutsu.activeReskin?.name ?? userjutsu.jutsu.name,
+                        description:
+                          userjutsu.activeReskin?.description ??
+                          userjutsu.jutsu.description,
                         battleDescription:
-                          userjutsu.activeReskin?.battleDescription || "",
+                          userjutsu.activeReskin?.battleDescription ??
+                          userjutsu.jutsu.battleDescription,
                         image: undefined,
                       });
                       setIsOpen(false);
@@ -621,6 +627,7 @@ export default function MyJutsu() {
           setIsOpen={setIsReskinOpen}
           proceed_label={userjutsu.activeReskin ? "Update Reskin" : "Create Reskin"}
           isValid={reskinForm.formState.isValid}
+          className="w-[800px] max-w-[99%] max-h-[99%]"
           onAccept={() => {
             if (!isReskinning && userjutsu) {
               const data = reskinForm.getValues();
@@ -630,18 +637,75 @@ export default function MyJutsu() {
             }
           }}
         >
-          <div className="space-y-4">
-            <div
-              className="reskin-rules"
-              style={{
-                maxWidth: "800px",
-                margin: "0 auto",
-                padding: "1rem",
-                fontFamily: "sans-serif",
-                lineHeight: "1.6",
-              }}
-            >
-              <p>
+          <div className="flex flex-col gap-4">
+            <div>
+              <form
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  if (reskinForm.formState.isValid) {
+                    const data = reskinForm.getValues();
+                    setReskinData(data);
+                    setIsReskinOpen(false);
+                    setIsConfirmOpen(true);
+                  }
+                }}
+                className="space-y-4 grid grid-cols-3 gap-4"
+              >
+                <div className="space-y-2 row-span-3">
+                  <p className="text-sm text-muted-foreground">
+                    Optional: upload a new image for this reskin
+                  </p>
+                  <div className="flex items-center gap-3 flex-col">
+                    <AvatarImage
+                      href={reskinForm.watch("image") || userjutsu.jutsu.image}
+                      alt={userjutsu.jutsu.name}
+                      size={64}
+                      hover_effect={false}
+                    />
+                    <UploadButton
+                      endpoint="imageUploader"
+                      onClientUploadComplete={(res) => {
+                        const url = res?.[0]?.url;
+                        if (url) {
+                          reskinForm.setValue("image", url, { shouldValidate: true });
+                        }
+                      }}
+                      onUploadError={(error: Error) => {
+                        showMutationToast({ success: false, message: error.message });
+                      }}
+                    />
+                  </div>
+                </div>
+                <div className="col-span-2">
+                  <Label htmlFor="name">Jutsu Name</Label>
+                  <Input
+                    placeholder="New jutsu name"
+                    defaultValue={userjutsu.jutsu.name}
+                    {...reskinForm.register("name")}
+                  />
+                </div>
+
+                <div className="col-span-2">
+                  <Label htmlFor="description">Jutsu Description</Label>
+                  <Textarea
+                    placeholder="New jutsu description"
+                    defaultValue={userjutsu.jutsu.description}
+                    {...reskinForm.register("description")}
+                  />
+                </div>
+
+                <div className="col-span-2">
+                  <Label htmlFor="battleDescription">Battle Description</Label>
+                  <Textarea
+                    placeholder="New battle description"
+                    defaultValue={userjutsu.jutsu.battleDescription}
+                    {...reskinForm.register("battleDescription")}
+                  />
+                </div>
+              </form>
+            </div>
+            <div>
+              <div>
                 <strong className="text-red-500">
                   {userjutsu.activeReskin
                     ? "Updating a reskin is free."
@@ -668,10 +732,42 @@ export default function MyJutsu() {
                 <br />
                 - Jutsu Description (what shows outside of combat)
                 <br />
-                - Battle Description (what appears in combat, e.g., &quot;%user uses
-                %jutsu on %target&quot;)
+                - Battle Description (what appears in combat, e.g., &quot;%user attacks
+                %target&quot;)
                 <br />
                 <br />
+                <ul className="list-disc pl-6">
+                  <li>
+                    <code>%user</code> or <code>%target</code>: The acting user&apos;s
+                    username.
+                  </li>
+                  <li>
+                    <code>%user_subject</code> or <code>%target_subject</code>: (
+                    <span className="italic">&quot;he&quot; or &quot;she&quot;</span>).
+                  </li>
+                  <li>
+                    <code>%user_object</code> or <code>%target_object</code>: (
+                    <span className="italic">&quot;him&quot; or &quot;her&quot;</span>).
+                  </li>
+                  <li>
+                    <code>%user_posessive</code> or <code>%target_posessive</code>: (
+                    <span className="italic">&quot;his&quot; or &quot;hers&quot;</span>
+                    ).
+                  </li>
+                  <li>
+                    <code>%user_reflexive</code> or <code>%target_reflexive</code>: (
+                    <span className="italic">
+                      &quot;himself&quot; or &quot;herself&quot;
+                    </span>
+                    ).
+                  </li>
+                  <li>
+                    <code>%location</code>: The location of the action, formatted as{" "}
+                    <span className="italic">[row, col]</span>.
+                  </li>
+                </ul>
+              </div>
+              <div>
                 <strong>Tone & Content Restrictions:</strong>
                 <br />
                 - No hostile, mocking, or negative wording toward other players, clans,
@@ -704,38 +800,8 @@ export default function MyJutsu() {
                 <br />
                 <strong>Note:</strong> Violation of these rules may result in the
                 modification or removal of the reskinned jutsu.
-              </p>
+              </div>
             </div>
-            <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                if (reskinForm.formState.isValid) {
-                  const data = reskinForm.getValues();
-                  setReskinData(data);
-                  setIsReskinOpen(false);
-                  setIsConfirmOpen(true);
-                }
-              }}
-              className="space-y-4"
-            >
-              <div>
-                <Input placeholder="New jutsu name" {...reskinForm.register("name")} />
-              </div>
-
-              <div>
-                <Textarea
-                  placeholder="New jutsu description"
-                  {...reskinForm.register("description")}
-                />
-              </div>
-
-              <div>
-                <Textarea
-                  placeholder="New battle description"
-                  {...reskinForm.register("battleDescription")}
-                />
-              </div>
-            </form>
           </div>
         </Modal2>
       )}

--- a/app/src/app/manual/bloodline/page.tsx
+++ b/app/src/app/manual/bloodline/page.tsx
@@ -8,7 +8,13 @@ import ContentBox from "@/layout/ContentBox";
 import Loader from "@/layout/Loader";
 import BloodFiltering, { useFiltering, getFilter } from "@/layout/BloodlineFiltering";
 import { Button } from "@/components/ui/button";
-import { FilePlus, ChartCandlestick, ChartPie, ListChecks } from "lucide-react";
+import {
+  FilePlus,
+  ChartCandlestick,
+  ChartPie,
+  ListChecks,
+  Palette,
+} from "lucide-react";
 import { useInfinitePagination } from "@/libs/pagination";
 import { api } from "@/app/_trpc/client";
 import { showMutationToast } from "@/libs/toast";
@@ -109,15 +115,20 @@ export default function ManualBloodlines() {
             {userData && canChangeContent(userData.role) && (
               <>
                 <Button id="create-bloodline" onClick={() => create()}>
-                  <FilePlus className="sm:mr-2 h-5 w-5" />
-                  New
+                  <FilePlus className="h-5 w-5" />
                 </Button>
                 <Link href="/manual/bloodline/mass_edit">
                   <Button id="mass-edit-bloodline">
-                    <ListChecks className="sm:mr-2 h-5 w-5" />
-                    Edit
+                    <ListChecks className="h-5 w-5" />
                   </Button>
                 </Link>
+                {userData && canChangeContent(userData.role) && (
+                  <Link href="/manual/bloodline/reskins">
+                    <Button id="bloodline-reskins" hoverText="Reskins (Staff)">
+                      <Palette className="h-6 w-6" />
+                    </Button>
+                  </Link>
+                )}
               </>
             )}
             <BloodFiltering state={state} />

--- a/app/src/app/manual/bloodline/reskins/edit/[reskinId]/page.tsx
+++ b/app/src/app/manual/bloodline/reskins/edit/[reskinId]/page.tsx
@@ -132,7 +132,7 @@ function SingleEditBloodlineReskin({ reskinId }: { reskinId: string }) {
             buttonTxt="Save Changes"
             allowImageUpload={true}
             relationId={reskinData?.id || reskinId}
-            type="jutsu_reskin"
+            type="bloodline_reskin"
             onAccept={onAccept}
             submitDisabled={!form.formState.isValid || isUpdating}
           />

--- a/app/src/app/manual/bloodline/reskins/edit/[reskinId]/page.tsx
+++ b/app/src/app/manual/bloodline/reskins/edit/[reskinId]/page.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import React, { use } from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import ContentBox from "@/layout/ContentBox";
+import Loader from "@/layout/Loader";
+import { EditContent, type FormEntry } from "@/layout/EditContent";
+import { api } from "@/app/_trpc/client";
+import { showMutationToast } from "@/libs/toast";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { canModerateReskin } from "@/utils/permissions";
+import { useRequiredUserData } from "@/utils/UserContext";
+import {
+  bloodlineReskinUpdateSchema,
+  type BloodlineReskinUpdateSchema,
+} from "@/validators/bloodline";
+
+export default function BloodlineReskinEdit(props: {
+  params: Promise<{ reskinId: string }>;
+}) {
+  const { reskinId } = use(props.params);
+  return <SingleEditBloodlineReskin reskinId={reskinId} />;
+}
+
+function SingleEditBloodlineReskin({ reskinId }: { reskinId: string }) {
+  const router = useRouter();
+  const { data: userData } = useRequiredUserData();
+  const utils = api.useUtils();
+
+  // Queries
+  const { data: reskin, isPending } = api.bloodline.getReskin.useQuery(
+    { reskinId },
+    { enabled: !!reskinId },
+  );
+
+  // Form handling
+  const form = useForm<BloodlineReskinUpdateSchema>({
+    mode: "all",
+    criteriaMode: "all",
+    resolver: zodResolver(bloodlineReskinUpdateSchema),
+    defaultValues: {
+      name: "",
+      description: "",
+      image: undefined,
+      reason: "",
+    },
+    values:
+      reskin && !("success" in reskin)
+        ? {
+            name: reskin.name,
+            description: reskin.description,
+            image: reskin.image,
+            reason: "",
+          }
+        : undefined,
+  });
+
+  // Mutation for updating reskin
+  const { mutate: updateReskin, isPending: isUpdating } =
+    api.bloodline.updateReskin.useMutation({
+      onSuccess: async (data) => {
+        showMutationToast(data);
+        if (data.success) {
+          await utils.bloodline.getReskin.invalidate({ reskinId });
+        }
+      },
+    });
+
+  // Redirect if not authorized
+  React.useEffect(() => {
+    if (userData && !canModerateReskin(userData.role)) {
+      router.push("/manual/bloodline/reskins");
+    }
+  }, [userData, router]);
+
+  // Prevent unauthorized access
+  if (isPending || !userData || !canModerateReskin(userData.role) || !reskin) {
+    return <Loader explanation="Loading data" />;
+  }
+
+  // Build EditContent config
+  const reskinData = reskin && !("success" in reskin) ? reskin : null;
+  const formData: FormEntry<keyof BloodlineReskinUpdateSchema>[] = [
+    {
+      id: "image",
+      type: "avatar",
+      label: "Image",
+      href: reskinData?.image || undefined,
+    },
+    { id: "name", type: "text", label: "Reskin Name" },
+    {
+      id: "description",
+      type: "richinput",
+      label: "Custom Description",
+    },
+    { id: "reason", type: "richinput", label: "Reason for update", doubleWidth: true },
+  ];
+
+  const onAccept = async () => {
+    const data = form.getValues();
+    updateReskin({ reskinId, data });
+  };
+
+  return (
+    <>
+      <ContentBox
+        title="Edit Bloodline Reskin"
+        subtitle="Modify reskin information"
+        defaultBackHref="/manual/bloodline/reskins"
+      >
+        <div className="space-y-4">
+          <div>
+            <Label htmlFor="original-bloodline">Original Bloodline</Label>
+            <Input
+              id="original-bloodline"
+              value={
+                reskin && !("success" in reskin) ? reskin.bloodline?.name || "" : ""
+              }
+              disabled
+              className="mt-1"
+            />
+          </div>
+
+          <EditContent
+            schema={bloodlineReskinUpdateSchema}
+            form={form}
+            formData={formData}
+            showSubmit={true}
+            buttonTxt="Save Changes"
+            allowImageUpload={true}
+            relationId={reskinData?.id || reskinId}
+            type="jutsu_reskin"
+            onAccept={onAccept}
+            submitDisabled={!form.formState.isValid || isUpdating}
+          />
+        </div>
+      </ContentBox>
+    </>
+  );
+}

--- a/app/src/app/manual/bloodline/reskins/page.tsx
+++ b/app/src/app/manual/bloodline/reskins/page.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import ItemWithEffects from "@/layout/ItemWithEffects";
+import ContentBox from "@/layout/ContentBox";
+import Loader from "@/layout/Loader";
+import BloodFiltering, { useFiltering, getFilter } from "@/layout/BloodlineFiltering";
+import { useInfinitePagination } from "@/libs/pagination";
+import { api } from "@/app/_trpc/client";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+import { FilePlus } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useRouter } from "next/navigation";
+import { useUserData } from "@/utils/UserContext";
+import { canChangeContent } from "@/utils/permissions";
+import { showMutationToast } from "@/libs/toast";
+
+export default function ManualBloodlineReskins() {
+  const [lastElement, setLastElement] = useState<HTMLDivElement | null>(null);
+  const router = useRouter();
+  const { data: userData } = useUserData();
+  const canEdit = Boolean(userData && canChangeContent(userData.role));
+  const [selectedBloodlineId, setSelectedBloodlineId] = useState<string>("");
+
+  // Filtering
+  const state = useFiltering();
+
+  // Get reskinned bloodlines
+  const {
+    data: reskins,
+    isFetching,
+    fetchNextPage,
+    hasNextPage,
+  } = api.bloodline.getAllReskins.useInfiniteQuery(
+    { limit: 10, ...getFilter(state) },
+    {
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+      placeholderData: (previousData) => previousData,
+    },
+  );
+  const allReskins = reskins?.pages.map((page) => page.data).flat();
+  useInfinitePagination({ fetchNextPage, hasNextPage, lastElement });
+
+  // Transform reskins to ItemWithEffects-friendly shape (overlay on base)
+  const transformedReskins = allReskins?.map((r) => ({
+    ...r.bloodline,
+    id: r.id,
+    name: r.name,
+    description: r.description,
+    image: r.image,
+    createdAt: r.createdAt,
+    createdBy: r.userUsername,
+    updatedAt: r.updatedAt,
+    isReskin: true,
+  }));
+
+  const totalLoading = isFetching;
+
+  // Fetch base bloodlines for creation
+  const { data: bloodlines } = api.bloodline.getAllNames.useQuery(undefined, {
+    enabled: canEdit,
+  });
+  // Initialize selection when list loads
+  useEffect(() => {
+    if (!selectedBloodlineId && bloodlines && bloodlines.length > 0) {
+      setSelectedBloodlineId(bloodlines[0]!.id);
+    }
+  }, [bloodlines]);
+
+  // Mutation: create reskin and jump to edit page
+  const { mutate: createReskin, isPending: isCreating } =
+    api.bloodline.createReskin.useMutation({
+      onSuccess: async (data) => {
+        showMutationToast(data);
+        if (data.success) {
+          router.push(`/manual/bloodline/reskins/edit/${data.message}`);
+        }
+      },
+    });
+
+  return (
+    <>
+      <ContentBox
+        title="Bloodline Reskins"
+        subtitle="Staff-curated cosmetics"
+        defaultBackHref="/manual/bloodline"
+      >
+        <p>
+          Bloodline reskins are curated by staff. They change only presentation (name,
+          description, image), not mechanics.
+        </p>
+      </ContentBox>
+      <ContentBox
+        title="Database"
+        subtitle="All bloodline reskins"
+        initialBreak={true}
+        topRightContent={
+          <div className="flex flex-row gap-1 items-center">
+            {canEdit && (
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    id="create-bloodline-reskin"
+                    disabled={!bloodlines || bloodlines.length === 0 || isCreating}
+                  >
+                    <FilePlus className="h-6 w-6" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-80">
+                  <div className="flex flex-col gap-2">
+                    <Label>Bloodline</Label>
+                    <Select
+                      value={selectedBloodlineId}
+                      onValueChange={setSelectedBloodlineId}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select bloodline" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {(bloodlines ?? []).map((b) => (
+                          <SelectItem key={b.id} value={b.id}>
+                            {b.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      disabled={!selectedBloodlineId || isCreating}
+                      onClick={() =>
+                        createReskin({
+                          bloodlineId: selectedBloodlineId,
+                          name: "New Bloodline Reskin",
+                          description: "New bloodline reskin description",
+                        })
+                      }
+                    >
+                      Create
+                    </Button>
+                  </div>
+                </PopoverContent>
+              </Popover>
+            )}
+            <BloodFiltering state={state} />
+          </div>
+        }
+      >
+        {totalLoading && <Loader explanation="Loading data" />}
+        {transformedReskins?.map((reskin, i) => (
+          <div
+            key={i}
+            ref={i === transformedReskins.length - 1 ? setLastElement : null}
+          >
+            <ItemWithEffects
+              item={reskin}
+              key={reskin.id}
+              showEdit="bloodline/reskins"
+            />
+          </div>
+        ))}
+        {!totalLoading && transformedReskins?.length === 0 && (
+          <div>No reskins found given the search criteria.</div>
+        )}
+      </ContentBox>
+    </>
+  );
+}

--- a/app/src/app/manual/jutsu/page.tsx
+++ b/app/src/app/manual/jutsu/page.tsx
@@ -8,7 +8,13 @@ import ContentBox from "@/layout/ContentBox";
 import Loader from "@/layout/Loader";
 import JutsuFiltering, { useFiltering, getFilter } from "@/layout/JutsuFiltering";
 import { Button } from "@/components/ui/button";
-import { FilePlus, ChartCandlestick, ChartPie, ListChecks } from "lucide-react";
+import {
+  FilePlus,
+  ChartCandlestick,
+  ChartPie,
+  ListChecks,
+  Palette,
+} from "lucide-react";
 import { useInfinitePagination } from "@/libs/pagination";
 import { api } from "@/app/_trpc/client";
 import { showMutationToast } from "@/libs/toast";
@@ -106,18 +112,21 @@ export default function ManualJutsus() {
           <div className="flex flex-row gap-1 items-center">
             {userData && canChangeContent(userData.role) && (
               <>
-                <Button id="create-jutsu" onClick={() => create()}>
-                  <FilePlus className="sm:mr-2 h-6 w-6" />
-                  <p className="hidden sm:block">New</p>
+                <Button id="create-jutsu" onClick={() => create()} hoverText="New">
+                  <FilePlus className="h-6 w-6" />
                 </Button>
                 <Link href="/manual/jutsu/mass_edit">
-                  <Button id="mass-edit-jutsu">
-                    <ListChecks className="sm:mr-2 h-6 w-6" />
-                    <p className="hidden sm:block">Edit</p>
+                  <Button id="mass-edit-jutsu" hoverText="Edit">
+                    <ListChecks className="h-6 w-6" />
                   </Button>
                 </Link>
               </>
             )}
+            <Link href="/manual/jutsu/reskins">
+              <Button id="jutsu-reskins" hoverText="Reskins">
+                <Palette className="h-6 w-6" />
+              </Button>
+            </Link>
             <JutsuFiltering state={state} />
           </div>
         }

--- a/app/src/app/manual/jutsu/reskins/edit/[reskinId]/page.tsx
+++ b/app/src/app/manual/jutsu/reskins/edit/[reskinId]/page.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { use } from "react";
+import ContentBox from "@/layout/ContentBox";
+import Loader from "@/layout/Loader";
+import { api } from "@/app/_trpc/client";
+import { showMutationToast } from "@/libs/toast";
+import { canModerateReskin } from "@/utils/permissions";
+import { useRequiredUserData } from "@/utils/UserContext";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import React from "react";
+import { EditContent, type FormEntry } from "@/layout/EditContent";
+import {
+  jutsuReskinUpdateSchema,
+  type JutsuReskinUpdateSchema,
+} from "@/validators/jutsu";
+
+export default function ReskinEdit(props: { params: Promise<{ reskinId: string }> }) {
+  // State
+  const params = use(props.params);
+  const router = useRouter();
+  const reskinId = params.reskinId;
+  const { data: userData } = useRequiredUserData();
+
+  // tRPC utils
+  const utils = api.useUtils();
+
+  // Queries
+  const { data: reskin, isPending } = api.jutsu.getReskin.useQuery(
+    { reskinId },
+    { enabled: !!reskinId },
+  );
+
+  // Form handling
+  const form = useForm<JutsuReskinUpdateSchema>({
+    mode: "all",
+    criteriaMode: "all",
+    resolver: zodResolver(jutsuReskinUpdateSchema),
+    defaultValues: {
+      name: "",
+      description: "",
+      battleDescription: "",
+      image: undefined,
+      reason: "",
+    },
+    values:
+      reskin && !("success" in reskin)
+        ? {
+            name: reskin.name,
+            description: reskin.description,
+            battleDescription: reskin.battleDescription,
+            image: reskin.image,
+            reason: "",
+          }
+        : undefined,
+  });
+
+  // Mutation for updating reskin
+  const { mutate: updateReskin, isPending: isUpdating } =
+    api.jutsu.updateReskin.useMutation({
+      onSuccess: async (data) => {
+        showMutationToast(data);
+        if (data.success) {
+          await utils.jutsu.getReskin.invalidate({ reskinId });
+        }
+      },
+    });
+
+  // Redirect if not authorized
+  React.useEffect(() => {
+    if (userData && !canModerateReskin(userData.role)) {
+      router.push("/manual/jutsu/reskins");
+    }
+  }, [userData, router]);
+
+  // Prevent unauthorized access
+  if (isPending || !userData || !canModerateReskin(userData.role) || !reskin) {
+    return <Loader explanation="Loading data" />;
+  }
+
+  // Build EditContent config
+  const reskinData = reskin && !("success" in reskin) ? reskin : null;
+  const formData: FormEntry<keyof JutsuReskinUpdateSchema>[] = [
+    {
+      id: "image",
+      type: "avatar",
+      label: "Image",
+      href: reskinData?.image || undefined,
+    },
+    { id: "name", type: "text", label: "Reskin Name" },
+    {
+      id: "description",
+      type: "richinput",
+      label: "Custom Description",
+    },
+    {
+      id: "battleDescription",
+      type: "richinput",
+      label: "Custom Battle Text",
+    },
+    { id: "reason", type: "richinput", label: "Reason for update", doubleWidth: true },
+  ];
+
+  const onAccept = async () => {
+    console.log("onAccept");
+    const data = form.getValues();
+    updateReskin({ reskinId, data });
+  };
+
+  return (
+    <>
+      <ContentBox
+        title="Edit Jutsu Reskin"
+        subtitle="Modify reskin information"
+        defaultBackHref="/manual/jutsu/reskins"
+      >
+        <div className="space-y-4">
+          <div>
+            <Label htmlFor="original-jutsu">Original Jutsu</Label>
+            <Input
+              id="original-jutsu"
+              value={reskin && !("success" in reskin) ? reskin.jutsu.name : ""}
+              disabled
+              className="mt-1"
+            />
+          </div>
+
+          <EditContent
+            schema={jutsuReskinUpdateSchema}
+            form={form}
+            formData={formData}
+            showSubmit={true}
+            buttonTxt="Save Changes"
+            allowImageUpload={true}
+            relationId={reskinData?.id || reskinId}
+            type="jutsu_reskin"
+            onAccept={onAccept}
+            submitDisabled={!form.formState.isValid || isUpdating}
+          />
+        </div>
+      </ContentBox>
+    </>
+  );
+}

--- a/app/src/app/manual/jutsu/reskins/page.tsx
+++ b/app/src/app/manual/jutsu/reskins/page.tsx
@@ -78,10 +78,10 @@ export default function ManualJutsuReskins() {
         {totalLoading && <Loader explanation="Loading data" />}
         {transformedReskins?.map((reskin, i) => (
           <div
-            key={i}
+            key={reskin.id}
             ref={i === transformedReskins.length - 1 ? setLastElement : null}
           >
-            <ItemWithEffects item={reskin} key={reskin.id} showEdit="jutsu/reskins" />
+            <ItemWithEffects item={reskin} showEdit="jutsu/reskins" />
           </div>
         ))}
         {!totalLoading && transformedReskins?.length === 0 && (

--- a/app/src/app/manual/jutsu/reskins/page.tsx
+++ b/app/src/app/manual/jutsu/reskins/page.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+import ItemWithEffects from "@/layout/ItemWithEffects";
+import ContentBox from "@/layout/ContentBox";
+import Loader from "@/layout/Loader";
+import JutsuFiltering, { useFiltering, getFilter } from "@/layout/JutsuFiltering";
+import { useInfinitePagination } from "@/libs/pagination";
+import { api } from "@/app/_trpc/client";
+
+export default function ManualJutsuReskins() {
+  const [lastElement, setLastElement] = useState<HTMLDivElement | null>(null);
+
+  // Two-level filtering
+  const state = useFiltering();
+
+  // Get reskinned jutsus
+  const {
+    data: reskins,
+    isFetching,
+    fetchNextPage,
+    hasNextPage,
+  } = api.jutsu.getAllReskins.useInfiniteQuery(
+    { limit: 10, ...getFilter(state) },
+    {
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+      placeholderData: (previousData) => previousData,
+    },
+  );
+  const allReskins = reskins?.pages.map((page) => page.data).flat();
+  useInfinitePagination({ fetchNextPage, hasNextPage, lastElement });
+
+  // Transform reskin data to jutsu-like objects for ItemWithEffects
+  const transformedReskins = allReskins?.map((reskin) => ({
+    ...reskin.jutsu,
+    id: reskin.id,
+    name: reskin.name,
+    description: reskin.description,
+    battleDescription: reskin.battleDescription,
+    createdAt: reskin.createdAt,
+    updatedAt: reskin.updatedAt,
+    createdBy: reskin.user.username,
+    originalJutsuName: reskin.jutsu.name,
+    isReskin: true,
+  }));
+
+  const totalLoading = isFetching;
+
+  return (
+    <>
+      <ContentBox
+        title="Jutsu Reskins"
+        subtitle="Community Customizations"
+        defaultBackHref="/manual/jutsu"
+      >
+        <p>
+          Jutsu reskins are customizations created by players to personalize their
+          jutsu&apos;s name, description, and battle text. These are purely cosmetic
+          changes that allow players to express their creativity while maintaining the
+          original jutsu&apos;s mechanics and balance.
+        </p>
+        <p className="pt-4">
+          Below you can browse all the reskins created by the community. Each reskin
+          shows the custom name, description, and battle text while preserving the
+          original jutsu&apos;s mechanics and effects.
+        </p>
+      </ContentBox>
+      <ContentBox
+        title="Database"
+        subtitle="All custom jutsu reskins"
+        initialBreak={true}
+        topRightContent={
+          <div className="flex flex-row gap-1 items-center">
+            <JutsuFiltering state={state} />
+          </div>
+        }
+      >
+        {totalLoading && <Loader explanation="Loading data" />}
+        {transformedReskins?.map((reskin, i) => (
+          <div
+            key={i}
+            ref={i === transformedReskins.length - 1 ? setLastElement : null}
+          >
+            <ItemWithEffects item={reskin} key={reskin.id} showEdit="jutsu/reskins" />
+          </div>
+        ))}
+        {!totalLoading && transformedReskins?.length === 0 && (
+          <div>No reskins found given the search criteria.</div>
+        )}
+      </ContentBox>
+    </>
+  );
+}

--- a/app/src/app/profile/edit/page.tsx
+++ b/app/src/app/profile/edit/page.tsx
@@ -1992,9 +1992,11 @@ const ResetSkills: React.FC = () => {
             {isPending ? (
               <Loader size={5} />
             ) : isFree ? (
-              canChangeContent(userData.role)
-                ? "Reset Skills (Free for staff)"
-                : `Reset Skills (${resetInfo?.freeResetsRemaining} free GOLD resets remaining)`
+              canChangeContent(userData.role) ? (
+                "Reset Skills (Free for staff)"
+              ) : (
+                `Reset Skills (${resetInfo?.freeResetsRemaining} free GOLD resets remaining)`
+              )
             ) : canAffordPaid ? (
               `Reset Skills for ${COST_SKILL_RESET} Reps`
             ) : (

--- a/app/src/app/profile/page.tsx
+++ b/app/src/app/profile/page.tsx
@@ -22,6 +22,8 @@ import { calcMedninRank } from "@/libs/hospital/hospital";
 import { calcLevelRequirements } from "@/libs/profile";
 import { capitalizeFirstLetter } from "@/utils/sanitize";
 import { differenceInDays, differenceInHours } from "date-fns";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import ItemWithEffects from "@/layout/ItemWithEffects";
 
 export default function Profile() {
   // State
@@ -167,7 +169,23 @@ export default function Profile() {
           <div>
             <b>Associations</b>
             <p>Village: {userData.village?.name}</p>
-            <p>Bloodline: {userData.bloodline?.name || "None"}</p>
+            <p>
+              Bloodline:{" "}
+              {userData.bloodline ? (
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <span className="font-bold cursor-pointer hover:text-orange-500">
+                      {userData.bloodline.name}
+                    </span>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-[500px] max-w-[90vw] ">
+                    <ItemWithEffects item={userData.bloodline} />
+                  </PopoverContent>
+                </Popover>
+              ) : (
+                "None"
+              )}
+            </p>
             <p>ANBU: {userData.anbuSquad?.name || "None"}</p>
             <p>
               {userData.isOutlaw ? "Faction" : "Clan"}: {userData.clan?.name || "None"}

--- a/app/src/app/staff/page.tsx
+++ b/app/src/app/staff/page.tsx
@@ -157,6 +157,21 @@ export default function Staff() {
             content admin. If the issue cannot be resolved, it should be escalated to
             the owner, at which point a resolution will be found.
           </p>
+          <p>
+            <b>Staff Benefits</b>
+            <br />
+            <ul className="list-disc pl-5">
+              <li>
+                For every year of service, based on review from direct admin (moderator,
+                content, event), the member will be allowed to roll for a random S-rank
+                from the S-ranks not currently owned. This is based of admin evaluation
+                of actual work + contribution done by the member.
+              </li>
+              <li>Gold federal support</li>
+              <li>Free bloodline reskins</li>
+              <li>Free jutsu swaps</li>
+            </ul>
+          </p>
         </div>
       </ContentBox>
     </>

--- a/app/src/components/ui/textarea.tsx
+++ b/app/src/components/ui/textarea.tsx
@@ -9,6 +9,7 @@ export interface TextareaProps
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, isDirty, value, ...props }, ref) => {
+    const isControlled = value !== undefined;
     return (
       <textarea
         className={cn(
@@ -17,7 +18,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
           isDirty ? "border-orange-300" : "border-input",
         )}
         ref={ref}
-        value={value || ""}
+        {...(isControlled ? { value } : {})}
         {...props}
       />
     );

--- a/app/src/hooks/profile.ts
+++ b/app/src/hooks/profile.ts
@@ -1,5 +1,5 @@
 import { calculateContentDiff } from "@/utils/diff";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { api } from "@/app/_trpc/client";
 import { UserRanks } from "@/drizzle/constants";
@@ -60,6 +60,11 @@ export const useUserEditForm = (
   const { data: lines, isPending: l3 } = api.bloodline.getAllNames.useQuery(undefined, {
     enabled: canEditBloodline,
   });
+  const selectedBloodlineId = useWatch({ control: form.control, name: "bloodlineId" });
+  const { data: lineReskins } = api.bloodline.getReskinsForBloodline.useQuery(
+    { bloodlineId: selectedBloodlineId || "" },
+    { enabled: canEditBloodline && !!selectedBloodlineId },
+  );
   const { data: villages, isPending: l5 } = api.village.getAllNames.useQuery(
     undefined,
     { enabled: canEditVillage },
@@ -117,6 +122,17 @@ export const useUserEditForm = (
       id: "bloodlineId",
       type: "db_values",
       values: lines || [],
+      resetButton: true,
+    });
+  if (canEditBloodline)
+    formData.push({
+      id: "bloodlineReskinId",
+      type: "db_values",
+      values:
+        [{ id: "", name: "None", image: "" }].concat(
+          (lineReskins ?? []).map((r) => ({ id: r.id, name: r.name, image: r.image })),
+        ) || [],
+      label: "Bloodline Reskin",
       resetButton: true,
     });
   if (canEditVillage)

--- a/app/src/layout/CombatActions.tsx
+++ b/app/src/layout/CombatActions.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import ContentImage from "./ContentImage";
 import DurabilityBar from "@/layout/DurabilityBar";
 import { useUserData } from "@/utils/UserContext";
-import { Info, HelpCircle, Star } from "lucide-react";
+import { Info, HelpCircle, Star, Palette } from "lucide-react";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import ItemWithEffects from "@/layout/ItemWithEffects";
 import ElementImage from "@/layout/ElementImage";
@@ -35,6 +35,7 @@ interface ActionItemProps {
   lastUsedRound?: number;
   durability?: number;
   maxDurability?: number;
+  isReskinned?: boolean;
 }
 
 interface ActionSelectorSettingsProps {
@@ -157,7 +158,17 @@ interface ActionOptionProps {
 
 export const ActionOption: React.FC<ActionOptionProps> = (props) => {
   const { item, settings } = props;
-  const { cooldown, image, name, rarity, frames, speed, lastUsedRound, warning } = item;
+  const {
+    cooldown,
+    image,
+    name,
+    rarity,
+    frames,
+    speed,
+    lastUsedRound,
+    warning,
+    isReskinned,
+  } = item;
 
   // Derived values
   const cooldownPerc = Math.max(
@@ -209,6 +220,19 @@ export const ActionOption: React.FC<ActionOptionProps> = (props) => {
                   <Info className="h-7 w-7 cursor-pointer hover:text-orange-500 fill-red-600 text-white" />
                 </TooltipTrigger>
                 <TooltipContent>{warning}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+        )}
+        {/* Warning icon - top right corner */}
+        {isReskinned && (
+          <div className="absolute bottom-0 right-1/2 translate-x-1/2">
+            <TooltipProvider delayDuration={50}>
+              <Tooltip>
+                <TooltipTrigger>
+                  <Palette className="h-7 w-7 cursor-pointer hover:text-orange-500  text-white" />
+                </TooltipTrigger>
+                <TooltipContent>Reskinned</TooltipContent>
               </Tooltip>
             </TooltipProvider>
           </div>
@@ -266,7 +290,7 @@ export const ActionOption: React.FC<ActionOptionProps> = (props) => {
             </PopoverContent>
           </Popover>
         )}
-        {/* Elements overlay */}
+        {/* Elements overlay - top left */}
         {elements.map((element, i) => (
           <div
             key={i}

--- a/app/src/layout/CombatActions.tsx
+++ b/app/src/layout/CombatActions.tsx
@@ -185,8 +185,8 @@ export const ActionOption: React.FC<ActionOptionProps> = (props) => {
   return (
     <div
       className={cn(
-        "relative text-center flex cursor-pointer flex-col items-center justify-start",
-        settings.combatMode ? "text-black" : "text-foreground",
+        "relative text-center flex cursor-pointer flex-col items-center justify-start rounded-md",
+        "text-black",
         props.isGreyed ? "hover:opacity-80" : "hover:opacity-90",
         props.className,
       )}

--- a/app/src/layout/ContentFiltering.tsx
+++ b/app/src/layout/ContentFiltering.tsx
@@ -670,9 +670,8 @@ export const ContentFiltering = <
   return (
     <Popover modal>
       <PopoverTrigger asChild>
-        <Button id={triggerButtonId} count={totalFilters}>
-          <Filter className="sm:mr-2 h-6 w-6 hover:text-orange-500" />
-          <p className="hidden sm:block">Filter</p>
+        <Button id={triggerButtonId} count={totalFilters} hoverText="Filter">
+          <Filter className="h-6 w-6 hover:text-orange-500" />
         </Button>
       </PopoverTrigger>
 

--- a/app/src/layout/EditContent.tsx
+++ b/app/src/layout/EditContent.tsx
@@ -206,6 +206,7 @@ export const EditContent = <
       return "scene";
     if (["nextObjectiveId", "failObjectiveId", "resetObjectiveId"].includes(id))
       return "graph";
+    if (id === "reason") return "xxx";
     return "default";
   };
 
@@ -633,20 +634,33 @@ export const EditContent = <
                     props.allowImageUpload &&
                     "href" in formEntry &&
                     props.type && (
-                      <ContentImageSelector
-                        label={formEntry.label ? formEntry.label : id}
-                        imageUrl={currentValues?.[id] ?? formEntry.href}
-                        id={props.relationId ?? nanoid()}
-                        allowImageUpload={props.allowImageUpload}
-                        prompt={prompt}
-                        type={props.type}
-                        onUploadComplete={(url) => {
-                          form.setValue(id, url as PathValue<S, K>, {
-                            shouldDirty: true,
-                          });
+                      <FormField
+                        control={form.control}
+                        name={id}
+                        render={({ field }) => {
+                          return props.type ? (
+                            <FormItem>
+                              <FormControl>
+                                <ContentImageSelector
+                                  label={formEntry.label ? formEntry.label : id}
+                                  imageUrl={(field.value as string) ?? formEntry.href}
+                                  id={props.relationId ?? nanoid()}
+                                  allowImageUpload={props.allowImageUpload}
+                                  prompt={prompt}
+                                  type={props.type}
+                                  onUploadComplete={(url) => {
+                                    field.onChange(url);
+                                  }}
+                                  size={formEntry.size ?? "square"}
+                                  maxDim={formEntry.maxDim ?? 256}
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          ) : (
+                            <div>Missing content type</div>
+                          );
                         }}
-                        size={formEntry.size ?? "square"}
-                        maxDim={formEntry.maxDim ?? 256}
                       />
                     )}
                   {formEntry.type === "dialog_options" ? (
@@ -913,7 +927,13 @@ export const EditContent = <
             <Button
               id="create"
               className="w-full"
-              onClick={props.onAccept}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                if (props?.onAccept) {
+                  void props.onAccept(e);
+                }
+              }}
               disabled={submitDisabled}
             >
               {buttonTxt ?? "Save"}

--- a/app/src/layout/ItemWithEffects.tsx
+++ b/app/src/layout/ItemWithEffects.tsx
@@ -31,6 +31,7 @@ export type GenericObject = {
   sector?: number;
   createdAt: Date;
   updatedAt: Date;
+  createdBy?: string;
   attacks?: string[];
   effects?: ZodAllTags[];
   village?: { name: string };
@@ -51,8 +52,10 @@ export interface ItemWithEffectsProps {
   imageExtra?: React.ReactNode;
   showEdit?:
     | "bloodline"
+    | "bloodline/reskins"
     | "item"
     | "jutsu"
+    | "jutsu/reskins"
     | "ai"
     | "quest"
     | "badge"
@@ -198,6 +201,12 @@ const ItemWithEffects: React.FC<ItemWithEffectsProps> = (props) => {
                     {item.updatedAt instanceof Date
                       ? item.updatedAt.toLocaleDateString()
                       : item.updatedAt}
+                  </div>
+                )}
+                {"createdBy" in item && item.createdBy && (
+                  <div>
+                    <b>Created By: </b>
+                    {item.createdBy}
                   </div>
                 )}
                 {"expireFromStoreAt" in item && item.expireFromStoreAt && (

--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -53,6 +53,7 @@ import { TrainingSpeeds, IMG_AVATAR_DEFAULT } from "@/drizzle/constants";
 import GlowingBorder from "./GlowingBorder";
 import { TransactionHistory } from "src/app/points/page";
 import { EditContent } from "@/layout/EditContent";
+import ItemWithEffects from "@/layout/ItemWithEffects";
 import {
   Flag,
   CopyCheck,
@@ -88,6 +89,13 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { canCloneUser } from "@/utils/permissions";
 import type { Jutsu, UserBadge, Badge, UserRank } from "@/drizzle/schema";
 import { NewConversationPrompt } from "@/app/inbox/page";
@@ -653,7 +661,23 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = (props) => {
             <b>Associations</b>
             <p>Clan: {profile.clan?.name || "None"}</p>
             <p>ANBU: {profile.anbuSquad?.name || "None"}</p>
-            <p>Bloodline: {profile.bloodline?.name || "None"}</p>
+            <p>
+              Bloodline:{" "}
+              {profile.bloodline ? (
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <span className="font-bold cursor-pointer hover:text-orange-500">
+                      {profile.bloodline.name}
+                    </span>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-[500px] max-w-[90vw] ">
+                    <ItemWithEffects item={profile.bloodline} />
+                  </PopoverContent>
+                </Popover>
+              ) : (
+                "None"
+              )}
+            </p>
             <p>
               Sensei:{" "}
               {profile.rank === "GENIN" && profile.senseiId && profile.sensei ? (
@@ -1077,14 +1101,16 @@ const EditUserComponent: React.FC<EditUserComponentProps> = ({ userId, profile }
   );
 
   // Jutsu-specific helpers
-  const jutsuLevelForm = useForm<{ level: number }>({
+  const jutsuLevelForm = useForm<{ level: number; reskinId: string }>({
     defaultValues: {
       level: userJutsus?.find((uj) => uj.jutsuId === jutsu?.id)?.level || 0,
+      reskinId:
+        userJutsus?.find((uj) => uj.jutsuId === jutsu?.id)?.activeReskin?.id || "none",
     },
   });
 
   // Mutation for adjusting jutsu level
-  const adjustJutsuLevel = api.jutsu.adjustJutsuLevel.useMutation({
+  const adjustJutsuLevel = api.jutsu.adjustUserJutsu.useMutation({
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
@@ -1093,6 +1119,14 @@ const EditUserComponent: React.FC<EditUserComponentProps> = ({ userId, profile }
       }
     },
   });
+
+  // Query all reskins for selected jutsu
+  const { data: jutsuReskins } = api.jutsu.getReskinsForJutsu.useQuery(
+    { jutsuId: jutsu?.id || "" },
+    { enabled: perms.canEditJutsus && !!jutsu?.id },
+  );
+
+  // Note: reskin is applied via adjustJutsuLevel to keep a single update action
 
   // Derived – only relevant if jutsu editing is permitted
   const userJutsu = userJutsus?.find((uj) => uj.jutsuId === jutsu?.id);
@@ -1108,10 +1142,13 @@ const EditUserComponent: React.FC<EditUserComponentProps> = ({ userId, profile }
   });
   const hasJutsus = perms.canEditJutsus && userJutsus && userJutsus.length > 0;
 
-  // Update jutsu level form default value when jutsu changes
+  // Update jutsu form default values when selected jutsu changes
   useEffect(() => {
     if (userJutsu) {
-      jutsuLevelForm.reset({ level: userJutsu.level });
+      jutsuLevelForm.reset({
+        level: userJutsu.level,
+        reskinId: userJutsu.activeReskin?.id || "none",
+      });
     }
   }, [userJutsu, jutsuLevelForm]);
 
@@ -1175,38 +1212,65 @@ const EditUserComponent: React.FC<EditUserComponentProps> = ({ userId, profile }
                           userId: userId,
                           jutsuId: jutsu.id,
                           level: data.level,
+                          reskinId: data.reskinId === "none" ? null : data.reskinId,
                         });
                       }
                     })}
                     className="flex items-center justify-between w-full gap-2"
                   >
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-end gap-2">
                       <FormField
                         control={jutsuLevelForm.control}
                         name="level"
                         render={({ field }) => (
                           <FormItem>
                             <FormLabel>Level</FormLabel>
-                            <div className="relative flex flex-row gap-2">
-                              <FormControl>
-                                <Input
-                                  type="number"
-                                  className="w-20"
-                                  min={0}
-                                  max={25}
-                                  {...field}
-                                  onChange={(e) => {
-                                    const value = e.target.value;
-                                    field.onChange(value ? parseInt(value) : 0);
-                                  }}
-                                />
-                              </FormControl>
-                              <Button type="submit">Update</Button>
-                            </div>
+                            <FormControl>
+                              <Input
+                                type="number"
+                                className="w-20"
+                                min={0}
+                                max={25}
+                                {...field}
+                                onChange={(e) => {
+                                  const value = e.target.value;
+                                  field.onChange(value ? parseInt(value) : 0);
+                                }}
+                              />
+                            </FormControl>
                             <FormMessage />
                           </FormItem>
                         )}
                       />
+                      {perms.canEditJutsus && (
+                        <FormField
+                          control={jutsuLevelForm.control}
+                          name="reskinId"
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Reskin</FormLabel>
+                              <Select
+                                value={field.value}
+                                onValueChange={field.onChange}
+                              >
+                                <SelectTrigger className="w-56">
+                                  <SelectValue placeholder="None" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectItem value="none">None</SelectItem>
+                                  {jutsuReskins?.map((r) => (
+                                    <SelectItem key={r.id} value={r.id}>
+                                      {r.name}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                      )}
+                      <Button type="submit">Update</Button>
                     </div>
                   </form>
                 </Form>
@@ -1964,13 +2028,17 @@ const RecruitedUsersTab: React.FC<RecruitedUsersTabProps> = ({
 
 // ---------------- Ranked Matches Tab ----------------
 
-const RankedMatchesTab: React.FC<TabComponentProps> = ({ userId, isActive }) => {
-  const { data: currentUser } = useUserData();
-
-  const { data: history, isPending } = api.combat.getBattleHistory.useQuery({
-    userId,
-    combatTypes: ["RANKED_PVP"],
-  });
+const RankedMatchesTab: React.FC<TabComponentProps> = ({
+  userId,
+  isActive: _isActive,
+}) => {
+  const { data: history, isPending } = api.combat.getBattleHistory.useQuery(
+    {
+      userId,
+      combatTypes: ["RANKED_PVP"],
+    },
+    { enabled: _isActive },
+  );
 
   const rankedMatches = history?.map((e) => ({
     attackerUsername: e.attacker?.username || "Deleted User",

--- a/app/src/libs/bloodline.ts
+++ b/app/src/libs/bloodline.ts
@@ -1,5 +1,10 @@
 import { PITY_BLOODLINE_ROLLS } from "@/drizzle/constants";
-import type { Bloodline, BloodlineRolls, UserData } from "@/drizzle/schema";
+import type {
+  Bloodline,
+  BloodlineReskin,
+  BloodlineRolls,
+  UserData,
+} from "@/drizzle/schema";
 import type { LetterRank } from "@/drizzle/constants";
 
 /**
@@ -46,4 +51,22 @@ export const getPityRolls = (roll: BloodlineRolls) => {
   const unusedRolls = nNormalRolls - PITY_BLOODLINE_ROLLS * nPityRolls;
   const availablePityRolls = Math.floor(unusedRolls / PITY_BLOODLINE_ROLLS);
   return availablePityRolls;
+};
+
+/**
+ * Get the reskinned bloodline, generic version
+ * @param bloodline  Bloodline to reskin
+ * @param reskin  Reskin to apply to the bloodline
+ * @returns Reskinned bloodline
+ */
+export const getReskinnedBloodline = <T extends Bloodline>(
+  bloodline: T,
+  reskin: BloodlineReskin,
+): T => {
+  return {
+    ...bloodline,
+    ...(reskin.name && { name: reskin.name }),
+    ...(reskin.image && { image: reskin.image }),
+    ...(reskin.description && { description: reskin.description }),
+  };
 };

--- a/app/src/libs/combat/actions.ts
+++ b/app/src/libs/combat/actions.ts
@@ -596,6 +596,8 @@ export const handleInjectedJutsus = (
         lastUsedRound: -jutsu.cooldown,
         originalCooldown: jutsu.cooldown,
         jutsu,
+        reskinId: null,
+        activeReskin: null,
       })) ?? []),
   ];
   return activeJutsus;
@@ -1081,11 +1083,7 @@ export const actionPointsAfterAction = (
         return true;
       }
       // For jutsu: apply only if there is an overlap with the action's elements
-      if (
-        action?.type === "jutsu" &&
-        action.data &&
-        "effects" in action.data
-      ) {
+      if (action?.type === "jutsu" && action.data && "effects" in action.data) {
         const actionElements = new Set(
           action.data.effects.flatMap((eff) =>
             "elements" in eff && eff.elements ? eff.elements : [],

--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -23,12 +23,13 @@ import type {
   VillageAlliance,
   Clan,
   War,
-  UserItemImbuement,
   VillageStructure,
   Village,
   GameSetting,
+  UserJutsuWithRelations,
+  UserItemWithRelations,
 } from "@/drizzle/schema";
-import type { UserJutsu, UserItem, UserData, AiProfile } from "@/drizzle/schema";
+import type { UserData, AiProfile } from "@/drizzle/schema";
 import type { AnbuSquad } from "@/drizzle/schema";
 import type { TerrainHex } from "@/libs/hexgrid";
 import type { BattleType } from "@/drizzle/constants";
@@ -47,8 +48,7 @@ export type BattleWar = War & {
  * BattleUserState is the data stored in the battle entry about a given user
  */
 export type BattleUserState = Omit<NonNullable<UserWithRelations>, "items"> & {
-  jutsus: (UserJutsu & {
-    jutsu: Jutsu;
+  jutsus: (UserJutsuWithRelations & {
     origin: "user" | "injected";
     lastUsedRound: number;
     originalCooldown: number;
@@ -60,9 +60,7 @@ export type BattleUserState = Omit<NonNullable<UserWithRelations>, "items"> & {
       })
     | null;
   basicActions: CombatAction[];
-  items: (UserItem & {
-    item: Item;
-    imbuements: (UserItemImbuement & { item: Item })[];
+  items: (UserItemWithRelations & {
     lastUsedRound: number;
     originalCooldown: number;
   })[];
@@ -935,6 +933,14 @@ export const IncreaseMarriageSlots = z.object({
   type: z.literal("marriageslotincrease").default("marriageslotincrease"),
 });
 
+export const IncreaseReskinSlots = z.object({
+  ...BaseAttributes,
+  rank: z.enum(LetterRanks).default("D"),
+  description: msg("Increases the number of allowed reskins"),
+  power: z.coerce.number().int().min(0).max(100).default(1),
+  type: z.literal("noncombatincreasereskins").default("noncombatincreasereskins"),
+});
+
 /**
  * InjectJutsusTag: Grants access to selected jutsus flagged as injectableInBattle
  * - editors must restrict selection to jutsus where injectableInBattle=true
@@ -987,6 +993,7 @@ export const AllTags = z.union([
   IncreaseDamageTakenTag.default({}),
   IncreaseHealGivenTag.default({}),
   IncreaseMarriageSlots.default({}),
+  IncreaseReskinSlots.default({}),
   InjectJutsusTag.default({}),
   IncreasePoolCostTag.default({}),
   IncreaseRangeTag.default({}),
@@ -1331,7 +1338,7 @@ export const JutsuValidatorRawSchema = z.object({
   image: z.string(),
   description: z.string(),
   battleDescription: z.string(),
-  extraBaseCost: z.coerce.number().min(0).max(65535),
+  extraBaseCost: z.coerce.number().min(0).max(65_535),
   jutsuWeapon: z.enum(WeaponTypes),
   jutsuType: z.enum(JutsuTypes),
   jutsuRank: z.enum(LetterRanks),
@@ -1355,6 +1362,8 @@ export const JutsuValidatorRawSchema = z.object({
   villageId: z.string().nullable(),
   effects: z.array(AllTags).superRefine(SuperRefineEffects),
 });
+
+// Final validator with additional cross-field checks
 export const JutsuValidator =
   JutsuValidatorRawSchema.superRefine(SuperRefineBase).superRefine(SuperRefineJutsu);
 export type ZodJutsuType = z.infer<typeof JutsuValidator>;

--- a/app/src/libs/item.ts
+++ b/app/src/libs/item.ts
@@ -43,6 +43,8 @@ export const nonCombatConsume = (item: Item, userData: UserData): boolean => {
       return true;
     } else if (effect.type === "marriageslotincrease") {
       return true;
+    } else if (effect.type === "noncombatincreasereskins") {
+      return true;
     } else if (effect.type === "noncombatconsumereward") {
       return true;
     } else if (effect.type === "noncombatgainskill") {

--- a/app/src/libs/jutsu.ts
+++ b/app/src/libs/jutsu.ts
@@ -3,6 +3,7 @@ import { JUTSU_TRANSFER_FREE_NORMAL } from "@/drizzle/constants";
 import { JUTSU_TRANSFER_FREE_SILVER } from "@/drizzle/constants";
 import { JUTSU_TRANSFER_FREE_GOLD } from "@/drizzle/constants";
 import type { FederalStatus } from "@/drizzle/constants";
+import type { UserJutsuWithRelations } from "@/drizzle/schema";
 
 /**
  * Get the number of free jutsu level transfers based on the federal status
@@ -20,4 +21,31 @@ export const getFreeTransfers = (federalStatus: FederalStatus) => {
     default:
       return JUTSU_TRANSFER_FREE_AMOUNT;
   }
+};
+
+/**
+ * Get the reskinned user jutsu, generic version
+ * @param userJutsu
+ * @returns
+ */
+export const getReskinnedUserJutsu = <T extends UserJutsuWithRelations>(
+  userJutsu: T,
+): T => {
+  if (!userJutsu.activeReskin) {
+    return userJutsu;
+  }
+  return {
+    ...userJutsu,
+    jutsu: {
+      ...userJutsu.jutsu,
+      ...(userJutsu.activeReskin.name && { name: userJutsu.activeReskin.name }),
+      ...(userJutsu.activeReskin.image && { image: userJutsu.activeReskin.image }),
+      ...(userJutsu.activeReskin.description && {
+        description: userJutsu.activeReskin.description,
+      }),
+      ...(userJutsu.activeReskin.battleDescription && {
+        battleDescription: userJutsu.activeReskin.battleDescription,
+      }),
+    },
+  } as T;
 };

--- a/app/src/libs/moderator.ts
+++ b/app/src/libs/moderator.ts
@@ -448,7 +448,7 @@ export const validateUserUpdateReason = async (update: string, reason: string) =
     model: openaiSdk(OPENAI_MODERATION_MODEL),
     schema: z.object({ allowUpdate: z.boolean(), comment: z.string() }),
     prompt: `
-      The following reason is supplied by a content member to update a user profile. 
+      The following reason is supplied by a content member to update a piece of game content 
       Please determine if the reason is valid and if the update should be allowed. 
       Content members are tasked with testing things, helping users, etc, and thus the reasons serves mostly as a way to provide transparency to the end users as for why a given update was made.
       You are not to judge the validity of the update, only verify that it explains the update in a way that reason is clear. 
@@ -456,6 +456,7 @@ export const validateUserUpdateReason = async (update: string, reason: string) =
       - The reason must not be offensive.
       - Ignore spelling errors, this is not important to the moderation process.
       - If the reason is not valid, please provide a comment explaining why the update should not be allowed.
+      - The reason does not have to include details about the update, the previous state, or new state
 
       <reason>
         ${reason}

--- a/app/src/server/api/routers/bloodline.ts
+++ b/app/src/server/api/routers/bloodline.ts
@@ -191,16 +191,18 @@ export const bloodlineRouter = createTRPCRouter({
       const id = nanoid();
       const resolvedImage = input.image ?? base.image;
       await Promise.all([
-        ctx.drizzle.insert(bloodlineReskin).values({
-          id,
-          bloodlineId: base.id,
-          name: input.name,
-          description: input.description,
-          image: resolvedImage,
-          createdBy: ctx.userId,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        }),
+        ctx.drizzle.insert(bloodlineReskin).values([
+          {
+            id: id,
+            bloodlineId: base.id,
+            name: input.name ?? base.name,
+            description: input.description ?? base.description,
+            image: resolvedImage,
+            createdBy: ctx.userId,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ]),
         ctx.drizzle.insert(actionLog).values({
           id: nanoid(),
           userId: ctx.userId,

--- a/app/src/server/api/routers/bloodline.ts
+++ b/app/src/server/api/routers/bloodline.ts
@@ -1,9 +1,21 @@
 import { z } from "zod";
 import { nanoid } from "nanoid";
 import { randomInt } from "crypto";
-import { eq, or, sql, gte, and, inArray, isNull, isNotNull, like } from "drizzle-orm";
+import {
+  eq,
+  or,
+  sql,
+  gte,
+  and,
+  inArray,
+  isNull,
+  isNotNull,
+  like,
+  desc,
+} from "drizzle-orm";
 import { userData } from "@/drizzle/schema";
 import { bloodline, bloodlineRolls, actionLog } from "@/drizzle/schema";
+import { bloodlineReskin } from "@/drizzle/schema";
 import { userJutsu, jutsu } from "@/drizzle/schema";
 import { createTRPCRouter, protectedProcedure, publicProcedure } from "@/api/trpc";
 import { serverError, baseServerResponse, errorResponse } from "@/api/trpc";
@@ -16,6 +28,11 @@ import { ROLL_CHANCE, REMOVAL_COST, BLOODLINE_COST } from "@/drizzle/constants";
 import { IMG_AVATAR_DEFAULT } from "@/drizzle/constants";
 import { calculateContentDiff } from "@/utils/diff";
 import { bloodlineFilteringSchema } from "@/validators/bloodline";
+import {
+  bloodlineReskinCreateSchema,
+  bloodlineReskinUpdateSchema,
+} from "@/validators/bloodline";
+import { validateUserUpdateReason } from "@/libs/moderator";
 import { filterRollableBloodlines, getPityRolls } from "@/libs/bloodline";
 import { LetterRanks, PITY_SYSTEM_ENABLED } from "@/drizzle/constants";
 import { COST_SWAP_BLOODLINE } from "@/drizzle/constants";
@@ -156,6 +173,184 @@ export const bloodlineRouter = createTRPCRouter({
         `Bloodline Swapped from ${user.bloodline?.name} to ${line.name}`,
       );
       return { success: true, message: "Bloodline swapped" };
+    }),
+  // Bloodline reskins (staff-only creation & moderation)
+  createReskin: protectedProcedure
+    .input(bloodlineReskinCreateSchema)
+    .output(baseServerResponse)
+    .mutation(async ({ ctx, input }) => {
+      // Query
+      const [user, base] = await Promise.all([
+        fetchUser(ctx.drizzle, ctx.userId),
+        fetchBloodline(ctx.drizzle, input.bloodlineId),
+      ]);
+      // Guard
+      if (!base) return errorResponse("Base bloodline not found");
+      if (!canChangeContent(user.role)) return errorResponse("Unauthorized");
+      // Mutate
+      const id = nanoid();
+      const resolvedImage = input.image ?? base.image;
+      await Promise.all([
+        ctx.drizzle.insert(bloodlineReskin).values({
+          id,
+          bloodlineId: base.id,
+          name: input.name,
+          description: input.description,
+          image: resolvedImage,
+          createdBy: ctx.userId,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }),
+        ctx.drizzle.insert(actionLog).values({
+          id: nanoid(),
+          userId: ctx.userId,
+          tableName: "bloodline",
+          changes: [`Reskin created for ${base.name}: ${input.name}`],
+          relatedId: base.id,
+          relatedMsg: `Reskin created: ${input.name}`,
+          relatedImage: resolvedImage,
+        }),
+      ]);
+      return { success: true, message: id };
+    }),
+  updateReskin: protectedProcedure
+    .input(z.object({ reskinId: z.string(), data: bloodlineReskinUpdateSchema }))
+    .output(baseServerResponse)
+    .mutation(async ({ ctx, input }) => {
+      // Query
+      const [user, reskin] = await Promise.all([
+        fetchUser(ctx.drizzle, ctx.userId),
+        fetchBloodlineReskin(ctx.drizzle, input.reskinId),
+      ]);
+      // Guard
+      if (!reskin) return errorResponse("Reskin not found");
+      if (!canChangeContent(user.role)) return errorResponse("Unauthorized");
+      // Prepare old/new objects for diff (exclude reason from new)
+      const oldData = {
+        name: reskin.name,
+        description: reskin.description,
+        image: reskin.image,
+      } as const;
+      const { reason, ...rest } = input.data;
+      const newData = { ...rest } as const;
+      const diff = calculateContentDiff(oldData, newData);
+      // AI moderation of reason
+      const aiCheck = await validateUserUpdateReason(diff.join(". "), reason);
+      if (!aiCheck.allowUpdate) {
+        await ctx.drizzle.insert(actionLog).values({
+          id: nanoid(),
+          userId: ctx.userId,
+          tableName: "bloodline",
+          changes: {},
+          relatedId: reskin.bloodlineId,
+          relatedMsg: `Reskin update rejected by AI: ${reason}`,
+          relatedImage: reskin.image,
+        });
+        return errorResponse(aiCheck.comment);
+      }
+      // Mutate
+      await Promise.all([
+        ctx.drizzle
+          .update(bloodlineReskin)
+          .set({
+            name: newData.name,
+            description: newData.description,
+            image: newData.image ?? reskin.image,
+            updatedAt: new Date(),
+          })
+          .where(eq(bloodlineReskin.id, reskin.id)),
+        ctx.drizzle.insert(actionLog).values({
+          id: nanoid(),
+          userId: ctx.userId,
+          tableName: "bloodline",
+          changes: diff,
+          relatedId: reskin.bloodlineId,
+          relatedMsg: `Reskin updated: ${reskin.name}`,
+          relatedImage: newData.image ?? reskin.image,
+        }),
+      ]);
+
+      return { success: true, message: "Bloodline reskin updated" };
+    }),
+  deleteReskin: protectedProcedure
+    .input(z.object({ reskinId: z.string() }))
+    .output(baseServerResponse)
+    .mutation(async ({ ctx, input }) => {
+      // Query
+      const [user, reskin] = await Promise.all([
+        fetchUser(ctx.drizzle, ctx.userId),
+        fetchBloodlineReskin(ctx.drizzle, input.reskinId),
+      ]);
+      // Guard
+      if (!canChangeContent(user.role)) return errorResponse("Unauthorized");
+      if (!reskin) return errorResponse("Reskin not found");
+      // Mutate
+      await Promise.all([
+        ctx.drizzle
+          .update(userData)
+          .set({ bloodlineReskinId: null })
+          .where(eq(userData.bloodlineReskinId, input.reskinId)),
+        ctx.drizzle
+          .delete(bloodlineReskin)
+          .where(eq(bloodlineReskin.id, input.reskinId)),
+        ctx.drizzle.insert(actionLog).values({
+          id: nanoid(),
+          userId: ctx.userId,
+          tableName: "bloodline",
+          changes: ["Reskin deleted"],
+          relatedId: reskin.bloodlineId,
+          relatedMsg: `Reskin deleted: ${reskin.name}`,
+          relatedImage: reskin.image,
+        }),
+      ]);
+      return { success: true, message: "Bloodline reskin deleted" };
+    }),
+  getReskin: protectedProcedure
+    .input(z.object({ reskinId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const res = await fetchBloodlineReskin(ctx.drizzle, input.reskinId);
+      return res ?? errorResponse("Reskin not found");
+    }),
+  getReskinsForBloodline: protectedProcedure
+    .input(z.object({ bloodlineId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const rows = await ctx.drizzle.query.bloodlineReskin.findMany({
+        where: eq(bloodlineReskin.bloodlineId, input.bloodlineId),
+        orderBy: (table, { desc }) => [desc(table.name)],
+      });
+      return rows;
+    }),
+  getAllReskins: publicProcedure
+    .input(
+      bloodlineFilteringSchema.extend({
+        cursor: z.number().nullish(),
+        limit: z.number().min(1).max(1000),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const currentCursor = input.cursor ?? 0;
+      const skip = currentCursor * input.limit;
+      const baseFilters = bloodlineDatabaseFilter(input);
+      const rows = await ctx.drizzle
+        .select({
+          reskin: bloodlineReskin,
+          base: bloodline,
+          userUsername: userData.username,
+        })
+        .from(bloodlineReskin)
+        .innerJoin(bloodline, eq(bloodlineReskin.bloodlineId, bloodline.id))
+        .innerJoin(userData, eq(bloodlineReskin.createdBy, userData.userId))
+        .where(and(...baseFilters))
+        .orderBy(desc(bloodlineReskin.updatedAt))
+        .offset(skip)
+        .limit(input.limit);
+      const results = rows.map((row) => ({
+        ...row.reskin,
+        userUsername: row.userUsername,
+        bloodline: row.base,
+      }));
+      const nextCursor = rows.length < input.limit ? null : currentCursor + 1;
+      return { data: results, nextCursor };
     }),
   // Delete a bloodline
   delete: protectedProcedure
@@ -548,6 +743,7 @@ export const updateBloodline = async (
       .update(userData)
       .set({
         bloodlineId: bloodline?.id || null,
+        bloodlineReskinId: null,
         reputationPoints: user.reputationPoints - repCost,
       })
       .where(
@@ -568,6 +764,20 @@ export const updateBloodline = async (
 /**
  * COMMON QUERIES WHICH ARE REUSED
  */
+
+export const fetchBloodlineReskin = async (client: DrizzleClient, reskinId: string) => {
+  return await client.query.bloodlineReskin.findFirst({
+    where: eq(bloodlineReskin.id, reskinId),
+    with: { bloodline: true },
+  });
+};
+
+/**
+ * Fetch natural bloodline roll of a user
+ * @param client Drizzle client
+ * @param userId User ID
+ * @returns Natural bloodline roll
+ */
 export const fetchNaturalBloodlineRoll = async (
   client: DrizzleClient,
   userId: string,
@@ -578,6 +788,12 @@ export const fetchNaturalBloodlineRoll = async (
   });
 };
 
+/**
+ * Fetch item bloodline rolls of a user
+ * @param client Drizzle client
+ * @param userId User ID
+ * @returns Item bloodline rolls
+ */
 export const fetchItemBloodlineRolls = async (
   client: DrizzleClient,
   userId: string,
@@ -588,6 +804,12 @@ export const fetchItemBloodlineRolls = async (
   });
 };
 
+/**
+ * Fetch user's historic bloodlines
+ * @param client Drizzle client
+ * @param userId User ID
+ * @returns User's historic bloodlines
+ */
 export const fetchUserHistoricBloodlines = async (
   client: DrizzleClient,
   userId: string,
@@ -607,12 +829,23 @@ export const fetchUserHistoricBloodlines = async (
   return userBloodlines;
 };
 
+/**
+ * Fetch a bloodline by ID
+ * @param client Drizzle client
+ * @param bloodlineId Bloodline ID
+ * @returns Bloodline
+ */
 export const fetchBloodline = async (client: DrizzleClient, bloodlineId: string) => {
   return await client.query.bloodline.findFirst({
     where: eq(bloodline.id, bloodlineId),
   });
 };
 
+/**
+ * Fetch all bloodlines
+ * @param client Drizzle client
+ * @returns All bloodlines
+ */
 export const fetchBloodlines = async (client: DrizzleClient) => {
   return await client.query.bloodline.findMany({ where: eq(bloodline.hidden, false) });
 };

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -23,6 +23,7 @@ import { fetchUserSkills } from "@/server/api/routers/skillTree";
 import { updateUser, updateBattle } from "@/libs/combat/database";
 import { calcHP, calcSP, calcCP, calcLevelRequirements } from "@/libs/profile";
 import { controlShownQuestLocationInformation } from "@/libs/quest";
+import { getReskinnedBloodline } from "@/libs/bloodline";
 import {
   selectJutsuLoadout,
   fetchJutsuLoadouts,
@@ -55,7 +56,7 @@ import { getServerPusher, updateUserOnMap } from "@/libs/pusher";
 import { getRandomElement } from "@/utils/array";
 import { applyEffects, checkFriendlyFire } from "@/libs/combat/process";
 import { manuallyAssignUserStats, scaleUserStats } from "@/libs/profile";
-import { capUserStats, getSoftCappedExperience } from "@/libs/profile";
+import { capUserStats } from "@/libs/profile";
 import { mockAchievementHistoryEntries } from "@/libs/quest";
 import { canAccessStructure } from "@/utils/village";
 import { fetchSectorVillage } from "@/routers/village";
@@ -80,6 +81,7 @@ import { findRelationship } from "@/utils/alliance";
 import { getDefaultBasicActions } from "@/libs/combat/actions";
 import { canTrainJutsu, checkJutsuItems } from "@/libs/train";
 import { toOffenceStat, toDefenceStat } from "@/libs/stats";
+import { getReskinnedUserJutsu } from "@/libs/jutsu";
 import type { RankedLoadout } from "@/drizzle/schema";
 import type { BattleType } from "@/drizzle/constants";
 import type { BattleUserState, StatSchemaType } from "@/libs/combat/types";
@@ -87,7 +89,7 @@ import type { GroundEffect, UserEffect } from "@/libs/combat/types";
 import type { ActionEffect } from "@/libs/combat/types";
 import type { CompleteBattle } from "@/libs/combat/types";
 import type { DrizzleClient } from "@/server/db";
-import { IMG_BG_FOREST, IMG_AVATAR_DEFAULT } from "@/drizzle/constants";
+import { IMG_BG_FOREST } from "@/drizzle/constants";
 import type { ZodBgSchemaType } from "@/validators/backgroundSchema";
 import type {
   VillageAlliance,
@@ -1141,7 +1143,10 @@ export const initiateBattle = async (
           orderBy: (table, { desc }) => [desc(table.quantity)],
         },
         jutsus: {
-          with: { jutsu: true },
+          with: {
+            jutsu: true,
+            activeReskin: true,
+          },
           where: (jutsus) => eq(jutsus.equipped, 1),
           orderBy: (table, { desc }) => [desc(table.level)],
         },
@@ -1241,6 +1246,8 @@ export const initiateBattle = async (
             equipped: 1,
             finishTraining: null,
             jutsu: jutsu,
+            reskinId: null,
+            activeReskin: null,
           }));
       }
     }
@@ -1642,6 +1649,11 @@ export const processUsersForBattle = async (
     user.curChakra = Math.min(user.curChakra + restored, user.maxChakra);
     user.curStamina = Math.min(user.curStamina + restored, user.maxStamina);
 
+    // Reskin bloodline if needed
+    if (user.bloodline && user.activeReskin) {
+      user.bloodline = getReskinnedBloodline(user.bloodline, user.activeReskin);
+    }
+
     // For kage challenges, set health/chakra/stamina to full
     if (["KAGE_AI", "KAGE_PVP"].includes(battleType)) {
       user.curHealth = user.maxHealth;
@@ -1917,6 +1929,7 @@ export const processUsersForBattle = async (
 
     // Set jutsus updatedAt to now (we use it for determining usage cooldowns)
     user.jutsus = user.jutsus
+      .map((userjutsu) => getReskinnedUserJutsu(userjutsu))
       .filter((userjutsu) => {
         // Not if no jutsu
         if (!userjutsu.jutsu) {

--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -482,6 +482,7 @@ export const itemRouter = createTRPCRouter({
         curStamina: user.curStamina,
         curChakra: user.curChakra,
         marriageSlots: user.marriageSlots,
+        extraReskinSlots: user.extraReskinSlots,
       };
       const data: unknown[] = [];
 
@@ -576,6 +577,11 @@ export const itemRouter = createTRPCRouter({
               `Your marriage slots are already at max! Current Slots: ${updates.marriageSlots}`,
             );
           }
+        } else if (effect.type === "noncombatincreasereskins") {
+          updates.extraReskinSlots += effect.power;
+          messages.push(
+            `Your number of allowed reskins was increased by ${effect.power}! `,
+          );
         } else if (effect.type === "heal") {
           const parsedEffect = HealTag.parse(effect);
           const poolsAffects = parsedEffect.poolsAffected || ["Health"];

--- a/app/src/server/api/routers/jutsu.ts
+++ b/app/src/server/api/routers/jutsu.ts
@@ -8,6 +8,7 @@ import {
   actionLog,
   jutsuLoadout,
   bloodline,
+  jutsuReskin,
   skillTree,
   item,
 } from "@/drizzle/schema";
@@ -30,24 +31,39 @@ import {
   calcJutsuEquipLimit,
 } from "@/libs/train";
 import { DAY_S, secondsFromDate } from "@/utils/time";
-import { getFreeTransfers } from "@/libs/jutsu";
+import { getFreeTransfers, getReskinnedUserJutsu } from "@/libs/jutsu";
 import { JutsuValidator } from "@/libs/combat/types";
-import { canChangeContent, canEditJutsus, canTransferJutsu } from "@/utils/permissions";
+import {
+  canChangeContent,
+  canEditJutsus,
+  canTransferJutsu,
+  canReskinFreely,
+  canModerateReskin,
+} from "@/utils/permissions";
 import { callDiscordContent } from "@/libs/discord";
 import { createTRPCRouter, errorResponse } from "@/server/api/trpc";
 import { protectedProcedure, publicProcedure } from "@/server/api/trpc";
 import { serverError, baseServerResponse } from "@/server/api/trpc";
 import { fedJutsuLoadouts } from "@/utils/paypal";
-import { IMG_AVATAR_DEFAULT } from "@/drizzle/constants";
+import {
+  IMG_AVATAR_DEFAULT,
+  RESKIN_LIMIT,
+  COST_RESKIN_JUTSU,
+} from "@/drizzle/constants";
 import { calculateContentDiff } from "@/utils/diff";
-import { jutsuFilteringSchema } from "@/validators/jutsu";
+import {
+  jutsuFilteringSchema,
+  jutsuReskinCreateSchema,
+  jutsuReskinUpdateSchema,
+} from "@/validators/jutsu";
 import { QuestTracker } from "@/validators/objectives";
 import type { JutsuFilteringSchema } from "@/validators/jutsu";
 import type { ZodAllTags } from "@/libs/combat/types";
-import type { UserData, JutsuLoadout, UserJutsu, Jutsu } from "@/drizzle/schema";
+import type { UserData, JutsuLoadout, UserJutsuWithRelations } from "@/drizzle/schema";
 import type { DrizzleClient } from "@/server/db";
 import { TRPCError } from "@trpc/server";
 import { fetchStudents } from "@/routers/sensei";
+import { validateUserUpdateReason } from "@/libs/moderator";
 
 export const jutsuRouter = createTRPCRouter({
   getRecentTransfers: protectedProcedure.query(async ({ ctx }) => {
@@ -230,43 +246,8 @@ export const jutsuRouter = createTRPCRouter({
         limit: input.limit,
       });
 
-      // Post-filter to handle "must have these elements, stats, etc." all in the SAME effect
-      const filtered = results.filter((oneJutsu) => {
-        if (
-          input.stat ||
-          input.effect ||
-          input.element ||
-          input.appear ||
-          input.static ||
-          input.disappear
-        ) {
-          return oneJutsu.effects.some((e) => {
-            const asString = JSON.stringify(e);
-
-            // Merge statTypes + generalTypes if that's how your code works
-            const effectStats = [
-              ...("statTypes" in e && e.statTypes ? e.statTypes : []),
-              ...("generalTypes" in e && e.generalTypes ? e.generalTypes : []),
-            ];
-            const effectElements = [
-              ...("elements" in e && e.elements ? e.elements : []),
-            ] as string[];
-
-            // Return true if it matches the includes
-            return (
-              (!input.stat || input.stat.every((x) => effectStats.includes(x))) &&
-              (!input.effect || input.effect.some((x) => x === e.type)) &&
-              (!input.element ||
-                input.element.every((x) => effectElements.includes(x))) &&
-              (!input.appear || asString.includes(input.appear)) &&
-              (!input.static || asString.includes(input.static)) &&
-              (!input.disappear || asString.includes(input.disappear))
-            );
-          });
-        }
-        // If no arrays, keep it
-        return true;
-      });
+      // Post-filter to ensure constraints are satisfied within the same effect
+      const filtered = filterByEffectConstraints(results, input);
 
       // Next cursor if more rows
       const nextCursor = results.length < input.limit ? null : currentCursor + 1;
@@ -501,15 +482,32 @@ export const jutsuRouter = createTRPCRouter({
       // Return
       return results;
     }),
-  // Adjust jutsu level of public user
-  adjustJutsuLevel: protectedProcedure
-    .input(z.object({ userId: z.string(), jutsuId: z.string(), level: z.number() }))
+  // Adjust jutsu level of public user (and optionally reskin)
+  adjustUserJutsu: protectedProcedure
+    .input(
+      z.object({
+        userId: z.string(),
+        jutsuId: z.string(),
+        level: z.number(),
+        reskinId: z.string().nullable().optional(),
+      }),
+    )
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
       // Fetch
-      const [user, userjutsus] = await Promise.all([
+      const [user, userjutsus, reskin] = await Promise.all([
         fetchUser(ctx.drizzle, ctx.userId),
         fetchUserJutsus(ctx.drizzle, input.userId),
+        ...(input.reskinId
+          ? [
+              ctx.drizzle.query.jutsuReskin.findFirst({
+                where: and(
+                  eq(jutsuReskin.id, input.reskinId),
+                  eq(jutsuReskin.jutsuId, input.jutsuId),
+                ),
+              }),
+            ]
+          : []),
       ]);
       // Guard)
       if (!canEditJutsus(user.role)) {
@@ -519,11 +517,32 @@ export const jutsuRouter = createTRPCRouter({
       if (!userjutsu) {
         return errorResponse("Jutsu not found for user");
       }
+      if (input.reskinId && !reskin) {
+        return errorResponse("Reskin not found for this jutsu");
+      }
+      // Action loggin
+      const prevReskinName = userjutsu.activeReskin?.name ?? null;
+      const newReskinName = reskin?.name ?? null;
+      const updateFields = {
+        level: input.level,
+        updatedAt: new Date(),
+        reskinId: input.reskinId,
+      };
+
+      const changes: string[] = [
+        `Jutsu ${userjutsu.jutsu.name} lvl ${userjutsu.level} -> ${input.level}`,
+      ];
+      if (input.reskinId !== undefined && prevReskinName !== newReskinName) {
+        changes.push(
+          `Jutsu ${userjutsu.jutsu.name} reskin ${prevReskinName ?? "None"} -> ${newReskinName ?? "None"}`,
+        );
+      }
+
       // Mutate
       await Promise.all([
         ctx.drizzle
           .update(userJutsu)
-          .set({ level: input.level })
+          .set(updateFields)
           .where(
             and(
               eq(userJutsu.userId, input.userId),
@@ -534,15 +553,13 @@ export const jutsuRouter = createTRPCRouter({
           id: nanoid(),
           userId: ctx.userId,
           tableName: "user",
-          changes: [
-            `Jutsu ${userjutsu.jutsu.name} lvl ${userjutsu.level} -> ${input.level}`,
-          ],
+          changes,
           relatedId: input.userId,
-          relatedMsg: `Update: ${userjutsu.jutsu.name} level ${userjutsu.level} -> ${input.level}`,
+          relatedMsg: `Update: ${userjutsu.jutsu.name}`,
           relatedImage: userjutsu.jutsu.image,
         }),
       ]);
-      return { success: true, message: `Jutsu level adjusted to ${input.level}` };
+      return { success: true, message: `Jutsu updated` };
     }),
   // Start training a given jutsu
   startTraining: protectedProcedure
@@ -846,6 +863,297 @@ export const jutsuRouter = createTRPCRouter({
 
       return { success: true, message: `Order updated` };
     }),
+
+  createReskin: protectedProcedure
+    .input(jutsuReskinCreateSchema)
+    .output(baseServerResponse)
+    .mutation(async ({ ctx, input }) => {
+      // Query
+      const [user, jutsuData, userReskins] = await Promise.all([
+        fetchUser(ctx.drizzle, ctx.userId),
+        fetchJutsu(ctx.drizzle, input.jutsuId),
+        fetchUserReskins(ctx.drizzle, ctx.userId),
+      ]);
+      // Derived
+      const curReskins = userReskins?.length || 0;
+      const maxReskins = user.extraReskinSlots + RESKIN_LIMIT;
+      const existingReskin = userReskins.find((r) => r.jutsuId === input.jutsuId);
+      // Guards
+      if (!jutsuData) {
+        return errorResponse("Original jutsu not found");
+      }
+      if (!existingReskin && curReskins >= maxReskins) {
+        return errorResponse(
+          `You have used all your reskins (${curReskins}/${maxReskins})`,
+        );
+      }
+      if (
+        !existingReskin &&
+        !canReskinFreely(user.role) &&
+        user.reputationPoints < COST_RESKIN_JUTSU
+      ) {
+        return errorResponse(
+          `Not enough reputation points. Required: ${COST_RESKIN_JUTSU}`,
+        );
+      }
+      // Default image fallback to original jutsu image if omitted
+      const resolvedImage = input.image ?? jutsuData.image;
+
+      // Run mutation (free update or new)
+      if (existingReskin) {
+        await Promise.all([
+          ctx.drizzle
+            .update(jutsuReskin)
+            .set({
+              name: input.name,
+              description: input.description,
+              battleDescription: input.battleDescription,
+              image: resolvedImage,
+              updatedAt: new Date(),
+            })
+            .where(eq(jutsuReskin.id, existingReskin.id)),
+          ctx.drizzle
+            .update(userJutsu)
+            .set({
+              reskinId: existingReskin.id,
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(userJutsu.jutsuId, jutsuData.id),
+                eq(userJutsu.userId, ctx.userId),
+              ),
+            ),
+        ]);
+        return { success: true, message: "Jutsu reskin updated successfully" };
+      } else {
+        const reskinId = nanoid();
+        await Promise.all([
+          ctx.drizzle
+            .update(userJutsu)
+            .set({
+              reskinId: reskinId,
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(userJutsu.jutsuId, jutsuData.id),
+                eq(userJutsu.userId, ctx.userId),
+              ),
+            ),
+          ctx.drizzle.insert(jutsuReskin).values({
+            id: reskinId,
+            userId: ctx.userId,
+            jutsuId: jutsuData.id,
+            name: input.name,
+            description: input.description,
+            battleDescription: input.battleDescription,
+            image: resolvedImage,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          }),
+          ...(canReskinFreely(user.role)
+            ? []
+            : [
+                ctx.drizzle
+                  .update(userData)
+                  .set({
+                    reputationPoints: sql`${userData.reputationPoints} - ${COST_RESKIN_JUTSU}`,
+                  })
+                  .where(eq(userData.userId, ctx.userId)),
+              ]),
+        ]);
+
+        return { success: true, message: "Jutsu reskin created successfully" };
+      }
+    }),
+
+  updateReskin: protectedProcedure
+    .input(z.object({ reskinId: z.string(), data: jutsuReskinUpdateSchema }))
+    .output(baseServerResponse)
+    .mutation(async ({ ctx, input }) => {
+      // Fetch current user and reskin
+      const [user, reskin] = await Promise.all([
+        fetchUser(ctx.drizzle, ctx.userId),
+        fetchUserReskin(ctx.drizzle, ctx.userId, input.reskinId),
+      ]);
+      // Guards
+      if (!reskin) return errorResponse("Reskin not found");
+      if (!canModerateReskin(user.role)) {
+        return errorResponse("Unauthorized");
+      }
+      // Prepare old/new objects for diff (exclude reason from new)
+      const oldData = {
+        name: reskin.name,
+        description: reskin.description,
+        battleDescription: reskin.battleDescription,
+        image: reskin.image,
+      };
+      const { reason, ...rest } = input.data;
+      const newData = { ...rest };
+      const diff = calculateContentDiff(oldData, newData);
+
+      // AI moderation of reason
+      const aiCheck = await validateUserUpdateReason(diff.join(". "), reason);
+      if (!aiCheck.allowUpdate) {
+        await ctx.drizzle.insert(actionLog).values({
+          id: nanoid(),
+          userId: ctx.userId,
+          tableName: "jutsu",
+          changes: {},
+          relatedId: reskin.jutsuId,
+          relatedMsg: `Reskin update rejected by AI: ${reason}`,
+          relatedImage: reskin.image,
+        });
+        return errorResponse(aiCheck.comment);
+      }
+
+      // Update database and log
+      await Promise.all([
+        ctx.drizzle
+          .update(jutsuReskin)
+          .set({
+            name: newData.name,
+            description: newData.description,
+            battleDescription: newData.battleDescription,
+            image: newData.image ?? reskin.image,
+            updatedAt: new Date(),
+          })
+          .where(eq(jutsuReskin.id, reskin.id)),
+        ctx.drizzle.insert(actionLog).values({
+          id: nanoid(),
+          userId: ctx.userId,
+          tableName: "jutsu",
+          changes: diff,
+          relatedId: reskin.jutsuId,
+          relatedMsg: `Reskin updated: ${reskin.jutsu?.name || reskin.name}`,
+          relatedImage: newData.image ?? reskin.image,
+        }),
+      ]);
+
+      return { success: true, message: "Jutsu reskin updated successfully" };
+    }),
+
+  getAllReskins: publicProcedure
+    .input(
+      jutsuFilteringSchema.extend({
+        cursor: z.number().nullish(),
+        limit: z.number().min(1).max(1000),
+        hideAi: z.boolean().optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const currentCursor = input.cursor ?? 0;
+      const skip = currentCursor * input.limit;
+
+      // Build the base DB filter (on underlying jutsu)
+      const baseFilters = jutsuDatabaseFilter(input);
+
+      // Query reskins joined with jutsu to allow filtering via jutsuDatabaseFilter
+      const rows = await ctx.drizzle
+        .select({
+          reskin: jutsuReskin,
+          jutsu: jutsu,
+          bloodlineName: bloodline.name,
+          userUsername: userData.username,
+        })
+        .from(jutsuReskin)
+        .innerJoin(jutsu, eq(jutsuReskin.jutsuId, jutsu.id))
+        .leftJoin(bloodline, eq(jutsu.bloodlineId, bloodline.id))
+        .innerJoin(userData, eq(jutsuReskin.userId, userData.userId))
+        .where(
+          and(...baseFilters, ...(input.hideAi ? [ne(jutsu.jutsuType, "AI")] : [])),
+        )
+        .orderBy(desc(jutsuReskin.updatedAt))
+        .offset(skip)
+        .limit(input.limit);
+
+      // Map back to the previous shape used by the frontend consumer
+      const results = rows
+        .filter((row) => filterByEffectConstraints([row.jutsu], input).length > 0)
+        .map((row) => ({
+          ...row.reskin,
+          jutsu: {
+            ...row.jutsu,
+            bloodline: row.bloodlineName ? { name: row.bloodlineName } : null,
+          },
+          user: {
+            username: row.userUsername,
+          },
+        }));
+
+      const nextCursor = rows.length < input.limit ? null : currentCursor + 1;
+      return {
+        data: results,
+        nextCursor,
+      };
+    }),
+
+  getUserReskins: protectedProcedure.query(async ({ ctx }) => {
+    return await fetchUserReskins(ctx.drizzle, ctx.userId);
+  }),
+
+  // List all reskins available for a given base jutsu
+  getReskinsForJutsu: protectedProcedure
+    .input(z.object({ jutsuId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const reskins = await ctx.drizzle.query.jutsuReskin.findMany({
+        where: eq(jutsuReskin.jutsuId, input.jutsuId),
+        orderBy: (table, { desc }) => [desc(table.updatedAt)],
+        with: {
+          user: {
+            columns: { username: true },
+          },
+        },
+      });
+      return reskins;
+    }),
+
+  getReskin: protectedProcedure
+    .input(z.object({ reskinId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      // Query
+      const reskin = await fetchUserReskin(ctx.drizzle, ctx.userId, input.reskinId);
+
+      // Return
+      if (!reskin) {
+        return errorResponse("Reskin not found");
+      }
+      // Return
+      return reskin;
+    }),
+  removeReskin: protectedProcedure
+    .input(z.object({ userJutsuId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      // Query
+      const userJutsuData = await ctx.drizzle.query.userJutsu.findFirst({
+        where: eq(userJutsu.id, input.userJutsuId),
+        with: { activeReskin: true },
+      });
+      // Guard
+      if (!userJutsuData) {
+        return errorResponse("User jutsu not found");
+      }
+      if (!userJutsuData.activeReskin) {
+        return errorResponse("No reskin found for this jutsu");
+      }
+      // Remove the reskin (but keep the record for history + free future updates)
+      await Promise.all([
+        ctx.drizzle
+          .update(userJutsu)
+          .set({
+            reskinId: null,
+            updatedAt: new Date(),
+          })
+          .where(eq(userJutsu.id, input.userJutsuId)),
+      ]);
+      // Return
+      return {
+        success: true,
+        message: "Jutsu reskin removed successfully",
+      };
+    }),
+
   getJutsuRelations: publicProcedure
     .input(z.object({ jutsuId: z.string() }))
     .query(async ({ ctx, input }) => {
@@ -905,6 +1213,12 @@ export const getJutsuRelations = async (client: DrizzleClient, jutsuId: string) 
 };
 export type JutsuRelations = Awaited<ReturnType<typeof getJutsuRelations>>;
 
+/**
+ * Fetch all loadouts for a user
+ * @param client - The database client
+ * @param userId - The ID of the user to fetch loadouts for
+ * @returns A promise that resolves to the result of the select
+ */
 export const fetchJutsuLoadouts = async (client: DrizzleClient, userId: string) => {
   return await client.query.jutsuLoadout.findMany({
     where: eq(jutsuLoadout.userId, userId),
@@ -912,23 +1226,82 @@ export const fetchJutsuLoadouts = async (client: DrizzleClient, userId: string) 
   });
 };
 
+/**
+ * Fetch a jutsu by id (for reskin update)
+ * @param client - The database client
+ * @param id - The ID of the jutsu to fetch
+ * @returns A promise that resolves to the result of the select
+ */
 export const fetchJutsu = async (client: DrizzleClient, id: string) => {
   return await client.query.jutsu.findFirst({
     where: eq(jutsu.id, id),
   });
 };
 
+/**
+ * Fetch a reskin for a user
+ * @param client - The database client
+ * @param userId - The ID of the user to fetch the reskin for
+ * @param reskinId - The ID of the reskin to fetch
+ * @returns A promise that resolves to the result of the select
+ */
+export const fetchUserReskin = async (
+  client: DrizzleClient,
+  userId: string,
+  reskinId: string,
+) => {
+  return await client.query.jutsuReskin.findFirst({
+    where: and(eq(jutsuReskin.userId, userId), eq(jutsuReskin.id, reskinId)),
+    with: {
+      jutsu: {
+        with: {
+          bloodline: {
+            columns: {
+              name: true,
+            },
+          },
+        },
+      },
+      user: {
+        columns: {
+          username: true,
+        },
+      },
+    },
+  });
+};
+
+/**
+ * Fetch all reskins for a user
+ * @param client - The database client
+ * @param userId - The ID of the user to fetch reskins for
+ * @returns A promise that resolves to the result of the select
+ */
+export const fetchUserReskins = async (client: DrizzleClient, userId: string) => {
+  return await client.query.jutsuReskin.findMany({
+    where: eq(jutsuReskin.userId, userId),
+  });
+};
+
+/**
+ * Fetch all jutsus for a user
+ * @param client - The database client
+ * @param userId - The ID of the user to fetch jutsus for
+ * @param input - The input object
+ * @returns
+ */
 export const fetchUserJutsus = async (
   client: DrizzleClient,
   userId: string,
   input?: JutsuFilteringSchema,
 ) => {
-  // Grab all userJutsus with Jutsu data
+  // Grab all userJutsus with Jutsu data and reskin data
   const userjutsus = await client
     .select()
     .from(userJutsu)
     .innerJoin(jutsu, eq(userJutsu.jutsuId, jutsu.id))
     .leftJoin(bloodline, eq(jutsu.bloodlineId, bloodline.id))
+    .leftJoin(jutsuReskin, eq(userJutsu.reskinId, jutsuReskin.id))
     .where(
       and(
         eq(userJutsu.userId, userId),
@@ -937,14 +1310,17 @@ export const fetchUserJutsus = async (
       ),
     )
     .orderBy(desc(userJutsu.level));
-
-  return userjutsus.map((result) => ({
+  // First map to query-format
+  const unskinnedUserJutsus = userjutsus.map((result) => ({
     ...result.UserJutsu,
     jutsu: {
       ...result.Jutsu,
       bloodline: result.Bloodline,
     },
+    activeReskin: result.JutsuReskin,
   }));
+  // Then map to reskinned format
+  return unskinnedUserJutsus.map((userjutsu) => getReskinnedUserJutsu(userjutsu));
 };
 
 /**
@@ -955,7 +1331,9 @@ export const jutsuDatabaseFilter = (input?: JutsuFilteringSchema) => {
     // -----------------------------
     // Existing "include" conditions
     // -----------------------------
-    ...(input?.name ? [like(jutsu.name, `%${input.name}%`)] : []),
+    ...(input?.name
+      ? [like(sql`LOWER(${jutsu.name})`, `%${input.name.toLowerCase()}%`)]
+      : []),
     ...(input?.bloodline ? [eq(jutsu.bloodlineId, input.bloodline)] : []),
     ...(input?.jutsuType ? [inArray(jutsu.jutsuType, input.jutsuType)] : []),
     ...(input?.requiredLevel ? [gte(jutsu.requiredLevel, input.requiredLevel)] : []),
@@ -1147,6 +1525,47 @@ export const jutsuDatabaseFilter = (input?: JutsuFilteringSchema) => {
 };
 
 /**
+ * Utility: Post-filter jutsu-like rows to ensure includes are satisfied within the same effect
+ */
+const filterByEffectConstraints = <T extends { effects: ZodAllTags[] }>(
+  rows: T[],
+  input: JutsuFilteringSchema,
+) => {
+  return rows.filter((row) => {
+    if (
+      input.stat ||
+      input.effect ||
+      input.element ||
+      input.appear ||
+      input.static ||
+      input.disappear
+    ) {
+      return row.effects.some((e) => {
+        const asString = JSON.stringify(e);
+
+        const effectStats = [
+          ...("statTypes" in e && e.statTypes ? e.statTypes : []),
+          ...("generalTypes" in e && e.generalTypes ? e.generalTypes : []),
+        ];
+        const effectElements = [
+          ...("elements" in e && e.elements ? e.elements : []),
+        ] as string[];
+
+        return (
+          (!input.stat || input.stat.every((x) => effectStats.includes(x))) &&
+          (!input.effect || input.effect.some((x) => x === e.type)) &&
+          (!input.element || input.element.every((x) => effectElements.includes(x))) &&
+          (!input.appear || asString.includes(input.appear)) &&
+          (!input.static || asString.includes(input.static)) &&
+          (!input.disappear || asString.includes(input.disappear))
+        );
+      });
+    }
+    return true;
+  });
+};
+
+/**
  * @param client - The database client
  * @param loadoutId - The ID of the loadout to select
  * @param loadouts - The loadouts to select from
@@ -1157,7 +1576,7 @@ export const selectJutsuLoadout = async (
   client: DrizzleClient,
   loadoutId: string,
   loadouts: JutsuLoadout[],
-  userjutsus: (UserJutsu & { jutsu: Jutsu })[],
+  userjutsus: UserJutsuWithRelations[],
   user: UserData,
 ) => {
   const loadout = loadouts.find((l) => l.id === loadoutId);

--- a/app/src/server/api/routers/jutsu.ts
+++ b/app/src/server/api/routers/jutsu.ts
@@ -945,9 +945,9 @@ export const jutsuRouter = createTRPCRouter({
             id: reskinId,
             userId: ctx.userId,
             jutsuId: jutsuData.id,
-            name: input.name,
-            description: input.description,
-            battleDescription: input.battleDescription,
+            name: input.name ?? jutsuData.name,
+            description: input.description ?? jutsuData.description,
+            battleDescription: input.battleDescription ?? jutsuData.battleDescription,
             image: resolvedImage,
             createdAt: new Date(),
             updatedAt: new Date(),
@@ -1000,7 +1000,7 @@ export const jutsuRouter = createTRPCRouter({
           id: nanoid(),
           userId: ctx.userId,
           tableName: "jutsu",
-          changes: {},
+          changes: [`Reskin update rejected by AI: ${aiCheck.comment}`],
           relatedId: reskin.jutsuId,
           relatedMsg: `Reskin update rejected by AI: ${reason}`,
           relatedImage: reskin.image,
@@ -1127,7 +1127,10 @@ export const jutsuRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       // Query
       const userJutsuData = await ctx.drizzle.query.userJutsu.findFirst({
-        where: eq(userJutsu.id, input.userJutsuId),
+        where: and(
+          eq(userJutsu.id, input.userJutsuId),
+          eq(userJutsu.userId, ctx.userId),
+        ),
         with: { activeReskin: true },
       });
       // Guard
@@ -1145,7 +1148,9 @@ export const jutsuRouter = createTRPCRouter({
             reskinId: null,
             updatedAt: new Date(),
           })
-          .where(eq(userJutsu.id, input.userJutsuId)),
+          .where(
+            and(eq(userJutsu.id, input.userJutsuId), eq(userJutsu.userId, ctx.userId)),
+          ),
       ]);
       // Return
       return {

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -105,8 +105,10 @@ import { createThumbnail } from "@/libs/replicate";
 import sanitize from "@/utils/sanitize";
 import { deleteUser } from "@/server/api/routers/staff";
 import { moderateContent } from "@/libs/moderator";
+import { getReskinnedBloodline } from "@/libs/bloodline";
 import { fetchKageReplacement } from "@/routers/kage";
 import { validateUserUpdateReason } from "@/libs/moderator";
+import type { BloodlineReskin } from "@/drizzle/schema";
 import type { UserVote } from "@/drizzle/schema";
 import type { GetPublicUsersSchema } from "@/validators/user";
 import type { UserJutsu, UserItem } from "@/drizzle/schema";
@@ -790,6 +792,12 @@ export const profileRouter = createTRPCRouter({
       if (bloodlineChanged && !canEditBloodline(user.role)) {
         return errorResponse("Not allowed to change bloodline");
       }
+      const bloodlineReskinChanged =
+        "bloodlineReskinId" in input.data &&
+        input.data.bloodlineReskinId !== target.bloodlineReskinId;
+      if (bloodlineReskinChanged && !canEditBloodline(user.role)) {
+        return errorResponse("Not allowed to change bloodline reskin");
+      }
 
       const villageChanged = village.id !== target.villageId;
       if (villageChanged && !canEditVillage(user.role)) {
@@ -891,6 +899,9 @@ export const profileRouter = createTRPCRouter({
             ...(bloodlineChanged ? { bloodlineId: input.data.bloodlineId } : {}),
             ...(villageChanged ? { villageId: input.data.villageId } : {}),
             ...(rankChanged ? { rank: input.data.rank } : {}),
+            ...(bloodlineReskinChanged
+              ? { bloodlineReskinId: input.data.bloodlineReskinId ?? null }
+              : {}),
             ...(staffAccountChanged ? { staffAccount: input.data.staffAccount } : {}),
             ...(rankedLpChanged ? { rankedLp: input.data.rankedLp } : {}),
             ...(roleChanged ? { role: input.data.role } : {}),
@@ -1299,6 +1310,7 @@ export const profileRouter = createTRPCRouter({
             villageId: true,
             tavernMessages: true,
             staffAccount: true,
+            bloodlineReskinId: true,
           },
           with: {
             village: true,
@@ -1308,6 +1320,7 @@ export const profileRouter = createTRPCRouter({
             jutsus: { with: { jutsu: { columns: { id: true, name: true } } } },
             items: { with: { item: { columns: { id: true, name: true } } } },
             badges: { with: { badge: true } },
+            activeReskin: true,
             recruitedUsers: {
               columns: {
                 userId: true,
@@ -1368,6 +1381,9 @@ export const profileRouter = createTRPCRouter({
       }
       if (!requester || !canSeeIps(requester.role)) {
         user.lastIp = "hidden";
+      }
+      if (user.bloodline && user.activeReskin) {
+        user.bloodline = getReskinnedBloodline(user.bloodline, user.activeReskin);
       }
       // Filter off entries that do not exist
       user.jutsus = user.jutsus.filter((j) => j.jutsu);
@@ -1814,6 +1830,7 @@ export const fetchUpdatedUser = async (props: {
       where: eq(userData.userId, userId),
       with: {
         bloodline: true,
+        activeReskin: true,
         clan: true,
         village: {
           with: {
@@ -1868,6 +1885,11 @@ export const fetchUpdatedUser = async (props: {
       )
       .limit(1),
   ]);
+
+  // Reskin bloodline if needed
+  if (user?.bloodline && user?.activeReskin) {
+    user.bloodline = getReskinnedBloodline(user.bloodline, user.activeReskin);
+  }
 
   // Add votes entry if it doesn't exist
   if (user && !user.votes) {
@@ -2270,6 +2292,7 @@ export const fetchAttributes = async (client: DrizzleClient, userId: string) => 
 export type UserWithRelations =
   | (UserData & {
       bloodline?: Bloodline | null;
+      activeReskin?: BloodlineReskin | null;
       anbuSquad?: { name: string } | null;
       clan?: Clan | null;
       items: UserItem[];

--- a/app/src/utils/permissions.ts
+++ b/app/src/utils/permissions.ts
@@ -18,6 +18,10 @@ export const canChangeContent = (role: UserRole) => {
   ].includes(role);
 };
 
+export const canModerateReskin = (role: UserRole) => {
+  return role !== "USER";
+};
+
 export const canControlBackups = (role: UserRole) => {
   return ["CODING-ADMIN", "CONTENT-ADMIN", "EVENT-ADMIN"].includes(role);
 };
@@ -518,6 +522,19 @@ export const canEditRankedLp = (role: UserRole) => {
 
 export const canSeeHiddenBountyInfo = (role: UserRole) => {
   return role !== "USER";
+};
+
+export const canReskinFreely = (role: UserRole) => {
+  return [
+    "CODER",
+    "CONTENT",
+    "EVENT",
+    "HEAD_MODERATOR",
+    "MODERATOR",
+    "CODING-ADMIN",
+    "MODERATOR-ADMIN",
+    "CONTENT-ADMIN",
+  ].includes(role);
 };
 
 /**

--- a/app/src/validators/bloodline.ts
+++ b/app/src/validators/bloodline.ts
@@ -15,3 +15,21 @@ export const bloodlineFilteringSchema = z.object({
 });
 
 export type BloodlineFilteringSchema = z.infer<typeof bloodlineFilteringSchema>;
+
+/** Schema for creating a bloodline reskin (staff only). */
+export const bloodlineReskinCreateSchema = z.object({
+  bloodlineId: z.string(),
+  name: z.string().min(1).max(100),
+  description: z.string().min(1).max(1000),
+  image: z.string().min(1).max(100).optional(),
+});
+export type BloodlineReskinCreateSchema = z.infer<typeof bloodlineReskinCreateSchema>;
+
+/** Schema for updating a bloodline reskin (staff only, includes reason). */
+export const bloodlineReskinUpdateSchema = z.object({
+  name: z.string().min(1).max(100),
+  description: z.string().min(1).max(1000),
+  image: z.string().min(1).max(100).optional(),
+  reason: z.string().min(5).max(500),
+});
+export type BloodlineReskinUpdateSchema = z.infer<typeof bloodlineReskinUpdateSchema>;

--- a/app/src/validators/bloodline.ts
+++ b/app/src/validators/bloodline.ts
@@ -20,7 +20,7 @@ export type BloodlineFilteringSchema = z.infer<typeof bloodlineFilteringSchema>;
 export const baseReskinSchema = z.object({
   name: z.string().min(0).max(100).optional(),
   description: z.string().min(0).max(1000).optional(),
-  image: z.string().min(1).max(100).optional(),
+  image: z.string().min(1).max(191).optional(),
 });
 
 /** Schema for creating a bloodline reskin (staff only). */

--- a/app/src/validators/bloodline.ts
+++ b/app/src/validators/bloodline.ts
@@ -16,20 +16,21 @@ export const bloodlineFilteringSchema = z.object({
 
 export type BloodlineFilteringSchema = z.infer<typeof bloodlineFilteringSchema>;
 
-/** Schema for creating a bloodline reskin (staff only). */
-export const bloodlineReskinCreateSchema = z.object({
-  bloodlineId: z.string(),
-  name: z.string().min(1).max(100),
-  description: z.string().min(1).max(1000),
+/** Base schema for reskins */
+export const baseReskinSchema = z.object({
+  name: z.string().min(0).max(100).optional(),
+  description: z.string().min(0).max(1000).optional(),
   image: z.string().min(1).max(100).optional(),
+});
+
+/** Schema for creating a bloodline reskin (staff only). */
+export const bloodlineReskinCreateSchema = baseReskinSchema.extend({
+  bloodlineId: z.string(),
 });
 export type BloodlineReskinCreateSchema = z.infer<typeof bloodlineReskinCreateSchema>;
 
 /** Schema for updating a bloodline reskin (staff only, includes reason). */
-export const bloodlineReskinUpdateSchema = z.object({
-  name: z.string().min(1).max(100),
-  description: z.string().min(1).max(1000),
-  image: z.string().min(1).max(100).optional(),
+export const bloodlineReskinUpdateSchema = baseReskinSchema.extend({
   reason: z.string().min(5).max(500),
 });
 export type BloodlineReskinUpdateSchema = z.infer<typeof bloodlineReskinUpdateSchema>;

--- a/app/src/validators/jutsu.ts
+++ b/app/src/validators/jutsu.ts
@@ -60,16 +60,22 @@ export const jutsuFilteringSchema = z.object({
 export type JutsuFilteringSchema = z.infer<typeof jutsuFilteringSchema>;
 
 /**
+ * Base schema for reskins
+ */
+export const baseReskinSchema = z.object({
+  name: z.string().min(0).max(100).optional(),
+  description: z.string().min(0).max(1000).optional(),
+  battleDescription: z.string().min(0).max(1000).optional(),
+  image: z.string().min(1).max(191).optional(),
+});
+
+/**
  * Schema for creating or updating a jutsu reskin.
  * Shared between client (react-hook-form) and server (tRPC input).
  * - image is optional from the client; router defaults to the base jutsu image when omitted.
  */
-export const jutsuReskinCreateSchema = z.object({
+export const jutsuReskinCreateSchema = baseReskinSchema.extend({
   jutsuId: z.string(),
-  name: z.string().min(1).max(100),
-  description: z.string().min(1).max(1000),
-  battleDescription: z.string().min(1).max(1000),
-  image: z.string().min(1).max(100).optional(),
 });
 
 export type JutsuReskinCreateSchema = z.infer<typeof jutsuReskinCreateSchema>;
@@ -78,11 +84,7 @@ export type JutsuReskinCreateSchema = z.infer<typeof jutsuReskinCreateSchema>;
  * Schema for editing an existing jutsu reskin by staff/content.
  * Mirrors create fields, but includes a mandatory reason field for audit/AI validation.
  */
-export const jutsuReskinUpdateSchema = z.object({
-  name: z.string().min(1).max(100),
-  description: z.string().min(1).max(1000),
-  battleDescription: z.string().min(1).max(1000),
-  image: z.string().min(1).max(100).optional(),
+export const jutsuReskinUpdateSchema = baseReskinSchema.extend({
   reason: z.string().min(10),
 });
 

--- a/app/src/validators/jutsu.ts
+++ b/app/src/validators/jutsu.ts
@@ -58,3 +58,32 @@ export const jutsuFilteringSchema = z.object({
 });
 
 export type JutsuFilteringSchema = z.infer<typeof jutsuFilteringSchema>;
+
+/**
+ * Schema for creating or updating a jutsu reskin.
+ * Shared between client (react-hook-form) and server (tRPC input).
+ * - image is optional from the client; router defaults to the base jutsu image when omitted.
+ */
+export const jutsuReskinCreateSchema = z.object({
+  jutsuId: z.string(),
+  name: z.string().min(1).max(100),
+  description: z.string().min(1).max(1000),
+  battleDescription: z.string().min(1).max(1000),
+  image: z.string().min(1).max(100).optional(),
+});
+
+export type JutsuReskinCreateSchema = z.infer<typeof jutsuReskinCreateSchema>;
+
+/**
+ * Schema for editing an existing jutsu reskin by staff/content.
+ * Mirrors create fields, but includes a mandatory reason field for audit/AI validation.
+ */
+export const jutsuReskinUpdateSchema = z.object({
+  name: z.string().min(1).max(100),
+  description: z.string().min(1).max(1000),
+  battleDescription: z.string().min(1).max(1000),
+  image: z.string().min(1).max(100).optional(),
+  reason: z.string().min(10),
+});
+
+export type JutsuReskinUpdateSchema = z.infer<typeof jutsuReskinUpdateSchema>;

--- a/app/src/validators/user.ts
+++ b/app/src/validators/user.ts
@@ -11,6 +11,7 @@ export const updateUserSchema = z.object({
   username: usernameSchema,
   customTitle: z.string().min(0).max(199).optional(),
   bloodlineId: z.string().nullable(),
+  bloodlineReskinId: z.string().nullable().optional(),
   villageId: z.string().nullable(),
   role: z.enum(UserRoles),
   rank: z.enum(UserRanks),


### PR DESCRIPTION
# Pull Request

This allows jutsu to be reskinned and also link a jutsu to a parent.  Updating a parent jutsu will update all children jutsu.  When a jutsu is reskinned, it copies all data about the parent jutsu to the reskin copy including level and experience.  The jutsu is automatically inserted into the list of learned jutsu.  I set the training filter so it'll only show the "Reskin" type if the user has the jutsu already.

When a new jutsu is created, whether by staff or a player creating a reskin, it will display who created it.  In the below screenshot it is a reskin, so "createdBy displays who reskinned it.

Limit on the number of reskins starts at 3(defined in constants), which can be increased by consuming a token (consumed count is in UserData).  It checks the number of reskins the user has done and if its less than the allowed and the user has enough rep, the reskin succeeds.  The screen will also display how many reskins are remaining.  I just can't upload the pictures until vercel finishes the push.

All that's left is having the edit screen properly list all parent jutsu, not just a chunk of them.  Speaking with content, we think it would be a good idea to have the report api used in the tavern also check to make sure that the descriptions being used are safe.

Current images of the reskin view.  This may be adjusted as I continue.

![image](https://github.com/user-attachments/assets/ba952391-6fd8-4988-899b-743bdd24a687)

![image](https://github.com/user-attachments/assets/0687699f-95c6-4d61-8601-8310b813aa04)

![image](https://github.com/user-attachments/assets/1af2f468-7b81-4e11-9931-1505577a92d1)



## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full reskin system: create/update/remove jutsu reskins (limits, costs, free for authorized roles); staff-managed bloodline reskins; select bloodline reskins in profile; reskinned jutsu and bloodlines applied across UI and combat.
  * Staff tools: reskin directories and editors with infinite scroll, filtering, edit flows, and moderation.
  * Consumables and items to increase reskin slots; permission helpers for reskin roles.

* **Style**
  * Icon-only action buttons with hover tooltips; palette icon denotes reskinned items; bloodline popovers and "Created By" on item cards.

* **Chores**
  * Added Makefile force-push-staging target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->