### PR TITLE
Add mute functionality for moderators

### DIFF
--- a/app/drizzle/schema.ts
+++ b/app/drizzle/schema.ts
@@ -1398,6 +1398,7 @@ export const userData = mysqlTable(
     travelFinishAt: datetime("travelFinishAt", { mode: "date", fsp: 3 }),
     isBanned: boolean("isBanned").default(false).notNull(),
     isSilenced: boolean("isSilenced").default(false).notNull(),
+    isMuted: boolean("isMuted").default(false).notNull(),
     role: mysqlEnum("role", consts.UserRoles).default("USER").notNull(),
     battleId: varchar("battleId", { length: 191 }),
     isAi: boolean("isAi").default(false).notNull(),

--- a/app/src/app/api/unmute-users/route.ts
+++ b/app/src/app/api/unmute-users/route.ts
@@ -1,0 +1,22 @@
+import { drizzleDB } from "@/server/db";
+import { userData } from "@/drizzle/schema";
+import { eq } from "drizzle-orm";
+import { cookies } from "next/headers";
+
+export async function GET() {
+  // disable cache for this server action
+  await cookies();
+
+  try {
+    // Update all muted users to unmuted
+    await drizzleDB
+      .update(userData)
+      .set({ isMuted: false })
+      .where(eq(userData.isMuted, true));
+
+    return Response.json("OK - All users unmuted");
+  } catch (error) {
+    console.error("Error unmuting users:", error);
+    return Response.json("Error unmuting users", { status: 500 });
+  }
+}

--- a/app/src/layout/Conversation.tsx
+++ b/app/src/layout/Conversation.tsx
@@ -463,10 +463,10 @@ const Conversation: React.FC<ConversationProps> = (props) => {
    * Submit comment
    */
   const handleSubmitComment = handleSubmit((data) => {
-    if (userData?.isSilenced) {
+    if (userData?.isSilenced || userData?.isMuted) {
       showMutationToast({
         success: false,
-        message: "You are silenced and cannot send a message.",
+        message: "You are silenced or muted and cannot send a message.",
       });
       return;
     }

--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -248,6 +248,15 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = (props) => {
     },
   });
 
+  const toggleMuteUser = api.profile.toggleMuteUser.useMutation({
+    onSuccess: async (data) => {
+      showMutationToast(data);
+      if (data.success) {
+        await utils.profile.getPublicUser.invalidate();
+      }
+    },
+  });
+
   const insertUserBadge = api.staff.insertUserBadge.useMutation({
     onSuccess: async (data) => {
       showMutationToast(data);
@@ -367,6 +376,20 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = (props) => {
                   federalStatus: profile.federalStatus,
                 }}
               />
+            )}
+            {userData && canMuteUsers(userData.role) && (
+              <Confirm
+                title="Toggle User Mute"
+                proceed_label={profile.isMuted ? "Unmute" : "Mute"}
+                button={
+                  <MessageCircle className="h-6 w-6 cursor-pointer hover:text-orange-500" />
+                }
+                onAccept={() => toggleMuteUser.mutate({ userId: profile.userId })}
+              >
+                {profile.isMuted
+                  ? "Are you sure you want to unmute this user?"
+                  : "Are you sure you want to mute this user?"}
+              </Confirm>
             )}
             {availableRoles &&
               availableRoles.length > 0 &&

--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -84,6 +84,7 @@ import {
 } from "@/components/ui/dialog";
 import type { Jutsu } from "@/drizzle/schema";
 import { NewConversationPrompt } from "@/app/inbox/page";
+import { canMuteUsers } from "@/utils/permissions";
 
 interface PublicUserComponentProps {
   userId: string;

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -1313,6 +1313,14 @@ export const profileRouter = createTRPCRouter({
         .set({ isMuted: !targetUser.isMuted })
         .where(eq(userData.userId, input.userId));
 
+      // Trigger a WebSocket event to force the muted user to reconnect
+      void pusher.trigger(input.userId, "event", {
+        type: "userMessage",
+        message: `You have been ${!targetUser.isMuted ? "muted" : "unmuted"}`,
+        route: "/profile",
+        routeText: "To Profile",
+      });
+
       return {
         success: true,
         message: targetUser.isMuted ? "User unmuted" : "User muted",

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -1321,6 +1321,12 @@ export const profileRouter = createTRPCRouter({
         routeText: "To Profile",
       });
 
+      // Force disconnect the user's WebSocket connection
+      void pusher.trigger(input.userId, "disconnect", {
+        type: "forceDisconnect",
+        reason: "userMuteStatusChanged",
+      });
+
       return {
         success: true,
         message: targetUser.isMuted ? "User unmuted" : "User muted",

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -1065,6 +1065,7 @@ export const profileRouter = createTRPCRouter({
             isAi: true,
             isBanned: true,
             isSilenced: true,
+            isMuted: true,
             isOutlaw: true,
             lastIp: true,
             level: true,

--- a/app/src/utils/permissions.ts
+++ b/app/src/utils/permissions.ts
@@ -199,13 +199,13 @@ export const canClearReport = (user: UserData, report: UserReport) => {
   );
 };
 
-export const canMuteUsers = (user: UserData) => {
+export const canMuteUsers = (role: UserRole) => {
   return [
     "MODERATOR-ADMIN",
     "HEAD_MODERATOR",
     "MODERATOR",
     "CODING-ADMIN",
-  ].includes(user.role);
+  ].includes(role);
 };
 
 export const canClearUserNindo = (user: UserData) => {

--- a/app/src/utils/permissions.ts
+++ b/app/src/utils/permissions.ts
@@ -199,6 +199,15 @@ export const canClearReport = (user: UserData, report: UserReport) => {
   );
 };
 
+export const canMuteUsers = (user: UserData) => {
+  return [
+    "MODERATOR-ADMIN",
+    "HEAD_MODERATOR",
+    "MODERATOR",
+    "CODING-ADMIN",
+  ].includes(user.role);
+};
+
 export const canClearUserNindo = (user: UserData) => {
   return ["MODERATOR", "HEAD_MODERATOR", "CODING-ADMIN", "MODERATOR-ADMIN"].includes(
     user.role,

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -63,6 +63,10 @@
     {
       "path": "/api/daily-war",
       "schedule": "0/2 0 * * *"
+    },
+    {
+      "path": "/api/unmute-users",
+      "schedule": "0 */3 * * *"
     }
   ],
   "functions": {


### PR DESCRIPTION
# Pull Request

When we had an issue with moderators being unable to report or take action on users, it was asked by Teni that I add a mute option that jr mods do not have access to.  The mute can be toggled from the public profile (Button and function only accessible to mods).  There is also a cronjob to unmute all users every three hours to prevent forgotten mutes.  While muted, users can view messages but can't send them.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
