### PR TITLE
Adjust copy and mirror

### DIFF
--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -168,6 +168,8 @@ export const copy = (
         "increasedamagegiven",
         "increasestat",
         "decreasedamagetaken",
+        "reflect",
+        "shield",
       ];
 
       const positiveEffects = usersEffects.filter(
@@ -245,8 +247,8 @@ export const mirror = (
   const primaryCheck = Math.random() < power / 100;
   if (effect.isNew && effect.rounds && effect.castThisRound) {
     if (primaryCheck) {
-      const excludedFromTypes = ["bloodline", "armor", "item", "village"];
-      const excludedEffectTypes = ["damage", "pierce", "clear"];
+      const excludedFromTypes = ["bloodline", "armor", "item", "village", "skill"];
+      const excludedEffectTypes = ["damage", "pierce", "clear", "buffprevent", "cleanseprevent"];
 
       const negativeEffects = usersEffects.filter(
         (e) =>


### PR DESCRIPTION
# Pull Request

Allow copy to copy the effects of reflect and shield

Disallow mirroring buffprevent and cleanseprevent

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Copy can now duplicate Reflect and Shield positive effects from opponents, expanding strategic options.
- Bug Fixes
  - Mirror behavior refined to avoid mirroring additional negative or blocked effects (e.g., those prevented by buffs or cleanses).
  - Mirror now ignores effects originating from skill-type sources to prevent unintended reflections.
  - Overall mirroring outcomes are more consistent and aligned with expected combat rules, reducing edge-case inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->