### PR TITLE
fix: change damage modifier tags from multiplicative to additive stacking

### DIFF
--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -413,6 +413,29 @@ export const getAffected = (effect: UserEffect, type?: "offence" | "defence") =>
   return result;
 };
 
+/**
+ * Helper to apply a percentage stat modifier additively.
+ * Uses baseStatsForModifiers to ensure additive stacking when multiple modifiers are applied.
+ */
+const applyPercentageStatModifier = (
+  target: BattleUserState,
+  statName: keyof NonNullable<BattleUserState["baseStatsForModifiers"]>,
+  power: number,
+) => {
+  // Initialize baseStatsForModifiers if not present
+  if (!target.baseStatsForModifiers) {
+    target.baseStatsForModifiers = {};
+  }
+  // Store base stat value if not already stored
+  if (target.baseStatsForModifiers[statName] === undefined) {
+    target.baseStatsForModifiers[statName] = target[statName] as number;
+  }
+  // Use base stat for percentage calculation to ensure additive stacking
+  const baseStat = target.baseStatsForModifiers[statName]!;
+  const change = (power / 100) * baseStat;
+  (target[statName] as number) = (target[statName] as number) + change;
+};
+
 /** Adjust stats of target based on effect */
 export const adjustStats = (effect: UserEffect, target: BattleUserState) => {
   const { power, adverb, qualifier } = getPower(effect);
@@ -455,37 +478,12 @@ export const adjustStats = (effect: UserEffect, target: BattleUserState) => {
               }
             }
           } else {
+            // Percentage calculation - use additive stacking
             if (effect.direction === "offence" || effect.direction === "both") {
-              switch (target.highestOffence) {
-                case "ninjutsuOffence":
-                  target.ninjutsuOffence *= (100 + power) / 100;
-                  break;
-                case "genjutsuOffence":
-                  target.genjutsuOffence *= (100 + power) / 100;
-                  break;
-                case "taijutsuOffence":
-                  target.taijutsuOffence *= (100 + power) / 100;
-                  break;
-                case "bukijutsuOffence":
-                  target.bukijutsuOffence *= (100 + power) / 100;
-                  break;
-              }
+              applyPercentageStatModifier(target, target.highestOffence, power);
             }
             if (effect.direction === "defence" || effect.direction === "both") {
-              switch (target.highestDefence) {
-                case "ninjutsuDefence":
-                  target.ninjutsuDefence *= (100 + power) / 100;
-                  break;
-                case "genjutsuDefence":
-                  target.genjutsuDefence *= (100 + power) / 100;
-                  break;
-                case "taijutsuDefence":
-                  target.taijutsuDefence *= (100 + power) / 100;
-                  break;
-                case "bukijutsuDefence":
-                  target.bukijutsuDefence *= (100 + power) / 100;
-                  break;
-              }
+              applyPercentageStatModifier(target, target.highestDefence, power);
             }
           }
         } else if (stat === "Ninjutsu") {
@@ -497,11 +495,12 @@ export const adjustStats = (effect: UserEffect, target: BattleUserState) => {
               target.ninjutsuDefence += power;
             }
           } else {
+            // Percentage calculation - use additive stacking
             if (effect.direction === "offence" || effect.direction === "both") {
-              target.ninjutsuOffence *= (100 + power) / 100;
+              applyPercentageStatModifier(target, "ninjutsuOffence", power);
             }
             if (effect.direction === "defence" || effect.direction === "both") {
-              target.ninjutsuDefence *= (100 + power) / 100;
+              applyPercentageStatModifier(target, "ninjutsuDefence", power);
             }
           }
         } else if (stat === "Genjutsu") {
@@ -513,11 +512,12 @@ export const adjustStats = (effect: UserEffect, target: BattleUserState) => {
               target.genjutsuDefence += power;
             }
           } else {
+            // Percentage calculation - use additive stacking
             if (effect.direction === "offence" || effect.direction === "both") {
-              target.genjutsuOffence *= (100 + power) / 100;
+              applyPercentageStatModifier(target, "genjutsuOffence", power);
             }
             if (effect.direction === "defence" || effect.direction === "both") {
-              target.genjutsuDefence *= (100 + power) / 100;
+              applyPercentageStatModifier(target, "genjutsuDefence", power);
             }
           }
         } else if (stat === "Taijutsu") {
@@ -529,11 +529,12 @@ export const adjustStats = (effect: UserEffect, target: BattleUserState) => {
               target.taijutsuDefence += power;
             }
           } else {
+            // Percentage calculation - use additive stacking
             if (effect.direction === "offence" || effect.direction === "both") {
-              target.taijutsuOffence *= (100 + power) / 100;
+              applyPercentageStatModifier(target, "taijutsuOffence", power);
             }
             if (effect.direction === "defence" || effect.direction === "both") {
-              target.taijutsuDefence *= (100 + power) / 100;
+              applyPercentageStatModifier(target, "taijutsuDefence", power);
             }
           }
         } else if (stat === "Bukijutsu") {
@@ -545,11 +546,12 @@ export const adjustStats = (effect: UserEffect, target: BattleUserState) => {
               target.bukijutsuDefence += power;
             }
           } else {
+            // Percentage calculation - use additive stacking
             if (effect.direction === "offence" || effect.direction === "both") {
-              target.bukijutsuOffence *= (100 + power) / 100;
+              applyPercentageStatModifier(target, "bukijutsuOffence", power);
             }
             if (effect.direction === "defence" || effect.direction === "both") {
-              target.bukijutsuDefence *= (100 + power) / 100;
+              applyPercentageStatModifier(target, "bukijutsuDefence", power);
             }
           }
         }
@@ -561,33 +563,34 @@ export const adjustStats = (effect: UserEffect, target: BattleUserState) => {
               target[gen] += power;
             });
           } else if (effect.calculation === "percentage") {
+            // Percentage calculation - use additive stacking
             target.highestGenerals.forEach((gen) => {
-              target[gen] *= (100 + power) / 100;
+              applyPercentageStatModifier(target, gen, power);
             });
           }
         } else if (general === "Strength") {
           if (effect.calculation === "static") {
             target.strength += power;
           } else if (effect.calculation === "percentage") {
-            target.strength *= (100 + power) / 100;
+            applyPercentageStatModifier(target, "strength", power);
           }
         } else if (general === "Intelligence") {
           if (effect.calculation === "static") {
             target.intelligence += power;
           } else if (effect.calculation === "percentage") {
-            target.intelligence *= (100 + power) / 100;
+            applyPercentageStatModifier(target, "intelligence", power);
           }
         } else if (general === "Willpower") {
           if (effect.calculation === "static") {
             target.willpower += power;
           } else if (effect.calculation === "percentage") {
-            target.willpower *= (100 + power) / 100;
+            applyPercentageStatModifier(target, "willpower", power);
           }
         } else if (general === "Speed") {
           if (effect.calculation === "static") {
             target.speed += power;
           } else if (effect.calculation === "percentage") {
-            target.speed *= (100 + power) / 100;
+            applyPercentageStatModifier(target, "speed", power);
           }
         }
       });

--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -177,6 +177,21 @@ export type CombatUserFields = {
   // Reference IDs to static data in extraState
   relationIds: string[];
   warIds: string[];
+  /** Base stat values used for additive percentage modifier calculations (e.g., increaseStat, decreaseStat) */
+  baseStatsForModifiers?: {
+    ninjutsuOffence?: number;
+    ninjutsuDefence?: number;
+    genjutsuOffence?: number;
+    genjutsuDefence?: number;
+    taijutsuOffence?: number;
+    taijutsuDefence?: number;
+    bukijutsuOffence?: number;
+    bukijutsuDefence?: number;
+    strength?: number;
+    speed?: number;
+    intelligence?: number;
+    willpower?: number;
+  };
 };
 
 /**


### PR DESCRIPTION
## Summary

- Changed damage modifier tags (increaseDamageGiven, decreaseDamageGiven, increaseDamageTaken, decreaseDamageTaken) from multiplicative to additive stacking
- Added `baseDamageForModifiers` field to store original damage for percentage calculations
- 30% applied 3 times now equals 90% total increase instead of ~120%

Closes #991

## Test plan

- [ ] Test with multiple stacking damage increase effects (e.g., 3× 30% should equal 90% total increase)
- [ ] Test with multiple stacking damage decrease effects
- [ ] Test mixed increase/decrease scenarios
- [ ] Verify static calculations still work correctly
- [ ] Test interaction with absorb, reflect, and other damage-modifying tags

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Percentage-based stat modifiers now stack additively from stable base values, preventing multiplicative inflation across multiple modifiers.
  * Percentage-based damage modifiers (instant and residual) now reference stable base values for consistent, predictable damage calculations.
  * Messaging and action info preserved while modifier stacking and consequence handling were corrected for reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->