### PR TITLE
Fix issue #701: Reduce Travel Time and Map related questions

### DIFF
--- a/app/src/libs/travel/constants.ts
+++ b/app/src/libs/travel/constants.ts
@@ -8,6 +8,8 @@ export const ALLIANCEHALL_LAT = 7;
 export const HOSPITAL_LONG = 12;
 export const HOSPITAL_LAT = 8;
 
+export const WAKE_ISLAND_SECTOR = 222;
+
 export const groundAssets = [
   {
     filepath: "https://utfs.io/f/6286b479-982f-473e-8c20-a9d7fbf3504b-aj4o7e.png",

--- a/app/src/libs/travel/controls.ts
+++ b/app/src/libs/travel/controls.ts
@@ -1,5 +1,5 @@
 import { type SectorPoint, type GlobalMapData } from "./types";
-import { SECTOR_HEIGHT, SECTOR_WIDTH } from "./constants";
+import { SECTOR_HEIGHT, SECTOR_WIDTH, WAKE_ISLAND_SECTOR } from "./constants";
 
 /**
  * Check if a given position is at the edge of a sector
@@ -29,14 +29,18 @@ export const calcGlobalTravelTime = (
   sectorB: number,
   map: GlobalMapData,
 ) => {
+  // Instant travel to Wake Island
+  if (sectorB === WAKE_ISLAND_SECTOR) return 0;
+
   const a = map?.tiles[sectorA]?.c;
   const b = map?.tiles[sectorB]?.c;
   const r = map?.radius;
   if (a && b && r) {
     const distance = r * Math.acos((a.x * b.x + a.y * b.y + a.z * b.z) / r ** 2);
-    return Math.floor(distance / 2) || 5;
+    const secs = Math.floor(distance / 2) || 5;
+    return Math.min(secs, 10); // Cap global travel to max 10s
   }
-  return 300;
+  return 10; // Fallback capped to 10s
 };
 
 // Calculate if we are in village or not.

--- a/app/tests/libs/travel-controls.test.ts
+++ b/app/tests/libs/travel-controls.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { calcGlobalTravelTime } from "@/libs/travel/controls";
+import { WAKE_ISLAND_SECTOR } from "@/libs/travel/constants";
+import type { GlobalMapData } from "@/libs/travel/types";
+
+const mockMap: GlobalMapData = {
+  radius: 100,
+  tiles: [
+    {
+      // Sector 0
+      c: { x: 100, y: 0, z: 0 },
+      b: [{ x: 0, y: 0, z: 0 }],
+      t: 1,
+    },
+    {
+      // Sector 1
+      c: { x: 0, y: 100, z: 0 },
+      b: [{ x: 0, y: 0, z: 0 }],
+      t: 1,
+    },
+  ],
+};
+
+describe("calcGlobalTravelTime", () => {
+  it("caps global travel time to a maximum of 10 seconds", () => {
+    const secs = calcGlobalTravelTime(0, 1, mockMap);
+    expect(secs).toBeLessThanOrEqual(10);
+    expect(secs).toBe(10);
+  });
+
+  it("returns 0 seconds for instant travel to Wake Island", () => {
+    const secs = calcGlobalTravelTime(0, WAKE_ISLAND_SECTOR, mockMap);
+    expect(secs).toBe(0);
+  });
+});


### PR DESCRIPTION
This pull request fixes #701.

- Added a new constant WAKE_ISLAND_SECTOR = 222.
- Updated calcGlobalTravelTime to:
  - Return 0 seconds when the destination sector equals WAKE_ISLAND_SECTOR (instant travel to Wake Island).
  - Cap computed global travel times to a maximum of 10 seconds via Math.min(secs, 10).
  - Reduce the fallback time from 300 seconds to 10 seconds to honor the cap even when map data is missing.
- Added tests that verify both the 10-second cap and the instant travel to Wake Island.

These changes directly address the requests: global map travel times will not exceed 10 seconds, and traveling to Wake Island is instantaneous.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌