### PR TITLE
fix: add injectjutsus and elementalseal to effect sort order

### DIFF
--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -660,6 +660,8 @@ export const sortEffects = (
     "summonprevent",
     "weakness",
     // Pre-modifiers
+    "elementalseal",
+    "injectjutsus",
     "cleanse",
     "clear",
     "decreasepoolcost",


### PR DESCRIPTION
Fixes #937

## Summary
- Added `injectjutsus` and `elementalseal` to the `sortEffects` ordered array in the Pre-modifiers section
- This ensures these effects have defined ordering and don't interfere with buff/debuff application

## Test plan
- [ ] Enter combat with active buffs/debuffs (including skill tree buffs)
- [ ] Use 60 AP of healing, then 40 AP Chakra Sword (inject action)
- [ ] Verify buffs still apply on the following turn
- [ ] Verify inject still functions correctly (adds jutsus to action pool)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to effect sorting; behavior only changes for combats involving `injectjutsus`/`elementalseal` ordering.
> 
> **Overview**
> Ensures `injectjutsus` and `elementalseal` have a deterministic application order by adding them to the `sortEffects` ordered list as *Pre-modifiers*.
> 
> This prevents these effects from being applied unpredictably relative to other buffs/debuffs during combat resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6504acf8b5b1f2278e6972b9dd63df53f40cdbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the ordering of certain combat effects to ensure proper priority and consistency during gameplay.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->