### PR TITLE
Add bulk crafting

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -1089,21 +1089,21 @@ export const CRAFTING_MAX_IMBUED_ITEMS: Record<CRAFTING_RANK, number> = {
 export const CRAFTING_TIMES_MINS: Record<CRAFTING_RANK, Record<ItemRarity, number>> = {
   NOVICE: {
     COMMON: 60,
-    RARE: 90,
+    RARE: 0, // Cannot craft rare items
     EPIC: 0, // Cannot craft epic items
     LEGENDARY: 0, // Cannot craft legendary items
   },
   APPRENTICE: {
     COMMON: 40,
     RARE: 65,
-    EPIC: 90,
+    EPIC: 0, // Cannot craft epic items
     LEGENDARY: 0, // Cannot craft legendary items
   },
   MASTER: {
     COMMON: 30,
     RARE: 50,
     EPIC: 70,
-    LEGENDARY: 240,
+    LEGENDARY: 0, // Cannot craft legendary items
   },
   FORGEMASTER: {
     COMMON: 15,

--- a/app/src/layout/OccupationCrafting.tsx
+++ b/app/src/layout/OccupationCrafting.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import ContentBox from "@/layout/ContentBox";
 import ItemWithEffects from "@/layout/ItemWithEffects";
 import Modal2 from "@/layout/Modal2";
@@ -11,6 +11,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import Confirm2 from "@/layout/Confirm2";
 import { Hammer, Star, Info, Gem, Zap, Wrench } from "lucide-react";
 import { api } from "@/app/_trpc/client";
@@ -127,6 +128,7 @@ export default function OccupationCrafting() {
 
   const [selectedItem, setSelectedItem] = useState<Item | undefined>(undefined);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [craftQuantity, setCraftQuantity] = useState<number>(1);
   const [selectedImbuableItem, setSelectedImbuableItem] = useState<
     UserItemWithRelations | undefined
   >(undefined);
@@ -139,6 +141,29 @@ export default function OccupationCrafting() {
   const craftingStatus = userData
     ? getCurrentCraftingStatus(userData, userItems || [])
     : null;
+
+  // Calculate max craftable quantity at component level
+  const maxCraftable = useMemo(() => {
+    if (!selectedItem || !craftableItems || !userItems) return 10;
+    
+    const craftableItem = craftableItems.find((item) => item.id === selectedItem.id);
+    if (!craftableItem?.craftingRequirements) return 10;
+    
+    let max = 10;
+    for (const req of craftableItem.craftingRequirements) {
+      const totalQuantity = getTotalItemQuantity(userItems, req.requirementItemId);
+      const maxForThisMaterial = Math.floor(totalQuantity / req.quantity);
+      max = Math.min(max, maxForThisMaterial);
+    }
+    return max;
+  }, [selectedItem, craftableItems, userItems]);
+
+  // Sync craftQuantity state when maxCraftable changes
+  useEffect(() => {
+    if (craftQuantity > maxCraftable) {
+      setCraftQuantity(Math.max(1, maxCraftable));
+    }
+  }, [maxCraftable, craftQuantity]);
 
   // Derive crystals and imbuable items from user inventory
   const crystals = (userItems || []).filter(
@@ -160,7 +185,7 @@ export default function OccupationCrafting() {
    */
   const handleCraftItem = () => {
     if (selectedItem) {
-      craftItemMutation.mutate({ itemId: selectedItem.id });
+      craftItemMutation.mutate({ itemId: selectedItem.id, quantity: craftQuantity });
     }
   };
 
@@ -286,10 +311,12 @@ export default function OccupationCrafting() {
                   if (id === selectedItem?.id) {
                     setSelectedItem(undefined);
                     setIsModalOpen(false);
+                    setCraftQuantity(1);
                   } else {
                     const item = craftableItems?.find((item) => item.id === id);
                     setSelectedItem(item as Item);
                     setIsModalOpen(true);
+                    setCraftQuantity(1);
                   }
                 }}
               />
@@ -309,7 +336,7 @@ export default function OccupationCrafting() {
                                 userItems || [],
                                 req.requirementItemId,
                               );
-                              return totalQuantity >= req.quantity;
+                              return totalQuantity >= req.quantity * craftQuantity;
                             }) ?? false;
                           return canCraft ? "Start Crafting" : "Missing Materials";
                         })()
@@ -327,7 +354,7 @@ export default function OccupationCrafting() {
                           userItems || [],
                           req.requirementItemId,
                         );
-                        return totalQuantity >= req.quantity;
+                        return totalQuantity >= req.quantity * craftQuantity;
                       }) ?? false;
                     if (canCraft) {
                       handleCraftItem();
@@ -343,7 +370,7 @@ export default function OccupationCrafting() {
                           userItems || [],
                           req.requirementItemId,
                         );
-                        return totalQuantity >= req.quantity;
+                        return totalQuantity >= req.quantity * craftQuantity;
                       }) ?? false;
                     return canCraft
                       ? "bg-blue-600 text-white hover:bg-blue-700"
@@ -372,36 +399,68 @@ export default function OccupationCrafting() {
                         userData?.village,
                       );
                       const shrineBoostFactor = shrineBoost ? 1 - shrineBoost : 1;
-                      const craftSeconds = Math.round(craftingTime * 60 * shrineBoostFactor);
-                      const timeDisplay = formatSecondsToTimeDisplay(craftSeconds);
 
-                      // Get crafting experience
-                      const expGain = selectedItem.craftingExperience ?? 0;
-
+                      // Use component-level maxCraftable (calculated in useMemo)
                       const hasRequirements =
                         craftableItem?.craftingRequirements &&
                         craftableItem.craftingRequirements.length > 0;
 
+                      // Handle edge case where user has insufficient materials
+                      const canAffordAny = maxCraftable > 0;
+                      const effectiveMax = canAffordAny ? maxCraftable : 0;
+                      const effectiveQuantity = canAffordAny
+                        ? Math.min(craftQuantity, maxCraftable)
+                        : 0;
+
+                      // Calculate time and exp - total when materials available, per item when not
+                      const displayQuantity = canAffordAny ? effectiveQuantity : 1;
+                      const displayCraftSeconds = Math.round(
+                        craftingTime * 60 * shrineBoostFactor * displayQuantity,
+                      );
+                      const displayTimeValue = formatSecondsToTimeDisplay(displayCraftSeconds);
+                      const displayExpGain = (selectedItem.craftingExperience ?? 0) * displayQuantity;
+
                       return (
                         <>
+                          {/* Quantity Selector */}
+                          <div className="bg-slate-100 dark:bg-slate-800 rounded-lg p-3">
+                            <label className="text-sm font-medium mb-2 block">
+                              Quantity to Craft (Max: {maxCraftable})
+                            </label>
+                            <Input
+                              type="number"
+                              min={canAffordAny ? 1 : 0}
+                              max={canAffordAny ? effectiveMax : 0}
+                              value={effectiveQuantity}
+                              onChange={(e) => {
+                                const val = parseInt(e.target.value);
+                                if (!isNaN(val) && val >= 1 && val <= effectiveMax) {
+                                  setCraftQuantity(val);
+                                }
+                              }}
+                              disabled={!canAffordAny}
+                              className="w-full"
+                            />
+                          </div>
+
                           {/* Crafting Info */}
                           <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-3 border border-blue-200 dark:border-blue-800">
                             <div className="space-y-2">
                               <div className="flex items-center justify-between">
                                 <span className="text-sm font-medium">
-                                  Crafting Time:
+                                  {canAffordAny ? "Total Crafting Time:" : "Crafting Time (per item):"}
                                 </span>
                                 <span className="text-sm font-semibold">
-                                  {timeDisplay}
+                                  {displayTimeValue}
                                 </span>
                               </div>
-                              {expGain > 0 && (
+                              {displayExpGain > 0 && (
                                 <div className="flex items-center justify-between">
                                   <span className="text-sm font-medium">
-                                    Experience Gain:
+                                    {canAffordAny ? "Total Experience Gain:" : "Experience Gain (per item):"}
                                   </span>
                                   <span className="text-sm font-semibold text-green-600">
-                                    +{expGain} EXP
+                                    +{displayExpGain} EXP
                                   </span>
                                 </div>
                               )}
@@ -420,7 +479,7 @@ export default function OccupationCrafting() {
                                 userItems || [],
                                 req.requirementItemId,
                               );
-                              const required = req.quantity;
+                              const required = req.quantity * craftQuantity;
                               const hasEnough = totalQuantity >= required;
 
                               return (
@@ -916,7 +975,6 @@ export default function OccupationCrafting() {
                     </Badge>
                     <ul className="space-y-1 text-muted-foreground">
                       <li>• Common: {CRAFTING_TIMES_MINS.NOVICE.COMMON} minutes</li>
-                      <li>• Rare: {CRAFTING_TIMES_MINS.NOVICE.RARE} minutes</li>
                     </ul>
                   </div>
                   <div>
@@ -927,7 +985,6 @@ export default function OccupationCrafting() {
                     <ul className="space-y-1 text-muted-foreground">
                       <li>• Common: {CRAFTING_TIMES_MINS.APPRENTICE.COMMON} minutes</li>
                       <li>• Rare: {CRAFTING_TIMES_MINS.APPRENTICE.RARE} minutes</li>
-                      <li>• Epic: {CRAFTING_TIMES_MINS.APPRENTICE.EPIC} minutes</li>
                     </ul>
                   </div>
                   <div>
@@ -939,9 +996,6 @@ export default function OccupationCrafting() {
                       <li>• Common: {CRAFTING_TIMES_MINS.MASTER.COMMON} minutes</li>
                       <li>• Rare: {CRAFTING_TIMES_MINS.MASTER.RARE} minutes</li>
                       <li>• Epic: {CRAFTING_TIMES_MINS.MASTER.EPIC} minutes</li>
-                      <li>
-                        • Legendary: {CRAFTING_TIMES_MINS.MASTER.LEGENDARY} minutes
-                      </li>
                     </ul>
                   </div>
                   <div>

--- a/app/src/server/api/routers/occupation.ts
+++ b/app/src/server/api/routers/occupation.ts
@@ -24,6 +24,7 @@ import { nanoid } from "nanoid";
 import { baseServerResponse } from "@/server/api/trpc";
 import { canChangeContent } from "@/utils/permissions";
 import { getNewTrackers } from "@/libs/quest";
+import { formatSecondsToTimeDisplay } from "@/utils/time";
 
 export const occupationRouter = createTRPCRouter({
   getCraftableItems: protectedProcedure.query(async ({ ctx }) => {
@@ -41,6 +42,7 @@ export const occupationRouter = createTRPCRouter({
 
   selectOccupation: protectedProcedure
     .input(z.object({ occupation: z.enum(OCCUPATIONS) }))
+    .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
       // Query
       const user = await fetchUser(ctx.drizzle, ctx.userId);
@@ -72,7 +74,12 @@ export const occupationRouter = createTRPCRouter({
     }),
 
   craftItem: protectedProcedure
-    .input(z.object({ itemId: z.string() }))
+    .input(
+      z.object({
+        itemId: z.string(),
+        quantity: z.number().int().min(1).max(10).default(1),
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
       // Run all initial queries in parallel
       const [{ user }, itemWithRequirements, useritems] = await Promise.all([
@@ -85,10 +92,7 @@ export const occupationRouter = createTRPCRouter({
       ]);
       // Derived
       const currentlyCrafting = useritems.find(
-        (item) =>
-          item.itemId === input.itemId &&
-          item.craftingFinishedAt &&
-          item.craftingFinishedAt > new Date(),
+        (item) => item.craftingFinishedAt && item.craftingFinishedAt > new Date(),
       );
       // Guards
       if (!user) return errorResponse("User not found");
@@ -124,8 +128,12 @@ export const occupationRouter = createTRPCRouter({
           : rankCraftingTime;
       // Guards - check rank eligibility regardless of item type
       if (rankCraftingTime === 0) {
+        const requiredRank = 
+          itemWithRequirements.rarity === "RARE" ? "Apprentice" :
+          itemWithRequirements.rarity === "EPIC" ? "Master" :
+          itemWithRequirements.rarity === "LEGENDARY" ? "Forgemaster" : "Unknown";
         return errorResponse(
-          `You need to be at least ${itemWithRequirements.rarity === "EPIC" ? "Apprentice" : "Master"} rank to craft ${itemWithRequirements.rarity} items`,
+          `You need to be at least ${requiredRank} rank to craft ${itemWithRequirements.rarity} items`,
         );
       }
       // Validate user has enough materials using collapsed quantities
@@ -134,10 +142,11 @@ export const occupationRouter = createTRPCRouter({
           useritems,
           requirement.requirementItemId,
         );
-        if (totalQuantity < requirement.quantity) {
+        const requiredQuantity = requirement.quantity * input.quantity;
+        if (totalQuantity < requiredQuantity) {
           const itemName = requirement.requirementItem?.name || "Unknown item";
           return errorResponse(
-            `You need ${requirement.quantity} ${itemName} (you have ${totalQuantity})`,
+            `You need ${requiredQuantity} ${itemName} (you have ${totalQuantity})`,
           );
         }
       }
@@ -146,7 +155,7 @@ export const occupationRouter = createTRPCRouter({
       const sectors = user.village?.sectors?.length || 0;
       const shrineBoost = getShrineBoost(sectors, "Crafting", user.village);
       const shrineBoostFactor = shrineBoost ? 1 - shrineBoost : 1;
-      const craftSeconds = craftingTime * 60 * shrineBoostFactor;
+      const craftSeconds = Math.round(craftingTime * 60 * shrineBoostFactor * input.quantity);
 
       // Calculate crafting finish time
       const finishTime = new Date(Date.now() + craftSeconds * 1000);
@@ -155,10 +164,11 @@ export const occupationRouter = createTRPCRouter({
       // Calculate consumption for each requirement
       const allConsumptions = [];
       for (const requirement of itemWithRequirements.craftingRequirements) {
+        const requiredQuantity = requirement.quantity * input.quantity;
         const consumption = calculateItemConsumption(
           useritems,
           requirement.requirementItemId,
-          requirement.quantity,
+          requiredQuantity,
         );
         if (!consumption.hasEnough) {
           const itemName = requirement.requirementItem?.name || "Unknown item";
@@ -181,17 +191,45 @@ export const occupationRouter = createTRPCRouter({
         }
       });
 
-      // Create crafting item entry (quantity 0 initially, will be 1 when finished)
-      const craftingItemInsert = ctx.drizzle.insert(userItem).values({
-        id: nanoid(),
-        userId: ctx.userId,
-        itemId: input.itemId,
-        quantity: 1,
-        craftingFinishedAt: finishTime,
-      });
+      // Create crafting item entry/entries
+      // Respect stackSize limit when creating items
+      const craftingItemInserts = [];
+      if (itemWithRequirements.stackSize === 1) {
+        // Create separate items for non-stackable items
+        for (let i = 0; i < input.quantity; i++) {
+          craftingItemInserts.push(
+            ctx.drizzle.insert(userItem).values({
+              id: nanoid(),
+              userId: ctx.userId,
+              itemId: input.itemId,
+              quantity: 1,
+              craftingFinishedAt: finishTime,
+            }),
+          );
+        }
+      } else {
+        // Create stacked items respecting stackSize limit
+        let remainingQuantity = input.quantity;
+        while (remainingQuantity > 0) {
+          const stackQuantity = Math.min(
+            remainingQuantity,
+            itemWithRequirements.stackSize,
+          );
+          craftingItemInserts.push(
+            ctx.drizzle.insert(userItem).values({
+              id: nanoid(),
+              userId: ctx.userId,
+              itemId: input.itemId,
+              quantity: stackQuantity,
+              craftingFinishedAt: finishTime,
+            }),
+          );
+          remainingQuantity -= stackQuantity;
+        }
+      }
 
       // Award crafting experience (from item config, or 0 if not set)
-      const expGain = itemWithRequirements.craftingExperience ?? 0;
+      const expGain = (itemWithRequirements.craftingExperience ?? 0) * input.quantity;
       // Update trackers with crafting experience gained
       const { trackers } = getNewTrackers(user, [
         { task: "crafting_experience_gained", increment: expGain },
@@ -204,11 +242,11 @@ export const occupationRouter = createTRPCRouter({
         })
         .where(eq(userData.userId, ctx.userId));
 
-      await Promise.all([...materialUpdates, craftingItemInsert, expUpdate]);
+      await Promise.all([...materialUpdates, ...craftingItemInserts, expUpdate]);
 
       return {
         success: true,
-        message: `Started crafting ${itemWithRequirements.name}. It will be ready in ${craftSeconds} seconds.`,
+        message: `Started crafting ${input.quantity}x ${itemWithRequirements.name}. ${expGain > 0 ? `+${expGain} EXP.` : ""} Ready in ${formatSecondsToTimeDisplay(craftSeconds)}.`,
         finishTime: finishTime.toISOString(),
       };
     }),

--- a/app/src/utils/permissions.ts
+++ b/app/src/utils/permissions.ts
@@ -297,8 +297,8 @@ export const canEditPublicUser = (user: UserData) => {
   ].includes(user.role);
 };
 
-export const canOnlyEditSelf = (role: UserRole) => {
-  return ["CONTENT", "EVENT"].includes(role);
+export const canOnlyEditSelf = (userRole: UserRole) => {
+  return ["CONTENT", "EVENT"].includes(userRole);
 };
 
 export const canAwardReputation = (role: UserRole) => {


### PR DESCRIPTION
# Pull Request

Adds the ability to craft a single item in bulk (up to 10).  The time to craft and required materials are multiplied by the number of crafts.  If it's an unstackable item, it will create separate instances of the item.  If they're stackable, it'll build the stack.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch crafting: craft 1–10 items at once; materials, time, and EXP scale with quantity.

* **UI Improvements**
  * Quantity selector bounded by max craftable, resets on target change, disables when unaffordable.
  * Per-material quantities and sufficiency indicators update with quantity.
  * Toggles between per-item and total displays; shows "Total Crafting Time" and "Total Experience Gain".

* **Backend / Messages**
  * Crafting endpoint accepts quantity and returns quantity, total EXP, and human-readable remaining time.
  * Some rarities become uncraftable at low ranks (reflected in time/availability).

* **Chores**
  * Minor permission helper parameter rename.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->