### PR TITLE
Fix THENINJARPG-2D3: Prevent cytoscape emit error on mobile touchmove

### DIFF
--- a/app/src/layout/GraphUsersGeneric.tsx
+++ b/app/src/layout/GraphUsersGeneric.tsx
@@ -37,10 +37,26 @@ const GraphUsersGeneric: React.FC<GraphUsersGenericProps> = (props) => {
     return () => {
       isMounted.current = false;
       if (cy.current) {
-        // Remove all listeners and destroy to prevent events firing on unmounted component
-        cy.current.removeAllListeners();
-        cy.current.destroy();
+        const cyInstance = cy.current;
         cy.current = null;
+        // Disable all user interactions immediately to prevent new touch events
+        cyInstance.autoungrabify(true);
+        cyInstance.autounselectify(true);
+        cyInstance.userPanningEnabled(false);
+        cyInstance.userZoomingEnabled(false);
+        cyInstance.boxSelectionEnabled(false);
+        // Remove all listeners before destroying
+        cyInstance.removeAllListeners();
+        // Use setTimeout to allow any pending touch event handlers to complete
+        // before destroying the instance. This prevents the "Cannot read properties
+        // of undefined (reading 'emit')" error on mobile devices.
+        setTimeout(() => {
+          try {
+            cyInstance.destroy();
+          } catch {
+            // Ignore errors during cleanup - the instance may already be partially destroyed
+          }
+        }, 0);
       }
     };
   }, []);


### PR DESCRIPTION
## Summary
Improve Cytoscape cleanup to prevent touch event race conditions during component unmount.

## Why
Fixes TypeError: Cannot read properties of undefined (reading 'emit') when touchmove fires on Cytoscape canvas during unmount on mobile devices.

**Sentry Issue:** [THENINJARPG-2D3](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2D3)

## Changes
- Disable all user interactions (autoungrabify, autounselectify, panning, zooming, box selection) before cleanup
- Defer `destroy()` call via setTimeout(0) to allow pending touch handlers to complete
- Wrap destroy in try-catch to handle already-destroyed instances gracefully

## Test plan
- [ ] Verified locally
- [ ] Tests pass (34/34)
- [ ] ESLint passes with 0 errors

Closes #903

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Cytoscape teardown to avoid touch event race conditions during unmount on mobile.
> 
> - On unmount, capture `cy` instance, set ref to `null`, disable interactions (`autoungrabify`, `autounselectify`, panning/zooming, box selection), and remove listeners
> - Defer `destroy()` via `setTimeout(0)` and wrap in `try/catch` to handle partially destroyed instances
> - Changes localized to `app/src/layout/GraphUsersGeneric.tsx` cleanup effect
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57c2d162c262ce71ebe4583f1f2ef2c4725f1ba9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced graph component cleanup to handle edge cases and prevent errors during unmounting, ensuring more stable operation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->