### PR TITLE
:bug: Fix war reporting bugs: village names, stats, and ally outcomes

### DIFF
--- a/app/src/layout/WarSystem.tsx
+++ b/app/src/layout/WarSystem.tsx
@@ -1224,16 +1224,16 @@ export const VillageWar: React.FC<{
             <>
               <p className="text-sm">Ended: {war.endedAt.toLocaleDateString()}</p>
               <p
-                className={`font-bold ${war.status === "DRAW" ? "text-yellow-500" : war.status === "ATTACKER_VICTORY" ? (war.attackerVillageId === user.villageId ? "text-green-500" : "text-red-500") : war.defenderVillageId === user.villageId ? "text-green-500" : "text-red-500"}`}
+                className={`font-bold ${war.status === "DRAW" ? "text-yellow-500" : war.status === "ATTACKER_VICTORY" ? (isAttacker ? "text-green-500" : "text-red-500") : !isAttacker ? "text-green-500" : "text-red-500"}`}
               >
                 Outcome:{" "}
                 {war.status === "DRAW"
                   ? "War ended in a Draw"
                   : war.status === "ATTACKER_VICTORY"
-                    ? war.attackerVillageId === user.villageId
+                    ? isAttacker
                       ? "Victory"
                       : "Defeat"
-                    : war.defenderVillageId === user.villageId
+                    : !isAttacker
                       ? "Victory"
                       : "Defeat"}
               </p>

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -1234,15 +1234,21 @@ export const calcBattleResult = (
               userVillageId,
             );
             wars.forEach((war) => {
+              // Determine if the user is on the attacker side (either as main attacker or ally)
+              const isUserOnAttackerSide =
+                war.attackerVillageId === userVillageId ||
+                war.warAllies?.some(
+                  (ally) =>
+                    ally.villageId === userVillageId &&
+                    ally.supportVillageId === war.attackerVillageId,
+                );
               // Get the names of the village
-              const userVillageName =
-                war.attackerVillageId === targetVillageId
-                  ? war?.defenderVillage?.name || ""
-                  : war?.attackerVillage?.name || "";
-              const targetVillageName =
-                war.attackerVillageId === targetVillageId
-                  ? war?.attackerVillage?.name || ""
-                  : war?.defenderVillage?.name || "";
+              const userVillageName = isUserOnAttackerSide
+                ? war?.attackerVillage?.name || ""
+                : war?.defenderVillage?.name || "";
+              const targetVillageName = isUserOnAttackerSide
+                ? war?.defenderVillage?.name || ""
+                : war?.attackerVillage?.name || "";
               // Reset to 0 if not in warHealthInfo
               if (targetVillageName && !(targetVillageName in warHealthInfo)) {
                 warHealthInfo[targetVillageName] = 0;

--- a/app/src/server/api/routers/war.ts
+++ b/app/src/server/api/routers/war.ts
@@ -1016,7 +1016,8 @@ export const warRouter = createTRPCRouter({
           .orderBy(desc(sql<number>`count(*)`));
       }
 
-      // Other aggregate fields
+      // Other aggregate fields - only sum positive values (actual damage contribution)
+      // Negative values represent losses, which shouldn't count as "damage dealt"
       const aggregateField =
         input.aggregateBy === "townhallHpChange"
           ? warKill.townhallHpChange
@@ -1029,14 +1030,14 @@ export const warRouter = createTRPCRouter({
           villageId: userData.villageId,
           villageName: village.name,
           killerAvatar: userData.avatar,
-          count: sql<number>`sum(${aggregateField})`,
+          count: sql<number>`sum(GREATEST(${aggregateField}, 0))`,
         })
         .from(warKill)
         .leftJoin(userData, eq(warKill.killerId, userData.userId))
         .leftJoin(village, eq(userData.villageId, village.id))
         .where(eq(warKill.warId, input.warId))
         .groupBy(warKill.killerId)
-        .orderBy(desc(sql<number>`sum(${aggregateField})`));
+        .orderBy(desc(sql<number>`sum(GREATEST(${aggregateField}, 0))`));
     }),
 });
 


### PR DESCRIPTION
Fixes #967

## Summary

- Fix battle result village names being swapped
- Fix townhall damage stats showing healing values
- Fix allied factions shown as losing when their side wins

## Test plan

- [ ] Win a battle in a war as an ally and verify village names are correct
- [ ] Check war health damage stats show positive values only
- [ ] End a war and verify allied factions see Victory/Defeat correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves multiple war reporting inconsistencies.
> 
> - **Outcome display:** `WarSystem.tsx` now uses `isAttacker` to determine Victory/Defeat labels and colors, ensuring allies see correct results
> - **Village name attribution:** `combat/util.ts` derives `isUserOnAttackerSide` (including allies) to correctly assign `userVillageName` and `targetVillageName`
> - **War statistics:** `getWarKillStats` sums `GREATEST(field, 0)` and sorts by it to exclude healing/negative values from "damage dealt"
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 100328959acb2aa45f7577e9831a13b62dce6bb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed war outcome UI to display correct colors and victory/defeat labels based on your role as attacker or defender
* Improved war kill statistics calculations to correctly exclude losses from damage-dealt metrics for accurate reporting
* Enhanced village name tracking in wars to properly resolve names for both attacking and defending positions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->