### PR TITLE
Properly display past auctions

### DIFF
--- a/app/src/app/auctionhouse/page.tsx
+++ b/app/src/app/auctionhouse/page.tsx
@@ -2,7 +2,7 @@
 
 import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { api } from "@/app/_trpc/client";
 import { useRequireInVillage, useRequiredUserData } from "@/utils/UserContext";
 import Loader from "@/layout/Loader";
@@ -24,6 +24,7 @@ import { createAuctionListingSchema } from "@/validators/auction";
 import type { CreateAuctionListingSchema } from "@/validators/auction";
 import { capitalizeFirstLetter } from "@/utils/sanitize";
 import { AUCTION_LISTING_STATES, AUCTION_LISTING_TYPES, TRADEABLE_CURRENCY_TYPES } from "@/drizzle/constants";
+import { useInfinitePagination } from "@/libs/pagination";
 import {
   Select,
   SelectContent,
@@ -116,24 +117,37 @@ const AuctionListing: React.FC<AuctionListingProps> = ({ selectedStatus }) => {
   const [maxPrice, setMaxPrice] = useState("");
   const [selectedAuction, setSelectedAuction] = useState<string | null>(null);
   const [showDialog, setShowDialog] = useState(false);
+  const [lastElement, setLastElement] = useState<HTMLDivElement | null>(null);
 
   // Queries
-  const { data: listings, isLoading } = api.auction.getAuctionListings.useQuery(
+  const {
+    data: listings,
+    isLoading,
+    fetchNextPage,
+    hasNextPage,
+  } = api.auction.getAuctionListings.useInfiniteQuery(
     {
       itemName: searchTerm || undefined,
       minPrice: minPrice ? parseFloat(minPrice) : undefined,
       maxPrice: maxPrice ? parseFloat(maxPrice) : undefined,
       status: selectedStatus as "ACTIVE" | "SOLD" | "EXPIRED" | "CANCELLED",
-      limit: 20,
+      limit: 10,
     },
     {
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
       refetchInterval: 10000,
     },
   );
 
+  // Infinite pagination
+  useInfinitePagination({ fetchNextPage, hasNextPage, lastElement });
+
+  // Flatten all pages data
+  const allListings = listings?.pages.map((page) => page.data).flat() ?? [];
+
   // Transform data to include JSX directly in the objects
   const transformedData =
-    listings?.data?.map((listing) => ({
+    allListings.map((listing) => ({
       ...listing,
       itemIcon: listing.userItem.item.image,
       itemName: (
@@ -256,17 +270,26 @@ const AuctionListing: React.FC<AuctionListingProps> = ({ selectedStatus }) => {
 
       {/* Auction Listings Table */}
       <div>
-        {isLoading ? (
+        {isLoading && transformedData.length === 0 ? (
           <Loader />
         ) : (
-          <Table
-            data={transformedData}
-            columns={columns}
-            onRowClick={(row) => {
-              setSelectedAuction(row.id);
-              setShowDialog(true);
-            }}
-          />
+          <>
+            <Table
+              data={transformedData}
+              columns={columns}
+              onRowClick={(row) => {
+                setSelectedAuction(row.id);
+                setShowDialog(true);
+              }}
+            />
+            {/* Infinite scroll trigger */}
+            <div ref={setLastElement} className="h-4" />
+            {isLoading && transformedData.length > 0 && (
+              <div className="flex justify-center p-4">
+                <Loader explanation="Loading more auctions..." />
+              </div>
+            )}
+          </>
         )}
       </div>
 

--- a/app/src/server/api/routers/auction.ts
+++ b/app/src/server/api/routers/auction.ts
@@ -88,8 +88,13 @@ export const auctionRouter = createTRPCRouter({
       // Build where conditions
       const whereConditions = [
         eq(auctionListing.status, status || "ACTIVE"),
-        gte(auctionListing.expiresAt, new Date()),
       ];
+
+      // Only filter by expire time for ACTIVE listings
+      // Other statuses (SOLD, EXPIRED, CANCELLED) should show even after expiration
+      if (status === "ACTIVE" || !status) {
+        whereConditions.push(gte(auctionListing.expiresAt, new Date()));
+      }
 
       if (listingType) {
         whereConditions.push(eq(auctionListing.listingType, listingType));
@@ -109,6 +114,8 @@ export const auctionRouter = createTRPCRouter({
       }
 
       // Get auction listings with joins for filtering
+      const currentCursor = cursor ?? 0;
+      const skip = currentCursor * limit;
       const listings = await ctx.drizzle
         .select({ id: auctionListing.id })
         .from(auctionListing)
@@ -117,7 +124,7 @@ export const auctionRouter = createTRPCRouter({
         .where(and(...whereConditions))
         .orderBy(desc(auctionListing.expiresAt))
         .limit(limit)
-        .offset(cursor ? parseInt(cursor) : 0);
+        .offset(skip);
 
       // Fetch full related data for the filtered results
       const listingIds = listings.map((listing) => listing.id);
@@ -152,10 +159,10 @@ export const auctionRouter = createTRPCRouter({
             })
           : [];
 
+      const nextCursor = listings.length < limit ? null : currentCursor + 1;
       return {
         data: fullListings,
-        nextCursor:
-          listings.length === limit ? (cursor ? parseInt(cursor) : 0) + limit : null,
+        nextCursor,
       };
     }),
 

--- a/app/src/validators/auction.ts
+++ b/app/src/validators/auction.ts
@@ -42,8 +42,8 @@ export const createAuctionListingSchema = z.object({
 });
 
 export const getAuctionListingsSchema = z.object({
-  limit: z.number().min(1).max(100).default(20),
-  cursor: z.string().optional(),
+  limit: z.number().min(1).max(100).default(10),
+  cursor: z.number().nullish(),
   itemName: z.string().optional(),
   minPrice: z.number().min(0).optional(),
   maxPrice: z.number().min(0).optional(),


### PR DESCRIPTION
# Pull Request

Currently every tab of the filter int he auction house only displays auctions that haven't met the expiration date yet.  This PR corrects it so that while the Active tab retains its current setup, the other tabs display past auctions.  I have also adjusted each of the tabs to have infinite scrolling with records loading in batches of 10.  This was previously a static number, so not everything could be viewed.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auction listings now feature infinite scroll pagination, automatically loading additional items as users scroll.
  * Enhanced loading indicators distinguish between initial data loading and subsequent page loads.

* **Enhancements**
  * Reduced pagination page size from 20 to 10 items for improved responsiveness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->