### PR TITLE
Add additional activity streak rewards

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -788,6 +788,7 @@ export const COST_SKILL_RESET = 30;
 export const MAX_EXTRA_JUTSU_SLOTS = 2;
 export const BATTLE_LOG_FULL_LIMIT = 1000;
 export const BATTLE_LOG_DEFAULT_LIMIT = 30;
+export const MAX_EXTRA_RESKIN_SLOTS = 255;
 export const BLOODLINE_ROLL_TYPES = [
   "NATURAL",
   "ITEM",

--- a/app/src/libs/profile.ts
+++ b/app/src/libs/profile.ts
@@ -162,9 +162,15 @@ export function manuallyAssignUserStats(user: UserData, stats: StatSchemaType) {
 }
 
 export const activityStreakRewards = (streak: number) => {
-  const rewards = { money: streak * 100, reputationPoints: 0 };
+  const rewards = { money: streak * 100, reputationPoints: 0, jobExperience: 0, reskinSlot: 0 };
   if (streak % 10 === 0) {
     rewards.reputationPoints = Math.floor(streak / 10);
+  }
+  if (streak % 7 === 0) {
+    rewards.jobExperience = 350;
+  }
+  if (streak % 60 === 0) {
+    rewards.reskinSlot = 1;
   }
   return rewards;
 };

--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -28,6 +28,7 @@ import {
   ANBU_ITEMSHOP_DISCOUNT_PERC,
   MEDNIN_HEAL_ITEM_DISCOUNT_PERC,
   TUTORIAL_ITEM_ID,
+  MAX_EXTRA_RESKIN_SLOTS,
 } from "@/drizzle/constants";
 import { nonCombatConsume } from "@/libs/item";
 import { getRandomElement } from "@/utils/array";
@@ -551,6 +552,19 @@ export const itemRouter = createTRPCRouter({
 
       // Rewards
       const rewards: ObjectiveRewardType[] = [];
+
+      // Check if item would increase reskin slots beyond max
+      const reskinIncreaseEffect = useritem.item.effects.find(
+        (e) => e.type === "noncombatincreasereskins",
+      );
+      if (
+        reskinIncreaseEffect &&
+        user.extraReskinSlots + reskinIncreaseEffect.power > MAX_EXTRA_RESKIN_SLOTS
+      ) {
+        return errorResponse(
+          `Your reskin slots would exceed the maximum! Current: ${user.extraReskinSlots}, Max: ${MAX_EXTRA_RESKIN_SLOTS}`,
+        );
+      }
 
       // Calculations
       const promises: Promise<any>[] = [];

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -95,7 +95,7 @@ import { capUserStats } from "@/libs/profile";
 import { calcActiveUserRegen } from "@/libs/profile";
 import { getServerPusher } from "@/libs/pusher";
 import { getShrineBoost } from "@/utils/village";
-import { RYO_CAP } from "@/drizzle/constants";
+import { RYO_CAP, MAX_EXTRA_RESKIN_SLOTS } from "@/drizzle/constants";
 import { USER_CAPS } from "@/drizzle/constants";
 import { getReducedGainsDays } from "@/libs/train";
 import { calculateContentDiff } from "@/utils/diff";
@@ -2094,6 +2094,32 @@ export const fetchUpdatedUser = async (props: {
             `Activity streak reward: ${rewards.reputationPoints} reputation points`,
           );
         }
+        if (rewards.jobExperience > 0) {
+          user.medicalExperience += rewards.jobExperience;
+          user.craftingExperience += rewards.jobExperience;
+          user.huntingExperience += rewards.jobExperience;
+          user.gatheringExperience += rewards.jobExperience;
+          toastMessages.push(
+            `Activity streak reward: ${rewards.jobExperience} experience for all jobs`,
+          );
+        }
+        if (rewards.reskinSlot > 0) {
+          if (user.extraReskinSlots >= MAX_EXTRA_RESKIN_SLOTS) {
+            // User is already at max, don't grant the reward
+            toastMessages.push(
+              `Activity streak reward: Reskin slot (already at max: ${user.extraReskinSlots})`,
+            );
+          } else {
+            const newValue = Math.min(
+              user.extraReskinSlots + rewards.reskinSlot,
+              MAX_EXTRA_RESKIN_SLOTS,
+            );
+            user.extraReskinSlots = newValue;
+            toastMessages.push(
+              `Activity streak reward: ${rewards.reskinSlot} extra reskin slot`,
+            );
+          }
+        }
       }
       user.updatedAt = now;
       user.regenAt = now;
@@ -2131,6 +2157,11 @@ export const fetchUpdatedUser = async (props: {
             status: user.status,
             travelFinishAt: user.travelFinishAt,
             ...(userIp ? { lastIp: userIp } : {}),
+            medicalExperience: user.medicalExperience,
+            craftingExperience: user.craftingExperience,
+            huntingExperience: user.huntingExperience,
+            gatheringExperience: user.gatheringExperience,
+            extraReskinSlots: user.extraReskinSlots,
           })
           .where(eq(userData.userId, userId)),
         ...(newDay


### PR DESCRIPTION
# Pull Request

- Added a streak reward of 350 experience for all jobs every 7 days
- Added a streak reward of 1 jutsu reskin slot every 60 days

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity streak rewards expanded: job experience awarded every 7 days and an extra reskin slot every 60 days
  * Job experience applied across multiple skill tracks and shown in profile data
  * Users receive toasts when gaining experience or reskin slots

* **Bug Fixes**
  * Prevented consuming items that would push extra reskin slots past the new maximum (now 255); toast shown if at cap

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->