### PR TITLE
Fix: Max Elder Limit Enforcement

### DIFF
--- a/app/src/server/api/routers/kage.ts
+++ b/app/src/server/api/routers/kage.ts
@@ -516,7 +516,8 @@ if (activeKageChallenges.length > 0) {
       if (village.kageId !== kage.userId) return errorResponse("Not kage");
       if (village.type !== "VILLAGE") return errorResponse("Only for village");
       if (prospect.villageId !== village.id) return errorResponse("Not in village");
-      if (elders.length > KAGE_MAX_ELDERS) {
+      // Only enforce max when PROMOTING to ELDER
+      if (newRank === "ELDER" && elders.length >= KAGE_MAX_ELDERS) {
         return errorResponse(`Already have ${KAGE_MAX_ELDERS} elders`);
       }
       if (secondsFromDate(lockout, village.leaderUpdatedAt) > new Date()) {


### PR DESCRIPTION
# Pull Request

Fixes an issue where villages could exceed the maximum number of elders due to an off-by-one comparison.

Updates the elder limit guard to correctly block promotion once the maximum is reached, and scopes the check to apply only when promoting to ELDER. This allows elder removal to function correctly even if a village temporarily enters an invalid state.


## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Updated elder rank promotion behavior to enforce maximum capacity limits conditionally—only when actively promoting users to elder status. This enables more flexible rank management while maintaining necessary capacity constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->