### PR TITLE
Fix THENINJARPG-2D5: Ignore Turbopack module factory errors

### DIFF
--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -58,6 +58,7 @@ Sentry.init({
     "Illegal invocation", // Third-party script error (Facebook in-app browser or Cookiebot)
     "Can't find variable: EmptyRanges", // Browser extension error (CodeMirror-based extensions)
     "postMessage is not a function", // Clerk internal error - occurs in clerk.browser.js with Web Workers
+    "module factory is not available", // Turbopack runtime error - occurs when browser caches stale JS chunks after deployment
   ],
 
   // Filter out third-party errors that slip through ignoreErrors


### PR DESCRIPTION
## Summary
Add Turbopack module factory error to Sentry ignore list

## Why
Turbopack runtime error occurs when browser caches stale JS chunks after deployment - not actionable in application code

**Sentry Issue:** [THENINJARPG-2D5](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2D5)

## Test plan
- Verified locally
- Code review passed

Closes #929

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds filtering for a known Turbopack runtime message to reduce false-positive error reports.
> 
> - Extends Sentry `ignoreErrors` in `app/instrumentation-client.ts` with `"module factory is not available"` (Turbopack stale chunk error)
> - No other logic or behavior changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9e6bf44beb5de124ff92d2fb583d5bf42acb9b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error logging by filtering out an unnecessary error pattern to reduce noise in error reports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->