### PR TITLE
fix: make friendly fire settings work in raid battles

### DIFF
--- a/app/src/libs/combat/actions.ts
+++ b/app/src/libs/combat/actions.ts
@@ -966,7 +966,7 @@ export const getTargetUser = (
     if (target === "SELF") {
       result = users.find((u) => u.userId === user.userId && u.hex === tile);
     } else if (target === "OPPONENT") {
-      result = users.find((u) => u.villageId !== user.villageId && u.hex === tile);
+      result = users.find((u) => u.direction !== user.direction && u.hex === tile);
     } else if (target === "ALLY") {
       result = users.find((u) => u.villageId === user.villageId && u.hex === tile);
     } else if (target === "OTHER_USER") {

--- a/app/src/libs/combat/process.ts
+++ b/app/src/libs/combat/process.ts
@@ -53,6 +53,7 @@ import type { BattleUserState } from "./types";
 import type { GroundEffect, UserEffect, ActionEffect, BattleEffect } from "./types";
 import type { CompleteBattle, Consequence, CombatAction } from "./types";
 import type { ShieldTagType } from "@/validators/combat";
+
 /**
  * Minimal user type for checkFriendlyFire
  */
@@ -60,11 +61,14 @@ type FriendlyFireUser = {
   userId: string;
   isSummon?: boolean;
   controllerId: string;
-  villageId: string | null;
+  direction: "left" | "right";
 };
 
 /**
- * Check whether to apply given effect to a user, based on friendly fire settings
+ * Check whether to apply given effect to a user, based on friendly fire settings.
+ * Uses the 'direction' property to determine teams - users on the same side (left/right)
+ * are allies, users on opposite sides are enemies. This works for all battle types
+ * because direction is set based on userIds (attackers=left) vs targetIds (defenders=right).
  */
 export const checkFriendlyFire = (
   effect: BattleEffect,
@@ -75,46 +79,24 @@ export const checkFriendlyFire = (
   const creator = usersState.find((u) => u.userId === effect.creatorId);
   if (!creator) return false;
 
-  // For summoned units, always check if they belong to the creator
+  // For summoned units, check if they belong to the creator (same team)
   if (target.isSummon) {
     const isFriendly = target.controllerId === creator.userId;
     return effect.friendlyFire === "FRIENDLY" ? isFriendly : !isFriendly;
   }
 
-  // Get unique village IDs from real (non-summoned) users
-  const uniqueVillages = new Set(
-    usersState.filter((u) => !u.isSummon).map((u) => u.villageId),
-  );
-
-  // If all real users are from the same village, treat them as enemies
-  const isIntraVillageBattle = uniqueVillages.size === 1;
-
-  // In same-village battles, everyone except summons is an enemy
-  if (isIntraVillageBattle) {
-    if (!effect.friendlyFire || effect.friendlyFire === "ALL") {
-      return true; // Allow all
-    }
-    if (effect.friendlyFire === "FRIENDLY") {
-      return false; // Block friendly-only effects in intra-village battles
-    }
-    if (effect.friendlyFire === "ENEMIES") {
-      return effect.creatorId !== target.userId; // Only allow targeting others, not self
-    }
-    return false;
-  }
-
-  // In multi-village battles, players from same village are allies
-  const isFriendly = creator.villageId === target.villageId;
+  // Determine if target is friendly based on direction (same side = allies)
+  const isFriendly = creator.direction === target.direction;
 
   // Check if effect should be applied based on friendly fire settings
   if (!effect.friendlyFire || effect.friendlyFire === "ALL") {
     return true; // Allow all
   }
   if (effect.friendlyFire === "FRIENDLY") {
-    return isFriendly; // Only apply to friends (same village)
+    return isFriendly; // Only apply to friends (same direction/team)
   }
   if (effect.friendlyFire === "ENEMIES") {
-    return !isFriendly; // Only apply to enemies (different village)
+    return !isFriendly; // Only apply to enemies (different direction/team)
   }
   return false;
 };

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -2036,7 +2036,9 @@ export const rollInitiative = (
 };
 
 /**
- * Checks if a move is valid on the battlefield
+ * Checks if a move is valid on the battlefield.
+ * Uses the 'direction' property to determine OPPONENT/ALLY - users on opposite
+ * sides are opponents, users on the same side are allies.
  * @param info {
  *  action: CombatAction;
  *  target: TerrainHex;
@@ -2056,7 +2058,7 @@ export const isValidMove = (info: {
   clicked: TerrainHex;
 }) => {
   const { action, user, users, target, clicked, barriers } = info;
-  const { villageId, userId } = user;
+  const { userId, direction } = user;
   const barrier = barriers.find(
     (b) => b.longitude === target.col && b.latitude === target.row,
   );
@@ -2071,11 +2073,13 @@ export const isValidMove = (info: {
     if (action.target === "CHARACTER") {
       if (opponent) return true;
     } else if (action.target === "OPPONENT") {
-      if (opponent && opponent?.villageId !== villageId) return true;
+      // Opponent = different direction/team
+      if (opponent && opponent.direction !== direction) return true;
     } else if (action.target === "OTHER_USER") {
       if (opponent && opponent?.userId !== userId) return true;
     } else if (action.target === "ALLY") {
-      if (opponent && opponent?.villageId === villageId) return true;
+      // Ally = same direction/team
+      if (opponent && opponent.direction === direction) return true;
     } else if (action.target === "SELF") {
       // Allow self-targeting abilities like basic heal even when stealthed
       if (opponent && opponent?.userId === userId) return true;

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -90,7 +90,6 @@ import { sector, gameAsset } from "@/drizzle/schema";
 import { performActionSchema, statSchema, BarrierTag } from "@/validators/combat";
 import { performBattleAction, stillInBattle } from "@/libs/combat/actions";
 import { availableUserActions } from "@/libs/combat/actions";
-import { fetchGameAssets } from "@/routers/misc";
 import { getServerPusher, updateUserOnMap } from "@/libs/pusher";
 import { getRandomElement } from "@/utils/array";
 import { applyEffects, checkFriendlyFire } from "@/libs/combat/process";
@@ -928,8 +927,10 @@ export const combatRouter = createTRPCRouter({
         (e) => e.creatorId !== ctx.userId,
       );
 
-      // Preserve original initiative to avoid changing it when updating loadouts
+      // Preserve original initiative and direction to avoid changing them when updating loadouts
+      // Direction is important for RAID battles where friendly fire is determined by direction
       const originalInitiative = user.initiative;
+      const originalDirection = user.direction;
 
       // Hydrate jutsus and items from extraState if not using new loadouts
       // We reconstruct CombatQueryUser format from BattleUserState refs + extraState
@@ -1023,9 +1024,10 @@ export const combatRouter = createTRPCRouter({
         },
       );
 
-      // Restore original initiative
+      // Restore original initiative and direction
       if (usersState[0]) {
         usersState[0].initiative = originalInitiative;
+        usersState[0].direction = originalDirection;
       }
 
       // Merge the user's state with the other user's state
@@ -2199,8 +2201,8 @@ export const processUsersForBattle = async (
       // Set controllerID and mark this user as the original
       controllerId: inputUser.userId,
       userId: inputUser.isAi ? nanoid() : inputUser.userId,
-      // Set direction
-      direction: i % 2 === 0 ? "right" : "left",
+      // Set direction based on team membership (leftSideUserIds determines left team)
+      direction: leftSideUserIds?.includes(inputUser.userId) ? "left" : "right",
       // Set the updated at to now, so that action bar starts at 0
       updatedAt: new Date(),
       // If no village, set to syndicate


### PR DESCRIPTION
## Summary
- Fixed friendly fire settings not working in raid battles
- Uses `direction` property to determine team membership instead of `villageId`
- Updated targeting logic (OPPONENT/ALLY) for RAID battles

Closes #1007

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core combat targeting/friendly-fire logic and team assignment, which could affect multiple battle types if `direction` is missing or mis-set; scope is localized but behavior-impacting.
> 
> **Overview**
> Fixes RAID battles where friendly-fire rules were evaluated incorrectly by switching team detection from `villageId` (and intra-village heuristics) to `direction` (left/right) in `checkFriendlyFire`.
> 
> Updates targeting validation so `OPPONENT`/`ALLY` checks use `direction` for move/target legality, and ensures `processUsersForBattle` assigns `direction` from `leftSideUserIds` while combat state updates preserve a user’s original `direction` (and initiative) across loadout hydration. Also removes an unused import in the combat router.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c010a28a3979134844bf1a0fc58c7ae051412e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Combat system now determines teams by player direction (left/right) instead of village affiliation.
  * Friendly-fire detection and move validation updated to use direction-based comparisons.
  * Target selection behavior on shared tiles adjusted to use direction for opponent/ally resolution.
  * Battle processing now preserves and restores players' direction alongside initiative values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->