### PR TITLE
 Expand report context to 20 and update UI subtitle

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -1310,7 +1310,7 @@ export const SECTOR_TYPES = [
 
 // Conversation config
 export const CONVERSATION_QUIET_MINS = 5;
-export const REPORT_CONTEXT_WINDOW = 10;
+export const REPORT_CONTEXT_WINDOW = 20;
 
 // Kage config
 export const FRIENDLY_PRESTIGE_COST = 10000; // Prestige cost of killing friendly

--- a/app/src/layout/UserReport.tsx
+++ b/app/src/layout/UserReport.tsx
@@ -37,8 +37,7 @@ import { canSilenceUsers } from "@/utils/permissions";
 import { canWarnUsers } from "@/utils/permissions";
 import { canEscalateBan } from "@/utils/permissions";
 import { canClearReport } from "@/utils/permissions";
-import { TimeUnits } from "@/drizzle/constants";
-import { TERR_BOT_ID } from "@/drizzle/constants";
+import { TimeUnits, REPORT_CONTEXT_WINDOW, TERR_BOT_ID } from "@/drizzle/constants";
 import type { ReportCommentSchema } from "@/validators/reports";
 import type { TimeUnit } from "@/drizzle/constants";
 import type { BaseServerResponse } from "@/server/api/trpc";
@@ -448,7 +447,10 @@ const DisplayUserReport: React.FC<UserReportProps> = (props) => {
       {report.additionalContext.length > 0 && (
         <ContentBox
           title="Conversation Context"
-          subtitle="Latest 10 messages leading up to report"
+          subtitle={`Latest ${Math.min(
+            REPORT_CONTEXT_WINDOW,
+            report.additionalContext.length,
+          )} messages leading up to report`}
           initialBreak
         >
           {report.additionalContext.map((context, i) => (


### PR DESCRIPTION
# Pull Request


## What was implemented

- Increased `REPORT_CONTEXT_WINDOW` constant from 10 to 20 in `app/drizzle/constants.ts`
- Updated the "Conversation Context" section subtitle in `app/src/layout/UserReport.tsx` to dynamically show the actual count of messages returned, using `Math.min(REPORT_CONTEXT_WINDOW, report.additionalContext.length)` instead of hardcoded text

## Why

Moderators need more context when reviewing reports. This change gives them up to 20 messages of context by default while ensuring the UI subtitle accurately reflects the number of messages actually displayed (avoiding misleading labels when fewer messages exist).

## Are there breaking changes?

No. This is a non-breaking UX and server change. The backend already uses the constant; we're just increasing its value and making the UI label dynamic.
## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Expanded the conversation history context available in user reports to include up to 20 messages (previously 10), providing more comprehensive background information for analysis and decision-making.
  * Enhanced the report display to dynamically show the actual number of context messages included, rather than displaying a static label.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->