### PR TITLE
Fix issue #691: Content & Coder cannot open private tickets

### DIFF
--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -542,6 +542,30 @@ export const profileRouter = createTRPCRouter({
           });
         }
       }
+      // Content and Coder (and any non-USER staff) should also see open ticket notifications
+      else if (user.role !== "USER") {
+        const [ticketCounts] = await Promise.all([
+          ctx.drizzle
+            .select({ count: sql<number>`count(*)`.mapWith(Number) })
+            .from(supportTicket)
+            .where(
+              inArray(supportTicket.status, [
+                "OPEN",
+                "IN_PROGRESS",
+                "WAITING_FOR_STAFF",
+              ]),
+            ),
+        ]);
+        const userTickets = ticketCounts?.[0]?.count ?? 0;
+        if (userTickets > 0) {
+          notifications.push({
+            href: "/support",
+            name: `${userTickets} waiting!`,
+            color: "hidden",
+            notificationCount: userTickets,
+          });
+        }
+      }
       // Check if user is banned
       if (user.isBanned) {
         notifications.push({

--- a/app/src/utils/permissions.ts
+++ b/app/src/utils/permissions.ts
@@ -602,7 +602,7 @@ export const canViewConversation = (
   const inConversation = conversation.users.some((u) => u.userId === userId);
   const isStaffAvailable = conversation.isStaffAvailable;
   if (isPublic || inConversation) return true;
-  if (isStaffAvailable && canModerate(userRole)) return true;
+  if (isStaffAvailable && userRole !== "USER") return true;
   return false;
 };
 

--- a/app/tests/utils/permissions.test.ts
+++ b/app/tests/utils/permissions.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { canViewConversation } from "@/utils/permissions";
+
+// Minimal helper to construct a conversation-like object
+const makeConversation = (opts?: Partial<any>) =>
+  ({
+    id: "convo1",
+    title: "Test",
+    createdById: "creator",
+    isPublic: false,
+    isLocked: 0,
+    isStaffAvailable: true,
+    users: [],
+    ...(opts || {}),
+  }) as any;
+
+describe("canViewConversation", () => {
+  it("allows CONTENT to view private conversations when staff is available", () => {
+    const convo = makeConversation({ isPublic: false, isStaffAvailable: true, users: [] });
+    expect(canViewConversation(convo, "random-user", "CONTENT")).toBe(true);
+  });
+
+  it("allows CODER to view private conversations when staff is available", () => {
+    const convo = makeConversation({ isPublic: false, isStaffAvailable: true, users: [] });
+    expect(canViewConversation(convo, "random-user", "CODER")).toBe(true);
+  });
+
+  it("does not allow USER to view private conversations when not in conversation", () => {
+    const convo = makeConversation({ isPublic: false, isStaffAvailable: true, users: [] });
+    expect(canViewConversation(convo, "random-user", "USER")).toBe(false);
+  });
+
+  it("allows USER to view public conversations", () => {
+    const convo = makeConversation({ isPublic: true, isStaffAvailable: false });
+    expect(canViewConversation(convo, "random-user", "USER")).toBe(true);
+  });
+
+  it("allows USER to view private conversations when in the conversation", () => {
+    const convo = makeConversation({
+      isPublic: false,
+      isStaffAvailable: false,
+      users: [{ userId: "random-user" }],
+    });
+    expect(canViewConversation(convo, "random-user", "USER")).toBe(true);
+  });
+});


### PR DESCRIPTION
This pull request fixes #691.

- Access fix: The permission check in canViewConversation was broadened from requiring canModerate(userRole) to allowing any non-USER role (including CONTENT and CODER) to view private conversations when isStaffAvailable is true. This directly addresses the problem where Content/Coder couldn’t open private help tickets, enabling them to load the ticket messages.
- Notifications fix: The profile router now adds a notification for non-USER roles showing the count of open/in-progress/waiting-for-staff support tickets and links to /support. This addresses the complaint that Content couldn’t see a notification when tickets are open.
- Tests: New unit tests assert that CONTENT and CODER can view private conversations when staff access is enabled, and that regular USERs cannot unless in the conversation or it’s public.

Together, these changes resolve both the viewing and notification issues for staff on private tickets.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌