### PR TITLE
fix: scouting filter reset, globe lag, and sensory reveal UI

### DIFF
--- a/app/src/app/travel/page.tsx
+++ b/app/src/app/travel/page.tsx
@@ -33,6 +33,7 @@ import {
   ZapOff,
   Ghost,
   Radar,
+  Swords,
 } from "lucide-react";
 import { HousePlus } from "lucide-react";
 import { api } from "@/app/_trpc/client";
@@ -88,6 +89,16 @@ export default function Travel() {
   const [showModal, setShowModal] = useState<boolean>(false);
   const [showSorrounding, setShowSorrounding] = useState<boolean>(false);
   const [showAutoAttackModal, setShowAutoAttackModal] = useState<boolean>(false);
+  const [revealedPlayers, setRevealedPlayers] = useState<
+    { userId: string; username: string; longitude: number; latitude: number }[]
+  >([]);
+  const [showRevealedPlayersModal, setShowRevealedPlayersModal] = useState<boolean>(false);
+  const [pendingAttackTarget, setPendingAttackTarget] = useState<{
+    userId: string;
+    username: string;
+    longitude: number;
+    latitude: number;
+  } | null>(null);
 
   const [activeTab, setActiveTab] = useState<string>("");
 
@@ -112,13 +123,17 @@ export default function Travel() {
     { sector: userData?.sector || -1 },
     { enabled: !!userData },
   );
-  const villages = villageData?.filter((v) => {
-    if (userData?.isOutlaw) {
-      return true;
-    } else {
-      return ["VILLAGE", "SAFEZONE"].includes(v.type);
-    }
-  });
+  // Memoize villages to prevent re-creating array reference on every render
+  // This is important because useLiveCountdown triggers re-renders every second
+  const villages = useMemo(() => {
+    return villageData?.filter((v) => {
+      if (userData?.isOutlaw) {
+        return true;
+      } else {
+        return ["VILLAGE", "SAFEZONE"].includes(v.type);
+      }
+    });
+  }, [villageData, userData?.isOutlaw]);
 
   // Fetch tracked bounties for map display
   const { data: trackedBounties } = api.bounty.getTrackedBounties.useQuery(undefined, {
@@ -297,6 +312,30 @@ export default function Travel() {
         if (data.success && data.data) {
           await updateUser({ lastSensoryAt: data.data.lastSensoryAt });
           await utils.travel.getSectorData.invalidate();
+          if (data.data.detectedUsers.length > 0) {
+            setRevealedPlayers(data.data.detectedUsers);
+            setShowRevealedPlayersModal(true);
+          }
+        }
+      },
+    });
+
+  const { mutate: attackRevealedUser, isPending: isAttackingRevealed } =
+    api.combat.attackUser.useMutation({
+      onSuccess: async (data) => {
+        if (data.success) {
+          setShowRevealedPlayersModal(false);
+          setRevealedPlayers([]);
+          await updateUser({
+            status: "BATTLE",
+            battleId: data.battleId,
+            updatedAt: new Date(),
+          });
+        } else {
+          showMutationToast({
+            success: false,
+            message: data.message,
+          });
         }
       },
     });
@@ -344,6 +383,49 @@ export default function Travel() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentPosition]);
+
+  // Attack revealed stealthed player after moving to their position
+  useEffect(() => {
+    if (
+      pendingAttackTarget &&
+      currentPosition &&
+      userData &&
+      currentPosition.x === pendingAttackTarget.longitude &&
+      currentPosition.y === pendingAttackTarget.latitude &&
+      !isAttackingRevealed
+    ) {
+      attackRevealedUser({
+        userId: pendingAttackTarget.userId,
+        longitude: pendingAttackTarget.longitude,
+        latitude: pendingAttackTarget.latitude,
+        sector: userData.sector,
+      });
+      setPendingAttackTarget(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentPosition, pendingAttackTarget]);
+
+  // Memoized Map component to prevent re-renders during countdown updates
+  const MapComponent = useMemo(() => {
+    return (
+      villages &&
+      globe && (
+        <Map
+          intersection={true}
+          highlights={villages}
+          usersHighlighted={trackedBounties}
+          userLocation={true}
+          showOwnership={showOwnership}
+          onTileClick={(sector) => {
+            setTargetSector(sector);
+            setShowModal(true);
+          }}
+          hexasphere={globe}
+        />
+      )
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [villages, globe, trackedBounties, showOwnership]);
 
   // Battle scene
   const SectorComponent = useMemo(() => {
@@ -608,20 +690,7 @@ export default function Travel() {
           </div>
         }
       >
-        {showGlobal && (
-          <Map
-            intersection={true}
-            highlights={villages}
-            usersHighlighted={trackedBounties}
-            userLocation={true}
-            showOwnership={showOwnership}
-            onTileClick={(sector) => {
-              setTargetSector(sector);
-              setShowModal(true);
-            }}
-            hexasphere={globe}
-          />
-        )}
+        {showGlobal && MapComponent}
         {mapError && <MapError />}
         {showSector && SectorComponent}
         {!villages && <Loader explanation="Loading data" />}
@@ -753,6 +822,83 @@ export default function Travel() {
         setIsOpen={setShowAutoAttackModal}
         onEnable={() => setAutoAttackMode(true)}
       />
+
+      {/* Revealed Players Modal (from Sensory Scan) */}
+      {showRevealedPlayersModal && revealedPlayers.length > 0 && (
+        <Modal2
+          title="Players Revealed by Sensory!"
+          isOpen={showRevealedPlayersModal}
+          setIsOpen={setShowRevealedPlayersModal}
+          isValid={false}
+        >
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              Your sensory ability detected the following stealthed players:
+            </p>
+            {revealedPlayers.map((player) => {
+              const sameHex =
+                player.latitude === userData?.latitude &&
+                player.longitude === userData?.longitude;
+              return (
+                <div
+                  key={player.userId}
+                  className="flex items-center justify-between p-3 bg-muted rounded-lg"
+                >
+                  <div>
+                    <p className="font-semibold">{player.username}</p>
+                    <p className="text-sm text-muted-foreground">
+                      Position: ({player.longitude}, {player.latitude})
+                      {sameHex && " - Same hex as you!"}
+                    </p>
+                  </div>
+                  <div className="flex gap-2">
+                    {sameHex && userData ? (
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() =>
+                          attackRevealedUser({
+                            userId: player.userId,
+                            longitude: player.longitude,
+                            latitude: player.latitude,
+                            sector: userData.sector,
+                          })
+                        }
+                        disabled={isAttackingRevealed}
+                      >
+                        <Swords className="h-4 w-4 mr-1" />
+                        Attack
+                      </Button>
+                    ) : (
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => {
+                          setPendingAttackTarget({
+                            userId: player.userId,
+                            username: player.username,
+                            longitude: player.longitude,
+                            latitude: player.latitude,
+                          });
+                          setTargetPosition({
+                            x: player.longitude,
+                            y: player.latitude,
+                          });
+                          setShowRevealedPlayersModal(false);
+                        }}
+                        disabled={isAttackingRevealed || !!pendingAttackTarget}
+                      >
+                        <Swords className="h-4 w-4 mr-1" />
+                        Attack
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </Modal2>
+      )}
     </>
   );
 }

--- a/app/src/layout/Sector.tsx
+++ b/app/src/layout/Sector.tsx
@@ -1165,7 +1165,7 @@ const SorroundingUsers: React.FC<SorroundingUsersProps> = (props) => {
 
   // Form schema
   const levelSliderSchema = z.object({
-    value: z.number().min(1).max(2),
+    value: z.number().min(0).max(100),
   });
   type LevelSliderSchema = z.infer<typeof levelSliderSchema>;
 
@@ -1179,7 +1179,7 @@ const SorroundingUsers: React.FC<SorroundingUsersProps> = (props) => {
     resolver: zodResolver(levelSliderSchema),
     defaultValues: { value: storedLvl || 1 },
   });
-  const watchedLevel = round(useWatch({ control, name: "value", defaultValue: 2 }));
+  const watchedLevel = round(useWatch({ control, name: "value" }));
 
   // Filter users
   const users = props.users


### PR DESCRIPTION
## Summary
- Fix scouting filter reset by correcting Zod schema and removing hardcoded defaultValue
- Fix globe lag during training by memoizing Map component
- Add sensory reveal popup with attack/move buttons

Closes #976

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves travel UX/performance and scouting controls.
> 
> - Adds sensory reveal flow: shows `Modal2` listing detected stealthed players; supports same-hex attack or sets a pending target to move then auto-attack; integrates `combat.attackUser` and updates user state on success
> - Optimizes globe rendering: memoizes `villages` and a `MapComponent` to prevent per-second re-renders from countdowns; replaces inline map render with memoized component
> - Fixes scouting filter: updates Zod schema and slider to `0–100`, removes hardcoded default watch value so the setting persists and filters correctly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce84c3bc095c8b8013496e8d1676f847186a5c75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Revealed Players modal showing detected users with Move-to and Attack actions; supports queuing an attack that triggers when you reach the target.

* **Improvements**
  * Optimized map rendering to reduce unnecessary re-renders.
  * Expanded surrounding-users level filter from 1–2 to 0–100 for broader filtering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->