### PR TITLE
#877: Remove instant shrine attack notification

### DIFF
--- a/app/src/server/api/routers/shrine.ts
+++ b/app/src/server/api/routers/shrine.ts
@@ -26,7 +26,6 @@ import {
   village,
   userData,
   shrineBoostSchedule,
-  notification,
   mpvpBattleQueue,
   mpvpBattleUser,
 } from "@/drizzle/schema";
@@ -893,18 +892,6 @@ export const shrineRouter = createTRPCRouter({
           defenderEntityId: targetSector.villageId,
           sector: input.sectorNumber,
         });
-
-        // Insert notification
-        await Promise.all([
-          ctx.drizzle.insert(notification).values({
-            userId: user.userId,
-            content: `${user.username} from ${user.village?.name} is attacking the shrine in sector ${input.sectorNumber}!`,
-          }),
-          ctx.drizzle
-            .update(userData)
-            .set({ unreadNotifications: sql`unreadNotifications + 1` })
-            .where(eq(userData.villageId, targetSector.villageId)),
-        ]);
 
         try {
           await ctx.drizzle.insert(mpvpBattleUser).values({


### PR DESCRIPTION
## Summary
Removed the instant notification sent when a player attacks a shrine

## Why
Implements #877: Shrine attacks now have a dedicated notification section, making instant notifications redundant and noisy for players

## Test plan
- Verified locally
- Code review passed

Closes #877

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes noisy per-attack notifications tied to shrine challenges.
> 
> - Deletes `notification` insert and `unreadNotifications` increment in `challengeShrine`
> - Removes `notification` import from `drizzle/schema`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c81b41f18dad9a4dff39203737f99f78c40796cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removals**
  * Removed SpacetimeDB Tower Defense game module, including server-side game logic, data persistence, and deployment infrastructure.
  * Removed notification sent to players when their shrine is attacked.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->