### PR TITLE
qol updates

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -328,10 +328,10 @@ export const UserStatNames = [
   "taijutsuDefence",
   "genjutsuDefence",
   "bukijutsuDefence",
-  "strength",
-  "speed",
   "intelligence",
+  "speed",
   "willpower",
+  "strength",
 ] as const;
 export type UserStatName = (typeof UserStatNames)[number];
 

--- a/app/src/app/combat/page.tsx
+++ b/app/src/app/combat/page.tsx
@@ -170,6 +170,7 @@ export default function CombatPage() {
                   showBgColor={true}
                   showLabels={true}
                   selectedId={actionId}
+                  combatMode={true}
                   onClick={(id) => {
                     if (id === actionId) {
                       setActionId(undefined);
@@ -217,6 +218,7 @@ export default function CombatPage() {
                     showBgColor={true}
                     showLabels={true}
                     selectedId={actionId}
+                    combatMode={true}
                     onClick={(id) => {
                       if (id === actionId) {
                         setActionId(undefined);

--- a/app/src/layout/CombatActions.tsx
+++ b/app/src/layout/CombatActions.tsx
@@ -62,6 +62,8 @@ interface ActionSelectorProps {
   ) => React.ReactNode;
   /** When true, display a help icon on each item that shows details in a pop-over */
   showInfoIcon?: boolean;
+  /** When true, jutsu names will be displayed in black text */
+  combatMode?: boolean;
 }
 
 export const ActionSelector: React.FC<ActionSelectorProps> = (props) => {
@@ -141,6 +143,7 @@ export const ActionSelector: React.FC<ActionSelectorProps> = (props) => {
                     txt={props.showLabels ? item.name : ""}
                     count={props.counts?.find((c) => c.id === item.id)?.quantity}
                     labelSingles={props.labelSingles}
+                    combatMode={props.combatMode}
                     onClick={() => {
                       props.onClick(item.id);
                     }}
@@ -226,11 +229,12 @@ interface ActionOptionProps {
   currentRound?: number;
   lastUsedRound?: number;
   aspectRatioClass?: string;
+  combatMode?: boolean;
   onClick?: () => void;
 }
 
 export const ActionOption: React.FC<ActionOptionProps> = (props) => {
-  const { cooldown, currentRound, lastUsedRound } = props;
+  const { cooldown, currentRound, lastUsedRound, combatMode } = props;
   const cooldownPerc = Math.max(
     cooldown && currentRound && lastUsedRound
       ? 100 - (100 * (currentRound - lastUsedRound)) / cooldown
@@ -240,7 +244,8 @@ export const ActionOption: React.FC<ActionOptionProps> = (props) => {
   return (
     <div
       className={cn(
-        "relative text-center flex cursor-pointer flex-col items-center justify-start text-black",
+        "relative text-center flex cursor-pointer flex-col items-center justify-start",
+        combatMode ? "text-black" : "text-foreground",
         props.isGreyed ? "hover:opacity-80" : "hover:opacity-90",
         props.className,
       )}

--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -274,6 +274,11 @@ export const mirror = (
           mirroredEffect.isNew = true;
           mirroredEffect.castThisRound = true;
           mirroredEffect.createdRound = effect.createdRound;
+          // Cut drain effects in half when mirrored
+          if (negEffect.type === "drain") {
+            mirroredEffect.power = Math.floor(mirroredEffect.power / (effect.rounds || 1));
+            mirroredEffect.powerPerLevel = Math.floor(mirroredEffect.powerPerLevel / (effect.rounds || 1));
+          }
           usersEffects.push(mirroredEffect);
           mirroredCount++;
 


### PR DESCRIPTION
# Pull Request

- Reorder generals on training page
- When a drain is mirrored, the drain amount is split between the number of mirrored rounds
- Jutsu names will follow light/dark mode. Always black in combat



## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new mode to action selection in combat, providing updated text color styling for action options when in combat mode.

* **Style**
  * Action option labels in combat mode now display with black text for improved visibility.

* **Bug Fixes**
  * Adjusted the mirroring of drain effects in combat so that their strength is reduced when mirrored, ensuring more balanced gameplay.

* **Chores**
  * Updated the order of user stat names for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->