### PR TITLE
Fix THENINJARPG-2BQ: Add output schema to checkRewards mutation

### DIFF
--- a/app/src/libs/toast.tsx
+++ b/app/src/libs/toast.tsx
@@ -167,7 +167,7 @@ export const showRewardToast = (
   rewards: PostProcessedRewards,
   title: string,
   resolved?: boolean,
-  quest?: Quest,
+  quest?: Pick<Quest, "successDescription">,
   badges?: { id: string; name: string; image: string }[],
 ) => {
   const message = (

--- a/app/src/server/api/routers/quests.ts
+++ b/app/src/server/api/routers/quests.ts
@@ -42,7 +42,7 @@ import {
   canAwardReputation,
 } from "@/utils/permissions";
 import { callDiscordContent } from "@/libs/socials";
-import { LetterRanks } from "@/drizzle/constants";
+import { LetterRanks, UserRanks, STARTER_VILLAGES } from "@/drizzle/constants";
 import { calculateContentDiff } from "@/utils/diff";
 import { initiateBattle } from "@/routers/combat";
 import { availableQuestLetterRanks, availableRanks } from "@/libs/train";
@@ -1048,6 +1048,64 @@ export const questsRouter = createTRPCRouter({
     }),
   checkRewards: protectedProcedure
     .input(z.object({ questId: z.string(), nextObjectiveId: z.string().optional() }))
+    .output(
+      z.union([
+        // Error response
+        z.object({
+          success: z.literal(false),
+          message: z.string(),
+        }),
+        // Success response
+        z.object({
+          success: z.literal(true),
+          notifications: z.array(z.string()),
+          rewards: z.object({
+            reward_money: z.number(),
+            reward_seichi_silver: z.number(),
+            reward_clanpoints: z.number(),
+            reward_anbupoints: z.number(),
+            reward_exp: z.number(),
+            reward_tokens: z.number(),
+            reward_prestige: z.number(),
+            reward_reputation: z.number(),
+            reward_skillpoints: z.number(),
+            reward_medical_experience: z.number(),
+            reward_hunting_experience: z.number(),
+            reward_crafting_experience: z.number(),
+            reward_gathering_experience: z.number(),
+            reward_war_damage: z.number(),
+            reward_war_healing: z.number(),
+            reward_rank: z.enum(UserRanks),
+            reward_village_membership: z.enum(STARTER_VILLAGES),
+            reward_items: z.array(z.string()),
+            reward_jutsus: z.array(z.string()),
+            reward_badges: z.array(z.string()),
+            reward_bloodlines: z.array(z.string()),
+            reward_hunter_items: z.boolean(),
+            reward_gathering_items: z.boolean(),
+            reward_hunter_items_ids: z.array(z.string()),
+            reward_gathering_items_ids: z.array(z.string()),
+          }),
+          userQuest: z
+            .object({
+              questId: z.string(),
+              quest: z.object({
+                name: z.string(),
+                successDescription: z.string().nullable(),
+              }),
+            })
+            .nullable(),
+          resolved: z.boolean(),
+          badges: z.array(
+            z.object({
+              id: z.string(),
+              name: z.string(),
+              image: z.string(),
+            }),
+          ),
+        }),
+      ]),
+    )
     .mutation(async ({ ctx, input }) => {
       // Query
       const { user, toastMessages, settings } = await fetchUpdatedUser({
@@ -1161,7 +1219,15 @@ export const questsRouter = createTRPCRouter({
         success: true,
         notifications: finalNotifications,
         rewards,
-        userQuest,
+        userQuest: userQuest
+          ? {
+              questId: userQuest.questId,
+              quest: {
+                name: userQuest.quest.name,
+                successDescription: userQuest.quest.successDescription,
+              },
+            }
+          : null,
         resolved,
         badges,
       };

--- a/app/src/server/api/trpc.ts
+++ b/app/src/server/api/trpc.ts
@@ -204,5 +204,5 @@ export const baseServerResponse = z.object({
 export type BaseServerResponse = z.infer<typeof baseServerResponse>;
 
 export const errorResponse = (msg: string) => {
-  return { success: false, message: msg };
+  return { success: false as const, message: msg };
 };


### PR DESCRIPTION
## Summary
- Add comprehensive Zod output schema to checkRewards mutation using discriminated union
- Sanitize userQuest response to only include fields used by frontend (questId, quest.name, quest.successDescription)
- Update errorResponse to use 'as const' for better TypeScript literal type inference
- Narrow Quest type in showRewardToast to Pick<Quest, 'successDescription'>

## Why
**Sentry Issue**: [THENINJARPG-2BQ](https://studie-tech-aps.sentry.io/issues/84727109/)

**Error observed**: TRPCClientError: Unable to transform response from server (HTTP 500)

**Frequency**: 5 events affecting 5 users since 2025-12-23

**Key insight from Sentry**: Stack trace showed the error occurs in tRPC's transformer layer (`@trpc/server/src/unstable-core-do-not-import/transformer.ts`) during response serialization, not during mutation logic. The breadcrumbs confirmed the error happens when users click 'Collect Reward' after completing combat.

**Root cause**: The `checkRewards` mutation returned the full `userQuest` object (including nested Quest with complex content JSON field, Date fields, and BigInt values) without output validation. Unlike `checkLocationQuest` which has an output schema, `checkRewards` passed the entire raw ORM object to superjson for serialization, causing failures in certain edge cases with malformed JSON, circular references, or BigInt edge cases.

**Sentry Issue:** [THENINJARPG-2BQ](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2BQ)

## Test plan
- Verified locally
- Code review passed

Closes #1046

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a core gameplay mutation and its response contract; while changes are mostly additive/type-focused, any mismatch between runtime responses and the new schema could cause client-visible failures.
> 
> **Overview**
> Prevents tRPC transformer errors when collecting quest rewards by adding an explicit Zod `.output()` schema to `quests.checkRewards`, with a typed success/error union and fully-specified `rewards`/`badges` shapes.
> 
> On success, the mutation now returns a **sanitized `userQuest` payload** (only `questId`, `quest.name`, and `quest.successDescription`) instead of the full ORM object; the frontend `showRewardToast` signature is narrowed accordingly (`Pick<Quest, "successDescription">`). `errorResponse` is also tightened to return `success: false as const` for better literal type inference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4715d338bb3ecd9e3b4a06209c41f71db90b84f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->