### PR TITLE
fix: allow crafted items to be sold on auction house

### DIFF
--- a/app/src/app/auctionhouse/page.tsx
+++ b/app/src/app/auctionhouse/page.tsx
@@ -721,7 +721,7 @@ export const NewAuctionListingDialog: React.FC = () => {
       return (
         item.item?.canBeTraded &&
         item.equipped === "NONE" &&
-        !item.craftingFinishedAt &&
+        (!item.craftingFinishedAt || new Date(item.craftingFinishedAt) < new Date()) &&
         !item.isInAuction
       );
     }) || [];

--- a/app/src/server/api/routers/auction.ts
+++ b/app/src/server/api/routers/auction.ts
@@ -1,5 +1,5 @@
 import { nanoid } from "nanoid";
-import { eq, sql, gte, and, desc, isNull, like, inArray } from "drizzle-orm";
+import { eq, sql, gte, and, desc, isNull, like, inArray, or, lt } from "drizzle-orm";
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { fetchUser } from "./profile";
@@ -189,7 +189,10 @@ export const auctionRouter = createTRPCRouter({
             eq(userItem.userId, ctx.userId),
             eq(userItem.equipped, "NONE"),
             eq(userItem.isInAuction, false),
-            isNull(userItem.craftingFinishedAt),
+            or(
+              isNull(userItem.craftingFinishedAt),
+              lt(userItem.craftingFinishedAt, new Date()),
+            ),
           ),
           with: {
             item: true,


### PR DESCRIPTION
Fixes #970

## Summary
- Crafted items can now be sold on the auction house after crafting completes
- Previously, all crafted items were excluded because the filter checked `isNull(craftingFinishedAt)` instead of checking if crafting was in progress

## Changes
- Backend: Changed filter to allow items where `craftingFinishedAt` is null OR in the past
- Frontend: Applied same fix to the item dropdown filter

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows crafted items to be listed once crafting has finished.
> 
> - Backend (`auction.ts`): Updated `createAuctionListing` item lookup to `or(isNull(userItem.craftingFinishedAt), lt(userItem.craftingFinishedAt, new Date()))`; added `or`/`lt` imports
> - Frontend (`auctionhouse/page.tsx`): Adjusted item dropdown filter to include items with `!craftingFinishedAt || craftingFinishedAt < now`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a1d14ba796b96b24642baa4f9751af1f8ba9127. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auction house listing criteria to properly handle items with completed crafting processes, expanding the range of craftable items available for sale.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->