### PR TITLE
fix: resolve mission assignment for wrong villages issue

### DIFF
--- a/app/src/libs/quest.ts
+++ b/app/src/libs/quest.ts
@@ -196,7 +196,7 @@ export const getReward = (
       userQuest.quest.questType,
     );
     const factor =
-      missionLike && user.dailyMissions > 9 ? ADDITIONAL_MISSION_REWARD_MULTIPLIER : 1;
+      missionLike && user.dailyMissions >= 9 ? ADDITIONAL_MISSION_REWARD_MULTIPLIER : 1;
     rawRewards.reward_money = Math.floor(rawRewards.reward_money * factor);
     rawRewards.reward_clanpoints = Math.floor(rawRewards.reward_clanpoints * factor);
     rawRewards.reward_anbupoints = Math.floor(rawRewards.reward_anbupoints * factor);

--- a/app/src/server/api/routers/quests.ts
+++ b/app/src/server/api/routers/quests.ts
@@ -315,12 +315,9 @@ export const questsRouter = createTRPCRouter({
                     gte(quest.startsAt, new Date().toISOString()),
                   ),
                   or(isNull(quest.endsAt), lte(quest.endsAt, new Date().toISOString())),
-                  or(
-                    isNull(quest.requiredVillage),
-                    eq(
-                      quest.requiredVillage,
-                      input.userVillageId ?? VILLAGE_SYNDICATE_ID,
-                    ),
+                  eq(
+                    quest.requiredVillage,
+                    input.userVillageId ?? VILLAGE_SYNDICATE_ID,
                   ),
                 ),
               )
@@ -349,12 +346,9 @@ export const questsRouter = createTRPCRouter({
                     gte(quest.startsAt, new Date().toISOString()),
                   ),
                   or(isNull(quest.endsAt), lte(quest.endsAt, new Date().toISOString())),
-                  or(
-                    isNull(quest.requiredVillage),
-                    eq(
-                      quest.requiredVillage,
-                      input.userVillageId ?? VILLAGE_SYNDICATE_ID,
-                    ),
+                  eq(
+                    quest.requiredVillage,
+                    input.userVillageId ?? VILLAGE_SYNDICATE_ID,
                   ),
                 ),
               ),


### PR DESCRIPTION
Fixed two issues in the mission/errand system:

1. Village filtering bug: Users were receiving missions/errands for random villages instead of their own because the system allowed quests with NULL requiredVillage to be assigned to all users. Now restricts quest assignment to only match the user's specific village.

2. Mission limit bug: The reward reduction for missions after the 9th daily mission was using > 9 instead of >= 9, causing reduced rewards to only apply starting from mission 11 instead of mission 10.

Fixes #602

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the mission reward multiplier to apply when completing 9 or more daily missions, instead of only when exceeding 9.

* **Refactor**
  * Updated quest selection to require a matching village, no longer including quests without a specified village requirement. Only quests with a village requirement matching the user's village or default syndicate will be available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->