### PR TITLE
Fix NotFoundError DOM exception on /profile/edit (iOS)

### DIFF
--- a/app/src/app/profile/edit/page.tsx
+++ b/app/src/app/profile/edit/page.tsx
@@ -962,36 +962,38 @@ const SwapVillage: React.FC = () => {
         />
       )}
       {isFetching && <Loader explanation="Loading villages" />}
-      {isOpen && userData && village && (
-        <Modal2
-          title="Confirm Purchase"
-          proceed_label={
-            isSwapping
-              ? undefined
-              : canAfford
-                ? `Swap for ${COST_SWAP_VILLAGE} reps`
-                : `Need ${COST_SWAP_VILLAGE - userData.reputationPoints} reps`
+      <Modal2
+        title="Confirm Purchase"
+        proceed_label={
+          isSwapping
+            ? undefined
+            : canAfford
+              ? `Swap for ${COST_SWAP_VILLAGE} reps`
+              : `Need ${COST_SWAP_VILLAGE - userData.reputationPoints} reps`
+        }
+        isOpen={isOpen && !!village}
+        setIsOpen={setIsOpen}
+        isValid={false}
+        onAccept={() => {
+          if (canAfford && village) {
+            swap({ villageId: village.id });
+          } else {
+            setIsOpen(false);
           }
-          isOpen={isOpen}
-          setIsOpen={setIsOpen}
-          isValid={false}
-          onAccept={() => {
-            if (canAfford) {
-              swap({ villageId: village.id });
-            } else {
-              setIsOpen(false);
-            }
-          }}
-          confirmClassName={
-            canAfford
-              ? "bg-blue-600 text-white hover:bg-blue-700"
-              : "bg-red-600 text-white hover:bg-red-700"
-          }
-        >
-          {!isSwapping && <ItemWithEffects item={village} key={village.id} />}
-          {isSwapping && <Loader explanation={`Purchasing ${village.name}`} />}
-        </Modal2>
-      )}
+        }}
+        confirmClassName={
+          canAfford
+            ? "bg-blue-600 text-white hover:bg-blue-700"
+            : "bg-red-600 text-white hover:bg-red-700"
+        }
+      >
+        {village && !isSwapping && (
+          <ItemWithEffects item={village} key={village.id} />
+        )}
+        {isSwapping && village && (
+          <Loader explanation={`Purchasing ${village.name}`} />
+        )}
+      </Modal2>
     </div>
   );
 };
@@ -1117,38 +1119,40 @@ const SwapBloodline: React.FC = () => {
           build your history.
         </div>
       )}
-      {isOpen && userData && bloodline && (
-        <Modal2
-          title="Confirm Purchase"
-          proceed_label={
-            isSwapping
-              ? undefined
-              : isFreeSwap
-                ? "Swap for free"
-                : canAfford
-                  ? `Swap for ${COST_SWAP_BLOODLINE} reps`
-                  : `Need ${COST_SWAP_BLOODLINE - userData.reputationPoints} reps`
+      <Modal2
+        title="Confirm Purchase"
+        proceed_label={
+          isSwapping
+            ? undefined
+            : isFreeSwap
+              ? "Swap for free"
+              : canAfford
+                ? `Swap for ${COST_SWAP_BLOODLINE} reps`
+                : `Need ${COST_SWAP_BLOODLINE - userData.reputationPoints} reps`
+        }
+        isOpen={isOpen && !!bloodline}
+        setIsOpen={setIsOpen}
+        isValid={false}
+        onAccept={() => {
+          if (canAfford && bloodline) {
+            swap({ bloodlineId: bloodline.id });
+          } else {
+            setIsOpen(false);
           }
-          isOpen={isOpen}
-          setIsOpen={setIsOpen}
-          isValid={false}
-          onAccept={() => {
-            if (canAfford) {
-              swap({ bloodlineId: bloodline.id });
-            } else {
-              setIsOpen(false);
-            }
-          }}
-          confirmClassName={
-            canAfford
-              ? "bg-blue-600 text-white hover:bg-blue-700"
-              : "bg-red-600 text-white hover:bg-red-700"
-          }
-        >
-          {!isSwapping && <ItemWithEffects item={bloodline} key={bloodline.id} />}
-          {isSwapping && <Loader explanation={`Purchasing ${bloodline.name}`} />}
-        </Modal2>
-      )}
+        }}
+        confirmClassName={
+          canAfford
+            ? "bg-blue-600 text-white hover:bg-blue-700"
+            : "bg-red-600 text-white hover:bg-red-700"
+        }
+      >
+        {bloodline && !isSwapping && (
+          <ItemWithEffects item={bloodline} key={bloodline.id} />
+        )}
+        {isSwapping && bloodline && (
+          <Loader explanation={`Purchasing ${bloodline.name}`} />
+        )}
+      </Modal2>
     </div>
   );
 };

--- a/app/src/layout/Confirm2.tsx
+++ b/app/src/layout/Confirm2.tsx
@@ -40,24 +40,22 @@ const Confirm2: React.FC<Confirm2Props> = (props) => {
         {props.button}
       </span>
 
-      {showModal && (
-        <Modal2
-          id={props.id}
-          title={props.title}
-          isOpen={showModal}
-          setIsOpen={setShowModal}
-          proceed_label={
-            props.proceed_label !== undefined ? props.proceed_label : "Proceed"
-          }
-          confirmClassName={props.confirmClassName}
-          onAccept={props.onAccept}
-          className={props.className}
-          isValid={props.isValid}
-          onClose={props.onClose}
-        >
-          {props.children}
-        </Modal2>
-      )}
+      <Modal2
+        id={props.id}
+        title={props.title}
+        isOpen={showModal}
+        setIsOpen={setShowModal}
+        proceed_label={
+          props.proceed_label !== undefined ? props.proceed_label : "Proceed"
+        }
+        confirmClassName={props.confirmClassName}
+        onAccept={props.onAccept}
+        className={props.className}
+        isValid={props.isValid}
+        onClose={props.onClose}
+      >
+        {props.children}
+      </Modal2>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- Fix `NotFoundError: The object can not be found here` (DOMException code 8) occurring on `/profile/edit` page
- Root cause: Conditionally rendered Modal2 components cause React portal cleanup race conditions on iOS Safari/Chrome
- Solution: Always render Modal2 with controlled visibility via `isOpen` prop instead of unmounting

## Changes
- **Confirm2.tsx**: Remove conditional rendering wrapper, always mount Modal2
- **profile/edit/page.tsx**: Fix SwapVillage and SwapBloodline components to always render Modal2 with `isOpen={isOpen && !!item}` pattern

## Sentry Issue
- Issue ID: THENINJARPG-13G
- 90 occurrences affecting 3 users
- Primary platform: iOS Chrome Mobile

## Test plan
- [x] Code compiles without errors
- [x] Tests pass in main project
- [ ] Manual testing on iOS Safari/Chrome to verify modal behavior

---
Fixes: #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)