### PR TITLE
Fix THENINJARPG-2D1: Hide activity streak link from non-staff users

### DIFF
--- a/app/src/app/manual/page.tsx
+++ b/app/src/app/manual/page.tsx
@@ -28,13 +28,18 @@ import {
 } from "@/drizzle/constants";
 import ContentBox from "@/layout/ContentBox";
 import { useUserData } from "@/utils/UserContext";
-import { canControlBackups, canViewRecruitmentAnalytics } from "@/utils/permissions";
+import {
+  canChangeContent,
+  canControlBackups,
+  canViewRecruitmentAnalytics,
+} from "@/utils/permissions";
 
 export default function ManualMain() {
   const { data: userData } = useUserData();
   const role = userData?.role ?? "USER";
   const hasBackupAccess = canControlBackups(role);
   const canSeeRecruitment = canViewRecruitmentAnalytics(role);
+  const canSeeActivityStreak = canChangeContent(role);
 
   const baseEntries = [
     // recruitment added conditionally below
@@ -57,14 +62,15 @@ export default function ManualMain() {
     { name: "balance", img: IMG_MANUAL_BALANCE },
     { name: "staff", img: IMG_MANUAL_STAFF },
     { name: "towerDefense", img: IMG_MANUAL_TOWER_UPGRADES },
-    { name: "activityStreak", img: IMG_MANUAL_ACTIVITY_STREAK },
   ];
 
-  // Add tower defense admin entry for content editors
-  const withTowerDefense = baseEntries;
+  // Add conditional entries based on permissions
+  const withActivityStreak = canSeeActivityStreak
+    ? [...baseEntries, { name: "activityStreak", img: IMG_MANUAL_ACTIVITY_STREAK }]
+    : baseEntries;
   const withRecruitment = canSeeRecruitment
-    ? [{ name: "recruitment", img: IMG_MANUAL_RECRUITMENT }, ...withTowerDefense]
-    : withTowerDefense;
+    ? [{ name: "recruitment", img: IMG_MANUAL_RECRUITMENT }, ...withActivityStreak]
+    : withActivityStreak;
   const entries = hasBackupAccess
     ? [{ name: "content_backups", img: IMG_MANUAL_BACKUP }, ...withRecruitment]
     : withRecruitment;


### PR DESCRIPTION
## Summary
Add canChangeContent permission check to hide activityStreak link on manual page for regular users

## Why
Fixes permission error occurring 136 times (114 users) when non-staff users visit /manual/activityStreak

**Sentry Issue:** [THENINJARPG-2D1](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2D1)

## Test plan
- Verified locally
- Code review passed

Closes #922

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restricts visibility of the `activityStreak` manual entry to users with content-edit permissions.
> 
> - Imports and uses `canChangeContent(role)` to conditionally include `activityStreak` in `entries`
> - Retains existing conditional additions for `recruitment` and `content_backups` while restructuring list composition
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f92efb7e88a11d9ed9f2c5bc65c6ea7689a11644. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->