### PR TITLE
Permission Changes/Staff Features/Fix Summons/Allow users to load more bounties

### DIFF
--- a/app/src/app/profile/edit/page.tsx
+++ b/app/src/app/profile/edit/page.tsx
@@ -1797,7 +1797,7 @@ const ManagementCommands: React.FC<ManagementCommandsProps> = ({ user }) => {
             resetAllUsersSkillPoints();
           }}
         >
-          This will reset all users' skill trees and refund their skill points <b>FOR ALL USERS</b>. Are you
+          This will reset all users&apos; skill trees and refund their skill points <b>FOR ALL USERS</b>. Are you
           sure you want to continue?
         </Confirm2>
       )}

--- a/app/src/app/profile/edit/page.tsx
+++ b/app/src/app/profile/edit/page.tsx
@@ -47,6 +47,7 @@ import {
   SendHorizontal,
   Ban,
   ShieldOff,
+  Zap,
 } from "lucide-react";
 import { attributes, getSearchValidator } from "@/validators/register";
 import { colors, skin_colors } from "@/validators/register";
@@ -71,6 +72,7 @@ import { getUserElements } from "@/validators/user";
 import { canSwapBloodline } from "@/utils/permissions";
 import { canSwapVillage, canUnequipAllUsers } from "@/utils/permissions";
 import { canClearSectors } from "@/utils/permissions";
+import { canAwardExperience } from "@/utils/permissions";
 import { useInfinitePagination } from "@/libs/pagination";
 import { capitalizeFirstLetter } from "@/utils/sanitize";
 import UserSearchSelect from "@/layout/UserSearchSelect";
@@ -1694,6 +1696,8 @@ interface ManagementCommandsProps {
 const ManagementCommands: React.FC<ManagementCommandsProps> = ({ user }) => {
   // State for sector selection
   const [sectorNumber, setSectorNumber] = useState<number>(1);
+  // State for mass experience award
+  const [experienceAmount, setExperienceAmount] = useState<number>(100);
 
   // Utility
   const utils = api.useUtils();
@@ -1725,6 +1729,27 @@ const ManagementCommands: React.FC<ManagementCommandsProps> = ({ user }) => {
       },
     });
 
+  const { mutate: awardExperienceToAll, isPending: isAwardingExperience } =
+    api.profile.awardExperienceToAll.useMutation({
+      onSuccess: async (data) => {
+        showMutationToast(data);
+        if (data.success) {
+          await utils.profile.getUser.invalidate();
+        }
+      },
+    });
+
+  const { mutate: resetAllUsersSkillPoints, isPending: isResettingSkillTrees } =
+    api.skillTree.resetAllUsersSkillPoints.useMutation({
+      onSuccess: async (data) => {
+        showMutationToast(data);
+        if (data.success) {
+          await utils.profile.getUser.invalidate();
+          await utils.skillTree.getUserSkills.invalidate();
+        }
+      },
+    });
+
   // Show options
   return (
     <div className="grid grid-cols-3 items-center gap-4 p-4">
@@ -1750,6 +1775,70 @@ const ManagementCommands: React.FC<ManagementCommandsProps> = ({ user }) => {
         >
           This will unequip all currently equipped gear <b>FOR ALL USERS</b>. Are you
           sure you want to continue?
+        </Confirm2>
+      )}
+      {canUnequipAllUsers(user) && (
+        <Confirm2
+          title="Confirm Reset All Skill Trees"
+          button={
+            <Button variant="destructive" disabled={isResettingSkillTrees} className="w-full">
+              {isResettingSkillTrees ? (
+                <Loader size={5} />
+              ) : (
+                <>
+                  <Trash2 className="h-4 w-4 mr-2" />
+                  Reset All Skill Trees
+                </>
+              )}
+            </Button>
+          }
+          onAccept={(e) => {
+            e.preventDefault();
+            resetAllUsersSkillPoints();
+          }}
+        >
+          This will reset all users' skill trees and refund their skill points <b>FOR ALL USERS</b>. Are you
+          sure you want to continue?
+        </Confirm2>
+      )}
+      {canAwardExperience(user) && (
+        <Confirm2
+          title="Confirm Mass Experience Award"
+          button={
+            <Button variant="default" disabled={isAwardingExperience} className="w-full">
+              {isAwardingExperience ? (
+                <Loader size={5} />
+              ) : (
+                <>
+                  <Zap className="h-4 w-4 mr-2" />
+                  Award Experience to All
+                </>
+              )}
+            </Button>
+          }
+          onAccept={(e) => {
+            e.preventDefault();
+            awardExperienceToAll({ amount: experienceAmount });
+          }}
+        >
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <Label htmlFor="experienceAmount">Experience Amount</Label>
+              <Input
+                id="experienceAmount"
+                type="number"
+                min={1}
+                max={100000}
+                value={experienceAmount}
+                onChange={(e) => setExperienceAmount(parseInt(e.target.value) || 100)}
+                className="w-32"
+              />
+            </div>
+            <p>
+              This will award <b>{experienceAmount}</b> experience points to <b>ALL USERS</b>. Are you
+              sure you want to continue?
+            </p>
+          </div>
         </Confirm2>
       )}
       {canClearSectors(user.role) && (

--- a/app/src/layout/BountyBoard.tsx
+++ b/app/src/layout/BountyBoard.tsx
@@ -44,6 +44,7 @@ import {
 import type { z } from "zod";
 import type { UserWithRelations } from "@/server/api/routers/profile";
 import { useRequiredUserData } from "@/utils/UserContext";
+import { useInfinitePagination } from "@/libs/pagination";
 
 type CreateBountyFormData = z.infer<typeof createBountySchema>;
 type UserSearchFormData = z.infer<ReturnType<typeof getSearchValidator>>;
@@ -61,6 +62,7 @@ export default function BountyBoard({ userData }: BountyBoardProps) {
   const [addingMoneyTo, setAddingMoneyTo] = useState<string | null>(null);
   const [addMoneyAmount, setAddMoneyAmount] = useState<number>(0);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [lastElement, setLastElement] = useState<HTMLDivElement | null>(null);
   const isStaff = canSeeHiddenBountyInfo(userData.role);
 
   const form = useForm<CreateBountyFormData>({
@@ -94,10 +96,27 @@ export default function BountyBoard({ userData }: BountyBoardProps) {
   }, [selectedUsers, form]);
 
   // Query
-  const { data, isLoading } = api.bounty.board.useQuery({
-    limit: 50,
-    status: bountyStatus,
-  });
+  const {
+    data,
+    isLoading,
+    isFetching,
+    hasNextPage,
+    fetchNextPage,
+  } = api.bounty.board.useInfiniteQuery(
+    {
+      limit: 20,
+      status: bountyStatus,
+    },
+    {
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+    }
+  );
+
+  // Flatten all pages data
+  const allBounties = data?.pages.flatMap(page => page.data) ?? [];
+
+  // Use infinite pagination hook
+  useInfinitePagination({ fetchNextPage, hasNextPage, lastElement });
 
   // Mutations
   const { mutate: createBounty, isPending: isCreating } = api.bounty.create.useMutation(
@@ -191,7 +210,7 @@ export default function BountyBoard({ userData }: BountyBoardProps) {
       header: "Hunters",
       type: "jsx",
     },
-    ...(data?.data.some((b) => b.creatorUser)
+    ...(allBounties.some((b) => b.creatorUser)
       ? [
           {
             key: "creatorInfo",
@@ -200,7 +219,7 @@ export default function BountyBoard({ userData }: BountyBoardProps) {
           },
         ]
       : []),
-    ...(data?.data.some((b) => b.huntingUsers)
+    ...(allBounties.some((b) => b.huntingUsers)
       ? [
           {
             key: "huntingInfo",
@@ -296,7 +315,7 @@ export default function BountyBoard({ userData }: BountyBoardProps) {
       )}
 
       <Table
-        data={data?.data.map((b) => ({
+        data={allBounties.map((b) => ({
           ...b,
           avatar: b.targetUser?.avatar,
           targetInfo: b.targetUser ? (
@@ -507,7 +526,15 @@ export default function BountyBoard({ userData }: BountyBoardProps) {
             type: "jsx",
           },
         ]}
+        setLastElement={setLastElement}
       />
+      
+      {/* Show loading indicator when fetching more data */}
+      {isFetching && (
+        <div className="flex justify-center p-4">
+          <Loader explanation="Loading more bounties" />
+        </div>
+      )}
     </div>
   );
 }

--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState, useRef } from "react";
 import { Input } from "@/components/ui/input";
 import { useForm, useWatch } from "react-hook-form";
-import type { z } from "zod";
+import { z } from "zod";
 import UserSearchSelect from "@/layout/UserSearchSelect";
 import { getSearchValidator } from "@/validators/register";
 import {
@@ -51,6 +51,7 @@ import {
   PersonStanding,
   MessageCircle,
   IdCard,
+  Award,
 } from "lucide-react";
 import { updateUserSchema } from "@/validators/user";
 import { canSeeSecretData, canSeeIps } from "@/utils/permissions";
@@ -97,6 +98,7 @@ import {
   canEditQuests,
   canDeleteReferral,
   canChangeUserRolesTo,
+  canAwardExperience,
 } from "@/utils/permissions";
 
 interface PublicUserComponentProps {
@@ -217,6 +219,12 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = (props) => {
     defaultValue: [],
   });
 
+  // Experience award form
+  const experienceForm = useForm<{ amount: number }>({
+    resolver: zodResolver(z.object({ amount: z.number().min(1).max(100000) })),
+    defaultValues: { amount: 100 },
+  });
+
   useEffect(() => {
     if (profile) {
       userSearchMethods.setValue("users", [
@@ -331,6 +339,15 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = (props) => {
   });
 
   const deleteReferral = api.staff.deleteReferral.useMutation({
+    onSuccess: async (data) => {
+      showMutationToast(data);
+      if (data.success) {
+        await utils.profile.getPublicUser.invalidate();
+      }
+    },
+  });
+
+  const awardExperience = api.profile.awardExperience.useMutation({
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
@@ -506,6 +523,54 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = (props) => {
                       placeholder="Enter reason for awarding"
                       control={form.control}
                       error={form.formState.errors.reason?.message}
+                    />
+                  </form>
+                </Form>
+              </Confirm2>
+            )}
+
+            {userData && canAwardExperience(userData) && (
+              <Confirm2
+                title="Award Experience Points"
+                proceed_label="Award Experience"
+                button={
+                  <Award className="h-6 w-6 cursor-pointer hover:text-orange-500" />
+                }
+                isValid={experienceForm.formState.isValid}
+                onAccept={experienceForm.handleSubmit((data) => {
+                  awardExperience.mutate({
+                    targetUserId: profile.userId,
+                    amount: data.amount,
+                  });
+                })}
+              >
+                Award unallocated experience points to {profile.username}. This will add to their
+                earned experience pool that they can then distribute to their stats.
+                <br /><br />
+                <b>DO NOT</b> abuse this feature! All assignments are logged and visible
+                to ALL users. Feature abuse for personal gain will result in severe
+                consequences.
+                <Form {...experienceForm}>
+                  <form className="space-y-4 mt-4">
+                    <FormField
+                      control={experienceForm.control}
+                      name="amount"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Experience Amount</FormLabel>
+                          <FormControl>
+                            <Input
+                              type="number"
+                              placeholder="Enter experience amount"
+                              {...field}
+                              onChange={(e) => field.onChange(parseInt(e.target.value) || 0)}
+                              min="1"
+                              max="100000"
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
                     />
                   </form>
                 </Form>

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -1609,11 +1609,11 @@ export const processUsersForBattle = (info: {
       .forEach((useritem) => {
         // Add any imbuement effects to the item effects
         const imbuementEffects = useritem.imbuements
-          ?.map((imbuement) => imbuement.item.effects as UserEffect[])
+          ?.map((imbuement) => Array.isArray(imbuement.item.effects) ? imbuement.item.effects as UserEffect[] : [])
           .flat();
         // Parse item
         const effects = [
-          ...(useritem.item.effects as UserEffect[]),
+          ...(Array.isArray(useritem.item.effects) ? useritem.item.effects as UserEffect[] : []),
           ...imbuementEffects,
         ];
         const itemType = useritem.item.itemType;

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -1609,11 +1609,11 @@ export const processUsersForBattle = (info: {
       .forEach((useritem) => {
         // Add any imbuement effects to the item effects
         const imbuementEffects = useritem.imbuements
-          ?.map((imbuement) => Array.isArray(imbuement.item.effects) ? imbuement.item.effects as UserEffect[] : [])
+          ?.map((imbuement) => imbuement.item.effects as UserEffect[])
           .flat();
         // Parse item
         const effects = [
-          ...(Array.isArray(useritem.item.effects) ? useritem.item.effects as UserEffect[] : []),
+          ...(useritem.item.effects as UserEffect[]),
           ...imbuementEffects,
         ];
         const itemType = useritem.item.itemType;

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -1171,7 +1171,13 @@ export const initiateBattle = async (
         bloodline: true,
         village: true,
         items: {
-          with: { item: true },
+          with: {
+            item: true,
+            imbuements: {
+              with: { item: true },
+              where: (imbuements) => lt(imbuements.craftingFinishedAt, new Date()),
+            },
+          },
           where: (items) => and(gt(items.quantity, 0), isNotNull(items.equipped)),
         },
         jutsus: {

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -38,6 +38,7 @@ import {
 import { canSeeSecretData, canDeleteUsers, canSeeIps } from "@/utils/permissions";
 import { canChangeContent, canModerateRoles } from "@/utils/permissions";
 import { canInteractWithPolls } from "@/utils/permissions";
+import { canAwardExperience } from "@/utils/permissions";
 import { usernameSchema } from "@/validators/register";
 import { insertNextQuest } from "@/routers/quests";
 import { fetchClan, removeFromClan } from "@/routers/clan";
@@ -1417,6 +1418,106 @@ export const profileRouter = createTRPCRouter({
       return {
         success: true,
         message: "Successfully claimed reputation points for voting",
+      };
+    }),
+  // Award experience to a user (staff only)
+  awardExperience: protectedProcedure
+    .input(z.object({ 
+      targetUserId: z.string(),
+      amount: z.number().min(1).max(100000)
+    }))
+    .output(baseServerResponse)
+    .mutation(async ({ ctx, input }) => {
+      // Query
+      const [awarder, target] = await Promise.all([
+        fetchUser(ctx.drizzle, ctx.userId),
+        fetchUser(ctx.drizzle, input.targetUserId),
+      ]);
+
+      // Guards
+      if (!awarder || !target) {
+        return errorResponse("User not found");
+      }
+
+      if (!canAwardExperience(awarder)) {
+        return errorResponse("You don't have permission to award experience");
+      }
+
+      // Mutation
+      const result = await ctx.drizzle
+        .update(userData)
+        .set({ 
+          earnedExperience: sql`${userData.earnedExperience} + ${input.amount}` 
+        })
+        .where(eq(userData.userId, input.targetUserId));
+
+      if (result.rowsAffected === 0) {
+        return errorResponse("Failed to award experience");
+      }
+
+      // Log the action
+      await ctx.drizzle.insert(actionLog).values({
+        id: nanoid(),
+        userId: ctx.userId,
+        tableName: "user",
+        changes: [`Awarded ${input.amount} experience points`],
+        relatedId: target.userId,
+        relatedMsg: `Experience awarded to ${target.username}`,
+        relatedImage: target.avatarLight,
+      });
+
+      return { 
+        success: true, 
+        message: `Awarded ${input.amount} experience points to ${target.username}` 
+      };
+    }),
+  // Award experience to all users (staff only)
+  awardExperienceToAll: protectedProcedure
+    .input(z.object({ 
+      amount: z.number().min(1).max(100000)
+    }))
+    .output(baseServerResponse)
+    .mutation(async ({ ctx, input }) => {
+      // Query
+      const awarder = await fetchUser(ctx.drizzle, ctx.userId);
+
+      // Guards
+      if (!canAwardExperience(awarder)) {
+        return errorResponse("You don't have permission to award experience");
+      }
+
+      // Get all users
+      const allUsers = await ctx.drizzle.select().from(userData);
+      
+      if (allUsers.length === 0) {
+        return errorResponse("No users found");
+      }
+
+      // Mutation - update all users
+      const result = await ctx.drizzle
+        .update(userData)
+        .set({ 
+          earnedExperience: sql`${userData.earnedExperience} + ${input.amount}` 
+        });
+
+      if (result.rowsAffected === 0) {
+        return errorResponse("Failed to award experience to users");
+      }
+
+      // Log the action
+      await ctx.drizzle.insert(actionLog).values({
+        id: nanoid(),
+        userId: ctx.userId,
+        tableName: "user",
+        changes: [`Mass awarded ${input.amount} experience points to all users`],
+        relatedId: null,
+        relatedMsg: `Mass experience awarded`,
+        relatedImage: awarder.avatarLight,
+      });
+
+      return { 
+        success: true, 
+        message: `Awarded ${input.amount} experience points to all ${allUsers.length} users` 
       };
     }),
 });

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -1486,13 +1486,6 @@ export const profileRouter = createTRPCRouter({
         return errorResponse("You don't have permission to award experience");
       }
 
-      // Get all users
-      const allUsers = await ctx.drizzle.select().from(userData);
-      
-      if (allUsers.length === 0) {
-        return errorResponse("No users found");
-      }
-
       // Mutation - update all users
       const result = await ctx.drizzle
         .update(userData)
@@ -1517,7 +1510,7 @@ export const profileRouter = createTRPCRouter({
 
       return { 
         success: true, 
-        message: `Awarded ${input.amount} experience points to all ${allUsers.length} users` 
+        message: `Awarded ${input.amount} experience points to all users` 
       };
     }),
 });

--- a/app/src/server/api/routers/skillTree.ts
+++ b/app/src/server/api/routers/skillTree.ts
@@ -10,6 +10,8 @@ import { callDiscordContent } from "@/libs/discord";
 import { calculateContentDiff } from "@/utils/diff";
 import { IMG_AVATAR_DEFAULT, COST_SKILL_RESET } from "@/drizzle/constants";
 import { SkillTreeValidator } from "@/libs/combat/types";
+import { canUnequipAllUsers } from "@/utils/permissions";
+import { actionLog } from "@/drizzle/schema";
 
 export const skillTreeRouter = createTRPCRouter({
   // Get single skill by ID
@@ -295,6 +297,54 @@ export const skillTreeRouter = createTRPCRouter({
       return {
         success: true,
         message: `Skills points reset!`,
+      };
+    }),
+
+  // Reset all users' skill points (staff only)
+  resetAllUsersSkillPoints: protectedProcedure
+    .output(baseServerResponse)
+    .mutation(async ({ ctx }) => {
+      // Fetch user data to check permissions
+      const { user } = await fetchUpdatedUser({
+        client: ctx.drizzle,
+        userId: ctx.userId,
+      });
+
+      if (!user) return errorResponse("User not found");
+
+      // Check if user has permission to unequip all users
+      if (!canUnequipAllUsers(user)) {
+        return errorResponse("You don't have permission to reset all users' skill trees");
+      }
+
+      // Get all users with skill trees
+      const allUsers = await ctx.drizzle.select().from(userData);
+      
+      if (allUsers.length === 0) {
+        return errorResponse("No users found");
+      }
+
+      // Delete all user skills (skill points remain, just reset used skills)
+      const result = await ctx.drizzle.delete(userSkill);
+
+      if (result.rowsAffected === 0) {
+        return errorResponse("Failed to reset skill trees");
+      }
+
+      // Log the action
+      await ctx.drizzle.insert(actionLog).values({
+        id: nanoid(),
+        userId: ctx.userId,
+        tableName: "userSkill",
+        changes: [`Mass reset all users' skill trees`],
+        relatedId: null,
+        relatedMsg: `Mass skill tree reset by ${user.username}`,
+        relatedImage: user.avatarLight,
+      });
+
+      return {
+        success: true,
+        message: `Reset skill trees for all ${allUsers.length} users`,
       };
     }),
 });

--- a/app/src/utils/permissions.ts
+++ b/app/src/utils/permissions.ts
@@ -566,3 +566,7 @@ export const canViewConversation = (
 export const canEditCannedResponses = (userRole: UserRole) => {
   return userRole !== "USER";
 };
+
+export const canAwardExperience = (user: UserData) => {
+  return ["CODING-ADMIN","CODER"].includes(user.role);
+};

--- a/app/src/utils/permissions.ts
+++ b/app/src/utils/permissions.ts
@@ -13,6 +13,7 @@ export const canChangeContent = (role: UserRole) => {
     "CODING-ADMIN",
     "MODERATOR-ADMIN",
     "CONTENT-ADMIN",
+    "CODER",
   ].includes(role);
 };
 
@@ -72,6 +73,8 @@ export const canChangeUserRolesTo = (role: UserRole): UserRole[] => {
     return ["CONTENT"];
   } else if (role === "EVENT") {
     return ["EVENT"];
+  } else if (role === "CODER") {
+    return ["CODER"];
   }
   return [];
 };
@@ -251,6 +254,7 @@ export const canEditPublicUser = (user: UserData) => {
     "CONTENT",
     "EVENT",
     "MODERATOR-ADMIN",
+    "CODER",
   ].includes(user.role);
 };
 
@@ -273,6 +277,7 @@ export const canEditClans = (role: UserRole) => {
     "MODERATOR-ADMIN",
     "CONTENT",
     "EVENT-ADMIN",
+    "CODER",
   ].includes(role);
 };
 
@@ -381,6 +386,7 @@ export const canEditUsername = (role: UserRole) => {
     "MODERATOR-ADMIN",
     "HEAD_MODERATOR",
     "MODERATOR",
+    "CODER",
   ].includes(role);
 };
 
@@ -392,6 +398,7 @@ export const canEditCustomTitle = (role: UserRole) => {
     "EVENT",
     "EVENT-ADMIN",
     "MODERATOR-ADMIN",
+    "CODER",
   ].includes(role);
 };
 
@@ -403,6 +410,7 @@ export const canEditBloodline = (role: UserRole) => {
     "EVENT",
     "EVENT-ADMIN",
     "MODERATOR-ADMIN",
+    "CODER",
   ].includes(role);
 };
 
@@ -414,6 +422,7 @@ export const canEditVillage = (role: UserRole) => {
     "EVENT",
     "EVENT-ADMIN",
     "MODERATOR-ADMIN",
+    "CODER",
   ].includes(role);
 };
 
@@ -425,6 +434,7 @@ export const canEditRank = (role: UserRole) => {
     "EVENT",
     "EVENT-ADMIN",
     "MODERATOR-ADMIN",
+    "CODER",
   ].includes(role);
 };
 
@@ -436,6 +446,7 @@ export const canEditJutsus = (role: UserRole) => {
     "EVENT",
     "EVENT-ADMIN",
     "MODERATOR-ADMIN",
+    "CODER",
   ].includes(role);
 };
 
@@ -447,6 +458,7 @@ export const canEditItems = (role: UserRole) => {
     "EVENT",
     "EVENT-ADMIN",
     "MODERATOR-ADMIN",
+    "CODER",
   ].includes(role);
 };
 
@@ -458,6 +470,7 @@ export const canEditQuests = (role: UserRole) => {
     "EVENT",
     "EVENT-ADMIN",
     "MODERATOR-ADMIN",
+    "CODER",
   ].includes(role);
 };
 


### PR DESCRIPTION
# Pull Request

- Added the ability for the coder role to edit themselves only
- Allow coder to edit items and jutsu when checking for bugs
- Added the ability for coder and code-admin to award exp to individual users through their user profile.
- Added the ability for coder and code-admin to mass award exp to all user under management commands
- Add the ability for users with the canUnequipAllUsers permission to reset the skills of all users.
- Fixed the issue with bloodline summons preventing combat.  Some of the summons had items on them and when the imbuement changes were made, they weren't implemented for summons.  Adding the new item processing allows users in battle if the summon has items.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability for authorized users to award experience points to individual users or all users, with input for the amount and confirmation modals.
  * Introduced a staff-only command to reset all users' skill trees and refund their skill points.
  * Enabled infinite scrolling and seamless pagination on the Bounty Board for improved browsing.
  * Expanded staff permissions to include the "CODER" role for various management actions.

* **Bug Fixes**
  * Improved data fetching for battle summons to include relevant item enhancements with proper filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->