### PR TITLE
Fix THENINJARPG-2EX: Cytoscape cleanup race condition on mobile

### DIFF
--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -109,6 +109,9 @@ Sentry.init({
     if (isWalletExtensionError(event)) {
       return null; // Drop cryptocurrency wallet extension errors (MetaMask, etc.)
     }
+    if (isCytoscapeCleanupError(event)) {
+      return null; // Drop Cytoscape cleanup race condition errors
+    }
     return event;
   },
 
@@ -392,7 +395,7 @@ function isDataCloneError(event: Sentry.ErrorEvent): boolean {
  * UX note: These errors are still displayed to users via the global tRPC error handler
  * in Provider.tsx which shows a toast notification. This filter only suppresses Sentry logging.
  *
- * THENINJARPG-2D1: Added safety filter error filtering for Replicate's content moderation.
+ * Safety filter error filtering handles Replicate's content moderation responses.
  */
 const isReplicateApiError = (event: Sentry.ErrorEvent): boolean => {
   const message = event.exception?.values?.[0]?.value ?? "";
@@ -533,6 +536,34 @@ const isInjectedJsonParseError = (event: Sentry.ErrorEvent): boolean => {
   });
 
   return isFromAnonymousOrInjectedCode;
+};
+
+/**
+ * Check if an error is a Cytoscape cleanup race condition error that should be filtered.
+ * These occur on mobile devices when touch events fire during/after the Cytoscape
+ * instance is being destroyed during React component unmount.
+ *
+ * UX note: This error occurs during component unmount cleanup - users do not see any
+ * error or broken UI. The Battle Graph dialog simply closes as expected. The
+ * GraphUsersGeneric component handles this gracefully with try/catch during destruction.
+ *
+ * Filters Cytoscape emit errors from mobile touch event race conditions.
+ */
+const isCytoscapeCleanupError = (event: Sentry.ErrorEvent): boolean => {
+  const message = event.exception?.values?.[0]?.value ?? "";
+  const stackFrames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
+
+  // Check for the specific error message pattern
+  if (!message.includes("Cannot read properties of undefined (reading 'emit')")) {
+    return false;
+  }
+
+  // Check if the error originates from Cytoscape
+  return stackFrames.some(
+    (frame) =>
+      frame.filename?.includes("cytoscape") ||
+      frame.abs_path?.includes("cytoscape"),
+  );
 };
 
 /**

--- a/app/src/layout/GraphUsersGeneric.tsx
+++ b/app/src/layout/GraphUsersGeneric.tsx
@@ -48,8 +48,10 @@ const GraphUsersGeneric: React.FC<GraphUsersGenericProps> = (props) => {
         // Remove all listeners before destroying
         cyRefInstance.removeAllListeners();
         // Use setTimeout to allow any pending touch event handlers to complete
-        // before destroying the instance. This prevents the "Cannot read properties
-        // of undefined (reading 'emit')" error on mobile devices.
+        // before destroying the instance. The 300ms delay accounts for the Radix
+        // Dialog closing animation (200ms) plus buffer for mobile touch events.
+        // This prevents the "Cannot read properties of undefined (reading 'emit')"
+        // error on mobile devices.
         // Intentionally fire-and-forget since this is cleanup code
         // eslint-disable-next-line @eslint-react/web-api/no-leaked-timeout
         setTimeout(() => {
@@ -58,7 +60,7 @@ const GraphUsersGeneric: React.FC<GraphUsersGenericProps> = (props) => {
           } catch {
             // Ignore errors during cleanup - the instance may already be partially destroyed
           }
-        }, 0);
+        }, 300);
       }
     };
   }, []);


### PR DESCRIPTION
## Summary
Increase cleanup timeout in GraphUsersGeneric.tsx from 0ms to 300ms to account for Radix Dialog animation (200ms) plus buffer for mobile touch events. Add Sentry error filter as safety net for remaining edge cases.

## Why
**Sentry Issue**: [THENINJARPG-2EX](https://studie-tech-aps.sentry.io/issues/89664048/)

**Error observed**: \`TypeError: Cannot read properties of undefined (reading 'emit')\`

**Frequency**: 8 events affecting 6 users (2026-01-20 to 2026-01-29)

**Key insight from Sentry**: Stack trace showed the error originates in Cytoscape's internal event emitter. Breadcrumbs revealed users opening Battle Graph dialog, interacting with the graph (touch/pan/zoom), then closing the dialog. All events were on mobile devices (Chrome Mobile on Android), indicating touch event race conditions.

**Root cause**: The existing 0ms setTimeout in GraphUsersGeneric cleanup was insufficient. Touch events queued in the browser's event loop during the Radix Dialog closing animation (200ms) were firing after Cytoscape began destruction, causing the emit error on undefined.

**Sentry Issue:** [THENINJARPG-2EX](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2EX)

## Test plan
- Verified locally
- Code review passed

Closes #1054

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes to client-side cleanup timing and Sentry filtering; primary risk is masking a legitimate Cytoscape error if the signature matches unexpectedly.
> 
> **Overview**
> Reduces a mobile-only Cytoscape teardown race by delaying `GraphUsersGeneric` unmount cleanup from `setTimeout(..., 0)` to `300ms` (aligned with the dialog close animation), lowering the chance that late touch events hit a destroyed instance.
> 
> Adds a Sentry `beforeSend` filter (`isCytoscapeCleanupError`) to drop the specific Cytoscape `...reading 'emit'` error when the stack trace indicates it originates from Cytoscape, as a safety net for remaining edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69fc675a98db0dafc7f8000c04f05ee840169358. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->