### PR TITLE
New bug fixes

### DIFF
--- a/app/src/app/api/daily-quest/route.ts
+++ b/app/src/app/api/daily-quest/route.ts
@@ -37,7 +37,6 @@ export async function GET() {
           rank: userData.rank,
           villageId: userData.villageId,
           minLevel: sql`min(${userData.level})`.mapWith(Number),
-          maxLevel: sql`max(${userData.level})`.mapWith(Number),
           count: sql`count(${userData.userId})`.mapWith(Number),
         })
         .from(userData)
@@ -57,7 +56,7 @@ export async function GET() {
 
     // For each user rank, get a random daily quest
     for (const config of userRankPerVillage) {
-      const { rank, villageId, minLevel, maxLevel } = config;
+      const { rank, villageId, minLevel } = config;
       const village = villages?.find((v) => v.id === villageId);
       const questRanks = availableQuestLetterRanks(rank);
       if (village && questRanks.length > 0) {
@@ -69,8 +68,7 @@ export async function GET() {
             (q) =>
               questRanks.includes(q.questRank) &&
               (!q.requiredVillage || q.requiredVillage === requiredVillage) &&
-              // Check that the quest's level range overlaps with users' level range
-              q.requiredLevel <= maxLevel &&
+              q.requiredLevel <= minLevel &&
               q.maxLevel >= minLevel,
           );
         if (newDaily) {

--- a/app/src/app/users/page.tsx
+++ b/app/src/app/users/page.tsx
@@ -180,7 +180,7 @@ export default function Users() {
               ))}
             </SelectContent>
           </Select>
-          <Link href="/staff">
+          <Link href="/manual/staff">
             <Button>
               <BriefcaseBusiness className="h-6 w-6" />
             </Button>

--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -97,6 +97,7 @@ export type BattleUserState = Omit<NonNullable<UserWithRelations>, "items"> & {
   originalLongitude: number;
   originalLatitude: number;
   originalMoney: number;
+  originalLevel: number;
   direction: "left" | "right";
   allyVillage: boolean;
   moneyStolen: number;

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -1312,8 +1312,10 @@ export const calcBattleResult = (
         loserMoneyGain *= battle.rewardScaling;
         // Apply 1.6x multiplier (same as winner gets)
         loserMoneyGain *= 1.6;
-        // Deduct this amount from the loser
-        result.money = -loserMoneyGain;
+        // Deduct this amount from the loser, but don't let money go below 0
+        const currentMoney = user?.money || 0;
+        const moneyToLose = Math.min(loserMoneyGain, currentMoney);
+        result.money = -moneyToLose;
       }
 
       // Return results

--- a/app/src/libs/quest.ts
+++ b/app/src/libs/quest.ts
@@ -617,7 +617,12 @@ export const getNewTrackers = (
 
           // General updates we want to apply every time
           if (task === "user_level") {
-            status.value = user.level;
+            // Use originalLevel if available (for combat-scaled users), otherwise use current level
+            const userLevel =
+              "originalLevel" in user && typeof user.originalLevel === "number"
+                ? user.originalLevel
+                : user.level ?? 1;
+            status.value = userLevel;
           } else if (task === "days_in_village") {
             const days = Math.floor(secondsPassed(user.joinedVillageAt) / 60 / 60 / 24);
             status.value = days;
@@ -1121,10 +1126,15 @@ export const isAvailableUserQuests = (
   const huntingRankCheck = !reqHuntRankIdx || userHuntRankIdx >= reqHuntRankIdx;
 
   // Level check - user must be >= requiredLevel and <= maxLevel
+  // Use originalLevel if available (for combat-scaled users), otherwise use current level
+  const userLevel =
+    "originalLevel" in user && typeof user.originalLevel === "number"
+      ? user.originalLevel
+      : user.level ?? 1;
   const levelCheck =
     (!questAndUserQuestInfo.requiredLevel ||
-      user.level >= questAndUserQuestInfo.requiredLevel) &&
-    (!questAndUserQuestInfo.maxLevel || user.level <= questAndUserQuestInfo.maxLevel);
+      userLevel >= questAndUserQuestInfo.requiredLevel) &&
+    (!questAndUserQuestInfo.maxLevel || userLevel <= questAndUserQuestInfo.maxLevel);
 
   // Event specific tests
   const eventCompletedCheck =
@@ -1146,6 +1156,13 @@ export const isAvailableUserQuests = (
       );
     });
 
+  // Daily quests should be available even if previously completed (they reset daily)
+  const completedCheck =
+    questAndUserQuestInfo.questType === "daily" ||
+    QuestTypesWithMaxAttempts.includes(questAndUserQuestInfo.questType) ||
+    !questAndUserQuestInfo.completed ||
+    questAndUserQuestInfo.completed === 0;
+
   // Check if quest is available
   const check =
     hideCheck &&
@@ -1157,7 +1174,8 @@ export const isAvailableUserQuests = (
     prerequisiteCheck &&
     medicalRankCheck &&
     huntingRankCheck &&
-    levelCheck;
+    levelCheck &&
+    completedCheck;
 
   // If quest is not available, return the reason
   let message = "";
@@ -1172,14 +1190,24 @@ export const isAvailableUserQuests = (
     message += `Quest requires medical rank ${capitalizeFirstLetter(questMedRank ?? "NONE")}\n`;
   if (!huntingRankCheck)
     message += `Quest requires hunting rank ${capitalizeFirstLetter(questHuntRank ?? "NONE")}\n`;
+  if (
+    !completedCheck &&
+    questAndUserQuestInfo.questType !== "daily" &&
+    !QuestTypesWithMaxAttempts.includes(questAndUserQuestInfo.questType)
+  ) {
+    message += "Quest has already been completed\n";
+  }
   if (!levelCheck) {
     if (
       questAndUserQuestInfo.requiredLevel &&
-      user.level < questAndUserQuestInfo.requiredLevel
+      userLevel < questAndUserQuestInfo.requiredLevel
     ) {
       message += `Quest requires level ${questAndUserQuestInfo.requiredLevel}\n`;
     }
-    if (questAndUserQuestInfo.maxLevel && user.level > questAndUserQuestInfo.maxLevel) {
+    if (
+      questAndUserQuestInfo.maxLevel &&
+      userLevel > questAndUserQuestInfo.maxLevel
+    ) {
       message += `Quest is only available up to level ${questAndUserQuestInfo.maxLevel}\n`;
     }
   }

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -1465,7 +1465,9 @@ export const initiateBattle = async (
     capUserStats(user);
 
     // If PvP rank, set pools to max & level to 100
+    // Save original level before setting to 100 for ranked battles (for quest validation)
     if (battleType === "RANKED_PVP" || battleType === "RANKED_SPARRING") {
+      (user as BattleUserState).originalLevel = user.level;
       user.maxHealth = calcHP(100);
       user.maxChakra = calcSP(100);
       user.maxStamina = calcCP(100);
@@ -1945,9 +1947,15 @@ export const processUsersForBattle = async (
     // By default set iAmHere to false
     user.iAmHere = false;
 
+    // Remember the original level before any combat scaling
+    // Only set if not already set (e.g., for ranked battles it's set in initiateBattle)
+    if (user.originalLevel === undefined) {
+      user.originalLevel = user.level;
+    }
+
     // Update user level to the effective level if he had leveled up (to combat level-holding, as some things are scaled based on level)
-    // Skip for ranked battles as they have their level set to 100
-    if (battleType !== "RANKED_SPARRING") {
+    // Skip for ranked battles as they have their level set to 100 in initiateBattle
+    if (battleType !== "RANKED_SPARRING" && battleType !== "RANKED_PVP") {
       user.level = calcLevel(user.experience);
     }
 

--- a/app/src/server/api/routers/home.ts
+++ b/app/src/server/api/routers/home.ts
@@ -7,7 +7,7 @@ import { fetchUpdatedUser } from "@/routers/profile";
 import { getServerPusher, updateUserOnMap } from "@/libs/pusher";
 import { calcIsInVillage } from "@/libs/travel";
 import { fetchSectorVillage } from "@/routers/village";
-import { HomeTypes, HomeTypeDetails } from "@/drizzle/constants";
+import { HomeTypes, HomeTypeDetails, MAP_WAR_TORN_BATTLEGROUND_SECTOR } from "@/drizzle/constants";
 import { fetchUserItems } from "@/routers/item";
 import {
   calcMaxItems,
@@ -55,6 +55,9 @@ export const homeRouter = createTRPCRouter({
       }
       if (user.sector !== user.village?.sector && !user.isOutlaw) {
         return errorResponse("Wrong sector");
+      }
+      if (newStatus === "ASLEEP" && user.sector === MAP_WAR_TORN_BATTLEGROUND_SECTOR) {
+        return errorResponse("You cannot sleep in the war-torn battleground");
       }
       // Mutate
       if (user.status === "ASLEEP") {


### PR DESCRIPTION
# Pull Request

- Don't allow users to sleep in wartorn sector
- When users lose money from wartorn, don't let it put them below 0 money
- Don't apply scaled levels from combat to user_level tasks
- Don't apply scaled levels from combat to minimum/maximum level needed for quests (Was causing quests to reset if going above max level)
- Properly assign dailies based on user level

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Money loss in war-torn/mixed combat no longer drops balances below zero.
  * Daily quests now respect players' preserved pre-combat level for availability and honor daily completion/reset rules.

* **New Features**
  * Sleeping is blocked while in dangerous battlegrounds.
  * Staff link on Users page now opens the in-app staff manual.
  * Players' original pre-combat level is preserved for quest and validation checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->