### PR TITLE
fix: show activity streak popup when user needs to catch up

### DIFF
--- a/app/src/layout/ActivityStreakPopup.tsx
+++ b/app/src/layout/ActivityStreakPopup.tsx
@@ -46,8 +46,9 @@ const ActivityStreakPopup: React.FC = () => {
   // Determine if we should show the popup
   const hasUnclaimedRewards =
     userStreaks?.streaks.some((s) => s.canClaimToday) ?? false;
+  const needsCatchUp = userStreaks?.streaks.some((s) => s.needsCatchUp) ?? false;
   const hasRecurringToEnroll = !!userStreaks?.activeRecurringConfig;
-  const shouldShowPopup = hasUnclaimedRewards || hasRecurringToEnroll;
+  const shouldShowPopup = hasUnclaimedRewards || needsCatchUp || hasRecurringToEnroll;
 
   // Show modal when there are unclaimed rewards and user hasn't dismissed today
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes #998 - Activity streak popup now appears when a user has missed a day and needs to catch up.

## Changes

- Added `needsCatchUp` check to popup visibility logic in `ActivityStreakPopup.tsx`
- When a user misses the 36-hour streak window, the popup now correctly shows with options to pay reputation or reset their streak

## Test Plan

- [ ] Verify popup shows normally when user can claim
- [ ] Verify popup shows when user has missed a day (needsCatchUp = true)
- [ ] Verify catch-up options (pay reputation / reset streak) are displayed

---

Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small UI visibility condition change with no new data writes or auth/security impact; main risk is increased popup frequency if `needsCatchUp` is mis-set.
> 
> **Overview**
> The activity streak popup visibility logic now treats `needsCatchUp` as a trigger, so the modal will open when a user has missed a day and must catch up (in addition to unclaimed rewards or recurring enrollment).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 811fdad6bc08986f17270dd637f80789a01222ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced activity streak popup display to appear in additional scenarios where users may need attention.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->