### PR TITLE
fix: normalize tag case in getEfficiencyRatio for damage modifiers

### DIFF
--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -2965,8 +2965,8 @@ const getEfficiencyRatio = (dmgEffect: UserEffect, effect: UserEffect) => {
       e.statTypes?.forEach((statType) =>
         tags.push(
           statType === "Highest" && e.highestOffence
-            ? getStatTypeFromStat(e.highestOffence)
-            : statType,
+            ? getStatTypeFromStat(e.highestOffence).toLowerCase()
+            : statType.toLowerCase(),
         ),
       );
     }
@@ -2974,9 +2974,9 @@ const getEfficiencyRatio = (dmgEffect: UserEffect, effect: UserEffect) => {
       tags.push(...getLowerGenerals(e.generalTypes, e.highestGenerals));
     }
     if ("elements" in e && e.elements && e.elements.length > 0) {
-      tags.push(...e.elements);
+      tags.push(...e.elements.map((el) => el.toLowerCase()));
     } else {
-      tags.push("None");
+      tags.push("none");
     }
     return tags;
   };


### PR DESCRIPTION
## Summary

- Fixes case sensitivity bug in `getEfficiencyRatio()` that caused damage modifiers to not apply correctly
- Normalizes all tag comparisons to lowercase

## Test plan

- [ ] Test 70% damage reduction - should now reduce damage by exactly 70%
- [ ] Test 90% damage increase - should increase damage by exactly 90%

Fixes #1017

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistency in damage modifier tag matching that could prevent certain combat effects from being properly applied during battles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->