### PR TITLE
Fix THENINJARPG-2DJ: Filter abort errors in tRPC client

### DIFF
--- a/app/src/app/_trpc/Provider.tsx
+++ b/app/src/app/_trpc/Provider.tsx
@@ -141,6 +141,15 @@ export const onError = (err: unknown) => {
   ) {
     return;
   }
+  // Ignore abort errors (user navigated away before request completed)
+  // Check both cause.name (spec-compliant) and message (fallback for browser variations)
+  if (
+    err instanceof TRPCClientError &&
+    (err.cause?.name === "AbortError" ||
+      err.message.includes("The operation was aborted"))
+  ) {
+    return;
+  }
   // Handle "not signed in" errors gracefully (from useGlobalOnMutateProtect)
   if (
     err instanceof Error &&


### PR DESCRIPTION
## Summary
Add filtering for AbortError in tRPC client onError handler

## Why
Sentry issue THENINJARPG-2DJ: TRPCClientError when users navigate away before requests complete

**Sentry Issue:** [THENINJARPG-2DJ](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2DJ)

## Test plan
- Verified locally
- Code review passed

Closes #906

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents user-navigation aborts from surfacing as errors in the tRPC client.
> 
> - Adds AbortError filtering in `Provider.tsx` `onError` (checks `err.cause?.name === "AbortError"` and message fallback) so aborted requests are ignored instead of logged or toasted
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a79f040d9c95272d876718cb4041d8ace497457. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->