### PR TITLE
Fix THENINJARPG-278: Filter PayPal SDK stack overflow errors from Sentry

### DIFF
--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -260,9 +260,14 @@ function isGoogleTranslateError(event: Sentry.ErrorEvent): boolean {
  * Check if an error is a PayPal SDK cleanup error that should be filtered.
  * These occur when users navigate away while PayPal buttons are initializing,
  * or when users close the PayPal popup before the transaction completes.
+ *
+ * THENINJARPG-278: Also filters stack overflow errors from PayPal SDK's zoid library,
+ * which can occur during component cleanup when the internal promise handlers
+ * (dispatch/resolve/reject) enter infinite recursion.
  */
 function isPayPalSdkError(event: Sentry.ErrorEvent): boolean {
   const message = event.exception?.values?.[0]?.value ?? "";
+  const errorType = event.exception?.values?.[0]?.type ?? "";
   const stackFrames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
 
   // Check message for PayPal-related error patterns
@@ -291,6 +296,17 @@ function isPayPalSdkError(event: Sentry.ErrorEvent): boolean {
   );
 
   if (isFromPayPalSdk && message.includes("closed")) {
+    return true;
+  }
+
+  // THENINJARPG-278: Filter PayPal SDK stack overflow errors
+  // These occur when zoid's internal promise handlers (dispatch/resolve) enter infinite
+  // recursion during component cleanup. This is an internal SDK bug we cannot fix.
+  // UX note: Users don't see this error - it occurs during navigation/cleanup.
+  const isStackOverflow =
+    errorType === "RangeError" && message.includes("Maximum call stack size exceeded");
+
+  if (isStackOverflow && isFromPayPalSdk) {
     return true;
   }
 


### PR DESCRIPTION
## Summary
Add filter to ignore stack overflow errors originating from PayPal SDK scripts

## Why
Reduces Sentry noise from non-actionable third-party errors

**Sentry Issue:** [THENINJARPG-278](https://studie-tech-aps.sentry.io/issues/THENINJARPG-278)

## Test plan
- Verified locally
- Code review passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts Sentry client-side filtering to ignore a specific third-party error signature; main risk is accidentally suppressing a real app error with a similar stack/message.
> 
> **Overview**
> Reduces client-side Sentry noise by extending `isPayPalSdkError` to also drop PayPal SDK `RangeError: Maximum call stack size exceeded` events when the stack trace indicates they originate from PayPal/zoid scripts.
> 
> Adds `type`-based detection plus inline documentation for THENINJARPG-278, without changing any runtime behavior beyond additional error filtering in `beforeSend`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0579c287731725053aaef75fb7bf8a5e0f5041c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for PayPal SDK integration by improving detection and suppression of stack overflow errors during component cleanup and navigation, resulting in increased stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->