### PR TITLE
Fix issue #578: Ability to report battle logs

### DIFF
--- a/app/src/app/api/cleaner/route.ts
+++ b/app/src/app/api/cleaner/route.ts
@@ -40,7 +40,7 @@ export async function GET() {
     await drizzleDB.execute(
       sql`DELETE FROM ${battleAction} a WHERE 
           NOT EXISTS (SELECT id FROM ${battle} b WHERE b.id = a.battleId) AND
-          createdAt < DATE_SUB(NOW(), INTERVAL ${3600 * 3} SECOND) LIMIT 99999`,
+          updatedAt < DATE_SUB(NOW(), INTERVAL ${3600 * 3} SECOND) LIMIT 99999`,
     );
 
     // One day in mseconds

--- a/app/src/app/battlelog/[battleid]/page.tsx
+++ b/app/src/app/battlelog/[battleid]/page.tsx
@@ -11,6 +11,14 @@ import type { BattleState } from "@/libs/combat/types";
 import { Button } from "@/components/ui/button";
 import { LayoutGrid } from "lucide-react";
 import { useLocalStorage } from "@/hooks/localstorage";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import ReportUser from "@/layout/Report";
+import { Flag } from "lucide-react";
 
 const Combat = dynamic(() => import("@/layout/Combat"));
 
@@ -30,6 +38,14 @@ export default function BattleLog(props: { params: Promise<{ battleid: string }>
     { battleId: battleId },
     { enabled: !!battleId },
   );
+  const { data: battleHistory } = api.combat.getBattleHistoryEntry.useQuery(
+    { battleId: battleId },
+    { enabled: !!battleId },
+  );
+  const otherUser =
+    battleHistory?.attacker?.userId === userData?.userId
+      ? battleHistory?.defender
+      : battleHistory?.attacker;
 
   // Derived variables
   const battle = battleState?.battle;
@@ -62,7 +78,7 @@ export default function BattleLog(props: { params: Promise<{ battleid: string }>
   return (
     <ContentBox
       title="Spectate"
-      subtitle="Available for 3h!"
+      subtitle="Available for 3h! "
       defaultBackHref="/profile"
       padding={false}
       topRightContent={
@@ -78,14 +94,39 @@ export default function BattleLog(props: { params: Promise<{ battleid: string }>
               isPending={battleState.isPending}
             />
           )}
-          <Button
-            variant={showGridNumbers ? "default" : "outline"}
-            size="icon"
-            onClick={() => setShowGridNumbers(!showGridNumbers)}
-            className="h-8 w-8 min-w-8 min-h-8"
-          >
-            <LayoutGrid className="h-4 w-4" />
-          </Button>
+          {otherUser && (
+            <ReportUser
+              button={
+                <TooltipProvider delayDuration={50}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Flag className="h-6 w-6 cursor-pointer hover:text-orange-500" />
+                    </TooltipTrigger>
+                    <TooltipContent>Report User</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              }
+              system="battle_log"
+              user={otherUser}
+              content={{
+                id: battleId,
+                title: "Report Battle Log",
+                content:
+                  "Reporting this battle log will cause it to not be deleted the next 72 hours, so that a moderator may review it",
+              }}
+            />
+          )}
+
+          {battle && (
+            <Button
+              variant={showGridNumbers ? "default" : "outline"}
+              size="icon"
+              onClick={() => setShowGridNumbers(!showGridNumbers)}
+              className="h-8 w-8 min-w-8 min-h-8"
+            >
+              <LayoutGrid className="h-4 w-4" />
+            </Button>
+          )}
         </div>
       }
     >

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -289,6 +289,39 @@ export const combatRouter = createTRPCRouter({
 
       return topFights;
     }),
+  getBattleHistoryEntry: protectedProcedure
+    .input(z.object({ battleId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      return await ctx.drizzle.query.battleHistory.findFirst({
+        where: eq(battleHistory.battleId, input.battleId),
+        with: {
+          attacker: {
+            columns: {
+              username: true,
+              userId: true,
+              avatar: true,
+              level: true,
+              rank: true,
+              isOutlaw: true,
+              role: true,
+              federalStatus: true,
+            },
+          },
+          defender: {
+            columns: {
+              username: true,
+              userId: true,
+              avatar: true,
+              level: true,
+              rank: true,
+              isOutlaw: true,
+              role: true,
+              federalStatus: true,
+            },
+          },
+        },
+      });
+    }),
   getBattleHistory: protectedProcedure
     .input(
       z.object({

--- a/app/src/server/api/routers/reports.ts
+++ b/app/src/server/api/routers/reports.ts
@@ -7,6 +7,8 @@ import { historicalAvatar, reportLog } from "@/drizzle/schema";
 import { forumPost, conversationComment, userNindo } from "@/drizzle/schema";
 import { userReport, userReportComment, userData, userReview } from "@/drizzle/schema";
 import { automatedModeration } from "@/drizzle/schema";
+import { battle, battleAction } from "@/drizzle/schema";
+import { secondsFromNow } from "@/utils/time";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { serverError, baseServerResponse, errorResponse } from "../trpc";
 import { userReportSchema } from "@/validators/reports";
@@ -430,6 +432,21 @@ export const reportsRouter = createTRPCRouter({
               infraction: await fetchImage(ctx.drizzle, input.system_id, ""),
               context: [],
             };
+          case "battle_log": {
+            await ctx.drizzle
+              .update(battleAction)
+              .set({ updatedAt: secondsFromNow(72 * 3600) })
+              .where(eq(battleAction.id, input.system_id));
+            return {
+              infraction: {
+                content:
+                  '<br /><a href="/battlelog/' +
+                  input.system_id +
+                  '"><b>Link to Battle Log (available for 72h)<b></a>',
+              },
+              context: [],
+            };
+          }
           default:
             throw serverError("INTERNAL_SERVER_ERROR", "Invalid report system");
         }

--- a/app/src/validators/reports.ts
+++ b/app/src/validators/reports.ts
@@ -9,6 +9,7 @@ export const systems = [
   "conversation_comment",
   "user_profile",
   "concept_art",
+  "battle_log",
 ] as const;
 
 export const userReportSchema = z.object({


### PR DESCRIPTION
# Pull Request
Implement ability to report battle logs

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Report opponents directly from the battle log spectate view via a new flag/Report button with tooltip.
  - Added support for submitting reports under a new “Battle Log” category.
  - The opponent is auto-detected to prefill the report target.

- UI
  - Top-right actions in spectate now include a reporting entry point.
  - Grid layout toggle now shows only when a battle is available, reducing clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->