### PR TITLE
Fix THENINJARPG-2F7: Add null checks for userItem in auction house

### DIFF
--- a/app/src/app/auctionhouse/page.tsx
+++ b/app/src/app/auctionhouse/page.tsx
@@ -146,8 +146,13 @@ const AuctionListing: React.FC<AuctionListingProps> = ({ selectedStatus }) => {
   // Infinite pagination
   useInfinitePagination({ fetchNextPage, hasNextPage, lastElement });
 
-  // Flatten all pages data
-  const allListings = listings?.pages.map((page) => page.data).flat() ?? [];
+  // Flatten all pages data and filter out listings with missing userItem data
+  // (can happen if item was deleted between query time and render time)
+  const allListings =
+    listings?.pages
+      .map((page) => page.data)
+      .flat()
+      .filter((listing) => listing.userItem && listing.userItem.item) ?? [];
 
   // Transform data to include JSX directly in the objects
   const transformedData =
@@ -375,6 +380,18 @@ const AuctionDetailsDialog: React.FC<AuctionDetailsDialogProps> = ({
     return (
       <Modal2 title="Auction Details" isOpen={isOpen} setIsOpen={setIsOpen}>
         <Loader />
+      </Modal2>
+    );
+  }
+  if (!listing.userItem || !listing.userItem.item) {
+    return (
+      <Modal2 title="Auction Details" isOpen={isOpen} setIsOpen={setIsOpen}>
+        <div className="p-4 text-center">
+          <p className="text-red-600">This auction is no longer available.</p>
+          <p className="text-muted-foreground text-sm mt-2">
+            The item associated with this auction could not be found.
+          </p>
+        </div>
       </Modal2>
     );
   }


### PR DESCRIPTION
## Summary
Add defensive null checks in auction house page to handle orphaned listings where userItem has been deleted

## Why
**Sentry Issue**: [THENINJARPG-2F7](https://studie-tech-aps.sentry.io/issues/91284891/)

**Error observed**: `TypeError: Cannot read properties of null (reading 'item')`

**Frequency**: 2 events affecting 1 user

**Key insight from Sentry**: The breadcrumbs showed a successful API fetch followed immediately by clicking a table row and the error occurring ~200ms later while rendering the dialog. The stack trace pointed to `auctionhouse/page.tsx` where `listing.userItem.item` properties were being accessed without null checks.

**Root cause**: When auction listings reference deleted `userItem` records (due to admin item deletion, user account deletion, or race conditions between queries), the code crashes accessing nested properties. PlanetScale's lack of foreign key constraints allows orphaned auction listings to exist.

**Sentry Issue:** [THENINJARPG-2F7](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2F7)

## Test plan
- Verified locally
- Code review passed

Closes #1044

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only defensive null checks that reduce crash risk; behavior change is limited to hiding/short-circuiting invalid listings.
> 
> **Overview**
> Prevents Auction House crashes when auction listings reference deleted/orphaned `userItem` records.
> 
> The listings table now filters out entries missing `listing.userItem.item`, and the `AuctionDetailsDialog` adds a guard that shows an “auction no longer available” message instead of dereferencing null.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 387a1f39e2bba8ace6b29ac6cd858bad62e8200f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->