### PR TITLE
Darkmode isn't being read when its enabled

### DIFF
--- a/app/src/components/layout/core4_default.tsx
+++ b/app/src/components/layout/core4_default.tsx
@@ -91,7 +91,12 @@ const LayoutCore4: React.FC<LayoutProps> = (props) => {
   const rightSideBarRef = React.useRef<HTMLDivElement | null>(null);
 
   // State
-  const [theme, setTheme] = useState<"light" | "dark">("light");
+  const [theme, setTheme] = useState<"light" | "dark">(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem("theme") as "light" | "dark" || "light";
+    }
+    return "light";
+  });
   const pathname = usePathname();
 
   // Derived data for layout
@@ -114,17 +119,12 @@ const LayoutCore4: React.FC<LayoutProps> = (props) => {
 
   // Set theme
   useEffect(() => {
-    if (
-      theme === "dark" ||
-      (!theme && window.matchMedia("(prefers-color-scheme: dark)").matches)
-    ) {
+    if (theme === "dark") {
       document.documentElement.classList.add("dark");
-      setTheme("dark");
     } else {
       document.documentElement.classList.remove("dark");
-      setTheme("light");
     }
-  }, [theme, setTheme]);
+  }, [theme]);
 
   // Images
   const imageset = getImageSet(userData);


### PR DESCRIPTION
# Pull Request

When players refresh or reopen the page after enabling darkmode, it goes back to lightmode.  It began occurring after one of the 5/25 updates

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
