### PR TITLE
fix: prevent raid players from getting stuck in queue

### DIFF
--- a/app/src/server/api/routers/raids.ts
+++ b/app/src/server/api/routers/raids.ts
@@ -615,14 +615,10 @@ export const raidsRouter = createTRPCRouter({
     .output(baseServerResponse.extend({ teamId: z.string().optional() }))
     .mutation(async ({ ctx, input }) => {
       // Query - parallel fetch all required data upfront
-      const [{ user }, raid, existingQueue, teamData] = await Promise.all([
+      const [{ user }, raid, teamData] = await Promise.all([
         fetchUpdatedUser({ client: ctx.drizzle, userId: ctx.userId }),
         ctx.drizzle.query.quest.findFirst({
           where: and(eq(quest.id, input.questId), eq(quest.questType, "raid")),
-        }),
-        ctx.drizzle.query.mpvpBattleUser.findFirst({
-          where: eq(mpvpBattleUser.userId, ctx.userId),
-          with: { clanBattle: true },
         }),
         // Fetch team if joining existing, otherwise skip
         input.teamId
@@ -643,9 +639,6 @@ export const raidsRouter = createTRPCRouter({
       if (!raid) return errorResponse("Raid not found");
       if (user.status !== "AWAKE") {
         return errorResponse("You cannot join a raid queue in your current status");
-      }
-      if (existingQueue?.clanBattle?.battleId === null) {
-        return errorResponse("You are already in a battle queue");
       }
 
       // Guard - raid active state
@@ -974,13 +967,14 @@ export const raidsRouter = createTRPCRouter({
         return errorResponse("You are not in this team");
       }
 
-      // Guard - lobby time check
+      // Guard - lobby time check (with 2 second buffer for network latency)
       const lobbyTimeElapsed = secondsFromDate(
         RAID_BATTLE_LOBBY_SECONDS,
         team.createdAt,
       );
+      const LOBBY_BUFFER_MS = 2000;
       if (
-        new Date() < lobbyTimeElapsed &&
+        Date.now() < lobbyTimeElapsed.getTime() - LOBBY_BUFFER_MS &&
         team.queue.length < RAID_BATTLE_MAX_USERS_PER_TEAM
       ) {
         return errorResponse("Please wait for the lobby timer or full team");


### PR DESCRIPTION
## Summary

- Remove redundant queue check in joinRaidQueue that caused false positives
- Add 2-second buffer to lobby timer check to prevent race condition

Closes #1005

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes to raid queue/join/start guards; risk is limited to edge cases around queue eligibility and battle start timing.
> 
> **Overview**
> Prevents players from being incorrectly blocked from `joinRaidQueue` by removing a redundant “already in a battle queue” lookup/guard that could trigger false positives.
> 
> Tweaks `startRaidBattle`’s lobby timer gating by applying a 2s buffer to the countdown check to better tolerate network latency and reduce race-condition rejections when starting a raid.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66453110e9a1c42f98a7880c27f59963afb2ef50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Expanded raid queue joining eligibility, allowing players to participate in previously restricted scenarios
  * Enhanced raid lobby timing tolerance to better accommodate network latency, reducing timeout-related rejections when joining or starting raids

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->