### PR TITLE
Fix THENINJARPG-219: Filter React recoverable hydration errors from Sentry

### DIFF
--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -109,6 +109,9 @@ Sentry.init({
     if (isWalletExtensionError(event)) {
       return null; // Drop cryptocurrency wallet extension errors (MetaMask, etc.)
     }
+    if (isRecoverableHydrationError(event)) {
+      return null; // Drop React recoverable errors (hydration recovery)
+    }
     return event;
   },
 
@@ -597,6 +600,37 @@ const isWalletExtensionError = (event: Sentry.ErrorEvent): boolean => {
   );
 
   return isFromWalletScript;
+};
+
+/**
+ * Check if an error is a React recoverable error that should be filtered.
+ * These occur when React encounters and recovers from an error during hydration
+ * or rendering. The errors appear as "Object captured as exception with keys:
+ * message, name, stack, toString" because React throws error-like objects
+ * (not Error instances) during recovery.
+ *
+ * UX note: These errors are completely invisible to users - React successfully
+ * recovers and continues rendering. The user experience is unaffected.
+ *
+ * THENINJARPG-219: Filter recoverable errors from Sentry.
+ */
+const isRecoverableHydrationError = (event: Sentry.ErrorEvent): boolean => {
+  const message = event.exception?.values?.[0]?.value ?? "";
+  const stackFrames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
+
+  // Check for Sentry's "Object captured as exception" message pattern
+  // This occurs when a non-Error object with error-like properties is thrown
+  const isObjectAsException = message.includes("Object captured as exception");
+
+  if (!isObjectAsException) return false;
+
+  // Check if the error originates from Next.js's onRecoverableError handler
+  return stackFrames.some(
+    (frame) =>
+      frame.filename?.includes("on-recoverable-error") ||
+      frame.abs_path?.includes("on-recoverable-error") ||
+      frame.function?.includes("onRecoverableError"),
+  );
 };
 
 function ensureBrowserErrorHandler() {


### PR DESCRIPTION
## Summary
Add isRecoverableHydrationError filter function to instrumentation-client.ts that detects and drops React recoverable errors from Sentry reporting

## Why
**Sentry Issue**: [THENINJARPG-219](https://studie-tech-aps.sentry.io/issues/70700037/)

**Error observed**: "Object captured as exception with keys: message, name, stack, toString" on /forum/:boardid/:threadid

**Frequency**: 24 events over 3+ months (very low frequency)

**Key insight from Sentry**: Stack trace shows only Next.js internal `on-recoverable-error.ts` with no application code frames. The error value is empty - no actual error message. This pattern indicates React's internal recovery mechanism is being captured rather than a real application error.

**Root cause**: React 18+ has a concurrent rendering model where certain hydration/rendering errors can be "recovered" from. React constructs error-like objects (not actual Error instances) during recovery, which Sentry captures and formats as "Object captured as exception". These errors are completely invisible to users - React successfully recovers and continues rendering.

**Sentry Issue:** [THENINJARPG-219](https://studie-tech-aps.sentry.io/issues/THENINJARPG-219)

## Test plan
- Verified locally
- Code review passed

Closes #1056

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change only adds a narrowly-scoped Sentry event filter and does not affect runtime behavior beyond reducing reported telemetry (with some potential for false-positive dropping if the signature is overly broad).
> 
> **Overview**
> Filters out React/Next.js *recoverable hydration* exceptions from client-side Sentry reporting by adding `isRecoverableHydrationError` and invoking it in `beforeSend`.
> 
> The filter matches Sentry’s “Object captured as exception” pattern and only drops events whose stack traces point to Next.js’s `onRecoverableError`/`on-recoverable-error`, reducing non-actionable noise without affecting user-visible errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cab6c7aedd5f28b6453455036add2a4c774ff94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved error monitoring to exclude specific recoverable React hydration errors from reports, reducing non-critical noise in error logs while preserving tracking of genuine issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->