### PR TITLE
Fix THENINJARPG-2D8: Hide notifications when already on target page

### DIFF
--- a/app/src/components/layout/core4_default.tsx
+++ b/app/src/components/layout/core4_default.tsx
@@ -137,7 +137,7 @@ const LayoutCore4: React.FC<LayoutProps> = (props) => {
   // Derived data for layout
   const navbarMenuItems = getMainNavbarLinks(notifications);
   const shownNotifications = notifications?.filter(
-    (n) => n.color !== "toast" && n.color !== "hidden",
+    (n) => n.color !== "toast" && n.color !== "hidden" && n.href !== pathname,
   );
 
   // Split menu into two parts


### PR DESCRIPTION
## Summary
Filter out notifications from display when current pathname matches the notification href

## Why
Prevents rage clicks when users click notification links to pages they are already viewing

**Sentry Issue:** [THENINJARPG-2D8](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2D8)

## Test plan
- Verified locally
- Code review passed

Closes #912

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Behavior change**
> - Updates `shownNotifications` in `core4_default.tsx` to filter out notifications where `n.href === pathname` in addition to excluding `toast`/`hidden`.
> 
> **Impact**
> - Removes notifications that point to the page the user is currently viewing across desktop/mobile notification displays and the right sidebar.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2c8bc5f15f530e467ca41235719d105f2ffeae8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->