### PR TITLE
Fix THENINJARPG-296: Prevent infinite loop in Cooldown component

### DIFF
--- a/app/src/layout/MenuBoxProfile.tsx
+++ b/app/src/layout/MenuBoxProfile.tsx
@@ -296,7 +296,7 @@ const MenuBoxProfile: React.FC = () => {
               <TooltipContent>Money on hand</TooltipContent>
             </Tooltip>
           </TooltipProvider>
-          {userData && userData.immunityUntil > new Date() && (
+          {userData && immunitySecsLeft > 0 && (
             <TooltipProvider delayDuration={50}>
               <Tooltip>
                 <TooltipTrigger className="w-full">
@@ -450,8 +450,11 @@ const Cooldown: React.FC<CooldownProps> = (props) => {
   const hasNotifiedRef = React.useRef(false);
 
   useEffect(() => {
-    // Reset notification flag when countdown restarts
-    hasNotifiedRef.current = false;
+    // Only reset notification flag when countdown actually restarts (has time remaining)
+    const secondsLeft = createdAt + totalSeconds * 1000 - Date.now();
+    if (secondsLeft > 0) {
+      hasNotifiedRef.current = false;
+    }
   }, [createdAt, totalSeconds]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
Replace unstable Date comparison with memoized immunitySecsLeft value and add conditional check to only reset notification flag when countdown has time remaining

## Why
**Sentry Issue**: [THENINJARPG-296](https://studie-tech-aps.sentry.io/issues/81240229/)

**Error observed**: Maximum update depth exceeded - React detects too many nested updates

**Frequency**: 3 events affecting 2 users

**Key insight from Sentry**: The mechanism `auto.browser.browserapierrors.setInterval` indicated the gameTime interval was involved. Stack trace pointed to MenuBoxProfile.tsx where the immunity countdown is rendered. The error occurs when viewing a user profile page at the exact moment their immunity timer expires.

**Root cause**: The condition `userData.immunityUntil > new Date()` at line 299 creates a new Date object on every render. When immunity is at exact expiration boundary, this causes the condition to rapidly flip between true/false. Combined with the first useEffect unconditionally resetting `hasNotifiedRef.current = false`, each re-render triggers another setState call, creating an infinite loop.

**Sentry Issue:** [THENINJARPG-296](https://studie-tech-aps.sentry.io/issues/THENINJARPG-296)

## Test plan
- Verified locally
- Code review passed

Closes #1052

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI state/timer logic change; main risk is an off-by-one/edge-case in when the immunity countdown hides or finishes.
> 
> **Overview**
> Prevents an infinite re-render loop on the profile menu when the PvP immunity timer hits its expiry boundary.
> 
> This switches the immunity display condition from a per-render `new Date()` comparison to a memoized `immunitySecsLeft` value, and updates `Cooldown` to only reset its “finished” notification flag when time is actually remaining (avoiding repeated parent `setState` triggers at/after expiry).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba3ded68f31a990b99e8e4c35bc3a66523150d91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->