### PR TITLE
Fix THENINJARPG-2D2: Prioritize public conversations when fetching by title

### DIFF
--- a/app/src/server/api/routers/comments.ts
+++ b/app/src/server/api/routers/comments.ts
@@ -930,24 +930,24 @@ export const fetchConversation = async (params: FetchConvoOptions) => {
       return await client.query.conversation.findFirst({
         where: eq(conversation.id, id),
         with: { users: true },
-        orderBy: [desc(conversation.isPublic)],
       });
     } else if (title) {
+      // First try to find a public conversation with this title
+      const publicConvo = await client.query.conversation.findFirst({
+        where: and(eq(conversation.title, title), eq(conversation.isPublic, true)),
+        with: { users: true },
+      });
+      if (publicConvo) return publicConvo;
+      // Fallback to any conversation with this title (for private convos)
       return await client.query.conversation.findFirst({
         where: eq(conversation.title, title),
         with: { users: true },
-        orderBy: [desc(conversation.isPublic)],
       });
     } else {
       throw serverError("BAD_REQUEST", "Invalid request");
     }
   };
-  const convo = await getConvo();
-  if (convo) {
-    return convo;
-  } else {
-    return null;
-  }
+  return await getConvo();
 };
 
 /**


### PR DESCRIPTION
## Summary
Explicitly search for public conversations first when fetching by title, then fall back to private conversations

## Why
Fixes Sentry issue THENINJARPG-2D2: Users getting 'You are not allowed to view this conversation' error when accessing tavern. The issue was that findFirst with orderBy didn't reliably prioritize public conversations.

**Sentry Issue:** [THENINJARPG-2D2](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2D2)

## Test plan
- Verified locally
- CodeRabbit review passed

Closes #890