### PR TITLE
Hospital: Require user to checkout after being healed

### DIFF
--- a/app/src/app/hospital/page.tsx
+++ b/app/src/app/hospital/page.tsx
@@ -57,6 +57,8 @@ export default function Hospital() {
   const healCost = userData && calcHealCost(userData);
   const canAfford = userData && healCost && userData.money >= healCost;
   const canHealOthers = hasRequiredRank(userData?.rank, MEDNIN_MIN_RANK);
+  // If user is fully healed, allow immediate checkout
+  const isFullyHealed = userData && userData.curHealth >= userData.maxHealth;
 
   // Heal finish time
   if (!userData) return <Loader explanation="Loading userdata" />;
@@ -90,22 +92,32 @@ export default function Hospital() {
       />
       {!isPending && isHospitalized && userData && healFinishAt && (
         <div className="p-3">
-          <p>You are hospitalized, either wait or pay to expedite treatment.</p>
+          <p>
+            {isFullyHealed
+              ? "You are fully healed. You can check out now."
+              : "You are hospitalized, either wait or pay to expedite treatment."}
+          </p>
           <div className="grid grid-cols-2 py-3 gap-2" id="tutorial-hospital-buttons">
             <Button
               id="check"
               className="w-full"
-              disabled={healFinishAt && healFinishAt > new Date()}
+              disabled={!isFullyHealed && healFinishAt && healFinishAt > new Date()}
               onClick={() => heal({ villageId: userData.villageId })}
             >
               <Clock className="mr-2 h-6 w-6" />
-              <div>Wait ({<Countdown targetDate={healFinishAt} />})</div>
+              <div>
+                {isFullyHealed ? (
+                  "Check Out"
+                ) : (
+                  <>Wait ({<Countdown targetDate={healFinishAt} />})</>
+                )}
+              </div>
             </Button>
             <Button
               id="check"
               className="w-full"
               color={canAfford ? "default" : "red"}
-              disabled={healFinishAt && healFinishAt <= new Date()}
+              disabled={isFullyHealed || (healFinishAt && healFinishAt <= new Date())}
               onClick={() => heal({ villageId: userData.villageId })}
             >
               {canAfford ? (

--- a/app/src/server/api/routers/hospital.ts
+++ b/app/src/server/api/routers/hospital.ts
@@ -176,7 +176,8 @@ export const hospitalRouter = createTRPCRouter({
                 ? { curStamina: sql`LEAST(${t.curStamina + toHeal}, ${t.maxStamina})` }
                 : {}),
               regenAt: new Date(),
-              status: "AWAKE",
+              // Don't change status - users must check out manually at the hospital
+              // unless they pay to be healed at the hospital while hospitalized
             })
             .where(eq(userData.userId, t.userId)),
           shareExp > 0


### PR DESCRIPTION
# Pull Request

Currently when a user gets healed by another player, they're immediately being moved to awake status.  This is allowed afk players to be farmed during wars.  This change makes it so even after being healed, they remain hospitalized until they check out of the hospital.  If a user is fully healed, their timer updates to allow them to checkout without waiting for the timer to finish.  Users can still pay to heal and be immediately moved to awake status.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Hospital checkout flow now responds to healing progress with updated status messages
  * "Check Out" button becomes available immediately when patient is fully healed
  * Hospitalization UI dynamically displays appropriate messaging based on recovery status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->