### PR TITLE
Fix THENINJARPG-2EJ: Add null checks for deleted sellers in auction house

### DIFF
--- a/app/src/app/auctionhouse/page.tsx
+++ b/app/src/app/auctionhouse/page.tsx
@@ -27,6 +27,7 @@ import {
   AUCTION_LISTING_STATES,
   AUCTION_LISTING_TYPES,
   TRADEABLE_CURRENCY_TYPES,
+  IMG_AVATAR_DEFAULT,
 } from "@/drizzle/constants";
 import { useInfinitePagination } from "@/libs/pagination";
 import {
@@ -178,7 +179,7 @@ const AuctionListing: React.FC<AuctionListingProps> = ({ selectedStatus }) => {
           )}
         </div>
       ),
-      seller: listing.seller.avatar,
+      seller: listing.seller?.avatar ?? IMG_AVATAR_DEFAULT,
       listingType:
         listing.listingType === "AUCTION" ? (
           <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded-md text-xs font-medium">
@@ -481,11 +482,11 @@ const AuctionDetailsDialog: React.FC<AuctionDetailsDialogProps> = ({
             <div className="flex flex-col items-center">
               <div className="flex flex-col items-center gap-2 w-20">
                 <AvatarImage
-                  href={listing.seller.avatar}
-                  alt={listing.seller.username}
+                  href={listing.seller?.avatar ?? IMG_AVATAR_DEFAULT}
+                  alt={listing.seller?.username ?? "Deleted User"}
                   size={40}
                 />
-                <span>{listing.seller.username}</span>
+                <span>{listing.seller?.username ?? "Deleted User"}</span>
               </div>
             </div>
             {listing.listingType === "DIRECT" && listing.targetUser && (
@@ -524,7 +525,7 @@ const AuctionDetailsDialog: React.FC<AuctionDetailsDialogProps> = ({
             <Table
               data={listing.bids.map((bid) => ({
                 ...bid,
-                bidder: bid.bidder.avatar,
+                bidder: bid.bidder?.avatar ?? IMG_AVATAR_DEFAULT,
               }))}
               columns={[
                 { key: "bidder", header: "Bidder", type: "avatar" },


### PR DESCRIPTION
## Summary
Added optional chaining with fallback values for seller and bidder avatars/usernames in the auction house page. Uses IMG_AVATAR_DEFAULT for missing avatars and 'Deleted User' for missing usernames.

## Why
**Sentry Issue**: [THENINJARPG-2EJ](https://studie-tech-aps.sentry.io/issues/89506579/)

**Error observed**: `TypeError: Cannot read properties of null (reading 'avatar')`

**Frequency**: 38 events affecting 15 users over 12 days

**Key insight from Sentry**: The stack trace pointed to `Array.map` in auctionhouse/page.tsx, and breadcrumbs showed the error occurred when fetching SOLD listings. Historical/completed auctions persist after seller accounts are deleted, and since PlanetScale doesn't enforce foreign key constraints, Drizzle returns null for the seller relation.

**Root cause**: The code accessed `listing.seller.avatar` without null checking. When a user deletes their account after creating an auction listing, the seller relation returns null, causing the crash.

**Sentry Issue:** [THENINJARPG-2EJ](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2EJ)

## Test plan
- Verified locally
- Code review passed

Closes #1028

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only null-safety changes with simple fallbacks; minimal behavioral impact aside from preventing runtime errors.
> 
> **Overview**
> Prevents crashes in the auction house UI when a `listing.seller` or `bid.bidder` relation is `null` (e.g., deleted accounts).
> 
> Updates listing rows, seller display in the details dialog, and bid history avatars to use optional chaining with fallbacks (`IMG_AVATAR_DEFAULT` and "Deleted User").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cf57b3fa439e457e204e6c46f36162c66135970. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing seller and bidder avatars to display a default avatar image instead of broken images. Auctions now gracefully handle deleted user profiles by showing "Deleted User" as fallback text when seller or bidder information is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->