### PR TITLE
Fix missions from disappearing after completion

### DIFF
--- a/app/src/libs/quest.ts
+++ b/app/src/libs/quest.ts
@@ -1156,13 +1156,6 @@ export const isAvailableUserQuests = (
       );
     });
 
-  // Daily quests should be available even if previously completed (they reset daily)
-  const completedCheck =
-    questAndUserQuestInfo.questType === "daily" ||
-    QuestTypesWithMaxAttempts.includes(questAndUserQuestInfo.questType) ||
-    !questAndUserQuestInfo.completed ||
-    questAndUserQuestInfo.completed === 0;
-
   // Check if quest is available
   const check =
     hideCheck &&
@@ -1174,8 +1167,7 @@ export const isAvailableUserQuests = (
     prerequisiteCheck &&
     medicalRankCheck &&
     huntingRankCheck &&
-    levelCheck &&
-    completedCheck;
+    levelCheck;
 
   // If quest is not available, return the reason
   let message = "";
@@ -1190,13 +1182,6 @@ export const isAvailableUserQuests = (
     message += `Quest requires medical rank ${capitalizeFirstLetter(questMedRank ?? "NONE")}\n`;
   if (!huntingRankCheck)
     message += `Quest requires hunting rank ${capitalizeFirstLetter(questHuntRank ?? "NONE")}\n`;
-  if (
-    !completedCheck &&
-    questAndUserQuestInfo.questType !== "daily" &&
-    !QuestTypesWithMaxAttempts.includes(questAndUserQuestInfo.questType)
-  ) {
-    message += "Quest has already been completed\n";
-  }
   if (!levelCheck) {
     if (
       questAndUserQuestInfo.requiredLevel &&


### PR DESCRIPTION
# Pull Request

Once a mission, crime, errand, pvp mission, or med mission was completed, it was unavailable to pick up again.  The change I had submitted to fix dailies was too strict.  I was able to remove some of the changes made and keep the dailies fix intact while also allowing regular missions to start working properly again.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Daily quests now use the same eligibility checks as other quest types, removing special-case completion logic.
  * Reduced unnecessary "already completed" messages so unavailable quests no longer emit redundant completion notices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->