### PR TITLE
Fix max capturable sectors display in village overview (#693)

### DIFF
--- a/app/src/app/village/page.tsx
+++ b/app/src/app/village/page.tsx
@@ -23,10 +23,15 @@ import { api } from "@/app/_trpc/client";
 import { showMutationToast } from "@/libs/toast";
 import { useRequireInVillage } from "@/utils/UserContext";
 import { hasRequiredRank } from "@/libs/train";
-import { VILLAGE_REDUCED_GAINS_DAYS } from "@/drizzle/constants";
-import { VILLAGE_LEAVE_REQUIRED_RANK } from "@/drizzle/constants";
-import Building from "@/layout/Building";
-import { StructureRewardEntries } from "@/layout/Building";
+
+import {
+  VILLAGE_REDUCED_GAINS_DAYS,
+  VILLAGE_LEAVE_REQUIRED_RANK,
+  WAR_VILLAGE_MAX_SECTORS,
+  WAR_FACTION_MAX_SECTORS,
+} from "@/drizzle/constants";
+
+import Building, { StructureRewardEntries } from "@/layout/Building";
 import { useTutorialStep } from "@/hooks/tutorial";
 import type { MutateContentSchema } from "@/validators/comments";
 
@@ -56,6 +61,11 @@ export default function VillageOverview() {
       : "Village";
   const subtitle = ownSector ? "Your Community" : `Ally of ${userData?.village?.name}`;
   const href = villageData ? `/users/village/${villageData.id}` : "/users";
+
+  // Determine sector cap
+  const maxSectors = userData?.isOutlaw
+    ? WAR_FACTION_MAX_SECTORS
+    : WAR_VILLAGE_MAX_SECTORS;
 
   // Specific structures
   const walls = villageData?.structures.find((s) => s.name === "Walls");
@@ -104,30 +114,22 @@ export default function VillageOverview() {
   if (!villageData) return <Loader explanation="Loading userdata" />;
   if (isLeaving) return <Loader explanation="Leaving village" />;
 
-  // Overwrite village tokens if user is outlaw
   villageData.tokens = userData.isOutlaw
     ? userData.clan?.points || 0
     : villageData.tokens;
 
-  // Derived
   const canLeave = hasRequiredRank(userData.rank, VILLAGE_LEAVE_REQUIRED_RANK);
 
-  // Which structures to show
   const shownStructures = villageData?.structures
     .filter((s) => s.hasPage !== 0)
     .filter((s) => s.showInVillagePage)
     .filter((s) => ownSector || s.allyAccess)
     .sort((a, v) => {
-      if (a.name === currentStep?.title) {
-        return -1;
-      }
-      if (v.name === currentStep?.title) {
-        return 1;
-      }
+      if (a.name === currentStep?.title) return -1;
+      if (v.name === currentStep?.title) return 1;
       return 0;
     });
 
-  // Render
   return (
     <>
       <ContentBox
@@ -140,12 +142,15 @@ export default function VillageOverview() {
                 <Tooltip>
                   <TooltipTrigger>
                     <div className="flex flex-row">
-                      <MapPinHouse className="w-6 h-6 mr-2" />{" "}
-                      {data?.sectorCount || "?"}
+                      <MapPinHouse className="w-6 h-6 mr-2" />
+                      {data?.sectorCount ?? "?"} / {maxSectors}
                     </div>
                   </TooltipTrigger>
-                  {walls && <TooltipContent>Number of sectors owned</TooltipContent>}
+                  <TooltipContent>
+                    Number of sectors owned (max {maxSectors})
+                  </TooltipContent>
                 </Tooltip>
+
                 <Tooltip>
                   <TooltipTrigger>
                     <div className="flex flex-row">
@@ -156,6 +161,7 @@ export default function VillageOverview() {
                     <TooltipContent>{StructureRewardEntries(walls)}</TooltipContent>
                   )}
                 </Tooltip>
+
                 <Tooltip>
                   <TooltipTrigger>
                     <div className="flex flex-row">
@@ -168,11 +174,12 @@ export default function VillageOverview() {
                     </TooltipContent>
                   )}
                 </Tooltip>
+
                 <Tooltip>
                   <TooltipTrigger>
                     <Link href={href}>
                       <div className="flex flex-row hover:text-orange-500 hover:cursor-pointer">
-                        <Users className="w-6 h-6 mr-2" />{" "}
+                        <Users className="w-6 h-6 mr-2" />
                         {prettyNumber(villageData?.populationCount ?? 0)}
                       </div>
                     </Link>
@@ -181,21 +188,23 @@ export default function VillageOverview() {
                     Total {userData?.isOutlaw ? "faction" : "village"} population
                   </TooltipContent>
                 </Tooltip>
+
                 <Tooltip>
                   <TooltipTrigger>
                     <div className="flex flex-row">
-                      <ReceiptJapaneseYen className="w-6 h-6 mr-2" />{" "}
+                      <ReceiptJapaneseYen className="w-6 h-6 mr-2" />
                       {prettyNumber(villageData?.tokens ?? 0)}
                     </div>
                   </TooltipTrigger>
                   <TooltipContent>
                     Tokens earned through PvP and quests can be used to improve{" "}
-                    {userData?.isOutlaw ? "faction" : "village"}. Current tokens:{" "}
-                    {villageData?.tokens.toLocaleString()}.
+                    {userData?.isOutlaw ? "faction" : "village"}.
+                    Current tokens: {villageData?.tokens.toLocaleString()}.
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
             </div>
+
             {!userData.isOutlaw && canLeave && ownSector && (
               <Confirm2
                 title="Leave Village"
@@ -237,10 +246,13 @@ export default function VillageOverview() {
         </div>
         {isFetchingVillage && <Loader explanation="Loading Village Information" />}
       </ContentBox>
+
       {["OUTLAW", "VILLAGE"].includes(sectorVillage?.type || "unknown") && (
         <ContentBox
           title="Notice Board"
-          subtitle={`Information from ${sectorVillage?.type === "OUTLAW" ? "Leader" : "Kage"}`}
+          subtitle={`Information from ${
+            sectorVillage?.type === "OUTLAW" ? "Leader" : "Kage"
+          }`}
           initialBreak={true}
           topRightContent={
             isKage && (


### PR DESCRIPTION
This PR fixes Support Ticket #693: "Maximum Capturable Sectors Bug".

What was implemented

Updated app/src/app/village/page.tsx to correctly display the maximum capturable sectors for the currentSectorCount / maxSectorLimit.

maxSectorLimit now derives from backend constants:

WAR_VILLAGE_MAX_SECTORS (villages)

WAR_FACTION_MAX_SECTORS (outlaw factions)

Updated tooltip to clearly explain the maximum sector limit.

Why this was needed

Players reported that they were unsure how many sectors their village or faction could still capture.
The backend already enforces different sector caps, but the UI did not show this information.

This PR aligns the UI with existing server-side war rules and resolves the confusion described in Support Ticket #693.

Breaking changes?

None.

UI-only change — no backend behavior modified.

Fully isolated to the village overview page.

License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added maximum sector limits display for war villages and factions.
  * Updated tooltips to reflect new sector maximum information.

* **Improvements**
  * Enhanced Notice Board subtitle rendering for improved clarity.
  * Refined sector count display UI to show capacity limits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->