### PR TITLE
Fix THENINJARPG-2CW: Add null checks for combat result fields

### DIFF
--- a/app/src/layout/Combat.tsx
+++ b/app/src/layout/Combat.tsx
@@ -1174,38 +1174,40 @@ const Combat: React.FC<CombatProps> = (props) => {
                   </p>
                 );
               })}
-              {Object.entries(result.warHealthInfo).map(([villageName, change]) => {
-                const key = `${villageName}-${change}`;
-                if (change > 0) {
-                  return (
-                    <p key={key} className="text-green-500">
-                      {villageName} War HP: +{change.toFixed(2)}
-                    </p>
-                  );
-                } else if (change < 0) {
-                  return (
-                    <p key={key} className="text-red-500">
-                      {villageName} War HP: {change.toFixed(2)}
-                    </p>
-                  );
-                }
-              })}
-              {Object.entries(result.shrineInfo).map(([sectorId, change]) => {
-                const key = `sector-${sectorId}-${change}`;
-                if (change > 0) {
-                  return (
-                    <p key={key} className="text-green-500">
-                      Shrine HP in sector {sectorId}: +{change.toFixed(2)}
-                    </p>
-                  );
-                } else if (change < 0) {
-                  return (
-                    <p key={key} className="text-red-500">
-                      Shrine HP in sector {sectorId}: {change.toFixed(2)}
-                    </p>
-                  );
-                }
-              })}
+              {result.warHealthInfo &&
+                Object.entries(result.warHealthInfo).map(([villageName, change]) => {
+                  const key = `${villageName}-${change}`;
+                  if (change > 0) {
+                    return (
+                      <p key={key} className="text-green-500">
+                        {villageName} War HP: +{change.toFixed(2)}
+                      </p>
+                    );
+                  } else if (change < 0) {
+                    return (
+                      <p key={key} className="text-red-500">
+                        {villageName} War HP: {change.toFixed(2)}
+                      </p>
+                    );
+                  }
+                })}
+              {result.shrineInfo &&
+                Object.entries(result.shrineInfo).map(([sectorId, change]) => {
+                  const key = `sector-${sectorId}-${change}`;
+                  if (change > 0) {
+                    return (
+                      <p key={key} className="text-green-500">
+                        Shrine HP in sector {sectorId}: +{change.toFixed(2)}
+                      </p>
+                    );
+                  } else if (change < 0) {
+                    return (
+                      <p key={key} className="text-red-500">
+                        Shrine HP in sector {sectorId}: {change.toFixed(2)}
+                      </p>
+                    );
+                  }
+                })}
               {result.droppedItems &&
                 result.droppedItems.length > 0 &&
                 result.droppedItems.map((d) => (


### PR DESCRIPTION
## Summary
Add null checks before calling Object.entries() on warHealthInfo and shrineInfo in Combat.tsx

## Why
TypeError occurring when result fields are undefined, impacting 7 users with 13 occurrences

**Sentry Issue:** [THENINJARPG-2CW](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2CW)

## Test plan
- Verified locally
- CodeRabbit review passed

Closes #891

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability in combat scenarios by ensuring health information displays correctly when specific in-game data is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->