### PR TITLE
Fix THENINJARPG-26H: Filter iOS Safari network errors

### DIFF
--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -52,6 +52,7 @@ Sentry.init({
     "Can not send postrobot", // PayPal SDK postrobot error - alternate format
     "Cannot set properties of undefined (setting 'iframeReady')", // Usercentrics (uc.js) consent management error - third-party script timing issue
     "Failed to fetch", // Network errors during navigation - occurs when user navigates away while fetch is in-flight (common on mobile)
+    "Load failed", // iOS Safari network error - occurs when device goes to sleep, network changes, or request is aborted
     "Clerk: Failed to load Clerk", // Clerk script load failure - typically on very old browsers (Android 5.x, Chrome 95) that don't support modern JS
     "failed to load script", // Clerk's underlying script loading error (cause of the above) - network issues on mobile devices
     "Illegal invocation", // Third-party script error (Facebook in-app browser or Cookiebot)
@@ -145,6 +146,17 @@ function isLocalStorageAccessError(err: unknown): boolean {
     msg.includes("Access is denied") &&
     msg.includes("SecurityError")
   );
+}
+
+/**
+ * Check if an error is a network fetch error that should be suppressed.
+ * These occur on iOS Safari when the device goes to sleep, network changes,
+ * or the request is aborted during navigation.
+ */
+function isNetworkFetchError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message ?? "";
+  return msg === "Load failed" || msg === "Failed to fetch";
 }
 
 /**
@@ -317,6 +329,12 @@ function ensureBrowserErrorHandler() {
 
     // Skip localStorage access errors - these occur when browser privacy settings block storage
     if (isLocalStorageAccessError(event.reason)) {
+      event.preventDefault();
+      return;
+    }
+
+    // Skip network fetch errors - these occur on iOS Safari due to device sleep or network changes
+    if (isNetworkFetchError(event.reason)) {
       event.preventDefault();
       return;
     }


### PR DESCRIPTION
## Summary
Add 'Load failed' to Sentry ignoreErrors and unhandled rejection handler

## Why
Fixes Sentry issue THENINJARPG-26H: TypeError 'Load failed' occurring on iOS Safari when device sleeps or network changes

**Sentry Issue:** [THENINJARPG-26H](https://studie-tech-aps.sentry.io/issues/THENINJARPG-26H)

## Test plan
- Verified locally
- CodeRabbit review passed

Closes #889