### PR TITLE
Fix THENINJARPG-2EZ: Add null checks for activity author in support tickets

### DIFF
--- a/app/src/app/support/[ticketId]/page.tsx
+++ b/app/src/app/support/[ticketId]/page.tsx
@@ -529,7 +529,7 @@ export default function TicketDetail(props: { params: Promise<{ ticketId: string
                 className="flex items-center gap-2 text-sm text-gray-600"
               >
                 <Clock className="h-3 w-3" />
-                <span>{activity.author.username}</span>
+                <span>{activity.author?.username ?? "Deleted User"}</span>
                 <span>{activity.action.toLowerCase().replace("_", " ")}</span>
                 {activity.oldValue && activity.newValue && (
                   <span>

--- a/app/src/server/api/routers/support.ts
+++ b/app/src/server/api/routers/support.ts
@@ -1034,7 +1034,7 @@ export const sanitizeSupportTicketForPublic = (
       )
       .map((activity) => ({
         ...activity,
-        author: anonymizeStaffInfo(activity.author, viewer),
+        author: activity.author ? anonymizeStaffInfo(activity.author, viewer) : null,
       }));
   }
   return sanitized;


### PR DESCRIPTION
## Summary
Add optional chaining and nullish coalescing for activity.author.username in the support ticket detail page. Also add null check in the sanitization function before calling anonymizeStaffInfo.

## Why
**Sentry Issue**: [THENINJARPG-2EZ](https://studie-tech-aps.sentry.io/issues/90060067/)

**Error observed**: TypeError: Cannot read properties of null (reading 'username')

**Frequency**: 1 event affecting 1 user

**Key insight from Sentry**: The stack trace showed the error occurs during Array.map iteration in the Activity Log section when rendering activities where the author user has been deleted from the database. The breadcrumbs revealed the exact sequence: user updated ticket status -> API returned successfully -> page re-rendered with fresh data -> crash at activity.author.username access.

**Root cause**: The activity.author relation returns null for deleted users, but the code at line 532 accessed activity.author.username directly without null checking. The fix adds optional chaining (`activity.author?.username`) with a fallback to "Deleted User", following the established pattern used in 6+ other locations in the codebase.

**Sentry Issue:** [THENINJARPG-2EZ](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2EZ)

## Test plan
- Verified locally
- Code review passed

Closes #1063

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk defensive changes that only adjust how missing activity authors are rendered/sanitized, without altering ticket mutation logic or permissions.
> 
> **Overview**
> Prevents crashes when rendering support ticket activity logs where an activity’s `author` is `null` (e.g., deleted users).
> 
> The ticket detail page now uses optional chaining with a fallback label ("Deleted User"), and the API sanitization path (`sanitizeSupportTicketForPublic`) avoids calling `anonymizeStaffInfo` on a missing `author` by returning `null` instead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a648a7330b65f66fadf10bb5c41d4b6a0f30bea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of deleted or missing user information in support ticket activity logs. The system now safely displays "Deleted User" when author details are unavailable, rather than causing errors. Enhanced consistency in how user data is displayed and anonymized across support views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->