### PR TITLE
Fix THENINJARPG-271: Hook order violation on /register page

### DIFF
--- a/app/src/utils/UserContext.tsx
+++ b/app/src/utils/UserContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { createContext, useEffect, useState, use } from "react";
+import React, { createContext, useContext, useEffect, useState } from "react";
 import { parseHtml } from "@/utils/parse";
 import { useRouter } from "next/navigation";
 import { useUser } from "@clerk/nextjs";
@@ -176,7 +176,7 @@ export function UserContextProvider(props: { children: React.ReactNode }) {
 
 // Easy hook for getting the current user data
 export const useUserData = () => {
-  return use(UserContext);
+  return useContext(UserContext);
 };
 
 // Require the user to be logged in


### PR DESCRIPTION
## Summary
Replace use() with useContext() in useUserData hook

## Why
React 19's use() hook can cause hook count instability during navigation transitions, resulting in 'Rendered more hooks than during the previous render' errors

**Sentry Issue:** [THENINJARPG-271](https://studie-tech-aps.sentry.io/issues/THENINJARPG-271)

## Test plan
- Verified locally
- Code review passed

Closes #920

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix user context hook usage**
> 
> - Replace `use()` with `useContext()` in `useUserData` within `UserContext.tsx`
> - Remove `use` from React imports accordingly
> 
> This stabilizes hook order during navigation and avoids React 19 hook count errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97b50338d5e21e09959afc9219ad43128cec5fde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal implementation for improved code maintainability. No changes to user-facing functionality or behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->