### PR TITLE
Fix THENINJARPG-2D1: Add optional chaining to prevent filter on undefined

### DIFF
--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -1780,14 +1780,14 @@ export const calcApReduction = (
 ) => {
   const user = battle?.usersState.find((u) => u.userId === userId);
   const stunEffects = [
-    ...(battle?.usersEffects.filter(
+    ...(battle?.usersEffects?.filter(
       (e) =>
         e.type === "stun" &&
         e.targetId === userId &&
         !e.castThisRound &&
         isEffectActive(e),
-    ) || []),
-    ...(battle?.groundEffects.filter((e) => {
+    ) ?? []),
+    ...(battle?.groundEffects?.filter((e) => {
       // Basic checks for stun effect at user's location
       const locationMatch =
         e.type === "stun" &&
@@ -1800,7 +1800,7 @@ export const calcApReduction = (
 
       // Use the existing checkFriendlyFire function to determine if effect should be applied
       return checkFriendlyFire(e, user, battle.usersState);
-    }) || []),
+    }) ?? []),
   ];
   const apReduction = stunEffects?.reduce((acc, e) => {
     if (e && "apReduction" in e) {


### PR DESCRIPTION
## Summary
Add optional chaining to usersEffects and groundEffects arrays in calcApReduction function

## Why
Fixes Sentry issue THENINJARPG-2D1: Cannot read properties of undefined (reading 'filter') - 105 occurrences affecting 91 users

**Sentry Issue:** [THENINJARPG-2D1](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2D1)

## Test plan
- Verified locally
- Code review passed

Closes #907

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `calcApReduction` safely handles absent effect arrays to avoid `undefined.filter` crashes.
> 
> - Add optional chaining to `battle?.usersEffects?.filter(...)` and `battle?.groundEffects?.filter(...)`, using `?? []` fallbacks
> - No logic changes to stun detection or AP reduction calculation; only null-safety guards
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 783b10f6e1e62991828240244cbe998dfbc822c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->