### PR TITLE
Fix THENINJARPG-2D7: Handle proxy/CDN error JSON parsing

### DIFF
--- a/app/src/app/_trpc/Provider.tsx
+++ b/app/src/app/_trpc/Provider.tsx
@@ -76,6 +76,13 @@ export default function TrpcClientProvider(props: { children: React.ReactNode })
             if (isSafariJsonError && opts.op.type === "query") {
               return opts.attempts <= 3;
             }
+            // Retry on proxy/CDN error pages (returns "An error occurred" text instead of JSON)
+            const isProxyError = opts.error.message?.includes(
+              '"An error o"... is not valid JSON',
+            );
+            if (isProxyError && opts.op.type === "query") {
+              return opts.attempts <= 3;
+            }
             // Don't retry on non-500s
             if (
               opts.error.data &&
@@ -138,6 +145,13 @@ export const onError = (err: unknown) => {
   if (
     err instanceof TRPCClientError &&
     err.message.includes("The string did not match the expected pattern")
+  ) {
+    return;
+  }
+  // Ignore proxy/CDN error pages (returns "An error occurred" text instead of JSON, retries handle it)
+  if (
+    err instanceof TRPCClientError &&
+    err.message.includes('"An error o"... is not valid JSON')
   ) {
     return;
   }


### PR DESCRIPTION
## Summary
Add retry logic and error suppression for proxy/CDN error pages that return HTML instead of JSON

## Why
Fixes Sentry issue THENINJARPG-2D7: TRPCClientError occurring when proxy/CDN returns 'An error occurred' text instead of JSON response

**Sentry Issue:** [THENINJARPG-2D7](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2D7)

## Test plan
- Verified locally
- Code review passed

Closes #918

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds resilience for non-JSON proxy/CDN responses that surface as JSON parse errors.
> 
> - In `Provider.tsx`, `retryLink` now retries queries up to 3 times when the error message matches proxy/CDN HTML (“An error occurred” not valid JSON)
> - `onError` now ignores the same proxy/CDN parse error, deferring to retry logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b14b4f2feb27f75f2b6efed7d4424209dde3e998. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->