### PR TITLE
feat: lift level restriction for PVP between warring factions

### DIFF
--- a/.claude/tasks/lift-pvp-protection-warring-factions.md
+++ b/.claude/tasks/lift-pvp-protection-warring-factions.md
@@ -1,0 +1,52 @@
+# Lift PVP Level Restriction Between Warring Factions
+
+## Issue
+- GitHub Issue: #859
+- Request: Lift PVP protection (level restriction) between warring factions/villages
+
+## Clarified Requirements
+Based on feedback from @theeneon:
+- **Only** the level restriction (±15 levels) needs to be bypassed during war
+- This should only apply to users whose villages/factions are at war with each other
+- Other protections (immunity, PVP disabled zones, rank restrictions) remain unchanged
+
+## Implementation Plan
+
+### Scope
+Only modify the level restriction check to bypass when attacker and target are at war.
+
+### Changes Made
+
+#### File: `/app/src/server/api/routers/combat.ts`
+
+1. **Added import** (line 151):
+   ```typescript
+   import { findWarsWithUser } from "@/libs/war";
+   ```
+
+2. **Modified level restriction check** (lines 1607-1635):
+   - When a non-compliant target is found (level difference > 15)
+   - Check if attacker and target villages are on opposing sides of an active war using `findWarsWithUser()`
+   - If at war: bypass the level restriction (allow attack)
+   - If not at war: enforce the level restriction as before
+
+### How It Works
+
+The `findWarsWithUser()` function from `/app/src/libs/war.ts`:
+- Takes attacker's wars, target's wars, target village ID, and attacker village ID
+- Returns wars where the two villages are on **opposing** sides (one on attacker side, one on defender side)
+- Also accounts for war allies (villages that joined the war on either side)
+
+### Behavior Summary
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| Level difference > 15, not in war-torn sector, not at war | Blocked | Blocked |
+| Level difference > 15, in war-torn sector | Allowed | Allowed |
+| Level difference > 15, villages at war with each other | Blocked | **Allowed** |
+| Level difference ≤ 15 | Allowed | Allowed |
+
+## Testing Considerations
+- Verify players from warring villages can attack each other regardless of level difference
+- Verify players not at war still have level restrictions enforced
+- Verify war allies are correctly included in the war check

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -148,6 +148,7 @@ import type {
 } from "@/drizzle/schema";
 import type { BattleWar } from "@/libs/combat/types";
 import type { GlobalMapData } from "@/libs/threejs/types";
+import { findWarsWithUser } from "@/libs/war";
 
 // Debug flag when testing battle
 const debug = false;
@@ -1589,7 +1590,7 @@ export const initiateBattle = async (
       }
     }
 
-    // Level restrictions - prevent attacking users more than 15 levels under or above (skip if in war-torn sector)
+    // Level restrictions - prevent attacking users more than 15 levels under or above (skip if in war-torn sector or at war)
     if (battleType === "COMBAT" && userIds.includes(user.userId)) {
       const isInWarTornSector = user.sector === MAP_WAR_TORN_BATTLEGROUND_SECTOR;
       if (!isInWarTornSector) {
@@ -1604,21 +1605,32 @@ export const initiateBattle = async (
         );
 
         if (nonCompliantTarget) {
-          const targetLevel = calcLevel(nonCompliantTarget.experience);
-          const levelDifference = attackerLevel - targetLevel;
+          // Check if attacker and target are at war - if so, bypass level restriction
+          const areAtWar =
+            findWarsWithUser(
+              activeWars,
+              activeWars,
+              nonCompliantTarget.villageId,
+              user.villageId,
+            ).length > 0;
 
-          if (levelDifference > 15) {
-            return {
-              success: false,
-              message: `Cannot attack ${nonCompliantTarget.username} - they are more than 15 levels below you (${levelDifference} level difference)`,
-            };
-          }
+          if (!areAtWar) {
+            const targetLevel = calcLevel(nonCompliantTarget.experience);
+            const levelDifference = attackerLevel - targetLevel;
 
-          if (levelDifference < -15) {
-            return {
-              success: false,
-              message: `Cannot attack ${nonCompliantTarget.username} - they are more than 15 levels above you (${Math.abs(levelDifference)} level difference)`,
-            };
+            if (levelDifference > 15) {
+              return {
+                success: false,
+                message: `Cannot attack ${nonCompliantTarget.username} - they are more than 15 levels below you (${levelDifference} level difference)`,
+              };
+            }
+
+            if (levelDifference < -15) {
+              return {
+                success: false,
+                message: `Cannot attack ${nonCompliantTarget.username} - they are more than 15 levels above you (${Math.abs(levelDifference)} level difference)`,
+              };
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

- Lift the ±15 level restriction for PVP combat when two users' villages are at war
- Uses the existing `findWarsWithUser()` utility to check war status (including war allies)

Closes #859

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Level-based PVP restrictions are now bypassed during active wars between factions/villages, allowing players to attack opponents with greater level differences when at war.
  * War participants can engage in PVP regardless of level differences when conflicts are active between their factions.
  * Standard level restrictions remain in effect for regular PVP encounters outside of wartime.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->