### PR TITLE
Fix THENINJARPG-2AT: Filter Cookiebot cc.js script errors from Sentry

### DIFF
--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -340,10 +340,17 @@ function isThirdPartyInjectedError(event: Sentry.ErrorEvent): boolean {
   // These are third-party consent management errors we cannot control.
   // UX note: Cookiebot handles these errors gracefully - users can still
   // interact with the consent dialog even when these occur.
-  const isCookiebotScript = stackFrames.some(
-    (frame) =>
-      frame.filename?.includes("cc.js") || frame.abs_path?.includes("cc.js"),
-  );
+  // Use domain-validated regex to prevent false positives from spoofed URLs.
+  const cookiebotScriptPattern =
+    /(?:^|[/:])consent(?:cdn)?\.cookiebot\.com\/cc\.js(?:[?#/]|$)/;
+  const isCookiebotScript = stackFrames.some((frame) => {
+    const filename = frame.filename ?? "";
+    const absPath = frame.abs_path ?? "";
+    return (
+      cookiebotScriptPattern.test(filename) ||
+      cookiebotScriptPattern.test(absPath)
+    );
+  });
 
   // For generic injected scripts, only filter "Illegal invocation" errors
   // For Cookiebot specifically, filter all errors as they are third-party issues


### PR DESCRIPTION
## Summary
Modified `isThirdPartyInjectedError` function in `instrumentation-client.ts` to filter ALL errors from Cookiebot's `cc.js` script, not just "Illegal invocation" errors. Created a dedicated `isCookiebotScript` check that identifies any error originating from `cc.js` and filters it.

## Why
**Sentry Issue**: [THENINJARPG-2AT](https://studie-tech-aps.sentry.io/issues/83163860/)

**Error observed**: `TypeError: element is null` in `calcFadeState` function

**Frequency**: 5 events since December 2025

**Key insight from Sentry**: Stack trace showed all frames pointing to `cc.js` (Cookiebot's consent script). Breadcrumbs revealed the error occurs when users click `CybotCookiebotDialogBodyEdgeMoreDetails` (the "More Details" button in the cookie consent dialog). The error message format "element is null" is Firefox-specific.

**Root cause**: Cookiebot's third-party consent management script (`cc.js`) has a race condition when users interact with the consent dialog. This is a third-party script we cannot modify - users can still interact with the consent dialog when these errors occur.

**Sentry Issue:** [THENINJARPG-2AT](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2AT)

## Test plan
- Verified locally
- Code review passed

Closes #1061

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only client-side Sentry `beforeSend` filtering; main risk is unintentionally hiding actionable errors if the new `cc.js` URL match is too broad.
> 
> **Overview**
> Client Sentry filtering now **drops all errors coming from Cookiebot’s `cc.js`** by detecting the script via a domain-validated regex on stack frame URLs.
> 
> The existing injected-script filter is tightened to no longer match `cc.js` by substring, and continues to suppress only `"Illegal invocation"` errors for other injected scripts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e04558de350264cc1a158859bd3dec3b32538c3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced error noise from third-party integrations by specifically recognizing and filtering errors originating from Cookiebot's cc.js, while preserving handling for other injected scripts. This improves stability and makes real issues easier to spot.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->