### PR TITLE
Ranked adjustments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,20 @@ bun: install ## Execute bun command in local development.
 	@echo $(DATABASE_URL)
 	cd app && bun $(ARGS)
 
+# Note: The start target below may crash due to Bun libuv compatibility issues with NAPI modules
+# Use 'make start-npm' instead if you encounter crashes
 .PHONY: start
 start: loadEnv # Run Next.js server, access at http://127.0.0.1:3000
 	@echo "${GREEN}start${RESET}"
 	rm -rf app/.next
 	@make bun -- OPENAI_API_KEY=$(OPENAI_API_KEY) dev
+
+.PHONY: start-npm
+start-npm: loadEnv # Run Next.js server with npm (avoids Bun libuv issues), access at http://127.0.0.1:3000
+	@echo "${GREEN}start-npm${RESET}"
+	rm -rf app/.next
+	@echo "Using npm to avoid Bun libuv compatibility issues"
+	cd app && npm run dev
 
 .PHONY: build
 build: # Build Next.js app

--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -1082,13 +1082,13 @@ export const KAGE_CHALLENGE_LOSE_PRESTIGE_MIN = 1500; // Minimum prestige cost p
 export const KAGE_CHALLENGE_LOSE_PRESTIGE_PERCENTAGE = 0.04; // 4% of current prestige for closed challenges (current implementation)
 export const KAGE_CHALLENGE_OPEN_FOR_SECONDS = 60 * 60; // Time in between being able to toggle challenges
 export const KAGE_CHALLENGE_MAX_DAILY_LOCKED_HOURS = 12; // Maximum hours per day that challenges can be locked
-export const KAGE_UNACCEPTED_CHALLENGE_COST = 15000; // Cost of unaccepted challenge, i.e. going to Ai vs Ai
+export const KAGE_UNACCEPTED_CHALLENGE_COST = 5000; // Cost of unaccepted challenge, i.e. going to Ai vs Ai
 export const WAR_FUNDS_COST = 10000; // Prestige cost of declaring war
 
 // Ranked PVP config
 export const RANKED_REQUIRED_RANK: UserRank = "CHUNIN";
 export const RANKED_ENTRY_COST = 40000;
-export const RANKED_STREAK_BONUS = 10;
+export const RANKED_STREAK_BONUS = 2;
 export const RANKED_SANNIN_TOP_PLAYERS = 10;
 export const RANKED_RANKS = [
   "Unranked",

--- a/app/src/app/api/cleaner/route.ts
+++ b/app/src/app/api/cleaner/route.ts
@@ -209,9 +209,13 @@ export async function GET() {
       sql`DELETE FROM ${mpvpBattleUser} a WHERE NOT EXISTS (SELECT id FROM ${mpvpBattleQueue} b WHERE b.id = a.clanBattleId)`,
     );
 
-    // Step 25: Set status to AWAKE for users who are QUEUED if they do not have any mpvpBattleUser entries
+    // Step 25: Set status to AWAKE for users who are QUEUED if they are not in any active battle systems
+    // This covers mpvp battles, kage challenges, and ranked PVP
     await drizzleDB.execute(
-      sql`UPDATE ${userData} a SET a.status="AWAKE" WHERE a.status="QUEUED" AND NOT EXISTS (SELECT id FROM ${mpvpBattleUser} b WHERE b.userId = a.userId)`,
+      sql`UPDATE ${userData} a SET a.status="AWAKE" WHERE a.status="QUEUED" 
+          AND NOT EXISTS (SELECT id FROM ${mpvpBattleUser} b WHERE b.userId = a.userId)
+          AND NOT EXISTS (SELECT id FROM ${userRequest} c WHERE c.senderId = a.userId AND c.type = 'KAGE' AND c.status = 'PENDING')
+          AND NOT EXISTS (SELECT id FROM ${rankedPvpQueue} d WHERE d.userId = a.userId)`,
     );
 
     // Step 26: Update the population of each village

--- a/app/src/app/api/daily-ranked-pvp/route.ts
+++ b/app/src/app/api/daily-ranked-pvp/route.ts
@@ -1,6 +1,6 @@
 import { and, sql, eq, gt } from "drizzle-orm";
 import { drizzleDB } from "@/server/db";
-import { rankedSeason, userData } from "@/drizzle/schema";
+import { rankedSeason, userData, battleHistory } from "@/drizzle/schema";
 import { updateGameSetting } from "@/libs/gamesettings";
 import { lockWithDailyTimer, handleEndpointError } from "@/libs/gamesettings";
 import { cookies } from "next/headers";
@@ -29,10 +29,34 @@ export async function GET() {
     if (endedSeason) {
       await endRankedSeason(drizzleDB, endedSeason.id);
     } else {
+      // Apply LP decay only to Legend rank users (900+ LP) who haven't had ranked matches in 5 days
+      const fiveDaysAgo = new Date();
+      fiveDaysAgo.setDate(fiveDaysAgo.getDate() - 5);
+      
       await drizzleDB
         .update(userData)
         .set({
-          rankedLp: sql`${userData.rankedLp} * 0.95`,
+          rankedLp: sql`${userData.rankedLp} - 70`,
+        })
+        .where(
+          and(
+            gt(userData.rankedLp, 899),
+            sql`${userData.userId} NOT IN (
+              SELECT DISTINCT userId FROM (
+                SELECT attackedId as userId FROM BattleHistory 
+                WHERE battleType = 'RANKED_PVP' AND createdAt > ${fiveDaysAgo}
+                UNION
+                SELECT defenderId as userId FROM BattleHistory 
+                WHERE battleType = 'RANKED_PVP' AND createdAt > ${fiveDaysAgo}
+              ) recent_battles
+            )`
+          )
+        );
+
+      // Reset streaks for all users (not just Legend/Sannin)
+      await drizzleDB
+        .update(userData)
+        .set({
           rankedStreak: 0,
         })
         .where(gt(userData.rankedLp, 0));

--- a/app/src/layout/Combat.tsx
+++ b/app/src/layout/Combat.tsx
@@ -720,6 +720,9 @@ const Combat: React.FC<CombatProps> = (props) => {
               {result.experience > 0 && (
                 <p>Experience Points: {result.experience.toFixed(2)}</p>
               )}
+              {result.earnedExperience > 0 && (
+                <p>Unassigned Experience: {result.earnedExperience.toFixed(2)}</p>
+              )}
               {result.ninjutsuOffence > 0 && (
                 <p>Offensive Ninjutsu: {result.ninjutsuOffence.toFixed(2)}</p>
               )}

--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -66,7 +66,7 @@ import {
   Award,
 } from "lucide-react";
 import { updateUserSchema } from "@/validators/user";
-import { canSeeSecretData, canSeeIps } from "@/utils/permissions";
+import { canSeeSecretData, canSeeIps, canSeeRankedHistory } from "@/utils/permissions";
 import { api } from "@/app/_trpc/client";
 import { showMutationToast } from "@/libs/toast";
 import { useUserData } from "@/utils/UserContext";
@@ -827,6 +827,9 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = (props) => {
                 {enableBloodlineHistory && (
                   <TabsTrigger value="bloodlineHistory">Bloodlines</TabsTrigger>
                 )}
+                {userData && canSeeRankedHistory(userData.role) && (
+                  <TabsTrigger value="ranked">Ranked</TabsTrigger>
+                )}
               </TabsList>
             </div>
           )}
@@ -975,6 +978,15 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = (props) => {
               <BloodlineHistoryTab
                 userId={profile.userId}
                 isActive={showActive === "bloodlineHistory"}
+              />
+            </TabsContent>
+          )}
+          {/* USER RANKED MATCHES */}
+          {userData && canSeeRankedHistory(userData.role) && (
+            <TabsContent value="ranked">
+              <RankedMatchesTab
+                userId={profile.userId}
+                isActive={showActive === "ranked"}
               />
             </TabsContent>
           )}
@@ -1947,6 +1959,47 @@ const RecruitedUsersTab: React.FC<RecruitedUsersTabProps> = ({
             </div>
           ))}
         </div>
+      )}
+    </ContentBox>
+  );
+};
+
+// ---------------- Ranked Matches Tab ----------------
+
+const RankedMatchesTab: React.FC<TabComponentProps> = ({ userId, isActive }) => {
+  const { data: currentUser } = useUserData();
+  const canSeeRanked = currentUser && canSeeRankedHistory(currentUser.role);
+
+  const { data: rankedMatches, isPending } = api.combat.getRankedMatchHistory.useQuery(
+    { userId },
+    { enabled: isActive && !!canSeeRanked },
+  );
+
+  if (!canSeeRanked) return null;
+
+  return (
+    <ContentBox
+      title="Ranked Match History"
+      subtitle="All ranked PvP matches for this user"
+      initialBreak={true}
+      padding={false}
+    >
+      {isPending && <Loader explanation="Loading ranked matches..." />}
+      {(!rankedMatches || rankedMatches.length === 0) && (
+        <p className="p-3">No ranked matches found</p>
+      )}
+      {rankedMatches && rankedMatches.length > 0 && (
+        <Table
+          data={rankedMatches}
+          columns={[
+            { key: "attackerAvatar", header: "Attacker", type: "avatar" },
+            { key: "defenderAvatar", header: "Defender", type: "avatar" },
+            { key: "battleId", header: "Battle ID", type: "string" },
+            { key: "createdAt", header: "Date", type: "date" },
+          ]}
+          linkPrefix="/battlelog/"
+          linkColumn={"battleId"}
+        />
       )}
     </ContentBox>
   );

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -639,6 +639,7 @@ export const updateUser = async (
         .update(userData)
         .set({
           experience: sql`experience + ${result.experience}`,
+          earnedExperience: sql`earnedExperience + ${result.earnedExperience}`,
           pvpStreak: result.pvpStreak,
           ...(curBattle.battleType !== "RANKED_PVP"
             ? {
@@ -669,7 +670,7 @@ export const updateUser = async (
           regenAt: new Date(),
           ...(curBattle.battleType === "RANKED_PVP"
             ? {
-                rankedLp: sql`GREATEST(rankedLp + ${result.lpDiff}, 0)`,
+                rankedLp: sql`GREATEST(rankedLp + ${result.lpDiff}, 1)`,
                 rankedStreak: result.didWin ? sql`${userData.rankedStreak} + 1` : 0,
                 rankedWins: sql`rankedWins + ${result.didWin ? 1 : 0}`,
                 rankedBattles: sql`rankedBattles + 1`,

--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -166,6 +166,7 @@ export type CombatResult = {
   eloDiff: number;
   lpDiff: number;
   experience: number;
+  earnedExperience: number;
   pvpStreak: number;
   curHealth: number;
   curStamina: number;

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -630,6 +630,7 @@ export const calcBattleResult = (
           "KAGE_PVP",
           "TRAINING",
           "VILLAGE_PROTECTOR",
+          "RANKED_PVP",
         ].includes(battleType)
       ) {
         experience = 0;
@@ -675,6 +676,7 @@ export const calcBattleResult = (
       let deltaPrestige = 0;
       let deltaAnbuPoints = 0;
       let clanPoints = 0;
+      let deltaEarnedExperience = 0;
 
       // Money/ryo calculation
       const moneyBoost = user?.clan?.ryoBoost ? 1 + user.clan.ryoBoost / 100 : 1;
@@ -687,9 +689,12 @@ export const calcBattleResult = (
 
       // If ranked PVP, add benefits
       if (battleType === "RANKED_PVP") {
-        moneyDelta *= 1.5;
-        deltaTokens += 10;
-        deltaPrestige += 10;
+        if (didWin) {
+          moneyDelta = 3000;
+          deltaTokens += 400;
+          deltaPrestige += 400;
+          deltaEarnedExperience += 100;
+        }
       }
 
       // Include money stolen during combat
@@ -1021,6 +1026,7 @@ export const calcBattleResult = (
         eloDiff: eloDiff,
         lpDiff: lpDiff,
         experience: 0.01,
+        earnedExperience: 0,
         pvpStreak: calculatePvpStreak(battleType, user, targets, didWin),
         curHealth: user.curHealth,
         curStamina: user.curStamina,
@@ -1115,12 +1121,21 @@ export const calcBattleResult = (
           );
         });
 
-        // Experience
-        result.experience = Math.floor(assignedExp * 100) / 100;
-      }
+              // Experience
+      result.experience = Math.floor(assignedExp * 100) / 100;
+    }
 
-      // Return results
-      return result;
+    // Ensure Ranked PvP winner rewards are applied despite noRewardBattles gating
+    if (battleType === "RANKED_PVP" && didWin) {
+      // Money (respect global reward scaling)
+      result.money = moneyDelta;
+      result.earnedExperience = deltaEarnedExperience;
+      result.villageTokens = deltaTokens;
+      result.villagePrestige = deltaPrestige;
+    }
+
+    // Return results
+    return result;
     }
   }
   return null;

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -58,6 +58,7 @@ import { manuallyAssignUserStats, scaleUserStats } from "@/libs/profile";
 import { capUserStats } from "@/libs/profile";
 import { mockAchievementHistoryEntries } from "@/libs/quest";
 import { canAccessStructure } from "@/utils/village";
+import { canSeeRankedHistory } from "@/utils/permissions";
 import { fetchSectorVillage } from "@/routers/village";
 import { fetchAiProfileById } from "@/routers/ai";
 import { getBattleGrid } from "@/libs/combat/util";
@@ -87,7 +88,7 @@ import type { GroundEffect, UserEffect } from "@/libs/combat/types";
 import type { ActionEffect } from "@/libs/combat/types";
 import type { CompleteBattle } from "@/libs/combat/types";
 import type { DrizzleClient } from "@/server/db";
-import { IMG_BG_FOREST } from "@/drizzle/constants";
+import { IMG_BG_FOREST, IMG_AVATAR_DEFAULT } from "@/drizzle/constants";
 import type { ZodBgSchemaType } from "@/validators/backgroundSchema";
 import type {
   VillageAlliance,
@@ -353,6 +354,51 @@ export const combatRouter = createTRPCRouter({
         orderBy: [desc(battleHistory.createdAt)],
       });
       return results;
+    }),
+  getRankedMatchHistory: protectedProcedure
+    .input(
+      z.object({
+        userId: z.string(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      // Authorization parity with UI
+      const me = await ctx.drizzle.query.userData.findFirst({
+        where: eq(userData.userId, ctx.userId),
+        columns: { role: true },
+      });
+      if (!me || !canSeeRankedHistory(me.role)) {
+        throw serverError("FORBIDDEN", "Not allowed to view ranked history");
+      }
+
+      const results = await ctx.drizzle.query.battleHistory.findMany({
+        where: and(
+          or(
+            eq(battleHistory.attackedId, input.userId),
+            eq(battleHistory.defenderId, input.userId),
+          ),
+          eq(battleHistory.battleType, "RANKED_PVP"),
+        ),
+        with: {
+          attacker: { columns: { username: true, userId: true, avatar: true } },
+          defender: { columns: { username: true, userId: true, avatar: true } },
+        },
+        orderBy: [desc(battleHistory.createdAt)],
+      });
+
+      // Transform the data to match the expected format for the table
+      const transformedResults = results.map((battle) => ({
+        attackerUsername: battle.attacker?.username || "Deleted User",
+        attackerUserId: battle.attacker?.userId || "Deleted User",
+        attackerAvatar: battle.attacker?.avatar || IMG_AVATAR_DEFAULT,
+        defenderUsername: battle.defender?.username || "Deleted User",
+        defenderUserId: battle.defender?.userId || "Deleted User",
+        defenderAvatar: battle.defender?.avatar || IMG_AVATAR_DEFAULT,
+        battleId: battle.battleId,
+        createdAt: battle.createdAt,
+      }));
+
+      return transformedResults;
     }),
   performAction: protectedProcedure
     .use(ratelimitMiddleware)

--- a/app/src/server/api/routers/home.ts
+++ b/app/src/server/api/routers/home.ts
@@ -52,6 +52,7 @@ export const homeRouter = createTRPCRouter({
       if (user.sector !== user.village?.sector && !user.isOutlaw) {
         return errorResponse("Wrong sector");
       }
+      
       // Mutate
       const newStatus: UserStatus = user.status === "ASLEEP" ? "AWAKE" : "ASLEEP";
       if (user.status === "ASLEEP") {

--- a/app/src/server/api/routers/kage.ts
+++ b/app/src/server/api/routers/kage.ts
@@ -107,6 +107,11 @@ export const kageRouter = createTRPCRouter({
       // Mutate
       await Promise.all([
         insertRequest(ctx.drizzle, user.userId, kage.userId, "KAGE"),
+        // Set challenger status to QUEUED while waiting for kage response
+        ctx.drizzle
+          .update(userData)
+          .set({ status: "QUEUED" })
+          .where(eq(userData.userId, ctx.userId)),
         pusher.trigger(input.kageId, "event", {
           type: "userMessage",
           message: "Your position as kage is being challenged",
@@ -208,6 +213,11 @@ export const kageRouter = createTRPCRouter({
             villagePrestige: sql`${userData.villagePrestige} - ${KAGE_CHALLENGE_REJECT_COST}`,
           })
           .where(eq(userData.userId, ctx.userId)),
+        // Set challenger status back to AWAKE when challenge is rejected
+        ctx.drizzle
+          .update(userData)
+          .set({ status: "AWAKE" })
+          .where(eq(userData.userId, challenge.senderId)),
         updateRequestState(ctx.drizzle, input.id, "REJECTED", "KAGE"),
       ]);
       return { success: true, message: "Challenge rejected" };
@@ -244,6 +254,11 @@ export const kageRouter = createTRPCRouter({
               villagePrestige: sql`${userData.villagePrestige} - ${KAGE_UNACCEPTED_CHALLENGE_COST}`,
             })
             .where(eq(userData.userId, challenge.receiverId)),
+          // Set challenger status back to AWAKE when challenge expires
+          ctx.drizzle
+            .update(userData)
+            .set({ status: "AWAKE" })
+            .where(eq(userData.userId, challenge.senderId)),
           pusher.trigger(challenge.senderId, "event", {
             type: "userMessage",
             message:
@@ -255,7 +270,15 @@ export const kageRouter = createTRPCRouter({
         ]);
         return result;
       } else {
-        return await updateRequestState(ctx.drizzle, input.id, "CANCELLED", "KAGE");
+        // Set challenger status back to AWAKE when challenge is cancelled
+        await Promise.all([
+          updateRequestState(ctx.drizzle, input.id, "CANCELLED", "KAGE"),
+          ctx.drizzle
+            .update(userData)
+            .set({ status: "AWAKE" })
+            .where(eq(userData.userId, ctx.userId)),
+        ]);
+        return { success: true, message: "Challenge cancelled" };
       }
     }),
   /**

--- a/app/src/server/api/routers/pvprank.ts
+++ b/app/src/server/api/routers/pvprank.ts
@@ -345,7 +345,7 @@ export const pvpRankRouter = createTRPCRouter({
       // Mutation
       await ctx.drizzle
         .update(userData)
-        .set({ rankedLp: 1, villagePrestige: user.villagePrestige - RANKED_ENTRY_COST })
+        .set({ rankedLp: 150, villagePrestige: user.villagePrestige - RANKED_ENTRY_COST })
         .where(eq(userData.userId, ctx.userId));
       return { success: true, message: "Ranked season entered successfully" };
     }),

--- a/app/src/utils/permissions.ts
+++ b/app/src/utils/permissions.ts
@@ -110,6 +110,10 @@ export const canSeeSecretData = (role: UserRole) => {
   ].includes(role);
 };
 
+export const canSeeRankedHistory = (role: UserRole) => {
+  return role !== "USER";
+};
+
 export const canSeeIps = (role: UserRole) => {
   return ["HEAD_MODERATOR", "CODING-ADMIN", "MODERATOR-ADMIN"].includes(role);
 };


### PR DESCRIPTION
# Pull Request

**Please fill: what was implemented, why, possibly include screenshots, are any of the changes breaking, etc.**

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Ranked tab on public profiles for eligible roles, showing ranked match history with avatars, dates, and links.
- Gameplay Balance
  - Ranked PvP rewards now apply on wins only, with increased payouts and experience.
  - Daily LP decay applies only to top-tier players; ranked streaks reset daily.
  - Reduced cost for unaccepted AI-vs-AI challenges and lowered ranked streak bonus.
- Chores
  - Refined queue wake-up behavior to avoid interrupting users active in battles.
  - Improved Kage challenge flows to update user status and navigation consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->