### PR TITLE
:sparkles: Add hunting/gathering experience to activity streak rewards

### DIFF
--- a/app/src/app/manual/activityStreak/edit/[configid]/page.tsx
+++ b/app/src/app/manual/activityStreak/edit/[configid]/page.tsx
@@ -284,6 +284,7 @@ const SingleEditConfig: React.FC<SingleEditConfigProps> = ({ config, refetch }) 
                           }));
                           setRewards(newRewards);
                         }}
+                        type="activityStreak"
                         hideFields={[
                           "reward_hunter_items",
                           "reward_hunter_items_ids",

--- a/app/src/layout/EditContent.tsx
+++ b/app/src/layout/EditContent.tsx
@@ -437,7 +437,9 @@ export const EditContent = <
                 "reward_hunter_items_ids",
                 "reward_hunter_items",
                 "reward_hunting_experience",
-              ].includes(formEntry.id) || questType === "hunting"
+              ].includes(formEntry.id) ||
+              questType === "hunting" ||
+              props.type === "activityStreak"
             );
           })
           .filter((formEntry) => {
@@ -446,7 +448,9 @@ export const EditContent = <
                 "reward_gathering_items_ids",
                 "reward_gathering_items",
                 "reward_gathering_experience",
-              ].includes(formEntry.id) || questType === "gathering"
+              ].includes(formEntry.id) ||
+              questType === "gathering" ||
+              props.type === "activityStreak"
             );
           })
           .map((formEntry) => {
@@ -2235,6 +2239,7 @@ interface RewardFormWrapperProps {
   setRewards: (rewards: ObjectiveRewardType[]) => void;
   formClassName?: string;
   hideFields?: string[];
+  type?: ContentType;
 }
 
 /**
@@ -2242,7 +2247,7 @@ interface RewardFormWrapperProps {
  * @returns React.ReactNode
  */
 export const RewardFormWrapper: React.FC<RewardFormWrapperProps> = (props) => {
-  const { idx, reward, rewards, formClassName, setRewards, hideFields = [] } = props;
+  const { idx, reward, rewards, formClassName, setRewards, hideFields = [], type } = props;
 
   // Parse reward with schema
   const parsedReward = ObjectiveReward.safeParse(reward);
@@ -2370,6 +2375,7 @@ export const RewardFormWrapper: React.FC<RewardFormWrapperProps> = (props) => {
       formData={formData}
       formClassName={formClassName}
       showSubmit={false}
+      type={type}
     />
   );
 };


### PR DESCRIPTION
Enable hunting and gathering experience fields in activity streak reward configuration.

**Changes:**
- Add optional `type` prop to `RewardFormWrapperProps` interface
- Pass `type` prop through `RewardFormWrapper` to `EditContent`
- Update filter conditions to allow hunting/gathering experience when `type` is `"activityStreak"`
- Set `type="activityStreak"` in activity streak edit page

Fixes #917

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables hunting/gathering reward fields in the activity streak editor by propagating content type and relaxing field filters.
> 
> - Update `EditContent` filters to include `reward_hunting_experience` and `reward_gathering_experience` (and related fields) when `type` is `activityStreak`
> - Add optional `type` prop to `RewardFormWrapper` and pass it through to `EditContent`
> - Set `type="activityStreak"` when rendering `RewardFormWrapper` in the activity streak config page
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51fa30b4958cf4f9c3095327b2824e86c5c8361f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity streak rewards are now fully supported in the reward configuration interface, with proper visibility of relevant reward fields for managing reward items and experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->