### PR TITLE
Fix THENINJARPG-26F: Prevent hooks error from conditional TutorialAssistant rendering

### DIFF
--- a/app/src/components/layout/core4_default.tsx
+++ b/app/src/components/layout/core4_default.tsx
@@ -361,13 +361,11 @@ const LayoutCore4: React.FC<LayoutProps> = (props) => {
 
   return (
     <GlobalAudioProvider userData={userData}>
-      {userData && (
-        <TutorialAssistant
-          rightSideBarOpen={rightSideBarOpen}
-          setRightSideBarOpen={setRightSideBarOpen}
-          rightSideBarRef={rightSideBarRef}
-        />
-      )}
+      <TutorialAssistant
+        rightSideBarOpen={rightSideBarOpen}
+        setRightSideBarOpen={setRightSideBarOpen}
+        rightSideBarRef={rightSideBarRef}
+      />
       <div className="w-full absolute top-0 bottom-0 md:relative">
         <div className="fixed right-1 bottom-1 md:right-5 md:bottom-5 z-50 bg-slate-500 rounded-full">
           <LowerRightHelpBtn className="hidden md:block">


### PR DESCRIPTION
## Summary
Always render TutorialAssistant component instead of conditionally rendering based on userData.

## Why
Sentry issue THENINJARPG-26F: "Rendered more hooks than during the previous render" occurring 64 times across 20 users on multiple pages (/travel, /profile, /, /register, etc.).

The root cause was that `TutorialAssistant` was conditionally rendered with `{userData && (<TutorialAssistant ... />)}`. When `userData` changed from undefined to defined, React mounted the component which calls many hooks, causing the error.

The fix removes the conditional rendering and always renders `TutorialAssistant`. The component already handles the case when `userData` is undefined via its internal early returns.

## Test plan
- Verified locally
- CodeRabbit review passed
- All 34 tests passing

Closes #880

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tutorial Assistant is now always available during your session, expanding accessibility in more contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->