### PR TITLE
Fix THENINJARPG-271: Filter React hook count errors from external DOM manipulation

### DIFF
--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -637,9 +637,23 @@ const isExternalHookCountError = (event: Sentry.ErrorEvent): boolean => {
     const filename = frame.filename ?? "";
     const absPath = frame.abs_path ?? "";
 
-    // Check for app source directories that indicate our code
+    // Check for specific app source directories that indicate our code
+    const isInAppDirectory =
+      filename.includes("/src/app/") ||
+      filename.includes("/src/libs/") ||
+      filename.includes("/src/layout/") ||
+      filename.includes("/src/hooks/") ||
+      filename.includes("/src/utils/") ||
+      filename.includes("/src/validators/") ||
+      absPath.includes("/src/app/") ||
+      absPath.includes("/src/libs/") ||
+      absPath.includes("/src/layout/") ||
+      absPath.includes("/src/hooks/") ||
+      absPath.includes("/src/utils/") ||
+      absPath.includes("/src/validators/");
+
     return (
-      (filename.includes("app/src/") || absPath.includes("app/src/")) &&
+      isInAppDirectory &&
       !filename.includes("node_modules") &&
       !absPath.includes("node_modules")
     );
@@ -648,26 +662,35 @@ const isExternalHookCountError = (event: Sentry.ErrorEvent): boolean => {
   // If there's no app code in the stack, it's external
   if (!hasAppCode) return true;
 
-  // Check if stack trace indicates external origin (extensions, injected scripts)
-  const hasExternalOrigin = stackFrames.some((frame) => {
+  // Check if stack trace indicates clear external origin (extensions, injected scripts)
+  // Use more specific patterns to avoid false positives from minified code
+  const hasClearExternalOrigin = stackFrames.some((frame) => {
     const filename = frame.filename ?? "";
     const absPath = frame.abs_path ?? "";
 
     return (
+      // Browser extension protocols are unambiguous
       filename.includes("extension://") ||
       absPath.includes("extension://") ||
-      filename.includes("inject") ||
-      absPath.includes("inject") ||
+      filename.includes("chrome-extension://") ||
+      absPath.includes("chrome-extension://") ||
+      filename.includes("moz-extension://") ||
+      absPath.includes("moz-extension://") ||
+      // Specific injected script patterns (not just "inject" substring)
+      filename.includes("inject_content") ||
+      absPath.includes("inject_content") ||
+      filename.includes("content_script") ||
+      absPath.includes("content_script") ||
+      // Google Translate proxy domain
       filename.includes("translate.goog") ||
-      absPath.includes("translate.goog") ||
-      filename === "<anonymous>" ||
-      absPath === "<anonymous>"
+      absPath.includes("translate.goog")
     );
   });
 
-  // Only filter if external origin is detected (even if app code is present)
-  // This catches cases where extension code triggers errors in our app
-  return hasExternalOrigin;
+  // Only filter if clear external origin is detected AND app code is present
+  // When app code is in the stack, we need strong evidence of external interference
+  // to avoid silencing real bugs
+  return hasClearExternalOrigin;
 };
 
 function ensureBrowserErrorHandler() {


### PR DESCRIPTION
## Summary
Add beforeSend filter (isExternalHookCountError) that filters React hook count mismatch errors ('Rendered more/fewer hooks') when they originate from external code. The filter verifies errors come from browser extensions or third-party scripts by checking stack traces for extension URLs, injected scripts, or absence of application source files.

## Why
**Sentry Issue**: [THENINJARPG-271](https://studie-tech-aps.sentry.io/issues/77799994/)

**Error observed**: 'Rendered more hooks than during the previous render' on /register page

**Frequency**: 25 events from 2 users (Chrome 144 on Linux) over 2+ months

**Key insight from Sentry**:
- Breadcrumbs show `NotFoundError: Failed to execute 'removeChild' on 'Node'` occurring BEFORE the hooks error - a classic sign of external DOM manipulation by browser extensions/Google Translate
- Stack trace contains only React internals (`react-dom-client.production.js`), no application code
- TikTok Pixel errors also appear in breadcrumbs, indicating third-party scripts are active

**Root cause**: Browser extensions and third-party scripts modify the DOM externally, causing React's reconciliation to fail when the virtual DOM no longer matches the actual DOM. This triggers the hook count error even though the application code is correct.

**Why stack trace verification**: The initial implementation used simple `ignoreErrors` but code review identified this could mask legitimate application bugs. The improved implementation uses a `beforeSend` filter that only suppresses errors when the stack trace confirms external origin (no app source code in stack, or extension/inject patterns present).

**Sentry Issue:** [THENINJARPG-271](https://studie-tech-aps.sentry.io/issues/THENINJARPG-271)

## Test plan
- Verified locally
- Code review passed

Closes #1047

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production error-reporting behavior; incorrect heuristics could suppress real hook-count bugs or fail to reduce noise, but it does not affect runtime app logic beyond Sentry filtering.
> 
> **Overview**
> Filters out noisy React hook-count mismatch errors ("Rendered more/fewer hooks") from client-side Sentry reporting when evidence suggests they were caused by **external DOM manipulation** rather than app code.
> 
> This introduces `isExternalHookCountError` and wires it into `beforeSend`, using stack-trace heuristics (no frames, no app source paths, or explicit extension/injected/`translate.goog` origins) to avoid masking genuine application hook bugs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc249a230b812f678afde16a4ed70274ffd16aae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->