### PR TITLE
Allow Syndi factions to take missions & Fix tags

### DIFF
--- a/app/src/app/missionhall/page.tsx
+++ b/app/src/app/missionhall/page.tsx
@@ -294,7 +294,9 @@ export default function MissionHall() {
                               rank: setting.rank,
                               userLevel: userData.level,
                               userSector: userData.sector,
-                              userVillageId: userData.villageId,
+                              userVillageId: userData.isOutlaw
+                              ? VILLAGE_SYNDICATE_ID
+                              : userData.villageId,
                             });
                           }}
                         >

--- a/app/src/libs/combat/process.ts
+++ b/app/src/libs/combat/process.ts
@@ -435,7 +435,8 @@ export const applyEffects = (
           });
         }
         if (c.absorb_hp && c.absorb_hp > 0 && target.curHealth > 0) {
-          const maxAbsorb = (c.damage ?? 0) * 0.6;
+          const totalDamage = c.rawDamage ?? 0;
+          const maxAbsorb = totalDamage * 0.6;
           if (c.absorb_hp > maxAbsorb) {
             c.absorb_hp = maxAbsorb;
           }

--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -1012,7 +1012,7 @@ export const damageUser = (
   // Store the raw damage before any calculations
   const rawDamage = damageCalc(effect, origin, target, config);
   // Calculate the final damage with modifiers
-  const damage = rawDamage * dmgModifier * (1 - effect.barrierAbsorb);
+  const damage = rawDamage * dmgModifier * (1 - (effect.barrierAbsorb ?? 0));
   // Find out if target has any weakness tag related to this damage effect
   // const weaknessTags =
   // Fetch types to show to the user

--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -1009,11 +1009,10 @@ export const damageUser = (
   dmgModifier: number,
   config: DmgConfig,
 ) => {
-  // Calculate the raw damage
-  const damage =
-    damageCalc(effect, origin, target, config) *
-    dmgModifier *
-    (1 - effect.barrierAbsorb);
+  // Store the raw damage before any calculations
+  const rawDamage = damageCalc(effect, origin, target, config);
+  // Calculate the final damage with modifiers
+  const damage = rawDamage * dmgModifier * (1 - effect.barrierAbsorb);
   // Find out if target has any weakness tag related to this damage effect
   // const weaknessTags =
   // Fetch types to show to the user
@@ -1032,8 +1031,8 @@ export const damageUser = (
       userId: effect.creatorId,
       targetId: effect.targetId,
       types: types,
-      ...(instant ? { damage: damage } : {}),
-      ...(residual ? { residual: damage } : {}),
+      ...(instant ? { damage: damage, rawDamage: rawDamage } : {}),
+      ...(residual ? { residual: damage, rawResidual: rawDamage } : {}),
     });
   }
   return getInfo(target, effect, "will take damage");

--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -1364,10 +1364,10 @@ export const drain = (
     pools.forEach((pool) => {
       const poolValue =
         pool === "Health"
-          ? target.curHealth
+          ? target.maxHealth
           : pool === "Chakra"
-            ? target.curChakra
-            : target.curStamina;
+            ? target.maxChakra
+            : target.maxStamina;
       const drainAmount =
         effect.calculation === "percentage"
           ? Math.floor((power / 100) * poolValue)

--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -683,7 +683,7 @@ export const StealthTag = z.object({
   ...BaseAttributes,
   ...PowerAttributes,
   type: z.literal("stealth").default("stealth"),
-  description: msg("Stealth the target, only allowing basic move and heal actions"),
+  description: msg("Stealth the target, only allowing non-damaging jutsu and actions"),
 });
 
 export type StealthTagType = z.infer<typeof StealthTag>;

--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -183,7 +183,9 @@ export type Consequence = {
   heal_sp?: number;
   heal_cp?: number;
   damage?: number;
+  rawDamage?: number;
   residual?: number;
+  rawResidual?: number;
   reflect?: number;
   recoil?: number;
   lifesteal_hp?: number;

--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -544,7 +544,7 @@ export const DrainTag = z.object({
   ...PoolAttributes,
   type: z.literal("drain").default("drain"),
   description: msg("Drain target's pools over time"),
-  calculation: z.enum(["percentage"]).default("percentage"),
+  calculation: z.enum(["static", "percentage"]).default("percentage"),
   rounds: z.coerce.number().int().min(1).max(10).default(3),
   poolsAffected: z.array(z.enum(PoolTypes)).default(["Chakra", "Stamina", "Health"]),
 });

--- a/app/src/libs/profile.ts
+++ b/app/src/libs/profile.ts
@@ -34,7 +34,7 @@ export const calcLevel = (experience: number) => {
       level += 1;
     }
   }
-  return level;
+  return Math.min(level, 100);
 };
 
 export const calcHP = (level: number) => {

--- a/app/src/libs/quest.ts
+++ b/app/src/libs/quest.ts
@@ -136,7 +136,7 @@ export const getReward = (user: NonNullable<UserWithRelations>, questId: string)
     const isMissionOrCrime =
       userQuest.quest.questType === "mission" || userQuest.quest.questType === "crime";
     const factor =
-      isMissionOrCrime && user.dailyMissions > MISSIONS_PER_DAY
+      isMissionOrCrime && user.dailyMissions > 9
         ? ADDITIONAL_MISSION_REWARD_MULTIPLIER
         : 1;
     rewards.reward_money = Math.floor(rewards.reward_money * factor);


### PR DESCRIPTION
This PR fixes the current issues:

- Syndi factions can once again take missions.  
- Mission reward gains are reduced to 40% again after 9 completions.
- Drain will now scale off max pools instead of current pools.  Static drain is now available as well.
- Absorb now is based off the full damage, not only remaining damage after shield calculation.  To do this, I added a raw damage consequence for DamageUser and then had it finish calculating the adjusted damage afterwards and put it on the damage consequence.
- Heal prevent will now allow existing heal tags continue while only blocking new ones.
- Adjust Stealth Tag description
- Fixed level scaling as it was scaling players above level 100 

Fix Issue #524 
Fix Issue #523 
Fix Issue #513 

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted mission acceptance logic to ensure outlaws start random missions under the correct village context.
	- Fixed absorb HP calculations in combat to use raw damage values, ensuring more accurate health absorption.
	- Updated drain mechanics to use maximum resource pools instead of current values for more consistent effects.
	- Improved prevention effect timing to ensure newer effects are not incorrectly blocked by older ones.
- **New Features**
	- Combat consequences now display both raw and modified damage values for greater transparency.
	- Drain effects now support both static and percentage-based calculations.
- **Documentation**
	- Clarified stealth effect descriptions to specify that only non-damaging actions are allowed while stealthed.
- **Chores**
	- Updated reward multiplier logic for missions and crimes to use a fixed threshold for daily missions.
- **Bug Fixes**
	- Enforced a maximum player level cap of 100 to maintain balanced progression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->