### PR TITLE
Fix THENINJARPG-2DK: Filter DataCloneError from third-party scripts

### DIFF
--- a/app/bun.lock
+++ b/app/bun.lock
@@ -86,6 +86,7 @@
         "embla-carousel-autoplay": "^8.6.0",
         "embla-carousel-react": "^8.6.0",
         "eslint-plugin-drizzle": "^0.2.3",
+        "eslint-scope": "^9.0.0",
         "fetch-retry": "^6.0.0",
         "gifuct-js": "^2.1.2",
         "honeycomb-grid": "4.1.5",
@@ -1543,7 +1544,7 @@
 
     "eslint-plugin-react-x": ["eslint-plugin-react-x@2.3.12", "", { "dependencies": { "@eslint-react/ast": "2.3.12", "@eslint-react/core": "2.3.12", "@eslint-react/eff": "2.3.12", "@eslint-react/shared": "2.3.12", "@eslint-react/var": "2.3.12", "@typescript-eslint/scope-manager": "^8.48.1", "@typescript-eslint/type-utils": "^8.48.1", "@typescript-eslint/types": "^8.48.1", "@typescript-eslint/utils": "^8.48.1", "compare-versions": "^6.1.1", "is-immutable-type": "^5.0.1", "string-ts": "^2.3.1", "ts-api-utils": "^2.1.0", "ts-pattern": "^5.9.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-G9ThX5LZQun3243JN/UchMbGPra9ZL1D7Wi4dwaIgqh26nRK8W6LBqRTJC+jlrmOanosg+flcxpUyFS/N+Ch7A=="],
 
-    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+    "eslint-scope": ["eslint-scope@9.0.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-+Yh0LeQKq+mW/tQArNj67tljR3L1HajDTQPuZOEwC00oBdoIDQrr89yBgjAlzAwRrY/5zDkM3v99iGHwz9y0dw=="],
 
     "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
@@ -2612,6 +2613,8 @@
     "domutils/domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
     "effect/@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+
+    "eslint/eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 

--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -77,6 +77,9 @@ Sentry.init({
     if (isEffectInterruptError(event)) {
       return null; // Drop Effect-TS fiber interruption errors (SpacetimeDB SDK)
     }
+    if (isDataCloneError(event)) {
+      return null; // Drop DataCloneError from third-party scripts (gtag, mediafilter)
+    }
     return event;
   },
 
@@ -305,6 +308,32 @@ function isEffectInterruptError(event: Sentry.ErrorEvent): boolean {
     message.includes("MicroCause.Interrupt") ||
     (message.includes("Cannot assign to read only property") &&
       message.includes("stack"))
+  );
+}
+
+/**
+ * Check if an error is a DataCloneError from third-party scripts.
+ * These occur when scripts like Google Analytics (gtag) or mediafilter inject
+ * code that tries to postMessage with DOM elements that cannot be cloned.
+ * Common in Facebook's in-app browser.
+ */
+function isDataCloneError(event: Sentry.ErrorEvent): boolean {
+  const message = event.exception?.values?.[0]?.value ?? "";
+  const stackFrames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
+
+  const isDataCloneMessage =
+    message.includes("DataCloneError") ||
+    (message.includes("postMessage") && message.includes("could not be cloned"));
+
+  if (!isDataCloneMessage) return false;
+
+  // Check if the error originates from third-party scripts
+  return stackFrames.some(
+    (frame) =>
+      frame.filename?.includes("gtag/js") ||
+      frame.filename?.includes("mediafilter") ||
+      frame.abs_path?.includes("gtag/js") ||
+      frame.abs_path?.includes("mediafilter"),
   );
 }
 

--- a/app/package.json
+++ b/app/package.json
@@ -104,6 +104,7 @@
     "embla-carousel-autoplay": "^8.6.0",
     "embla-carousel-react": "^8.6.0",
     "eslint-plugin-drizzle": "^0.2.3",
+    "eslint-scope": "^9.0.0",
     "fetch-retry": "^6.0.0",
     "gifuct-js": "^2.1.2",
     "honeycomb-grid": "4.1.5",


### PR DESCRIPTION
## Summary
Add isDataCloneError filter to suppress DataCloneError from gtag and mediafilter scripts

## Why
Sentry issue THENINJARPG-2DK: DataCloneError from third-party scripts in Facebook in-app browser

**Sentry Issue:** [THENINJARPG-2DK](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2DK)

## Test plan
- Verified locally
- CodeRabbit review passed

Closes #899

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error monitoring by implementing targeted filtering for DataCloneError events that originate from third-party scripts, particularly from common tracking and analytics sources. This enhancement reduces reporting noise in error logs and enhances overall error tracking quality, enabling clearer visibility into actual application performance issues and stability concerns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->