### PR TITLE
New afterburn tag/Item Cloning/Moveprevent GCD

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -68,6 +68,7 @@ export const SHARED_COOLDOWN_TAGS = [
   "shield",
   "drain",
   "poison",
+  "moveprevent",
   "clear",
   "cleanse",
   "pierce",

--- a/app/src/app/manual/item/page.tsx
+++ b/app/src/app/manual/item/page.tsx
@@ -133,6 +133,7 @@ export default function ManualItems() {
               onDelete={(id: string) => remove({ id })}
               showEdit="item"
               showStatistic="item"
+              showCopy="item"
             />
           </div>
         ))}

--- a/app/src/layout/ItemWithEffects.tsx
+++ b/app/src/layout/ItemWithEffects.tsx
@@ -59,7 +59,7 @@ export interface ItemWithEffectsProps {
     | "backgroundSchema"
     | "skillTree";
   showStatistic?: "bloodline" | "item" | "jutsu" | "ai";
-  showCopy?: "quest" | "ai";
+  showCopy?: "quest" | "ai" | "item";
   show3d?: boolean;
   hideTitle?: boolean;
   hideImage?: boolean;
@@ -96,6 +96,15 @@ const ItemWithEffects: React.FC<ItemWithEffectsProps> = (props) => {
       showMutationToast(data);
       if (data.success) {
         router.push(`/manual/ai/edit/${data.message}`);
+      }
+    },
+  });
+
+  const { mutate: cloneItem } = api.item.clone.useMutation({
+    onSuccess: (data) => {
+      showMutationToast(data);
+      if (data.success) {
+        router.push(`/manual/item/edit/${data.message}`);
       }
     },
   });
@@ -223,6 +232,21 @@ const ItemWithEffects: React.FC<ItemWithEffectsProps> = (props) => {
                     >
                       This will create a copy of this AI. You will be redirected to edit
                       the new AI.
+                    </Confirm2>
+                  )}
+                  {showCopy === "item" && (
+                    <Confirm2
+                      title="Clone Item"
+                      button={
+                        <Copy className="h-6 w-6 hover:text-popover-foreground/50" />
+                      }
+                      onAccept={(e) => {
+                        e.preventDefault();
+                        cloneItem({ id: item.id });
+                      }}
+                    >
+                      This will create a copy of this item. You will be redirected to
+                      edit the new item.
                     </Confirm2>
                   )}
                   {show3d && "avatar" in item && "avatar3d" in item && item.avatar3d ? (

--- a/app/src/layout/MenuBoxProfile.tsx
+++ b/app/src/layout/MenuBoxProfile.tsx
@@ -612,6 +612,9 @@ const VisualizeEffects: React.FC<VisualizeEffectsProps> = ({ effects, userId }) 
         case "recoil":
           insert(image, "text-red-500", `↓ Dmg recoil`, true, e);
           break;
+        case "afterburn":
+          insert(image, "text-red-500", `↓ Afterburn`, true, e);
+          break;
         case "drain":
           insert(image, "text-purple-500", `↓ Draining`, true, e);
           break;

--- a/app/src/libs/combat/process.ts
+++ b/app/src/libs/combat/process.ts
@@ -10,6 +10,7 @@ import {
   absorb,
   reflect,
   recoil,
+  afterburn,
   lifesteal,
   drain,
   shield,
@@ -421,6 +422,16 @@ export const applyEffects = (
             });
           }
         }
+        if (c.afterburn && c.afterburn > 0) {
+          if (c.afterburn > 0) {
+            target.curHealth -= c.afterburn;
+            target.curHealth = Math.max(0, target.curHealth);
+            actionEffects.push({
+              txt: `${target.username} takes ${c.afterburn.toFixed(2)} afterburn damage`,
+              color: "red",
+            });
+          }
+        }
         if (
           c.lifesteal_hp &&
           c.lifesteal_hp > 0 &&
@@ -680,6 +691,8 @@ export const applySingleEffect = (
           info = reflect(effect, usersEffects, consequences, curTarget);
         } else if (effect.type === "recoil") {
           info = recoil(effect, usersEffects, consequences, curTarget);
+        } else if (effect.type === "afterburn") {
+          info = afterburn(effect, usersEffects, consequences, curTarget);
         } else if (effect.type === "lifesteal") {
           info = lifesteal(effect, usersEffects, consequences, curTarget);
         } else if (effect.type === "fleeprevent") {

--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -1365,6 +1365,40 @@ export const recoil = (
   return getInfo(target, effect, `will recoil ${qualifier} damage`);
 };
 
+/** Afterburn damage - take a percentage of incoming damage as self-damage */
+export const afterburn = (
+  effect: UserEffect,
+  usersEffects: UserEffect[],
+  consequences: Map<string, Consequence>,
+  target: BattleUserState,
+) => {
+  const { pass, preventTag } = preventCheck(usersEffects, "debuffprevent", target);
+  if (preventTag && preventTag.createdRound < effect.createdRound) {
+    if (!pass) return preventResponse(effect, target, "cannot be debuffed with afterburn");
+  }
+  const { power, qualifier } = getPower(effect);
+  if (!effect.isNew && !effect.castThisRound) {
+    consequences.forEach((consequence, effectId) => {
+      if (consequence.userId === effect.targetId && consequence.damage) {
+        const damageEffect = usersEffects.find((e) => e.id === effectId);
+        if (damageEffect) {
+          const ratio = getEfficiencyRatio(damageEffect, effect);
+          const convert =
+            Math.floor(
+              effect.calculation === "percentage"
+                ? consequence.damage * (power / 100)
+                : power > consequence.damage
+                  ? consequence.damage
+                  : power,
+            ) * ratio;
+          consequence.afterburn = convert;
+        }
+      }
+    });
+  }
+  return getInfo(target, effect, `will take ${qualifier} of incoming damage as afterburn`);
+};
+
 /** Steal damage back to attacker as HP */
 export const lifesteal = (
   effect: UserEffect,

--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -1365,7 +1365,7 @@ export const recoil = (
   return getInfo(target, effect, `will recoil ${qualifier} damage`);
 };
 
-/** Afterburn damage - take a percentage of incoming damage as self-damage */
+/** Afterburn damage - take a percentage of damage received as self-damage */
 export const afterburn = (
   effect: UserEffect,
   usersEffects: UserEffect[],
@@ -1379,7 +1379,8 @@ export const afterburn = (
   const { power, qualifier } = getPower(effect);
   if (!effect.isNew && !effect.castThisRound) {
     consequences.forEach((consequence, effectId) => {
-      if (consequence.userId === effect.targetId && consequence.damage) {
+      // Look for damage that the afterburn target is receiving
+      if (consequence.targetId === effect.targetId && consequence.damage) {
         const damageEffect = usersEffects.find((e) => e.id === effectId);
         if (damageEffect) {
           const ratio = getEfficiencyRatio(damageEffect, effect);
@@ -1396,7 +1397,7 @@ export const afterburn = (
       }
     });
   }
-  return getInfo(target, effect, `will take ${qualifier} of incoming damage as afterburn`);
+  return getInfo(target, effect, `will take ${qualifier} of damage received as afterburn`);
 };
 
 /** Steal damage back to attacker as HP */

--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -1397,7 +1397,12 @@ export const afterburn = (
       }
     });
   }
-  return getInfo(target, effect, `will take ${qualifier} of damage received as afterburn`);
+  
+  const description = effect.calculation === "percentage" 
+    ? `will take ${qualifier} of damage received as afterburn`
+    : `will take ${qualifier} afterburn damage`;
+    
+  return getInfo(target, effect, description);
 };
 
 /** Steal damage back to attacker as HP */

--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -668,7 +668,7 @@ export const AfterburnTag = z.object({
   ...IncludeStats,
   ...PowerAttributes,
   type: z.literal("afterburn").default("afterburn"),
-  description: msg("Take a percentage of incoming damage as self-damage"),
+  description: msg("Take a percentage of incoming damage as afterburndamage"),
   calculation: z.enum(["static", "percentage"]).default("percentage"),
 });
 

--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -211,6 +211,7 @@ export type Consequence = {
   rawResidual?: number;
   reflect?: number;
   recoil?: number;
+  afterburn?: number;
   lifesteal_hp?: number;
   absorb_hp?: number;
   absorb_sp?: number;
@@ -662,6 +663,15 @@ export const RecoilTag = z.object({
   calculation: z.enum(["static", "percentage"]).default("percentage"),
 });
 
+export const AfterburnTag = z.object({
+  ...BaseAttributes,
+  ...IncludeStats,
+  ...PowerAttributes,
+  type: z.literal("afterburn").default("afterburn"),
+  description: msg("Take a percentage of incoming damage as self-damage"),
+  calculation: z.enum(["static", "percentage"]).default("percentage"),
+});
+
 export const RobPreventTag = z.object({
   ...BaseAttributes,
   ...PowerAttributes,
@@ -802,6 +812,7 @@ export const IncreaseMarriageSlots = z.object({
 /******************** */
 export const AllTags = z.union([
   AbsorbTag.default({}),
+  AfterburnTag.default({}),
   BarrierTag.default({}),
   BuffPreventTag.default({}),
   CleansePreventTag.default({}),
@@ -906,6 +917,7 @@ export const isPositiveUserEffect = (tag: ZodAllTags) => {
 export const isNegativeUserEffect = (tag: ZodAllTags) => {
   if (
     [
+      "afterburn",
       "buffprevent",
       // "cleanseprevent",
       "clear",

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -224,6 +224,7 @@ export const calcApplyRatio = (
   // Certain buff/debuffs are applied always (e.g. resolving against each attack)
   const alwaysApply: ZodAllTags["type"][] = [
     "absorb",
+    "afterburn",
     "buffprevent",
     "cleanseprevent",
     "clearprevent",

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -358,6 +358,7 @@ export const sortEffects = (
     "lifesteal",
     "drain",
     "poison",
+    "afterburn",
     "absorb",
     "recoil",
     "reflect",

--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -104,6 +104,50 @@ export const itemRouter = createTRPCRouter({
         return { success: false, message: `Not allowed to create item` };
       }
     }),
+  // Clone an existing item
+  clone: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .output(baseServerResponse)
+    .mutation(async ({ ctx, input }) => {
+      // Fetch
+      const [user, itemData] = await Promise.all([
+        fetchUser(ctx.drizzle, ctx.userId),
+        fetchItemWithCraftingRequirements(ctx.drizzle, input.id),
+      ]);
+      // Guard
+      if (!itemData) return errorResponse("Item not found");
+      if (!canChangeContent(user.role)) return errorResponse("Not allowed");
+
+      // Create new item with copied data
+      const newItemId = nanoid();
+      const clonedItem = {
+        ...itemData,
+        id: newItemId,
+        name: `${itemData.name} - copy`,
+        hidden: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      // Run all inserts at once
+      await Promise.all([
+        ctx.drizzle.insert(item).values(clonedItem),
+        ...(itemData.craftingRequirements && itemData.craftingRequirements.length > 0
+          ? [
+              ctx.drizzle.insert(craftingRequirement).values(
+                itemData.craftingRequirements.map((req) => ({
+                  id: nanoid(),
+                  craftItemId: newItemId,
+                  requirementItemId: req.requirementItemId,
+                  quantity: req.quantity,
+                })),
+              ),
+            ]
+          : []),
+      ]);
+
+      return { success: true, message: newItemId };
+    }),
   // Delete a item
   delete: protectedProcedure
     .input(z.object({ id: z.string() }))


### PR DESCRIPTION
# Pull Request

- Adds a new afterburn tag that deals additional damage based on damage taken.  If the effect is 10% and the afflicted user take 1000 damage, afterburn would deal an additional 100 after.
- Allows staff to clone items.  Automatically set the item to hidden so the clone cannot be purchased.
- Add moveprevent to GCD.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "afterburn" effect in combat, causing additional damage after receiving an attack.
  * Added visual indicators for the "afterburn" effect in effect displays.
  * Enabled item cloning, allowing users to create and edit copies of existing items.

* **Improvements**
  * Updated shared cooldown tags to include "moveprevent" for broader cooldown management.

* **Bug Fixes**
  * None.

* **Documentation**
  * None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->