### PR TITLE
Add missing tag exclusions

### DIFF
--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -251,11 +251,15 @@ export const mirror = (
     if (primaryCheck) {
       const excludedFromTypes = ["bloodline", "armor", "item", "village", "skill"];
       const excludedEffectTypes = [
-        "damage",
-        "pierce",
-        "clear",
-        "buffprevent",
-        "cleanseprevent",
+        "damage", 
+        "pierce", 
+        "clear", 
+        "buffprevent", 
+        "cleanseprevent", 
+        "moveprevent", 
+        "healPrevent",
+        "wound",
+        "timecompression"
       ];
 
       const negativeEffects = usersEffects.filter(

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -370,6 +370,9 @@ export const sortEffects = (
     "increaseheal",
     "copy",
     "mirror",
+    // Time effects
+    "timecompression",
+    "timedilation",
     // End-modifiers
     "move",
     "visual",


### PR DESCRIPTION
# Pull Request

Move prevent and heal prevent were not added as exclusions to the mirror tag.  I have added them in so mirror cannot send their effects back at the opponent.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mirror will no longer reflect additional negative effects such as movement prevention, heal prevention, wounding, and time-compression, preventing unintended harmful reflections.
  * Adjusted timing/order for time-based effects so time-compression and time-dilation resolve in the intended sequence relative to mirror and end-of-turn modifiers, improving consistency of effect resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->