### PR TITLE
Repair rework

### DIFF
--- a/app/src/app/items/page.tsx
+++ b/app/src/app/items/page.tsx
@@ -7,8 +7,8 @@ import {
   Cookie,
   ArrowDownToLine,
   Zap,
-  Wrench,
   Split,
+  Wrench,
 } from "lucide-react";
 import Image from "next/image";
 import ContentBox from "@/layout/ContentBox";
@@ -40,13 +40,13 @@ import { showMutationToast, showRewardToast } from "@/libs/toast";
 import {
   calcMaxItems,
   calcMaxEventItems,
-  calcItemRepairCost,
   calcMaxMaterials,
 } from "@/libs/item";
 import { CircleFadingArrowUp, Shirt } from "lucide-react";
 import { COST_EXTRA_ITEM_SLOT, IMG_EQUIP_SILHOUETTE } from "@/drizzle/constants";
 import type { UserWithRelations } from "@/routers/profile";
 import type { Item, UserItemWithRelations, UserItem, ItemSlot } from "@/drizzle/schema";
+import { calculateKitsToUse, getRepairKits, type RepairKit } from "@/libs/repair";
 
 export default function MyItems() {
   // State
@@ -79,6 +79,17 @@ export default function MyItems() {
         showMutationToast(data);
         if (data.success) {
           await utils.item.getUserItems.invalidate();
+        }
+      },
+    });
+
+  const { mutate: mutateRepairAll, isPending: isRepairingAll } =
+    api.item.useRepairAll.useMutation({
+      onSuccess: async (data) => {
+        showMutationToast(data);
+        if (data.success) {
+          await utils.item.getUserItems.invalidate();
+          await utils.profile.getUser.invalidate();
         }
       },
     });
@@ -116,6 +127,23 @@ export default function MyItems() {
   // Can afford removing
   const canAfford =
     userData.reputationPoints && userData.reputationPoints >= COST_EXTRA_ITEM_SLOT;
+
+  // Calculate items needing repair and which kits will be used
+  const itemsNeedingRepair = (userItems || []).filter(
+    (useritem) =>
+      useritem.durability < useritem.item.maxDurability &&
+      useritem.item.maxDurability > 0,
+  );
+  const repairKits = getRepairKits(userItems);
+
+  // Calculate which kits will be used (same algorithm as backend)
+  const repairKitCalculation = calculateKitsToUse(
+    itemsNeedingRepair,
+    repairKits,
+    userItems,
+  );
+
+  const repairAllInfo = repairKitCalculation;
 
   return (
     <>
@@ -192,27 +220,241 @@ export default function MyItems() {
         <div>
           <ItemLoadoutSelector />
         </div>
-        <Confirm2
-          title="Auto Equip"
-          isValid={!isPending}
-          button={
-            <Button disabled={isAutoEquipping} variant="default">
-              <Zap className="mr-2 h-4 w-4" />
-              {isAutoEquipping ? "Auto Equipping..." : "Auto Equip"}
-            </Button>
-          }
-          onAccept={(e) => {
-            e.preventDefault();
-            autoEquipOptimal();
-          }}
-        >
-          <p>
-            You are about to auto-equip your items. This will equip unequipped items in
-            the best possible way. Are you sure?
-          </p>
-        </Confirm2>
+        <div className="flex gap-2">
+          {itemsNeedingRepair.length > 0 && repairKits.length > 0 && (
+            <Confirm2
+              title="Repair All Items"
+              proceed_label={
+                repairAllInfo.canRepairAll
+                  ? isRepairingAll
+                    ? undefined
+                    : "Repair All"
+                  : undefined
+              }
+              isValid={repairAllInfo.canRepairAll && !isRepairingAll}
+              button={
+                <Button disabled={isRepairingAll} variant="outline">
+                  <Wrench className="mr-2 h-4 w-4" />
+                  {isRepairingAll ? "Repairing..." : "Repair All"}
+                </Button>
+              }
+              onAccept={(e) => {
+                e.preventDefault();
+                if (repairAllInfo.canRepairAll) {
+                  mutateRepairAll();
+                }
+              }}
+            >
+              <div className="space-y-3">
+                {repairAllInfo.canRepairAll ? (
+                  <>
+                    <p>
+                      You are about to repair all {itemsNeedingRepair.length} item
+                      {itemsNeedingRepair.length !== 1 ? "s" : ""} using repair kits.
+                    </p>
+                    {repairAllInfo.kitsToUse.length > 0 && (
+                      <div>
+                        <p className="font-semibold mb-2">Repair kits to be used:</p>
+                        <div className="space-y-1">
+                          {repairAllInfo.kitsToUse.map((kit) => (
+                            <div
+                              key={kit.repairItemId}
+                              className="flex items-center justify-between text-sm"
+                            >
+                              <span>{kit.repairItemName}</span>
+                              <span className="font-medium">x{kit.quantityUsed}</span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <div>
+                    <p className="text-red-600 font-semibold mb-2">
+                      Not enough repair kits
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      You have {itemsNeedingRepair.length} damaged item
+                      {itemsNeedingRepair.length !== 1 ? "s" : ""} that need{" "}
+                      {repairAllInfo.totalDurabilityNeeded} total durability, but you
+                      don't have enough repair kits to repair all of them.
+                    </p>
+                  </div>
+                )}
+              </div>
+            </Confirm2>
+          )}
+          <Confirm2
+            title="Auto Equip"
+            isValid={!isPending}
+            button={
+              <Button disabled={isAutoEquipping} variant="default">
+                <Zap className="mr-2 h-4 w-4" />
+                {isAutoEquipping ? "Auto Equipping..." : "Auto Equip"}
+              </Button>
+            }
+            onAccept={(e) => {
+              e.preventDefault();
+              autoEquipOptimal();
+            }}
+          >
+            <p>
+              You are about to auto-equip your items. This will equip unequipped items in
+              the best possible way. Are you sure?
+            </p>
+          </Confirm2>
+        </div>
       </div>
     </>
+  );
+}
+
+/**
+ * Repair Item Selection Modal Component
+ */
+type SetIsOpenType = React.Dispatch<React.SetStateAction<boolean>>;
+
+interface RepairItemModalProps {
+  isOpen: boolean;
+  setIsOpen: SetIsOpenType;
+  targetItem: UserItemWithRelations;
+  repairItems: UserItemWithRelations[];
+  onSelectRepairItem: (repairItemId: string, targetItemId: string) => void;
+  isPending?: boolean;
+}
+
+function RepairItemSelectionModal({
+  isOpen,
+  setIsOpen,
+  targetItem,
+  repairItems,
+  onSelectRepairItem,
+  isPending = false,
+}: RepairItemModalProps) {
+  if (!isOpen || !targetItem) return null;
+
+
+  return (
+    <Modal2
+      title="Select Repair Item"
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
+      isValid={false}
+    >
+      <div className="space-y-4">
+        <div>
+          <p className="text-sm text-muted-foreground mb-2">
+            Repairing: <strong>{targetItem.item.name}</strong>
+          </p>
+          <p className="text-sm text-muted-foreground">
+            Durability: {targetItem.durability} / {targetItem.item.maxDurability}
+          </p>
+        </div>
+        {repairItems.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            You don't have any repair items in your inventory.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {repairItems.map((repairItem) => {
+              const repairEffect = repairItem.item.effects.find((e) => e.type === "repair");
+              const repairAmount = Math.floor(repairEffect?.power || 0);
+              const newDurability = Math.min(
+                targetItem.durability + repairAmount,
+                targetItem.item.maxDurability,
+              );
+              const actualRepair = newDurability - targetItem.durability;
+              return (
+                <div
+                  key={repairItem.id}
+                  className={`border rounded-lg p-3 transition-colors ${
+                    isPending
+                      ? "opacity-50 cursor-not-allowed bg-slate-50"
+                      : "hover:bg-slate-100 cursor-pointer"
+                  }`}
+                  onClick={() => {
+                    if (!isPending) {
+                      onSelectRepairItem(repairItem.id, targetItem.id);
+                    }
+                  }}
+                >
+                  <div className="flex items-center gap-3">
+                    <ContentImage
+                      image={repairItem.item.image}
+                      alt={repairItem.item.name}
+                      className="w-12 h-12"
+                    />
+                    <div className="flex-1">
+                      <h4 className="font-semibold">{repairItem.item.name}</h4>
+                      <p className="text-sm text-muted-foreground">
+                        Quantity: {repairItem.quantity}
+                      </p>
+                    </div>
+                    <div className="text-right">
+                      {isPending ? (
+                        <p className="text-sm font-medium text-muted-foreground">
+                          Repairing...
+                        </p>
+                      ) : (
+                        <>
+                          <p className="text-sm font-medium text-green-600">
+                            +{actualRepair} Durability
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {targetItem.durability} → {newDurability} / {targetItem.item.maxDurability}
+                          </p>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </Modal2>
+  );
+}
+
+/**
+ * Shared Repair Modal Wrapper Component
+ * Handles the repair item selection modal with mutation logic
+ */
+interface RepairModalWrapperProps {
+  useritem: UserItemWithRelations | undefined;
+  repairItems: UserItemWithRelations[];
+  isRepairModalOpen: boolean;
+  setIsRepairModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  onRepairItem: (params: { repairItemId: string; targetItemId: string }) => void;
+  isPending?: boolean;
+}
+
+function RepairModalWrapper({
+  useritem,
+  repairItems,
+  isRepairModalOpen,
+  setIsRepairModalOpen,
+  onRepairItem,
+  isPending = false,
+}: RepairModalWrapperProps) {
+  if (!useritem) return null;
+
+  return (
+    <RepairItemSelectionModal
+      isOpen={isRepairModalOpen}
+      setIsOpen={setIsRepairModalOpen}
+      targetItem={useritem}
+      repairItems={repairItems}
+      onSelectRepairItem={(repairItemId, targetItemId) => {
+        onRepairItem({
+          repairItemId,
+          targetItemId,
+        });
+      }}
+      isPending={isPending}
+    />
   );
 }
 
@@ -235,6 +477,7 @@ const Backpack: React.FC<BackpackProps> = (props) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [isSplitDialogOpen, setIsSplitDialogOpen] = useState<boolean>(false);
   const [quantityToKeep, setQuantityToKeep] = useState<string>("");
+  const [isRepairModalOpen, setIsRepairModalOpen] = useState<boolean>(false);
 
   // tRPC utility
   const utils = api.useUtils();
@@ -299,16 +542,6 @@ const Backpack: React.FC<BackpackProps> = (props) => {
     onSettled,
   });
 
-  const { mutate: repair, isPending: isRepairing } = api.item.repair.useMutation({
-    onSuccess: async (data) => {
-      showMutationToast(data);
-      if (data.success) {
-        await utils.item.getUserItems.invalidate();
-        await utils.profile.getUser.invalidate();
-      }
-    },
-    onSettled,
-  });
 
   const { mutate: splitStack, isPending: isSplitting } = api.item.splitStack.useMutation({
     onSuccess: async (data) => {
@@ -322,12 +555,29 @@ const Backpack: React.FC<BackpackProps> = (props) => {
     onSettled,
   });
 
+  const { mutate: mutateRepairItem, isPending: isUsingRepairItem } =
+    api.item.useRepairItem.useMutation({
+      onSuccess: async (data) => {
+        showMutationToast(data);
+        if (data.success) {
+          setIsRepairModalOpen(false);
+          await utils.item.getUserItems.invalidate();
+          await utils.profile.getUser.invalidate();
+        }
+      },
+    });
+
   // Derived
   const structures = userData?.village?.structures;
   const isLoading =
-    isMerging || isConsuming || isSelling || isEquipping || isRepairing || isSplitting;
+    isMerging || isConsuming || isSelling || isEquipping || isSplitting || isUsingRepairItem;
   const items = useritems?.map((useritem) => ({ ...useritem.item, ...useritem }));
   const sellPrice = calcItemSellingPrice(userData, useritem, structures);
+  const repairItems = (useritems || []).filter(
+    (userItem: UserItemWithRelations) =>
+      userItem.item?.effects?.some((e: { type: string }) => e.type === "repair") &&
+      userItem.quantity > 0,
+  );
 
   // Split stack handler
   const handleSplitStack = () => {
@@ -390,15 +640,6 @@ const Backpack: React.FC<BackpackProps> = (props) => {
                   Equip
                 </Button>
               )}
-              {useritem.durability < useritem.item.maxDurability && (
-                <Button
-                  variant="info"
-                  onClick={() => repair({ userItemId: useritem.id })}
-                >
-                  <Wrench className="mr-2 h-5 w-5" />
-                  Repair ({calcItemRepairCost(useritem)} ryo)
-                </Button>
-              )}
               {useritem.item.canStack && (
                 <>
                   <Button
@@ -431,6 +672,17 @@ const Backpack: React.FC<BackpackProps> = (props) => {
                   Consume
                 </Button>
               )}
+              {useritem.durability < useritem.item.maxDurability &&
+                useritem.item.maxDurability > 0 && (
+                  <Button
+                    variant="outline"
+                    onClick={() => setIsRepairModalOpen(true)}
+                    disabled={repairItems.length === 0}
+                  >
+                    <Wrench className="mr-2 h-5 w-5" />
+                    Use Repair Item
+                  </Button>
+                )}
               <div className="grow"></div>
               <Confirm2
                 title="Security Confirmation"
@@ -520,6 +772,15 @@ const Backpack: React.FC<BackpackProps> = (props) => {
           </DialogContent>
         </Dialog>
       )}
+      {/* Repair Item Selection Modal */}
+      <RepairModalWrapper
+        useritem={useritem}
+        repairItems={repairItems}
+        isRepairModalOpen={isRepairModalOpen}
+        setIsRepairModalOpen={setIsRepairModalOpen}
+        onRepairItem={mutateRepairItem}
+        isPending={isUsingRepairItem}
+      />
     </>
   );
 };
@@ -540,12 +801,18 @@ const Character: React.FC<CharacterProps> = (props) => {
   );
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [showItemDetails, setShowItemDetails] = useState<boolean>(false);
+  const [isRepairModalOpen, setIsRepairModalOpen] = useState<boolean>(false);
 
   // The item on the current slot
 
   // Collapse UserItem and Item
   const items = useritems?.map((useritem) => ({ ...useritem.item, ...useritem }));
   const equipped = items?.find((item) => item.equipped === slot);
+  const repairItems = (useritems || []).filter(
+    (userItem: UserItemWithRelations) =>
+      userItem.item?.effects?.some((e: { type: string }) => e.type === "repair") &&
+      userItem.quantity > 0,
+  );
 
   // tRPC utility
   const utils = api.useUtils();
@@ -578,21 +845,18 @@ const Character: React.FC<CharacterProps> = (props) => {
     },
   });
 
-  const { mutate: repairEquipped, isPending: isRepairingEquipped } =
-    api.item.repair.useMutation({
+  const { mutate: mutateRepairItem, isPending: isUsingRepairItem } =
+    api.item.useRepairItem.useMutation({
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
+          setIsRepairModalOpen(false);
           await utils.item.getUserItems.invalidate();
           await utils.profile.getUser.invalidate();
         }
       },
-      onSettled: () => {
-        document.body.style.cursor = "default";
-        setShowItemDetails(false);
-        setUserItem(undefined);
-      },
     });
+
 
   // Placement of equip boxes
   const l = "left-[10%] ";
@@ -667,10 +931,6 @@ const Character: React.FC<CharacterProps> = (props) => {
             isOpen={showItemDetails}
             setIsOpen={setShowItemDetails}
             isValid={false}
-            proceed_label="Unequip"
-            onAccept={() => {
-              equip({ userItemId: useritem.id, slot: slot! });
-            }}
           >
             <ItemWithEffects
               item={{
@@ -681,27 +941,48 @@ const Character: React.FC<CharacterProps> = (props) => {
               key={useritem.id}
               showStatistic="item"
             />
-            {!isEquipping && !isRepairingEquipped && (
+            {!isEquipping && !isUsingRepairItem && (
               <div className="flex flex-row gap-1 mt-2">
-                {useritem.durability < useritem.item.maxDurability && (
-                  <Button
-                    variant="info"
-                    onClick={() => repairEquipped({ userItemId: useritem.id })}
-                  >
-                    <Wrench className="mr-2 h-5 w-5" />
-                    Repair ({calcItemRepairCost(useritem)} ryo)
-                  </Button>
-                )}
+                <Button
+                  variant="info"
+                  onClick={() => {
+                    if (slot) equip({ userItemId: useritem.id, slot });
+                  }}
+                  disabled={!slot}
+                >
+                  <Shirt className="mr-2 h-4 w-4" />
+                  Unequip
+                </Button>
+                {useritem.durability < useritem.item.maxDurability &&
+                  useritem.item.maxDurability > 0 && (
+                    <Button
+                      variant="outline"
+                      onClick={() => setIsRepairModalOpen(true)}
+                      disabled={repairItems.length === 0}
+                    >
+                      <Wrench className="mr-2 h-4 w-4" />
+                      Use Repair Item
+                    </Button>
+                  )}
                 <div className="grow"></div>
               </div>
             )}
-            {(isEquipping || isRepairingEquipped) && (
+            {(isEquipping || isUsingRepairItem) && (
               <Loader
                 explanation={`${isEquipping ? "Unequipping" : "Repairing"} ${useritem.item.name}`}
               />
             )}
           </Modal2>
         )}
+        {/* Repair Item Selection Modal */}
+        <RepairModalWrapper
+          useritem={useritem}
+          repairItems={repairItems}
+          isRepairModalOpen={isRepairModalOpen}
+          setIsRepairModalOpen={setIsRepairModalOpen}
+          onRepairItem={mutateRepairItem}
+          isPending={isUsingRepairItem}
+        />
       </div>
     </div>
   );

--- a/app/src/layout/EditContent.tsx
+++ b/app/src/layout/EditContent.tsx
@@ -1567,6 +1567,21 @@ export const EffectFormWrapper: React.FC<EffectFormWrapperProps> = (props) => {
     })
     .filter((value) => {
       return (
+        !["repair"].includes(watchType) ||
+        ![
+          "staticAnimation",
+          "staticAssetPath",
+          "appearAnimation",
+          "disappearAnimation",
+          "rounds",
+          "target",
+          "friendlyFire",
+          "calculation",
+        ].includes(value)
+      );
+    })
+    .filter((value) => {
+      return (
         !["rollbloodline", "removebloodline", "marriageslotincrease"].includes(
           watchType,
         ) ||

--- a/app/src/layout/OccupationCrafting.tsx
+++ b/app/src/layout/OccupationCrafting.tsx
@@ -12,7 +12,7 @@ import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { Button } from "@/components/ui/button";
 import Confirm2 from "@/layout/Confirm2";
-import { Hammer, Star, Info, Gem, Zap } from "lucide-react";
+import { Hammer, Star, Info, Gem, Zap, Wrench } from "lucide-react";
 import { api } from "@/app/_trpc/client";
 import { useRequiredUserData } from "@/utils/UserContext";
 import { showMutationToast } from "@/libs/toast";
@@ -29,6 +29,7 @@ import {
   getTotalItemQuantity,
   getEffectiveMaxImbuements,
 } from "@/libs/crafting";
+import { calcItemRepairCost } from "@/libs/item";
 import type { Item, UserItemWithRelations } from "@/drizzle/schema";
 
 export default function OccupationCrafting() {
@@ -98,6 +99,27 @@ export default function OccupationCrafting() {
       await utils.item.getUserItems.invalidate();
     },
   });
+
+  const repairItemMutation = api.item.repair.useMutation({
+    onSuccess: async (data) => {
+      showMutationToast(data);
+      if (data.success) {
+        await utils.item.getUserItems.invalidate();
+        await utils.profile.getUser.invalidate();
+      }
+    },
+  });
+
+  const repairAllMutation = api.item.repairAll.useMutation({
+    onSuccess: async (data) => {
+      showMutationToast(data);
+      if (data.success) {
+        await utils.item.getUserItems.invalidate();
+        await utils.profile.getUser.invalidate();
+      }
+    },
+  });
+
 
   const [selectedItem, setSelectedItem] = useState<Item | undefined>(undefined);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
@@ -696,6 +718,128 @@ export default function OccupationCrafting() {
                       )}
                     </div>
                   ))}
+                </div>
+              </CardContent>
+            </Card>
+          ) : null;
+        })()}
+
+        {/* Repair Items */}
+        {(() => {
+          const itemsNeedingRepair = (userItems || []).filter(
+            (userItem) =>
+              userItem.durability < userItem.item.maxDurability &&
+              userItem.item.maxDurability > 0,
+          );
+
+          return itemsNeedingRepair.length > 0 ? (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Wrench className="h-5 w-5" />
+                  Repair Items
+                  <Badge variant="outline" className="ml-auto">
+                    {itemsNeedingRepair.length} item{itemsNeedingRepair.length !== 1 ? "s" : ""}
+                  </Badge>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-4">
+                  {/* Repair All Button */}
+                  {(() => {
+                    const totalRepairCost = itemsNeedingRepair.reduce(
+                      (total, userItem) => total + calcItemRepairCost(userItem),
+                      0,
+                    );
+                    const canAfford = (userData?.money || 0) >= totalRepairCost;
+                    return (
+                      <div className="mb-4 flex items-center justify-between rounded-lg border p-4 bg-muted/50">
+                        <div>
+                          <p className="font-semibold">Repair All Items</p>
+                          <p className="text-sm text-muted-foreground">
+                            Total cost:{" "}
+                            <span className={canAfford ? "text-green-600" : "text-red-600"}>
+                              {totalRepairCost.toLocaleString()} ryo
+                            </span>
+                            {!canAfford && (
+                              <span className="ml-2">
+                                (You have {(userData?.money ?? 0).toLocaleString()} ryo)
+                              </span>
+                            )}
+                          </p>
+                        </div>
+                        <Confirm2
+                          title="Repair All Items"
+                          proceed_label={
+                            repairAllMutation.isPending ? undefined : "Repair All"
+                          }
+                          button={
+                            <Button
+                              variant="default"
+                              disabled={repairAllMutation.isPending || !canAfford}
+                              loading={repairAllMutation.isPending}
+                            >
+                              <Wrench className="mr-2 h-4 w-4" />
+                              Repair All
+                            </Button>
+                          }
+                          onAccept={() => repairAllMutation.mutate()}
+                        >
+                          <p>
+                            Are you sure you want to repair all {itemsNeedingRepair.length} item
+                            {itemsNeedingRepair.length !== 1 ? "s" : ""} for{" "}
+                            <strong>{totalRepairCost.toLocaleString()} ryo</strong>?
+                          </p>
+                        </Confirm2>
+                      </div>
+                    );
+                  })()}
+                  {itemsNeedingRepair.map((userItem) => {
+                    const repairCost = calcItemRepairCost(userItem);
+                    const durabilityPercent = Math.round(
+                      (userItem.durability / userItem.item.maxDurability) * 100,
+                    );
+                    return (
+                      <div key={userItem.id} className="border rounded-lg p-4">
+                        <div className="flex items-center gap-3 mb-3">
+                          <ContentImage
+                            image={userItem.item?.image || ""}
+                            alt={userItem.item?.name || "Unknown"}
+                            className="w-12 h-12"
+                          />
+                          <div className="flex-1">
+                            <h4 className="font-semibold">{userItem.item?.name}</h4>
+                            <p className="text-sm text-muted-foreground">
+                              Durability: {userItem.durability} / {userItem.item.maxDurability} (
+                              {durabilityPercent}%)
+                            </p>
+                          </div>
+                        </div>
+                        <ItemWithEffects
+                          item={{
+                            ...userItem.item,
+                            imbuements: userItem.imbuements?.map((i) => i.item) || [],
+                            curDurability: userItem.durability,
+                          }}
+                        />
+                        <div className="mt-3 flex items-center justify-between">
+                          <div className="text-sm">
+                            <span className="font-medium">Repair Cost: </span>
+                            <span className="text-green-600">{repairCost.toLocaleString()} ryo</span>
+                          </div>
+                          <Button
+                            variant="info"
+                            onClick={() => repairItemMutation.mutate({ userItemId: userItem.id })}
+                            disabled={repairItemMutation.isPending}
+                            loading={repairItemMutation.isPending}
+                          >
+                            <Wrench className="mr-2 h-4 w-4" />
+                            Repair
+                          </Button>
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
               </CardContent>
             </Card>

--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -852,6 +852,13 @@ export const NonCombatConsumeRewardTag = z.object({
 });
 export type NonCombatConsumeRewardTagType = z.infer<typeof NonCombatConsumeRewardTag>;
 
+export const RepairTag = z.object({
+  ...BaseAttributes,
+  type: z.literal("repair").default("repair"),
+  description: msg("Repair an item's durability by the power amount"),
+});
+export type RepairTagType = z.infer<typeof RepairTag>;
+
 export const SealPreventTag = z.object({
   ...BaseAttributes,
   ...PowerAttributes,
@@ -1025,6 +1032,7 @@ export const AllTags = z.union([
   MoveTag.default({}),
   NonCombatConsumeRewardTag.default({}),
   NonCombatGainSkill.default({}),
+  RepairTag.default({}),
   OneHitKillPreventTag.default({}),
   OneHitKillTag.default({}),
   PierceTag.default({}),

--- a/app/src/libs/item.ts
+++ b/app/src/libs/item.ts
@@ -49,6 +49,8 @@ export const nonCombatConsume = (item: Item, userData: UserData): boolean => {
       return true;
     } else if (effect.type === "noncombatgainskill") {
       return true;
+    } else if (effect.type === "repair") {
+      return true;
     }
   }
 

--- a/app/src/libs/repair.ts
+++ b/app/src/libs/repair.ts
@@ -1,0 +1,170 @@
+import type { UserItemWithRelations } from "@/drizzle/schema";
+
+/**
+ * Repair kit with its power/repair amount
+ */
+export interface RepairKit {
+  userItem: UserItemWithRelations;
+  repairAmount: number;
+}
+
+/**
+ * Result of calculating which kits to use for repair
+ */
+export interface RepairKitCalculationResult {
+  kitsToUse: Array<{
+    repairItemId: string;
+    repairItemName: string;
+    quantityUsed: number;
+  }>;
+  totalDurabilityNeeded: number;
+  canRepairAll: boolean;
+}
+
+/**
+ * Calculates which repair kits to use for repairing all items needing repair.
+ * Uses a pooled durability approach, prioritizing lowest power kits first to minimize waste.
+ * This mirrors the backend algorithm in @/server/api/routers/item.ts
+ *
+ * @param itemsNeedingRepair - Items that need repair
+ * @param repairKits - Available repair kits with their repair amounts
+ * @param userItems - All user items (used to look up kit names)
+ * @returns Calculation result with kits to use, total durability needed, and whether all items can be repaired
+ */
+/**
+ * Gets all repair kits from user items
+ */
+export const getRepairKits = (
+  userItems: UserItemWithRelations[] | undefined,
+): RepairKit[] => {
+  return (userItems || [])
+    .filter(
+      (userItem) =>
+        userItem.item?.effects?.some((e) => e.type === "repair") &&
+        userItem.quantity > 0,
+    )
+    .map((userItem) => {
+      const repairEffect = userItem.item.effects.find((e) => e.type === "repair");
+      return {
+        userItem,
+        repairAmount: Math.floor(repairEffect?.power || 0),
+      };
+    })
+    .filter((kit) => kit.repairAmount > 0)
+    .sort((a, b) => a.repairAmount - b.repairAmount);
+};
+
+/**
+ * Calculates which repair kits to use for repairing all items needing repair.
+ * Uses a pooled durability approach, prioritizing lowest power kits first to minimize waste.
+ * This mirrors the backend algorithm in @/server/api/routers/item.ts
+ *
+ * @param itemsNeedingRepair - Items that need repair
+ * @param repairKits - Available repair kits with their repair amounts
+ * @param userItems - All user items (used to look up kit names)
+ * @returns Calculation result with kits to use, total durability needed, and whether all items can be repaired
+ */
+export const calculateKitsToUse = (
+  itemsNeedingRepair: UserItemWithRelations[],
+  repairKits: RepairKit[],
+  userItems: UserItemWithRelations[] | undefined,
+): RepairKitCalculationResult => {
+  // If nothing needs repair, all items are already repaired (vacuously true)
+  if (itemsNeedingRepair.length === 0) {
+    return { kitsToUse: [], totalDurabilityNeeded: 0, canRepairAll: true };
+  }
+  
+  const totalDurabilityNeeded = itemsNeedingRepair.reduce(
+    (total, useritem) =>
+      total + (useritem.item.maxDurability - useritem.durability),
+    0,
+  );
+
+  // If no repair kits available, cannot repair
+  if (repairKits.length === 0) {
+    return { kitsToUse: [], totalDurabilityNeeded, canRepairAll: false };
+  }
+
+  const kitUsage: Map<string, number> = new Map();
+  const kitAvailability: Map<string, number> = new Map();
+  for (const kit of repairKits) {
+    kitAvailability.set(kit.userItem.id, kit.userItem.quantity);
+  }
+
+  // Pool all durability together and use kits starting with lowest power first
+  // Group kits by power level and aggregate quantities
+  const kitsByPower = new Map<
+    number,
+    Array<{ kitId: string; available: number; power: number }>
+  >();
+  for (const kit of repairKits) {
+    const available = kitAvailability.get(kit.userItem.id) || 0;
+    if (available <= 0) continue;
+
+    if (!kitsByPower.has(kit.repairAmount)) {
+      kitsByPower.set(kit.repairAmount, []);
+    }
+    kitsByPower.get(kit.repairAmount)!.push({
+      kitId: kit.userItem.id,
+      available,
+      power: kit.repairAmount,
+    });
+  }
+
+  // Sort by power (smallest first)
+  const sortedPowers = Array.from(kitsByPower.keys()).sort((a, b) => a - b);
+
+  // Use kits starting with lowest power first until all durability is covered
+  let remainingDurability = totalDurabilityNeeded;
+  for (const power of sortedPowers) {
+    if (remainingDurability <= 0) break;
+
+    const kitsWithThisPower = kitsByPower.get(power)!;
+    const totalAvailable = kitsWithThisPower.reduce((sum, k) => sum + k.available, 0);
+
+    if (totalAvailable <= 0) continue;
+
+    const kitsNeeded = Math.ceil(remainingDurability / power);
+    let kitsToUse = Math.min(kitsNeeded, totalAvailable);
+
+    // Distribute across all stacks of this power level
+    for (const { kitId, available } of kitsWithThisPower) {
+      if (kitsToUse <= 0) break;
+      const useFromThisStack = Math.min(kitsToUse, available);
+      if (useFromThisStack > 0) {
+        const currentUsage = kitUsage.get(kitId) || 0;
+        kitUsage.set(kitId, currentUsage + useFromThisStack);
+        const currentAvailable = kitAvailability.get(kitId) || 0;
+        kitAvailability.set(kitId, currentAvailable - useFromThisStack);
+        kitsToUse -= useFromThisStack;
+        remainingDurability -= useFromThisStack * power;
+      }
+    }
+  }
+
+  const canRepairAll = remainingDurability <= 0;
+
+  const kitsToUseArray: Array<{
+    repairItemId: string;
+    repairItemName: string;
+    quantityUsed: number;
+  }> = [];
+  for (const [repairItemId, quantityUsed] of kitUsage.entries()) {
+    if (quantityUsed > 0) {
+      const repairUserItem = userItems?.find((ui) => ui.id === repairItemId);
+      const repairItemName = repairUserItem?.item.name ?? "Unknown Repair Kit";
+      kitsToUseArray.push({
+        repairItemId,
+        repairItemName,
+        quantityUsed,
+      });
+    }
+  }
+
+  return {
+    kitsToUse: kitsToUseArray,
+    totalDurabilityNeeded,
+    canRepairAll,
+  };
+};
+

--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -749,6 +749,9 @@ export const itemRouter = createTRPCRouter({
       if (!user) return errorResponse("User not found");
       if (!useritem) return errorResponse("User item not found");
       if (useritem.userId !== user.userId) return errorResponse("Not yours to repair");
+      if (user.occupation !== "CRAFTING") {
+        return errorResponse("You must have the Crafting occupation to repair items");
+      }
       if (user.status !== "AWAKE") {
         return errorResponse(`Cannot repair items while ${user.status.toLowerCase()}`);
       }
@@ -760,20 +763,355 @@ export const itemRouter = createTRPCRouter({
       if (user.money < repairCost) {
         return errorResponse(`Insufficient funds. Repair costs ${repairCost} ryo`);
       }
-      // Mutate
-      await Promise.all([
-        ctx.drizzle
-          .update(userData)
-          .set({ money: sql`${userData.money} - ${repairCost}` })
-          .where(eq(userData.userId, ctx.userId)),
-        ctx.drizzle
-          .update(userItem)
-          .set({ durability: useritem.item.maxDurability })
-          .where(eq(userItem.id, input.userItemId)),
-      ]);
+      // Mutate - update money with conditional guard to prevent race conditions
+      const moneyUpdateResult = await ctx.drizzle
+        .update(userData)
+        .set({ money: sql`${userData.money} - ${repairCost}` })
+        .where(
+          and(
+            eq(userData.userId, ctx.userId),
+            gte(userData.money, repairCost),
+          ),
+        );
+      if (moneyUpdateResult.rowsAffected !== 1) {
+        return errorResponse("Insufficient funds for this repair");
+      }
+      // Update item durability
+      await ctx.drizzle
+        .update(userItem)
+        .set({ durability: useritem.item.maxDurability })
+        .where(eq(userItem.id, input.userItemId));
       return {
         success: true,
         message: `Repaired ${useritem.item.name} for ${repairCost} ryo`,
+      };
+    }),
+  // Repair all user items
+  repairAll: protectedProcedure
+    .output(baseServerResponse)
+    .mutation(async ({ ctx }) => {
+      // Query
+      const [user, useritems] = await Promise.all([
+        fetchUser(ctx.drizzle, ctx.userId),
+        fetchUserItems(ctx.drizzle, ctx.userId),
+      ]);
+      // Guard
+      if (!user) return errorResponse("User not found");
+      if (user.occupation !== "CRAFTING") {
+        return errorResponse("You must have the Crafting occupation to repair items");
+      }
+      if (user.status !== "AWAKE") {
+        return errorResponse(`Cannot repair items while ${user.status.toLowerCase()}`);
+      }
+      // Filter items that need repair
+      const itemsNeedingRepair = useritems.filter(
+        (useritem) =>
+          useritem.durability < useritem.item.maxDurability &&
+          useritem.item.maxDurability > 0,
+      );
+      if (itemsNeedingRepair.length === 0) {
+        return errorResponse("No items need repair");
+      }
+      // Calculate total repair cost
+      const totalRepairCost = itemsNeedingRepair.reduce(
+        (total, useritem) => total + calcItemRepairCost(useritem),
+        0,
+      );
+      if (user.money < totalRepairCost) {
+        return errorResponse(
+          `Insufficient funds. Total repair cost is ${totalRepairCost} ryo, but you only have ${user.money} ryo`,
+        );
+      }
+      // Mutate - repair all items and update money
+      // Update money with conditional guard to prevent race conditions
+      const moneyUpdateResult = await ctx.drizzle
+        .update(userData)
+        .set({ money: sql`${userData.money} - ${totalRepairCost}` })
+        .where(
+          and(
+            eq(userData.userId, ctx.userId),
+            gte(userData.money, totalRepairCost),
+          ),
+        );
+      if (moneyUpdateResult.rowsAffected !== 1) {
+        return errorResponse("Insufficient funds for this repair");
+      }
+      // Update item durabilities
+      await Promise.all(
+        itemsNeedingRepair.map((useritem) =>
+          ctx.drizzle
+            .update(userItem)
+            .set({ durability: useritem.item.maxDurability })
+            .where(eq(userItem.id, useritem.id)),
+        ),
+      );
+      return {
+        success: true,
+        message: `Repaired ${itemsNeedingRepair.length} item${itemsNeedingRepair.length !== 1 ? "s" : ""} for ${totalRepairCost.toLocaleString()} ryo`,
+      };
+    }),
+  // Use repair item on another item
+  useRepairItem: protectedProcedure
+    .input(z.object({ repairItemId: z.string(), targetItemId: z.string() }))
+    .output(baseServerResponse)
+    .mutation(async ({ ctx, input }) => {
+      // Query
+      const [user, repairUserItem, targetUserItem] = await Promise.all([
+        fetchUser(ctx.drizzle, ctx.userId),
+        fetchUserItem(ctx.drizzle, ctx.userId, input.repairItemId),
+        fetchUserItem(ctx.drizzle, ctx.userId, input.targetItemId),
+      ]);
+      // Guard
+      if (!user) return errorResponse("User not found");
+      if (!repairUserItem) return errorResponse("Repair item not found");
+      if (!targetUserItem) return errorResponse("Target item not found");
+      if (repairUserItem.userId !== user.userId) return errorResponse("Not your repair item");
+      if (targetUserItem.userId !== user.userId) return errorResponse("Not your target item");
+      if (user.status !== "AWAKE") {
+        return errorResponse(`Cannot use items while ${user.status.toLowerCase()}`);
+      }
+      if (repairUserItem.quantity <= 0) {
+        return errorResponse("You don't have any of this repair item");
+      }
+      if (targetUserItem.durability >= targetUserItem.item.maxDurability) {
+        return errorResponse("Item is already at full durability");
+      }
+      // Check if repair item has repair tag
+      const repairEffect = repairUserItem.item.effects.find((e) => e.type === "repair");
+      if (!repairEffect) {
+        return errorResponse("This item does not have a repair effect");
+      }
+      // Calculate repair amount
+      const repairAmount = Math.floor(repairEffect.power || 0);
+      if (repairAmount <= 0) {
+        return errorResponse("Repair item has invalid power");
+      }
+      // Calculate new durability
+      const newDurability = Math.min(
+        targetUserItem.durability + repairAmount,
+        targetUserItem.item.maxDurability,
+      );
+      const actualRepair = newDurability - targetUserItem.durability;
+      if (actualRepair <= 0) {
+        return errorResponse("Item is already at full durability");
+      }
+      // Mutate
+      const promises: Promise<any>[] = [
+        ctx.drizzle
+          .update(userItem)
+          .set({ durability: newDurability })
+          .where(eq(userItem.id, input.targetItemId)),
+      ];
+      // Consume repair item if it's consumable
+      if (repairUserItem.item.destroyOnUse) {
+        if (repairUserItem.quantity <= 1) {
+          promises.push(
+            ctx.drizzle.delete(userItem).where(eq(userItem.id, input.repairItemId)),
+          );
+        } else {
+          promises.push(
+            ctx.drizzle
+              .update(userItem)
+              .set({ quantity: sql`${userItem.quantity} - 1` })
+              .where(eq(userItem.id, input.repairItemId)),
+          );
+        }
+      }
+      await Promise.all(promises);
+      return {
+        success: true,
+        message: `Repaired ${targetUserItem.item.name} by ${actualRepair} durability using ${repairUserItem.item.name}`,
+      };
+    }),
+  // Use repair items to repair all items
+  useRepairAll: protectedProcedure
+    .output(
+      baseServerResponse.extend({
+        kitsUsed: z
+          .array(
+            z.object({
+              repairItemId: z.string(),
+              repairItemName: z.string(),
+              quantityUsed: z.number(),
+            }),
+          )
+          .optional(),
+      }),
+    )
+    .mutation(async ({ ctx }) => {
+      // Query
+      const [user, useritems] = await Promise.all([
+        fetchUser(ctx.drizzle, ctx.userId),
+        fetchUserItems(ctx.drizzle, ctx.userId),
+      ]);
+      // Guard
+      if (!user) return errorResponse("User not found");
+      if (user.status !== "AWAKE") {
+        return errorResponse(`Cannot use items while ${user.status.toLowerCase()}`);
+      }
+      // Filter items that need repair
+      const itemsNeedingRepair = useritems.filter(
+        (useritem) =>
+          useritem.durability < useritem.item.maxDurability &&
+          useritem.item.maxDurability > 0,
+      );
+      if (itemsNeedingRepair.length === 0) {
+        return errorResponse("No items need repair");
+      }
+      // Get all available repair kits
+      const repairKits = useritems
+        .filter(
+          (userItem) =>
+            userItem.item?.effects?.some((e: { type: string }) => e.type === "repair") &&
+            userItem.quantity > 0,
+        )
+        .map((userItem) => {
+          const repairEffect = userItem.item.effects.find(
+            (e: { type: string }) => e.type === "repair",
+          );
+          return {
+            userItem,
+            repairAmount: Math.floor(repairEffect?.power || 0),
+            repairEffect,
+          };
+        })
+        .filter((kit) => kit.repairAmount > 0)
+        .sort((a, b) => a.repairAmount - b.repairAmount); // Sort by repair power (smallest first) to minimize waste
+
+      if (repairKits.length === 0) {
+        return errorResponse("You don't have any repair items in your inventory");
+      }
+
+      // Calculate total durability needed (pool all together)
+      const totalDurabilityNeeded = itemsNeedingRepair.reduce(
+        (total, useritem) =>
+          total + (useritem.item.maxDurability - useritem.durability),
+        0,
+      );
+
+      // Track kit usage and available quantities
+      const kitUsage: Map<string, number> = new Map(); // Map of userItemId -> quantity used
+      const kitAvailability: Map<string, number> = new Map(); // Map of userItemId -> available quantity
+      for (const kit of repairKits) {
+        kitAvailability.set(kit.userItem.id, kit.userItem.quantity);
+      }
+
+      // Group kits by power level and aggregate quantities
+      const kitsByPower = new Map<number, Array<{ kitId: string; available: number; power: number }>>();
+      for (const kit of repairKits) {
+        const available = kitAvailability.get(kit.userItem.id) || 0;
+        if (available <= 0) continue;
+
+        if (!kitsByPower.has(kit.repairAmount)) {
+          kitsByPower.set(kit.repairAmount, []);
+        }
+        kitsByPower.get(kit.repairAmount)!.push({
+          kitId: kit.userItem.id,
+          available,
+          power: kit.repairAmount,
+        });
+      }
+
+      // Sort by power (smallest first)
+      const sortedPowers = Array.from(kitsByPower.keys()).sort((a, b) => a - b);
+
+      // Use kits starting with lowest power first until all durability is covered
+      let remainingDurability = totalDurabilityNeeded;
+      for (const power of sortedPowers) {
+        if (remainingDurability <= 0) break;
+
+        const kitsWithThisPower = kitsByPower.get(power)!;
+        const totalAvailable = kitsWithThisPower.reduce((sum, k) => sum + k.available, 0);
+        
+        if (totalAvailable <= 0) continue;
+
+        const kitsNeeded = Math.ceil(remainingDurability / power);
+        let kitsToUse = Math.min(kitsNeeded, totalAvailable);
+
+        // Distribute across all stacks of this power level
+        for (const { kitId, available } of kitsWithThisPower) {
+          if (kitsToUse <= 0) break;
+          const useFromThisStack = Math.min(kitsToUse, available);
+          if (useFromThisStack > 0) {
+            const currentUsage = kitUsage.get(kitId) || 0;
+            kitUsage.set(kitId, currentUsage + useFromThisStack);
+            const currentAvailable = kitAvailability.get(kitId) || 0;
+            kitAvailability.set(kitId, currentAvailable - useFromThisStack);
+            kitsToUse -= useFromThisStack;
+            remainingDurability -= useFromThisStack * power;
+          }
+        }
+      }
+
+      if (remainingDurability > 0) {
+        return errorResponse(
+          `Insufficient repair kits. Need ${totalDurabilityNeeded} durability total, but only have enough for ${totalDurabilityNeeded - remainingDurability} durability`,
+        );
+      }
+
+      // All items will be repaired to full durability
+      const itemRepairs: Array<{ userItemId: string; newDurability: number }> =
+        itemsNeedingRepair.map((useritem) => ({
+          userItemId: useritem.id,
+          newDurability: useritem.item.maxDurability,
+        }));
+
+      // Build kits used summary
+      const kitsToUse: Array<{
+        repairItemId: string;
+        repairItemName: string;
+        quantityUsed: number;
+      }> = [];
+      for (const [repairItemId, quantityUsed] of kitUsage.entries()) {
+        const repairUserItem = useritems.find((ui) => ui.id === repairItemId);
+        if (repairUserItem && quantityUsed > 0) {
+          kitsToUse.push({
+            repairItemId,
+            repairItemName: repairUserItem.item.name,
+            quantityUsed,
+          });
+        }
+      }
+
+      // Apply repairs to all items
+      const repairPromises: Promise<any>[] = itemRepairs.map((repair) =>
+        ctx.drizzle
+          .update(userItem)
+          .set({ durability: repair.newDurability })
+          .where(eq(userItem.id, repair.userItemId)),
+      );
+
+      // Consume repair kits
+      for (const [repairItemId, quantityUsed] of kitUsage.entries()) {
+        const repairUserItem = useritems.find((ui) => ui.id === repairItemId);
+        if (!repairUserItem) continue;
+
+        if (repairUserItem.item.destroyOnUse) {
+          if (repairUserItem.quantity <= quantityUsed) {
+            repairPromises.push(
+              ctx.drizzle.delete(userItem).where(eq(userItem.id, repairItemId)),
+            );
+          } else {
+            repairPromises.push(
+              ctx.drizzle
+                .update(userItem)
+                .set({ quantity: sql`${userItem.quantity} - ${quantityUsed}` })
+                .where(eq(userItem.id, repairItemId)),
+            );
+          }
+        }
+      }
+
+      await Promise.all(repairPromises);
+
+      const kitsUsedSummary = kitsToUse
+        .map((kit) => `${kit.quantityUsed}x ${kit.repairItemName}`)
+        .join(", ");
+
+      return {
+        success: true,
+        message: `Repaired ${itemsNeedingRepair.length} item${itemsNeedingRepair.length !== 1 ? "s" : ""} using ${kitsUsedSummary}`,
+        kitsUsed: kitsToUse,
       };
     }),
   // Buy user item


### PR DESCRIPTION
# Pull Request

- Allow only crafters to repair gear using money
- Add repair all button on occupation screen for crafters
- Add repair tag that can be placed on an item to be used as a repair kit (Durability repaired = power)
- Adjusted repair display on items screen.  Allow users to select a specific repair kit when repairing an item.
- Added a repair all button on the items page to repair everything.  Displays what kits and how many are being used for the repair.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk "Repair All" with automatic kit selection and kits-used summary.
  * Per-item Repair modal to choose specific repair kits.

* **Changes**
  * Repair actions unified into modal-driven flow across Backpack, Character, Item Details, and Crafting screens.
  * Repair operations now require the Crafting occupation.

* **UI**
  * Shows total durability needed, kit breakdown, per-item costs, affordability checks, confirmations, and contextual edit-screen field filtering for "repair" tags.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->