### PR TITLE
Fix THENINJARPG-2D4: Update Load failed pattern to match CDN errors

### DIFF
--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -52,7 +52,7 @@ Sentry.init({
     "Can not send postrobot", // PayPal SDK postrobot error - alternate format
     "Cannot set properties of undefined (setting 'iframeReady')", // Usercentrics (uc.js) consent management error - third-party script timing issue
     "Failed to fetch", // Network errors during navigation - occurs when user navigates away while fetch is in-flight (common on mobile)
-    /Load failed/, // iOS Safari network error - occurs when device goes to sleep, network changes, or CDN requests fail (may include domain suffix)
+    /^Load failed/, // iOS Safari network error - occurs when device goes to sleep, network changes, or CDN requests fail (may include domain suffix)
     "Clerk: Failed to load Clerk", // Clerk script load failure - typically on very old browsers (Android 5.x, Chrome 95) that don't support modern JS
     "failed to load script", // Clerk's underlying script loading error (cause of the above) - network issues on mobile devices
     "Illegal invocation", // Third-party script error (Facebook in-app browser or Cookiebot)


### PR DESCRIPTION
## Summary
Change Load failed ignoreErrors entry from string to regex and update isNetworkFetchError to use startsWith for matching

## Why
iOS Safari Load failed errors now include domain suffix like (uploadthing.b-cdn.net) which wasn't matched by exact string

**Sentry Issue:** [THENINJARPG-2D4](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2D4)

## Test plan
- Verified locally
- Code review passed

Closes #931

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Sentry filtering of transient iOS Safari network errors that now include domain suffixes.
> 
> - Changes `ignoreErrors` from literal "Load failed" to regex `/^Load failed/` in `app/instrumentation-client.ts` to match CDN-suffixed messages
> - Updates `isNetworkFetchError` to use `startsWith("Load failed")` (instead of exact match) and clarifies comments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 973860e2526bf7f5fa6df8020904cbc4ecbb73f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of network loading errors so failures that include additional text (such as CDN/domain suffixes) are now recognized and treated consistently, reducing missed or misclassified load failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->