### PR TITLE
Adjust Ranked PVP & Add Minor UI adjustments

### DIFF
--- a/app/src/app/bank/page.tsx
+++ b/app/src/app/bank/page.tsx
@@ -199,6 +199,7 @@ export default function Bank() {
       ...entry,
       sender: entry.sender?.username ?? "Unknown",
       receiver: entry.receiver?.username ?? "Unknown",
+      amountFormatted: entry.amount.toLocaleString(),
     }));
   type Transfer = ArrayElement<typeof allTransfers>;
 
@@ -213,7 +214,7 @@ export default function Bank() {
     { key: "sender", header: "Sender", type: "string" },
     { key: "receiver", header: "Receiver", type: "string" },
     { key: "type", header: "Type", type: "string" },
-    { key: "amount", header: "Amount", type: "string" },
+    { key: "amountFormatted", header: "Amount", type: "string" },
     { key: "createdAt", header: "Date", type: "date" },
   ];
 
@@ -253,7 +254,7 @@ export default function Bank() {
         <div className="grid grid-cols-2 text-center my-4">
           <div className="flex flex-col items-center">
             <Coins className="h-20 w-20" />
-            <p className="text-lg">{money} ryo</p>
+            <p className="text-lg">{money.toLocaleString()} ryo</p>
             <h2 className="font-bold text-xl">Money on hand</h2>
             <div className="w-full px-4 pt-3">
               <Form {...toBankForm}>
@@ -283,7 +284,7 @@ export default function Bank() {
           </div>
           <div className="flex flex-col items-center">
             <Landmark className="h-20 w-20" />
-            <p className="text-lg">{bank} ryo</p>
+            <p className="text-lg">{bank.toLocaleString()} ryo</p>
             <h2 className="font-bold text-xl">Money in bank</h2>
             <div className="w-full px-4 pt-3">
               <Form {...toPocketForm}>

--- a/app/src/app/blackmarket/page.tsx
+++ b/app/src/app/blackmarket/page.tsx
@@ -357,9 +357,9 @@ const RyoShop: React.FC<{ userData: NonNullable<UserWithRelations> }> = ({
         ...offer,
         item: (
           <div className="flex flex-col whitespace-nowrap">
-            <b>Reps for sale: {offer.repsForSale}</b>
-            <b>Ryo price: {offer.requestedRyo}</b>
-            <b>Ryo/Rep price: {offer.ryoPerRep}</b>
+            <b>Reps for sale: {offer.repsForSale.toLocaleString()}</b>
+            <b>Ryo price: {offer.requestedRyo.toLocaleString()}</b>
+            <b>Ryo/Rep price: {offer.ryoPerRep.toLocaleString()}</b>
           </div>
         ),
         creator: (
@@ -489,8 +489,8 @@ const RyoShop: React.FC<{ userData: NonNullable<UserWithRelations> }> = ({
       {tradeableReps > 0 && (
         <div className="pb-5">
           <p className="p-3">
-            You have <b>{tradeableReps} reputation points</b> and{" "}
-            <b>{userData.money} ryo</b> in your pocket. You may list reputation points
+            You have <b>{tradeableReps.toLocaleString()} reputation points</b> and{" "}
+            <b>{userData.money.toLocaleString()} ryo</b> in your pocket. You may list reputation points
             here for sale, so that other users may buy them for a pre-determined amount
             of ryo. Once listed, your sale cannot be delisted for{" "}
             {RYO_FOR_REP_DAYS_FROZEN} days. You can not trade the first 10 reputation
@@ -588,11 +588,13 @@ const RyoShop: React.FC<{ userData: NonNullable<UserWithRelations> }> = ({
                     >
                       {offerReps > 0 && offerRyo > 0 && (
                         <p>
-                          Confirm that you wish to put {offerReps} reputation points up
-                          for sale for a total price of {offerRyo} ryo, i.e. at a{" "}
-                          <b>ryo/rep price of {round(offerRyo / offerReps)}</b>. This
-                          offer will be listed for at least {RYO_FOR_REP_DAYS_FROZEN}{" "}
-                          days, after which you can delist them.
+                          Confirm that you wish to put{" "}
+                          {Number(offerReps).toLocaleString()} reputation points up for
+                          sale for a total price of{" "} {Number(offerRyo).toLocaleString()}
+                          ryo, i.e. at a{" "}<b>ryo/rep price of{" "}
+                          {round(Number(offerRyo) / Number(offerReps)).toLocaleString()}</b>
+                          . This offer will be listed for at least{" "}{RYO_FOR_REP_DAYS_FROZEN}
+                           days, after which you can delist them.
                         </p>
                       )}
                       {(offerReps === 0 || offerRyo === 0) && (

--- a/app/src/app/jutsus/page.tsx
+++ b/app/src/app/jutsus/page.tsx
@@ -425,7 +425,7 @@ export default function MyJutsu() {
             }
           >
             <div>
-              <p>- You have {userData.money} ryo in your pocket</p>
+              <p>- You have {userData.money.toLocaleString()} ryo in your pocket</p>
               <p>- Need {JUTSU_XP_TO_LEVEL - userjutsu.experience} XP more to level</p>
             </div>
             {!isPending && (

--- a/app/src/app/occupation/page.tsx
+++ b/app/src/app/occupation/page.tsx
@@ -117,7 +117,7 @@ export default function Occupations() {
         <DialogTrigger asChild>
           <Button>
             <Settings className="mr-2 h-5 w-5" />
-            Edit
+            Change Job
           </Button>
         </DialogTrigger>
         <DialogContent className="max-w-4xl">

--- a/app/src/app/profile/experience/page.tsx
+++ b/app/src/app/profile/experience/page.tsx
@@ -41,7 +41,7 @@ export default function AssignExperience() {
       onAccept={updateStats}
       availableStats={userData.earnedExperience}
       title="Assign Experience Points"
-      subtitle={`You have ${userData.earnedExperience} unused experience points`}
+      subtitle={`You have ${userData.earnedExperience.toLocaleString()} unused experience points`}
       defaultBackHref="/profile"
     />
   );

--- a/app/src/app/profile/page.tsx
+++ b/app/src/app/profile/page.tsx
@@ -84,15 +84,15 @@ export default function Profile() {
             <p>
               Lvl. {userData.level} {showUserRank(userData)}
             </p>
-            <p>Money: {userData.money?.toFixed(2)}</p>
-            <p>Bank: {userData.bank?.toFixed(2)}</p>
+            <p>Money: {userData.money?.toLocaleString()}</p>
+            <p>Bank: {userData.bank?.toLocaleString()}</p>
             <p>Status: {userData.status}</p>
             <p>Regen per minute: {userData.regeneration?.toFixed(2)}</p>
             <p>Gender: {userData.gender}</p>
           </div>
           <div className="flex flex-col items-start">
             <b>Activity</b>
-            <p>Exp: {userData.experience?.toFixed(2)}</p>
+            <p>Exp: {userData.experience?.toLocaleString()}</p>
             <p>Exp for lvl: {expRequired ? expRequired.toFixed(2) : "--"}</p>
             <p>PvE Fights: {userData.pveFights}</p>
             <TooltipProvider delayDuration={50}>
@@ -148,15 +148,15 @@ export default function Profile() {
                 </Tooltip>
               </TooltipProvider>
             )}
-            <p>Medical Exp: {userData.medicalExperience}</p>
+            <p>Medical Exp: {userData.medicalExperience?.toLocaleString()}</p>
           </div>
           <div>
             <b>Reputation</b>
-            <p>Reputation points: {userData.reputationPoints}</p>
+            <p>Reputation points: {userData.reputationPoints?.toLocaleString()}</p>
             <p>Federal Support: {(userData.federalStatus || "NONE").toLowerCase()}</p>
             <p>Activity Streak: {userData.activityStreak}</p>
-            {userData.isOutlaw && <p>Notoriety: {userData.villagePrestige}</p>}
-            {!userData.isOutlaw && <p>Village prestige: {userData.villagePrestige}</p>}
+            {userData.isOutlaw && (<p>Notoriety: {userData.villagePrestige?.toLocaleString()}</p>)}
+            {!userData.isOutlaw && (<p>Village prestige: {userData.villagePrestige?.toLocaleString()}</p>)}
             {userData.joinedVillageAt && (
               <p>
                 Village Member:{" "}

--- a/app/src/app/traininggrounds/page.tsx
+++ b/app/src/app/traininggrounds/page.tsx
@@ -795,7 +795,7 @@ const JutsuTraining: React.FC<TrainingProps> = (props) => {
                 }
               >
                 <div className="relative">
-                  <p className="pb-3">You have {userData.money} ryo in your pocket</p>
+                  <p className="pb-3">You have {userData.money.toLocaleString()} ryo in your pocket</p>
                   {!isPending && (
                     <ItemWithEffects
                       item={jutsu}

--- a/app/src/layout/Clan.tsx
+++ b/app/src/layout/Clan.tsx
@@ -1118,7 +1118,7 @@ export const ClanInfo: React.FC<ClanInfoProps> = (props) => {
                 >
                   <p>
                     Confirm donating money from pocket to clan bank. You currently have{" "}
-                    {userData.money} ryo in your pocket.
+                    {userData.money.toLocaleString()} ryo in your pocket.
                   </p>
                   {userData.isOutlaw && (
                     <p>

--- a/app/src/layout/MenuBoxProfile.tsx
+++ b/app/src/layout/MenuBoxProfile.tsx
@@ -280,7 +280,7 @@ const MenuBoxProfile: React.FC = () => {
                   className="hover:text-orange-500"
                 >
                   <div className="flex flex-row items-center">
-                    <p className="text-xl mr-3">両</p> {userData?.money ?? "??"}
+                    <p className="text-xl mr-3">両</p>{userData?.money?.toLocaleString() ?? "??"}
                   </div>
                 </Link>
               </TooltipTrigger>

--- a/app/src/layout/PvpRank.tsx
+++ b/app/src/layout/PvpRank.tsx
@@ -24,6 +24,7 @@ import {
   RANKED_LOADOUT_MAX_INCREASECOST_ITEMS,
   RANKED_LOADOUT_MAX_INCREASECOST_JUTSUS,
   RANKED_ENTRY_COST,
+  RANKED_DIVISIONS,
 } from "@/drizzle/constants";
 import { validateJutsuLoadout, validateItemLoadout } from "@/libs/ranked_pvp";
 import { QueueTimer } from "@/layout/Countdown";
@@ -190,6 +191,21 @@ export const RankedArenaMain: React.FC = () => {
         Queue for ranked PvP battles! You will be matched with players of similar LP.
         All battles are fought with level 100 characters with max stats.
       </p>
+      <div className="text-sm text-muted-foreground">
+        <p className="mb-1 font-medium">Rank Requirements:</p>
+        <div className="flex flex-col gap-y-1">
+          {RANKED_DIVISIONS.filter((d) => d.name !== "Unranked").map((division) => (
+            <div key={division.name} className="flex justify-between">
+              <span>{division.name}:</span>
+              <span className="font-mono">
+                {division.rankedLp === Infinity
+                  ? "Top 10"
+                  : `${division.rankedLp.toLocaleString()} LP`}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
       <p className="text-sm text-muted-foreground">
         Current LP: <b>{userData.rankedLp}</b> | Players in queue:{" "}
         <b>{queueData?.queueCount ?? 0}</b>

--- a/app/src/layout/Shop.tsx
+++ b/app/src/layout/Shop.tsx
@@ -127,17 +127,17 @@ const Shop: React.FC<ShopProps> = (props) => {
     userData.reputationPoints >= repsCost &&
     userData.seichiSilver >= seichiSilverCost;
   const costs = [
-    ...(ryoCost > 0 ? [`${ryoCost} ryo`] : []),
-    ...(repsCost > 0 ? [`${repsCost} reputation points`] : []),
-    ...(seichiSilverCost > 0 ? [`${seichiSilverCost} seichi silver`] : []),
+    ...(ryoCost > 0 ? [`${ryoCost.toLocaleString()} ryo`] : []),
+    ...(repsCost > 0 ? [`${repsCost.toLocaleString()} reputation points`] : []),
+    ...(seichiSilverCost > 0 ? [`${seichiSilverCost.toLocaleString()} seichi silver`] : []),
   ];
   const missing = [
-    ...(ryoCost > userData.money ? [`${ryoCost - userData.money} more ryo`] : []),
+    ...(ryoCost > userData.money ? [`${(ryoCost - userData.money).toLocaleString()} more ryo`] : []),
     ...(repsCost > userData.reputationPoints
-      ? [`${repsCost - userData.reputationPoints} more reputation points`]
+      ? [`${(repsCost - userData.reputationPoints).toLocaleString()} more reputation points`,] 
       : []),
     ...(seichiSilverCost > userData.seichiSilver
-      ? [`${seichiSilverCost - userData.seichiSilver} more seichi silver`]
+      ? [`${(seichiSilverCost - userData.seichiSilver).toLocaleString()} more seichi silver`]
       : []),
   ];
   // Simple cost string for the purchase button

--- a/app/src/layout/StatsDistributionForm.tsx
+++ b/app/src/layout/StatsDistributionForm.tsx
@@ -285,7 +285,7 @@ const SimpleDistribution: React.FC<SimpleDistributionProps> = (props) => {
           >
             <div>
               <p className="mb-2">
-                This will distribute {availableStats} stat points across:
+                This will distribute {availableStats.toLocaleString()} stat points across:
               </p>
               <ul className="list-disc list-inside mb-2">
                 {option.stats.map((stat, index) => {
@@ -368,9 +368,9 @@ const AdvancedDistribution: React.FC<AdvancedDistributionProps> = (props) => {
   // Figure out what to show on button, and whether it is disabled or not
   let buttonText = `Assign points`;
   if (misalignment > 0) {
-    buttonText = `Remove ${misalignment} points`;
+    buttonText = `Remove ${misalignment.toLocaleString()} points`;
   } else if (forceUseAll && misalignment < 0) {
-    buttonText = `Place ${-misalignment} more points`;
+    buttonText = `Place ${(-misalignment).toLocaleString()} more points`;
   } else if (isDefault) {
     buttonText = "Nothing changed";
   }
@@ -418,7 +418,7 @@ const AdvancedDistribution: React.FC<AdvancedDistributionProps> = (props) => {
                       <FormLabel>
                         {capitalizeFirstLetter(noCase(stat))}
                         {currentValue
-                          ? ` - Selected: ${currentValue.toFixed(2)} / ${availableStats.toFixed(2)}`
+                          ? ` - Selected: ${Number(currentValue.toFixed(2)).toLocaleString()} / ${Number(availableStats.toFixed(2), ).toLocaleString()}`
                           : ""}
                       </FormLabel>
                     )}

--- a/app/src/layout/StrengthWeaknesses.tsx
+++ b/app/src/layout/StrengthWeaknesses.tsx
@@ -120,19 +120,19 @@ export const StatsTab: React.FC<StatsTabProps> = ({ userData }) => {
           <b>Offences</b>
           <div className="flex flex-row items-center">
             <ElementImage element="Ninjutsu" className="w-6 h-6 mr-1 mb-1" />
-            Ninjutsu offence: {userData.ninjutsuOffence.toFixed(2)}
+            Ninjutsu offence: {Number(userData.ninjutsuOffence.toFixed(2)).toLocaleString()}
           </div>
           <div className="flex flex-row items-center">
             <ElementImage element="Genjutsu" className="w-6 h-6 mr-1 mb-1" />
-            Genjutsu offence: {userData.genjutsuOffence.toFixed(2)}
+            Genjutsu offence: {Number(userData.genjutsuOffence.toFixed(2)).toLocaleString()}
           </div>
           <div className="flex flex-row items-center">
             <ElementImage element="Taijutsu" className="w-6 h-6 mr-1 mb-1" />
-            Taijutsu offence: {userData.taijutsuOffence.toFixed(2)}
+            Taijutsu offence: {Number(userData.taijutsuOffence.toFixed(2)).toLocaleString()}
           </div>
           <div className="flex flex-row items-center">
             <ElementImage element="Bukijutsu" className="w-6 h-6 mr-1 mb-1" />
-            Bukijutsu offence: {userData.bukijutsuOffence.toFixed(2)}
+            Bukijutsu offence: {Number(userData.bukijutsuOffence.toFixed(2)).toLocaleString()}
           </div>
         </div>
 
@@ -140,19 +140,19 @@ export const StatsTab: React.FC<StatsTabProps> = ({ userData }) => {
           <b>Defences</b>
           <div className="flex flex-row items-center">
             <ElementImage element="Ninjutsu" className="w-6 h-6 mr-1 mb-1" />
-            Ninjutsu defence: {userData.ninjutsuDefence.toFixed(2)}
+            Ninjutsu defence: {Number(userData.ninjutsuDefence.toFixed(2)).toLocaleString()}
           </div>
           <div className="flex flex-row items-center">
             <ElementImage element="Genjutsu" className="w-6 h-6 mr-1 mb-1" />
-            Genjutsu defence: {userData.genjutsuDefence.toFixed(2)}
+            Genjutsu defence: {Number(userData.genjutsuDefence.toFixed(2)).toLocaleString()}
           </div>
           <div className="flex flex-row items-center">
             <ElementImage element="Taijutsu" className="w-6 h-6 mr-1 mb-1" />
-            Taijutsu defence: {userData.taijutsuDefence.toFixed(2)}
+            Taijutsu defence: {Number(userData.taijutsuDefence.toFixed(2)).toLocaleString()}
           </div>
           <div className="flex flex-row items-center">
             <ElementImage element="Bukijutsu" className="w-6 h-6 mr-1 mb-1" />
-            Bukijutsu defence: {userData.bukijutsuDefence.toFixed(2)}
+            Bukijutsu defence: {Number(userData.bukijutsuDefence.toFixed(2)).toLocaleString()}
           </div>
         </div>
       </div>
@@ -162,19 +162,19 @@ export const StatsTab: React.FC<StatsTabProps> = ({ userData }) => {
             <b>Generals</b>
             <div className="flex flex-row items-center">
               <ElementImage element="Strength" className="w-6 h-6 mr-1 mb-1" />
-              Strength: {userData.strength.toFixed(2)}
+              Strength: {Number(userData.strength.toFixed(2)).toLocaleString()}
             </div>
             <div className="flex flex-row items-center">
               <ElementImage element="Intelligence" className="w-6 h-6 mr-1 mb-1" />
-              Intelligence: {userData.intelligence.toFixed(2)}
+              Intelligence: {Number(userData.intelligence.toFixed(2)).toLocaleString()}
             </div>
             <div className="flex flex-row items-center">
               <ElementImage element="Willpower" className="w-6 h-6 mr-1 mb-1" />
-              Willpower: {userData.willpower.toFixed(2)}
+              Willpower: {Number(userData.willpower.toFixed(2)).toLocaleString()}
             </div>
             <div className="flex flex-row items-center">
               <ElementImage element="Speed" className="w-6 h-6 mr-1 mb-1" />
-              Speed: {userData.speed.toFixed(2)}
+              Speed: {Number(userData.speed.toFixed(2)).toLocaleString()}
             </div>
           </div>
           <div>

--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -1187,7 +1187,7 @@ export type UserEffect = BattleEffect & {
   targetId: string;
   fromEffectId?: string;
   fromGround?: boolean;
-  fromType?: "jutsu" | "armor" | "item" | "basic" | "bloodline" | "village" | "skill";
+  fromType?: "jutsu" | "armor" | "item" | "basic" | "bloodline" | "village" | "skill" | "ranked";
   elements?: ElementName[]; // TODO: Remove this, should already be in the tag
   cpSpent?: number;
   spSpent?: number;

--- a/app/src/libs/ranked_pvp.ts
+++ b/app/src/libs/ranked_pvp.ts
@@ -2,6 +2,7 @@ import {
   RANKED_RANKS,
   RANKED_STREAK_BONUS,
   RANKED_DIVISIONS,
+  RANKED_SANNIN_TOP_PLAYERS,
   RANKED_LOADOUT_MAX_RESIDUAL_JUTSUS,
   RANKED_LOADOUT_MAX_POISON_JUTSUS,
   RANKED_LOADOUT_MAX_INCREASECOST_JUTSUS,
@@ -20,12 +21,12 @@ import type { RankedRank } from "@/drizzle/constants";
 /**
  * Determine player rank based on LP and top players
  * @param lp - Player's LP
- * @param topPlayersLP - Array of top 20 players' LP values
+ * @param topPlayersLP - Array of top players' LP values
  * @returns Player's rank
  */
 export function getRankedRank(lp: number, topPlayersLP: number[]): RankedRank {
-  // Sannin rank requires being in top 20 players
-  if (topPlayersLP.length >= 20 && lp >= Math.min(...topPlayersLP)) {
+  // Sannin rank requires being in top players
+  if (topPlayersLP.length >= RANKED_SANNIN_TOP_PLAYERS && lp >= Math.min(...topPlayersLP)) {
     return "Sannin";
   }
   // Find the highest division the player qualifies for

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -2424,6 +2424,33 @@ export const processUsersForBattle = async (
     }
   }
 
+  // Apply decreasedamagetaken to all users in ranked PvP battles
+  if (battleType === "RANKED_PVP" || battleType === "RANKED_SPARRING") {
+    for (const user of usersState) {
+      const effect = DecreaseDamageTakenTag.parse({
+        target: "SELF",
+        statTypes: StatTypes,
+        generalTypes: GeneralTypes,
+        type: "decreasedamagetaken",
+        power: 150,
+        calculation: "static",
+        rounds: undefined,
+      }) as unknown as UserEffect;
+      const realized = realizeTag({
+        tag: effect,
+        user: user,
+        actionId: "ranked_pvp",
+        target: user,
+        level: user.level,
+      });
+      realized.isNew = false;
+      realized.castThisRound = false;
+      realized.targetId = user.userId;
+      realized.fromType = "ranked";
+      userEffects.push(realized);
+    }
+  }
+
   return { userEffects, usersState };
 };
 

--- a/app/src/server/api/routers/pvprank.ts
+++ b/app/src/server/api/routers/pvprank.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { nanoid } from "nanoid";
 import { createTRPCRouter, protectedProcedure } from "@/api/trpc";
-import { eq, gte, gt, sql, and, inArray, lte, desc } from "drizzle-orm";
+import { eq, gte, gt, sql, and, inArray, lte, desc, asc } from "drizzle-orm";
 import { item, jutsu, rankedLoadout, rankedPvpQueue, userData } from "@/drizzle/schema";
 import { TRPCError } from "@trpc/server";
 import {
@@ -468,7 +468,7 @@ export const pvpRankRouter = createTRPCRouter({
       const [queuedPlayers, topPlayersLP] = await Promise.all([
         ctx.drizzle.query.rankedPvpQueue.findMany({
           with: { user: { columns: { status: true }, with: { rankedLoadout: true } } },
-          orderBy: desc(rankedPvpQueue.queueStartTime),
+          orderBy: asc(rankedPvpQueue.queueStartTime),
         }),
         fetchSanninRankedPlayers(ctx.drizzle),
       ]);
@@ -635,8 +635,16 @@ export const getRankedRadius = (secondsInQueue: number) => {
     return 200;
   } else if (secondsInQueue < 300) {
     return 250;
-  } else {
+  } else if (secondsInQueue < 600) {
     return 300;
+  } else if (secondsInQueue < 900) {
+    return 350;
+  } else if (secondsInQueue < 1200) {
+    return 400;
+  } else if (secondsInQueue < 1500) {
+    return 450;
+  } else {
+    return 500;
   }
 };
 


### PR DESCRIPTION
# Pull Request

**Ranked adjustments**
- Increase max lp range from 300 to 500.
- Prioritize the longest waiting person in the queue instead of the newest.
- Added a static 150 damage reduction in Ranked and Ranked Spars.
- Constants has it for top 10 legends to be sannin, but the rewards were hardcoded to 20.  The constant is now used instead for determining sannin rewards.

**UI Adjustments**
- Changed the swap job button from "Edit" to "Change Job".
- Display LP for each rank on the ranked screen in the battle arena.
- Added commas to several places that have long numbers all run together such as money and experience.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rank Requirements UI now shows division names and LP thresholds.
  * Ranked PvP matches apply a temporary damage-reduction effect to participants.

* **Bug Fixes**
  * Ranked queue ordering adjusted to improve match selection and wait-time behavior.
  * Ranked matchmaking radius/time thresholds extended for broader matching.

* **Style**
  * Monetary and numeric values across ledgers, shop, profiles, and UIs use locale-aware formatting.
  * Job button label changed from "Edit" to "Change Job."

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->