### PR TITLE
fix: return fresh bank values to prevent stale cache updates

### DIFF
--- a/app/src/server/api/routers/bank.ts
+++ b/app/src/server/api/routers/bank.ts
@@ -39,10 +39,12 @@ export const bankRouter = createTRPCRouter({
       if (result.rowsAffected === 0) {
         return { success: false, message: "Not enough money in pocket" };
       }
+      // Re-fetch user to get accurate balances after concurrent updates
+      const updatedUser = await fetchUser(ctx.drizzle, ctx.userId);
       return {
         success: true,
         message: `Successfully deposited ${value} ryo`,
-        data: { bank: user.bank + value, money: user.money - value },
+        data: { bank: updatedUser.bank, money: updatedUser.money },
       };
     }),
   toPocket: protectedProcedure
@@ -76,10 +78,12 @@ export const bankRouter = createTRPCRouter({
       if (result.rowsAffected === 0) {
         return { success: false, message: "Not enough money in bank" };
       }
+      // Re-fetch user to get accurate balances after concurrent updates
+      const updatedUser = await fetchUser(ctx.drizzle, ctx.userId);
       return {
         success: true,
         message: `Successfully withdrew ${value} ryo`,
-        data: { bank: user.bank - value, money: user.money + value },
+        data: { bank: updatedUser.bank, money: updatedUser.money },
       };
     }),
   transfer: protectedProcedure
@@ -122,10 +126,12 @@ export const bankRouter = createTRPCRouter({
           amount: value,
         }),
       ]);
+      // Re-fetch user to get accurate bank balance after concurrent updates
+      const updatedUser = await fetchUser(ctx.drizzle, ctx.userId);
       return {
         success: true,
         message: `Successfully transferred ${value} ryo to ${target.username}`,
-        data: { bank: user.bank - value },
+        data: { bank: updatedUser.bank },
       };
     }),
   getGraph: protectedProcedure
@@ -276,11 +282,14 @@ export const bankRouter = createTRPCRouter({
           ),
       ]);
 
+      // Re-fetch user to get accurate bank balance after concurrent updates
+      const updatedUser = await fetchUser(ctx.drizzle, ctx.userId);
+
       return {
         success: true,
         message: `Successfully claimed ${finalAmount} ryo in bank interest!`,
         data: {
-          bank: user.bank + finalAmount,
+          bank: updatedUser.bank,
           claimedAmount: finalAmount,
         },
       };


### PR DESCRIPTION
Re-fetch user data after bank mutations to return accurate balances.
This fixes an issue where concurrent operations (like black market sales)
could cause the returned bank value to be stale, leading to incorrect
frontend cache updates and users seeing "lost" money.

Fixes #947

Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures responses return authoritative balances after concurrent updates.
> 
> - In `toBank`, `toPocket`, `transfer`, and `claimInterest`, re-fetches the user post-update and returns `updatedUser.bank`/`updatedUser.money` instead of computed values
> - Prevents stale balances in API responses that could desync frontend caches during concurrent operations
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 214e8103e0791d9495fd8197e0305e2eebb0ca81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where bank balances displayed in deposit, withdrawal, transfer, and interest claim operations may have been outdated. The system now refreshes account data after transactions to ensure users see current, accurate balance information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->