### PR TITLE
Add npm-start option to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,20 @@ bun: install ## Execute bun command in local development.
 	@echo $(DATABASE_URL)
 	cd app && bun $(ARGS)
 
+# Note: The start target below may crash due to Bun libuv compatibility issues with NAPI modules
+# Use 'make start-npm' instead if you encounter crashes
 .PHONY: start
 start: loadEnv # Run Next.js server, access at http://127.0.0.1:3000
 	@echo "${GREEN}start${RESET}"
 	rm -rf app/.next
 	@make bun -- OPENAI_API_KEY=$(OPENAI_API_KEY) dev
+
+.PHONY: start-npm
+start-npm: loadEnv # Run Next.js server with npm (avoids Bun libuv issues), access at http://127.0.0.1:3000
+	@echo "${GREEN}start-npm${RESET}"
+	rm -rf app/.next
+	@echo "Using npm to avoid Bun libuv compatibility issues"
+	cd app && npm run dev
 
 .PHONY: build
 build: # Build Next.js app


### PR DESCRIPTION
# Pull Request

Add the ability to start the local environment using npm instead of bun. 

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Added an alternative way to start the development server using npm for improved stability and compatibility.
  - Retained the existing start method for flexibility.
  - Ensures a clean build state before launching and provides a clear success message on startup.

- Documentation
  - Added a warning about potential crashes with the existing start method and guidance to use the npm-based alternative for a more reliable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->