### PR TITLE
Add immunity jutsu prevent tag support

### DIFF
--- a/app/src/layout/ItemWithEffects.tsx
+++ b/app/src/layout/ItemWithEffects.tsx
@@ -9,6 +9,7 @@ import { canChangeContent } from "@/utils/permissions";
 import { useUserData } from "@/utils/UserContext";
 import { SquarePen, Trash2, BarChartBig, Copy, Box } from "lucide-react";
 import { getTagSchema } from "@/validators/combat";
+import { getPreventTypeName } from "@/libs/combat/util";
 import { capitalizeFirstLetter } from "@/utils/sanitize";
 import { formatBattleUsageType } from "@/utils/string";
 import { showMutationToast } from "@/libs/toast";
@@ -741,6 +742,19 @@ const ItemWithEffects: React.FC<ItemWithEffectsProps> = (props) => {
               const result = schema.safeParse(effect);
               const parsedEffect = result.success ? result.data : undefined;
 
+              // Get custom description for immunity effects
+              const getEffectDescription = () => {
+                if (
+                  parsedEffect?.type === "immunity" &&
+                  "blocks" in parsedEffect &&
+                  parsedEffect.blocks
+                ) {
+                  const preventType = getPreventTypeName(parsedEffect.blocks as string);
+                  return `Grants immunity to ${preventType} prevention effects`;
+                }
+                return parsedEffect?.description;
+              };
+
               return (
                 <div
                   key={effect.type + i.toString()}
@@ -757,7 +771,7 @@ const ItemWithEffects: React.FC<ItemWithEffectsProps> = (props) => {
                   {parsedEffect && (
                     <>
                       <div className="pb-1">
-                        <b>Effect {i + 1}: </b> <i>{parsedEffect.description}</i>
+                        <b>Effect {i + 1}: </b> <i>{getEffectDescription()}</i>
                       </div>
                       <div className="grid grid-cols-2">
                         {"rounds" in parsedEffect &&
@@ -770,6 +784,13 @@ const ItemWithEffects: React.FC<ItemWithEffectsProps> = (props) => {
                           <span>
                             <b>Calculation: </b>
                             {parsedEffect.calculation}
+                          </span>
+                        )}
+                        {"blocks" in parsedEffect && parsedEffect.blocks && (
+                          <span>
+                            <b>Blocks: </b>
+                            {getPreventTypeName(parsedEffect.blocks as string) +
+                              " prevention"}
                           </span>
                         )}
                         {"power" in parsedEffect && (

--- a/app/src/layout/MenuBoxProfile.tsx
+++ b/app/src/layout/MenuBoxProfile.tsx
@@ -17,7 +17,7 @@ import { useUserData } from "@/utils/UserContext";
 import { ShieldCheck, Swords, Moon, Sun, Dumbbell, Star } from "lucide-react";
 import { LayoutList, Atom } from "lucide-react";
 import { sealCheck } from "@/libs/combat/tags";
-import { isEffectActive } from "@/libs/combat/util";
+import { isEffectActive, getPreventTypeName } from "@/libs/combat/util";
 import { getDaysHoursMinutesSeconds, getGameTime } from "@/utils/time";
 import { useGameMenu } from "@/libs/menus";
 import { secondsFromDate } from "@/utils/time";
@@ -487,6 +487,7 @@ type CollapsedEffect = {
   upDownEffect: boolean;
   rounds: number[];
   sealed: boolean;
+  blocks?: string; // For immunity effects
 };
 
 interface VisualizeEffectsProps {
@@ -589,12 +590,14 @@ export const VisualizeEffects: React.FC<VisualizeEffectsProps> = ({
           value = Math.abs(val.power + val.level * val.powerPerLevel) * sign;
         }
         cats.forEach((cat) => {
+          const valBlocks = "blocks" in val ? (val.blocks as string) : undefined;
           const found = acc.find(
             (e) =>
               e.type === baseType &&
               e.calculation === val.calculation &&
               e.category === cat &&
-              e.sealed === isSealed,
+              e.sealed === isSealed &&
+              e.blocks === valBlocks,
           );
           if (found) {
             found.value += value;
@@ -608,6 +611,7 @@ export const VisualizeEffects: React.FC<VisualizeEffectsProps> = ({
               upDownEffect: dual,
               rounds: val.rounds ? [val.rounds] : [],
               sealed: isSealed,
+              blocks: valBlocks,
             });
           }
         });
@@ -649,7 +653,7 @@ export const VisualizeEffects: React.FC<VisualizeEffectsProps> = ({
 
     return (
       <div
-        key={`${i}-${e.type}-${e.category}`}
+        key={`${i}-${e.type}-${e.category}-${e.blocks || ""}`}
         className="flex flex-row items-center gap-2"
       >
         <ElementImage element={e.category} className="w-6 h-6 shrink-0" />
@@ -692,6 +696,7 @@ export const VisualizeEffects: React.FC<VisualizeEffectsProps> = ({
     "range",
     "onehitkillprevent",
     "summonprevent",
+    "immunity",
     "seal",
     "stun",
     "stealth",
@@ -775,17 +780,18 @@ export const VisualizeEffects: React.FC<VisualizeEffectsProps> = ({
     increasecooldown: "Increase Cooldown",
     decreasecooldown: "Decrease Cooldown",
     fleeprevent: "Cannot Flee",
-    robprevent: "Rob Immunity",
-    buffprevent: "Buff Immunity",
-    debuffprevent: "Debuff Immunity",
-    clearprevent: "Clear Immunity",
-    cleanseprevent: "Cleanse Immunity",
-    healprevent: "Heal Prevention",
-    stunprevent: "Stun Resistance",
+    robprevent: "Cannot be Robbed",
+    buffprevent: "Cannot be Buffed",
+    debuffprevent: "Cannot be Debuffed",
+    clearprevent: "Cannot be Cleared",
+    cleanseprevent: "Cannot be Cleansed",
+    healprevent: "Cannot be Healed",
+    stunprevent: "Cannot be Stunned",
     moveprevent: "Immobilized",
-    sealprevent: "Seal Immunity",
-    onehitkillprevent: "OHKO Immunity",
-    summonprevent: "Summons Prevented",
+    sealprevent: "Cannot be Sealed",
+    onehitkillprevent: "Cannot be OHKO'd",
+    summonprevent: "Cannot Summon",
+    immunity: "Immunity",
     seal: "BL Sealed",
     stun: "Stunned",
     stealth: "Stealthed",
@@ -798,15 +804,23 @@ export const VisualizeEffects: React.FC<VisualizeEffectsProps> = ({
     redirection: "Redirection",
   };
 
+  const getEffectLabel = (e: (typeof statusEffects)[number]) => {
+    if (e.type === "immunity" && "blocks" in e && e.blocks) {
+      const preventType = getPreventTypeName(e.blocks as string);
+      return `Immune to ${preventType.charAt(0).toUpperCase() + preventType.slice(1)} Prevent`;
+    }
+    return statusLabel[e.type] || e.type;
+  };
+
   const statusVisuals = statusEffects.map((e) => (
     <div
-      key={`${e.type}-${e.category}`}
+      key={`${e.type}-${e.category}-${e.blocks || ""}`}
       className="flex flex-row items-center gap-2 text-xs"
     >
       <ElementImage element={e.category} className="w-6 h-6 shrink-0" />
       <div
         className={cn(e.sealed && "line-through")}
-      >{`${statusLabel[e.type] || e.type} ${valueTxt(e)} ${roundsTxt(e)}`}</div>
+      >{`${getEffectLabel(e)} ${valueTxt(e)} ${roundsTxt(e)}`}</div>
     </div>
   ));
 

--- a/app/src/libs/combat/process.ts
+++ b/app/src/libs/combat/process.ts
@@ -15,6 +15,7 @@ import {
   lifesteal,
   drain,
   shield,
+  immunity,
   poison,
   finalStand,
   increaseRange,
@@ -738,6 +739,7 @@ export const applySingleEffect = (
       appliedEffects.add(idx);
       longitude = curTarget?.longitude;
       latitude = curTarget?.latitude;
+
       // Figure if tag should be applied
       const ratio = calcApplyRatio(effect, battle, effect.targetId, isTargetOrNew);
       if (ratio > 0) {
@@ -824,37 +826,39 @@ export const applySingleEffect = (
         } else if (effect.type === "lifesteal") {
           info = lifesteal(effect, usersEffects, consequences, curTarget);
         } else if (effect.type === "fleeprevent") {
-          info = fleePrevent(effect, curTarget);
+          info = fleePrevent(effect, usersEffects, curTarget);
         } else if (effect.type === "healprevent") {
-          info = healPrevent(effect, curTarget);
+          info = healPrevent(effect, usersEffects, curTarget);
         } else if (effect.type === "stealth") {
           info = stealth(effect, curTarget);
         } else if (effect.type === "elementalseal") {
           info = elementalseal(effect, curTarget);
         } else if (effect.type === "buffprevent") {
-          info = buffPrevent(effect, curTarget);
+          info = buffPrevent(effect, usersEffects, curTarget);
         } else if (effect.type === "debuffprevent") {
-          info = debuffPrevent(effect, curTarget);
+          info = debuffPrevent(effect, usersEffects, curTarget);
         } else if (effect.type === "onehitkillprevent") {
-          info = onehitkillPrevent(effect, curTarget);
+          info = onehitkillPrevent(effect, usersEffects, curTarget);
         } else if (effect.type === "robprevent") {
-          info = robPrevent(effect, curTarget);
+          info = robPrevent(effect, usersEffects, curTarget);
         } else if (effect.type === "cleanseprevent") {
-          info = cleansePrevent(effect, curTarget);
+          info = cleansePrevent(effect, usersEffects, curTarget);
         } else if (effect.type === "clearprevent") {
-          info = clearPrevent(effect, curTarget);
+          info = clearPrevent(effect, usersEffects, curTarget);
         } else if (effect.type === "sealprevent") {
-          info = sealPrevent(effect, curTarget);
+          info = sealPrevent(effect, usersEffects, curTarget);
         } else if (effect.type === "stunprevent") {
-          info = stunPrevent(effect, curTarget);
+          info = stunPrevent(effect, usersEffects, curTarget);
         } else if (effect.type === "moveprevent") {
-          info = movePrevent(effect, curTarget);
+          info = movePrevent(effect, usersEffects, curTarget);
         } else if (effect.type === "summonprevent") {
-          info = summonPrevent(effect, curTarget);
+          info = summonPrevent(effect, usersEffects, curTarget);
         } else if (effect.type === "weakness") {
           info = weakness(effect, curTarget);
         } else if (effect.type === "shield") {
           info = shield(effect, curTarget);
+        } else if (effect.type === "immunity") {
+          info = immunity(effect, curTarget);
         } else if (effect.type === "poison" && action) {
           info = poison(effect, action, actorId, consequences, curTarget, usersEffects);
         } else if (effect.type === "injectjutsus") {

--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -8,11 +8,16 @@ import {
   DecreaseCooldownTag,
   HealTag,
 } from "@/validators/combat";
-import { isEffectActive } from "@/libs/combat/util";
+import { isEffectActive, getPreventTypeName } from "@/libs/combat/util";
 import type { BattleUserState, Consequence, ReturnedUserState } from "./types";
 import type { GroundEffect, UserEffect, ActionEffect } from "./types";
 import type { StatNames, GenNames, DmgConfig } from "./constants";
-import type { WeaknessTagType, ShieldTagType } from "@/validators/combat";
+import type {
+  WeaknessTagType,
+  ShieldTagType,
+  ImmunityTagType,
+  PreventTagType,
+} from "@/validators/combat";
 import type { CombatAction } from "@/libs/combat/types";
 import type { GeneralType } from "@/drizzle/constants";
 import type { BattleType } from "@/drizzle/constants";
@@ -141,11 +146,45 @@ export const absorb = (
   );
 };
 
+/**
+ * Check if an immunity effect blocks a prevent effect.
+ * Only checks immunity for NEW effects being applied.
+ * Returns an ActionEffect if blocked, undefined if not blocked.
+ */
+const checkPreventImmunity = (
+  effect: UserEffect,
+  usersEffects: UserEffect[],
+  target: BattleUserState,
+  preventName: string,
+): ActionEffect | undefined => {
+  if (effect.isNew) {
+    const hasImmunity = usersEffects.some(
+      (e) =>
+        e.type === "immunity" &&
+        e.targetId === target.userId &&
+        (e.rounds === undefined || e.rounds > 0) &&
+        "blocks" in e &&
+        e.blocks === effect.type,
+    );
+    if (hasImmunity) {
+      effect.rounds = 0;
+      return {
+        txt: `${target.username}'s immunity blocked ${preventName} prevention!`,
+        color: "blue" as const,
+      };
+    }
+  }
+  return undefined;
+};
+
 /** Prevent buffing */
 export const buffPrevent = (
   effect: UserEffect,
+  usersEffects: UserEffect[],
   target: BattleUserState,
 ): ActionEffect | undefined => {
+  const immunityBlocked = checkPreventImmunity(effect, usersEffects, target, "buff");
+  if (immunityBlocked) return immunityBlocked;
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
@@ -357,8 +396,11 @@ export const injectjutsus = (
 /** Prevent debuffing */
 export const debuffPrevent = (
   effect: UserEffect,
+  usersEffects: UserEffect[],
   target: BattleUserState,
 ): ActionEffect | undefined => {
+  const immunityBlocked = checkPreventImmunity(effect, usersEffects, target, "debuff");
+  if (immunityBlocked) return immunityBlocked;
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
@@ -741,12 +783,9 @@ export const adjustDamageGiven = (
           const ratio = getEfficiencyRatio(damageEffect, effect);
           // Use baseDamageForModifiers for percentage calculations to ensure additive stacking
           // This prevents multiplicative behavior when multiple modifiers are applied
-          const baseDamage =
-            consequence.baseDamageForModifiers ?? consequence.damage;
+          const baseDamage = consequence.baseDamageForModifiers ?? consequence.damage;
           const change =
-            effect.calculation === "percentage"
-              ? (power / 100) * baseDamage
-              : power;
+            effect.calculation === "percentage" ? (power / 100) * baseDamage : power;
           if (effect.fromType === "bloodline") {
             if (
               "allowBloodlineDamageIncrease" in damageEffect &&
@@ -814,12 +853,9 @@ export const adjustDamageTaken = (
           const ratio = getEfficiencyRatio(damageEffect, effect);
           // Use baseDamageForModifiers for percentage calculations to ensure additive stacking
           // This prevents multiplicative behavior when multiple modifiers are applied
-          const baseDamage =
-            consequence.baseDamageForModifiers ?? consequence.damage;
+          const baseDamage = consequence.baseDamageForModifiers ?? consequence.damage;
           const change =
-            effect.calculation === "percentage"
-              ? (power / 100) * baseDamage
-              : power;
+            effect.calculation === "percentage" ? (power / 100) * baseDamage : power;
           consequence.damage = consequence.damage + change * ratio;
         }
       }
@@ -1372,8 +1408,11 @@ export const flee = (
 /** Check if flee prevent is successful depending on static chance calculation */
 export const fleePrevent = (
   effect: UserEffect,
+  usersEffects: UserEffect[],
   target: BattleUserState,
 ): ActionEffect | undefined => {
+  const immunityBlocked = checkPreventImmunity(effect, usersEffects, target, "flee");
+  if (immunityBlocked) return immunityBlocked;
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
@@ -1445,8 +1484,11 @@ export const heal = (
 /** Prevent healing */
 export const healPrevent = (
   effect: UserEffect,
+  usersEffects: UserEffect[],
   target: BattleUserState,
 ): ActionEffect | undefined => {
+  const immunityBlocked = checkPreventImmunity(effect, usersEffects, target, "heal");
+  if (immunityBlocked) return immunityBlocked;
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
@@ -1864,6 +1906,16 @@ export const shield = (effect: UserEffect, target: BattleUserState) => {
   return info;
 };
 
+/** Blocks prevent effects from being applied to the target */
+export const immunity = (effect: UserEffect, target: BattleUserState) => {
+  const immunityEffect = effect as ImmunityTagType;
+  if (effect.isNew && effect.rounds) {
+    const preventType = getPreventTypeName(immunityEffect.blocks);
+    return getInfo(target, effect, `has immunity to ${preventType} prevention`);
+  }
+  return undefined;
+};
+
 /** Prevents the user from being reduced below 1 HP */
 export const finalStand = (effect: UserEffect, target: BattleUserState) => {
   const { power } = getPower(effect);
@@ -1935,8 +1987,16 @@ export const move = (
 /** Prevent target from moving */
 export const movePrevent = (
   effect: UserEffect,
+  usersEffects: UserEffect[],
   target: BattleUserState,
 ): ActionEffect | undefined => {
+  const immunityBlocked = checkPreventImmunity(
+    effect,
+    usersEffects,
+    target,
+    "movement",
+  );
+  if (immunityBlocked) return immunityBlocked;
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
@@ -1980,8 +2040,16 @@ export const onehitkill = (
 /** Status effect to prevent OHKO */
 export const onehitkillPrevent = (
   effect: UserEffect,
+  usersEffects: UserEffect[],
   target: BattleUserState,
 ): ActionEffect | undefined => {
+  const immunityBlocked = checkPreventImmunity(
+    effect,
+    usersEffects,
+    target,
+    "one-hit-kill",
+  );
+  if (immunityBlocked) return immunityBlocked;
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
@@ -2055,8 +2123,11 @@ export const rob = (
 /** Prevent robbing */
 export const robPrevent = (
   effect: UserEffect,
+  usersEffects: UserEffect[],
   target: BattleUserState,
 ): ActionEffect | undefined => {
+  const immunityBlocked = checkPreventImmunity(effect, usersEffects, target, "rob");
+  if (immunityBlocked) return immunityBlocked;
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
@@ -2075,8 +2146,11 @@ export const robPrevent = (
 /** Prevent cleansing */
 export const cleansePrevent = (
   effect: UserEffect,
+  usersEffects: UserEffect[],
   target: BattleUserState,
 ): ActionEffect | undefined => {
+  const immunityBlocked = checkPreventImmunity(effect, usersEffects, target, "cleanse");
+  if (immunityBlocked) return immunityBlocked;
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
@@ -2095,8 +2169,11 @@ export const cleansePrevent = (
 /** Prevent clearing */
 export const clearPrevent = (
   effect: UserEffect,
+  usersEffects: UserEffect[],
   target: BattleUserState,
 ): ActionEffect | undefined => {
+  const immunityBlocked = checkPreventImmunity(effect, usersEffects, target, "clear");
+  if (immunityBlocked) return immunityBlocked;
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
@@ -2149,8 +2226,11 @@ export const sealCheck = (effect: UserEffect, sealEffects: UserEffect[]) => {
 /** Prevent sealing of bloodline effects with a static chance */
 export const sealPrevent = (
   effect: UserEffect,
+  usersEffects: UserEffect[],
   target: BattleUserState,
 ): ActionEffect | undefined => {
+  const immunityBlocked = checkPreventImmunity(effect, usersEffects, target, "seal");
+  if (immunityBlocked) return immunityBlocked;
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
@@ -2604,8 +2684,11 @@ export const redirection = (
 /** Prevent target from being stunned */
 export const stunPrevent = (
   effect: UserEffect,
+  usersEffects: UserEffect[],
   target: BattleUserState,
 ): ActionEffect | undefined => {
+  const immunityBlocked = checkPreventImmunity(effect, usersEffects, target, "stun");
+  if (immunityBlocked) return immunityBlocked;
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
@@ -2739,11 +2822,14 @@ export const summon = (
   }
 };
 
-/** Prevent target from being stunned */
+/** Prevent target from summoning */
 export const summonPrevent = (
   effect: UserEffect,
+  usersEffects: UserEffect[],
   target: BattleUserState,
 ): ActionEffect | undefined => {
+  const immunityBlocked = checkPreventImmunity(effect, usersEffects, target, "summon");
+  if (immunityBlocked) return immunityBlocked;
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
@@ -2913,13 +2999,14 @@ const getEfficiencyRatio = (dmgEffect: UserEffect, effect: UserEffect) => {
  */
 const preventCheck = (
   usersEffects: UserEffect[],
-  type: string,
+  type: PreventTagType,
   target: BattleUserState,
   effect?: UserEffect, // Add optional effect parameter to check creation time
 ) => {
   const preventTag = usersEffects.find(
     (e) => e.type == type && e.targetId === target.userId && !e.castThisRound,
   );
+
   if (preventTag && (preventTag.rounds === undefined || preventTag.rounds > 0)) {
     // Only prevent if the effect being checked was created after the prevent effect
     if (effect && preventTag.createdRound >= effect.createdRound) {

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -2271,3 +2271,12 @@ export const getDistanceToClosestEnemy = (
 
   return Math.min(...distances);
 };
+
+/**
+ * Extracts the base name from a prevent type by removing the "prevent" suffix
+ * @param preventType - The full prevent type (e.g., "buffprevent", "healprevent")
+ * @returns The base name without "prevent" suffix (e.g., "buff", "heal")
+ */
+export const getPreventTypeName = (preventType: string): string => {
+  return preventType.replace(/prevent$/, "");
+};

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -79,7 +79,7 @@ import { performAIaction } from "@/libs/combat/ai_v2";
 import { userData, questHistory, quest, gameSetting, jutsu } from "@/drizzle/schema";
 import { battle, battleAction, battleHistory, war, item } from "@/drizzle/schema";
 import { villageAlliance, village, tournamentMatch, bounty } from "@/drizzle/schema";
-import { sector } from "@/drizzle/schema";
+import { sector, gameAsset } from "@/drizzle/schema";
 import { performActionSchema, statSchema, BarrierTag } from "@/validators/combat";
 import { performBattleAction, stillInBattle } from "@/libs/combat/actions";
 import { availableUserActions } from "@/libs/combat/actions";
@@ -1409,8 +1409,10 @@ export const initiateBattle = async (
   ] = await Promise.all([
     // Essentials
     fetchBattleEssentials(client),
-    // Fetch game assets
-    fetchGameAssets(client),
+    // Fetch game assets (only battlefield ones to avoid row limit)
+    client.query.gameAsset.findMany({
+      where: and(eq(gameAsset.hidden, false), eq(gameAsset.onInitialBattleField, true)),
+    }),
     // Fetch achievements
     client
       .select()
@@ -2223,16 +2225,32 @@ export const processUsersForBattle = async (
       relationIds: [],
       warIds: [],
       // Initialize jutsus and items (will be processed below)
-      jutsus: inputUser.jutsus.map((uj) => ({
-        ...uj,
-        lastUsedRound: -uj.jutsu.cooldown,
-        originalCooldown: uj.jutsu.cooldown,
-      })),
-      items: inputUser.items.map((ui) => ({
-        ...ui,
-        lastUsedRound: -ui.item.cooldown,
-        originalCooldown: ui.item.cooldown,
-      })),
+      jutsus: inputUser.jutsus
+        .filter((uj) => {
+          if (!uj.jutsu) {
+            console.error(`Jutsu not found for UserJutsu ${uj.id}`);
+            return false;
+          }
+          return true;
+        })
+        .map((uj) => ({
+          ...uj,
+          lastUsedRound: -uj.jutsu.cooldown,
+          originalCooldown: uj.jutsu.cooldown,
+        })),
+      items: inputUser.items
+        .filter((ui) => {
+          if (!ui.item) {
+            console.error(`Item not found for UserItem ${ui.id}`);
+            return false;
+          }
+          return true;
+        })
+        .map((ui) => ({
+          ...ui,
+          lastUsedRound: -ui.item.cooldown,
+          originalCooldown: ui.item.cooldown,
+        })),
     };
 
     // Add regen to pools. Pools are not updated "live" in the database, but rather are calculated on the frontend

--- a/app/src/validators/combat.ts
+++ b/app/src/validators/combat.ts
@@ -114,6 +114,25 @@ const IncludeStats = {
 /******************** */
 /*******  TAGS  *******/
 /******************** */
+
+// Prevent-type effect tags that can be blocked by ImmunityTag (content-selectable)
+export const PreventTagTypes = [
+  "buffprevent",
+  "clearprevent",
+  "cleanseprevent",
+  "debuffprevent",
+  "fleeprevent",
+  "healprevent",
+  "moveprevent",
+  "onehitkillprevent",
+  "robprevent",
+  "sealprevent",
+  "stunprevent",
+  "summonprevent",
+] as const;
+
+export type PreventTagType = (typeof PreventTagTypes)[number];
+
 export const AbsorbTag = z.object({
   ...BaseAttributes,
   ...IncludeStats,
@@ -639,6 +658,18 @@ export const StunPreventTag = z.object({
   description: msg("Prevents being stunned"),
 });
 
+export const ImmunityTag = z.object({
+  ...BaseAttributes,
+  ...PowerAttributes,
+  type: z.literal("immunity").default("immunity"),
+  description: msg("Grants immunity against the specified prevent-type effect"),
+  target: z.enum(BaseTagTargets).optional().default("SELF"),
+  blocks: z.enum(PreventTagTypes).default("buffprevent"),
+  rounds: z.coerce.number().int().min(1).max(20).default(2),
+  calculation: z.enum(["static"]).default("static"),
+});
+export type ImmunityTagType = z.infer<typeof ImmunityTag>;
+
 export const StunTag = z.object({
   ...BaseAttributes,
   ...PowerAttributes,
@@ -765,6 +796,7 @@ export const AllTags = z.union([
   IncreasePoolCostTag.default({}),
   IncreaseRangeTag.default({}),
   IncreaseStatTag.default({}),
+  ImmunityTag.default({}),
   LifeStealTag.default({}),
   MirrorTag.default({}),
   MovePreventTag.default({}),
@@ -837,6 +869,7 @@ export const isPositiveUserEffect = (tag: ZodAllTags) => {
       "summon",
       "timedilation",
       "injectjutsus",
+      "immunity",
     ].includes(tag.type)
   ) {
     return true;


### PR DESCRIPTION
# Pull Request

**Please fill: what was implemented, why, possibly include screenshots, are any of the changes breaking, etc.**
Added a new combat tag: Immunity

This tag allows a jutsu to block specific prevent-type effects from being applied to a target. The immunity is configurable per effect type

Categories supported: 

Buff prevent, De-buff prevent, Move prevent, Cleanse prevent, Clear prevent

The code: 

Checks active effects for an Immunity tag before applying prevent effects

Allows jutsu to specify which prevent type is blocked via the blocks field

Ensures immunity only triggers when valid (not cast same round, rounds active, correct target)

Displays the blocked prevent type in the jutsu description so players know exactly what is protected

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added immunity effects that prevent specific action types (e.g., cannot be robbed, sealed, or stunned).
  * Immunities are now explicitly labeled and displayed with clear descriptions in status effects.
  * UI updated to show which prevention types are blocked by immunities.

* **Bug Fixes**
  * Improved validation of combat items and abilities to prevent data integrity issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->