### PR TITLE
No longer apply durability loss in spars

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -452,6 +452,7 @@ export type HEXTILE_TYPE = (typeof HEXTILE_BIOMES)[number];
 // HEX grid settings
 export const HEX_STACKING_DISPLACEMENT = 0.25; // To compensate for how hexagons stack, this is how much (in percent of width) we lose from a stacking op
 export const HEX_ASPECT_RATIO = 0.5; // To give perspective, make hex height smaller than width
+export const NO_DURABILITY_LOSS_COMBATS: BattleType[] = ["SPARRING"];
 
 // Sector settings
 export const SECTOR_WIDTH = 20;

--- a/app/src/layout/PvpRank.tsx
+++ b/app/src/layout/PvpRank.tsx
@@ -551,7 +551,6 @@ export const RankedLoadoutSelector: React.FC = () => {
   if (!access) return <Loader explanation="Accessing Ranked PvP" />;
   if (!userData) return <Loader explanation="Loading user" />;
   if (userData?.isBanned) return <BanInfo />;
-  if (!currentSeason) return null;
 
   return (
     <>

--- a/app/src/libs/combat/actions.ts
+++ b/app/src/libs/combat/actions.ts
@@ -50,6 +50,7 @@ import {
   NonActionItemTypes,
   ID_SFX_CLEANSE,
   ID_SFX_CLEAR,
+  NO_DURABILITY_LOSS_COMBATS,
 } from "@/drizzle/constants";
 import type { AttackTargets, ElementName } from "@/drizzle/constants";
 import type { BattleUserState, ReturnedUserState } from "@/libs/combat/types";
@@ -948,8 +949,8 @@ export const performBattleAction = (props: {
     throw new Error(`Action ${action.name} no longer possible for ${user.username}`);
   }
 
-  // Track weapon durability usage
-  if (action.type === "item") {
+  // Track weapon durability usage (skip for battles that don't lose durability)
+  if (action.type === "item" && !NO_DURABILITY_LOSS_COMBATS.includes(battle.battleType)) {
     const used = user.items.find((i) => i.item.id === action.id);
     if (used && used.item.itemType === "WEAPON") {
       const currentDurability = Math.min(used.durability, used.item.maxDurability);

--- a/app/src/libs/combat/process.ts
+++ b/app/src/libs/combat/process.ts
@@ -46,6 +46,7 @@ import {
   BATTLE_TAG_STACKING,
   ID_ANIMATION_SMOKE,
   DURABILITY_USABILITY_THR,
+  NO_DURABILITY_LOSS_COMBATS,
 } from "@/drizzle/constants";
 import type { BattleUserState, ReturnedUserState } from "./types";
 import type { GroundEffect, UserEffect, ActionEffect, BattleEffect } from "./types";
@@ -413,17 +414,19 @@ export const applyEffects = (
             color: "red",
             types: c.types,
           });
-          // Reduce armor durability by 1 when hit
-          const t = newUsersState.find((u) => u.userId === target.userId);
-          t?.items.forEach((ui) => {
-            if (ui.item.itemType === "ARMOR" && ui.equipped !== "NONE") {
-              const currentDurability = Math.min(ui.durability, ui.item.maxDurability);
-              ui.durability = Math.max(0, currentDurability - 1);
-              if (ui.durability <= DURABILITY_USABILITY_THR) {
-                ui.equipped = "NONE" as const;
+          // Reduce armor durability by 1 when hit (skip for battles that don't lose durability)
+          if (!NO_DURABILITY_LOSS_COMBATS.includes(battle.battleType)) {
+            const t = newUsersState.find((u) => u.userId === target.userId);
+            t?.items.forEach((ui) => {
+              if (ui.item.itemType === "ARMOR" && ui.equipped !== "NONE") {
+                const currentDurability = Math.min(ui.durability, ui.item.maxDurability);
+                ui.durability = Math.max(0, currentDurability - 1);
+                if (ui.durability <= DURABILITY_USABILITY_THR) {
+                  ui.equipped = "NONE" as const;
+                }
               }
-            }
-          });
+            });
+          }
         }
         if (c.residual !== undefined && c.residual >= 0) {
           target.curHealth -= c.residual;
@@ -433,17 +436,19 @@ export const applyEffects = (
             color: "red",
             types: c.types,
           });
-          // Track armor hits from residual damage as well
-          const t = newUsersState.find((u) => u.userId === target.userId);
-          t?.items.forEach((ui) => {
-            if (ui.item.itemType === "ARMOR" && ui.equipped !== "NONE") {
-              const currentDurability = Math.min(ui.durability, ui.item.maxDurability);
-              ui.durability = Math.max(0, currentDurability - 1);
-              if (ui.durability <= DURABILITY_USABILITY_THR) {
-                ui.equipped = "NONE" as const;
+          // Track armor hits from residual damage as well (skip for battles that don't lose durability)
+          if (!NO_DURABILITY_LOSS_COMBATS.includes(battle.battleType)) {
+            const t = newUsersState.find((u) => u.userId === target.userId);
+            t?.items.forEach((ui) => {
+              if (ui.item.itemType === "ARMOR" && ui.equipped !== "NONE") {
+                const currentDurability = Math.min(ui.durability, ui.item.maxDurability);
+                ui.durability = Math.max(0, currentDurability - 1);
+                if (ui.durability <= DURABILITY_USABILITY_THR) {
+                  ui.equipped = "NONE" as const;
+                }
               }
-            }
-          });
+            });
+          }
         }
         if (c.wound !== undefined && c.wound >= 0) {
           target.curHealth -= c.wound;
@@ -453,17 +458,19 @@ export const applyEffects = (
             color: "red",
             types: c.types,
           });
-          // Track armor hits from wound damage as well
-          const t = newUsersState.find((u) => u.userId === target.userId);
-          t?.items.forEach((ui) => {
-            if (ui.item.itemType === "ARMOR" && ui.equipped !== "NONE") {
-              const currentDurability = Math.min(ui.durability, ui.item.maxDurability);
-              ui.durability = Math.max(0, currentDurability - 1);
-              if (ui.durability <= DURABILITY_USABILITY_THR) {
-                ui.equipped = "NONE" as const;
+          // Track armor hits from wound damage as well (skip for battles that don't lose durability)
+          if (!NO_DURABILITY_LOSS_COMBATS.includes(battle.battleType)) {
+            const t = newUsersState.find((u) => u.userId === target.userId);
+            t?.items.forEach((ui) => {
+              if (ui.item.itemType === "ARMOR" && ui.equipped !== "NONE") {
+                const currentDurability = Math.min(ui.durability, ui.item.maxDurability);
+                ui.durability = Math.max(0, currentDurability - 1);
+                if (ui.durability <= DURABILITY_USABILITY_THR) {
+                  ui.equipped = "NONE" as const;
+                }
               }
-            }
-          });
+            });
+          }
         }
         if (c.heal_hp !== undefined && c.heal_hp >= 0 && target.curHealth > 0) {
           target.curHealth += c.heal_hp;


### PR DESCRIPTION
# Pull Request

- Prevents durability from being lost when sparring.  Ranked spars don't need this since it uses their ranked loadouts and doesn't effect their gear.
- Allows users to modify their ranked loadout when there isn't an active season.  This allows users to edit their loadout for ranked spars in the off-season.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weapon and armor durability are no longer consumed during sparring battles.

* **Improvements**
  * Ranked loadout selector now renders without requiring an active season.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->