### PR TITLE
Fix THENINJARPG-2F2: Filter MetaMask extension errors from Sentry

### DIFF
--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -63,6 +63,8 @@ Sentry.init({
     "postMessage is not a function", // Clerk internal error - occurs in clerk.browser.js with Web Workers
     "module factory is not available", // Turbopack runtime error - occurs when browser caches stale JS chunks after deployment
     "Cannot assign to read only property 'then' of object", // Turbopack Promise assignment error - occurs when browser extensions freeze Promise objects or stale caches cause conflicts
+    "Failed to connect to MetaMask", // MetaMask extension error - occurs when extension is disabled/uninstalled but inpage.js still runs
+    "No extension found with id:", // Browser extension not found error - occurs when any extension (MetaMask, etc.) is disabled after page load
   ],
 
   // Filter out third-party errors that slip through ignoreErrors
@@ -99,6 +101,9 @@ Sentry.init({
     }
     if (isClerkSyntaxError(event)) {
       return null; // Drop Clerk script parsing errors (network truncation)
+    }
+    if (isWalletExtensionError(event)) {
+      return null; // Drop cryptocurrency wallet extension errors (MetaMask, etc.)
     }
     return event;
   },
@@ -535,6 +540,43 @@ const isClerkSyntaxError = (event: Sentry.ErrorEvent): boolean => {
       frame.abs_path?.includes("@clerk/clerk-js") ||
       frame.abs_path?.includes("clerk.browser"),
   );
+};
+
+/**
+ * Check if an error is from a cryptocurrency wallet browser extension.
+ * These occur when users have MetaMask or similar wallet extensions installed,
+ * and the extension's injected script encounters an error independently of our app.
+ *
+ * UX note: These errors are not actionable - they originate from third-party
+ * browser extensions we don't control. Users don't see these errors as they
+ * occur in the extension's isolated context. The application has no Web3/
+ * cryptocurrency functionality.
+ */
+const isWalletExtensionError = (event: Sentry.ErrorEvent): boolean => {
+  const message = event.exception?.values?.[0]?.value ?? "";
+  const stackFrames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
+
+  // Check for wallet-specific error patterns
+  const isWalletErrorMessage =
+    message.includes("Failed to connect to MetaMask") ||
+    message.includes("No extension found with id:");
+
+  if (isWalletErrorMessage) {
+    return true;
+  }
+
+  // Check if error originates from wallet extension's injected script
+  // - inpage.js is the common name for wallet extension content scripts
+  // - app:///scripts/ is the URL scheme for browser extension injected scripts
+  const isFromWalletScript = stackFrames.some(
+    (frame) =>
+      frame.filename?.includes("inpage.js") ||
+      frame.filename?.startsWith("app:///scripts/") ||
+      frame.abs_path?.includes("inpage.js") ||
+      frame.abs_path?.startsWith("app:///scripts/"),
+  );
+
+  return isFromWalletScript;
 };
 
 function ensureBrowserErrorHandler() {


### PR DESCRIPTION
## Summary
Add filter for MetaMask browser extension errors in Sentry beforeSend hook

## Why
MetaMask extension errors are third-party noise that don't affect users and pollute error monitoring

**Sentry Issue:** [THENINJARPG-2F2](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2F2)

## Test plan
- Verified locally
- Code review passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts Sentry client-side error filtering; main risk is accidentally dropping legitimate errors if they match the new wallet-extension heuristics.
> 
> **Overview**
> Client-side Sentry filtering is expanded to suppress cryptocurrency wallet browser extension noise.
> 
> Adds MetaMask/extension-specific patterns to `ignoreErrors` and introduces `isWalletExtensionError` in `beforeSend` to drop events based on known messages and stack traces from injected wallet scripts (e.g., `inpage.js`, `app:///scripts/`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e515a8cb049a33ed8db54d0fe21935b73a9f4b4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error tracking by filtering out cryptocurrency wallet browser extension-related errors, reducing noise in error logs and enhancing visibility of genuine application issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->