### PR TITLE
Fix THENINJARPG-2ER: Filter Cytoscape internal emit errors from Sentry

### DIFF
--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -622,9 +622,10 @@ const isCytoscapeEmitError = (event: Sentry.ErrorEvent): boolean => {
   if (errorType !== "TypeError") return false;
 
   // Check for the specific error pattern (may vary slightly in minified code)
+  // Safari-style messages show `evaluating 'z.emit'` while others show `.emit`
   const isCytoscapeEmitMessage =
     message.includes("undefined is not an object") &&
-    message.includes(".emit");
+    (message.includes(".emit") || message.includes("emit'"));
 
   if (!isCytoscapeEmitMessage) return false;
 


### PR DESCRIPTION
## Summary
Add Sentry error filter for Cytoscape internal emit errors on iOS Safari

## Why
**Sentry Issue**: [THENINJARPG-2ER](https://studie-tech-aps.sentry.io/issues/89555319/)

**Error observed**: TypeError: undefined is not an object (evaluating 'z.emit')

**Frequency**: 3 events from 2 users

**Key insight from Sentry**: Stack trace shows error originates in cytoscape.esm.mjs internal event handler. All occurrences are on iOS Mobile Safari 26.2. Breadcrumbs show user opening Battle Graph dialog, interacting with graph, then error during dialog close. The error is unhandled, confirming it originates from third-party code.

**Root cause**: Race condition in Cytoscape.js's internal event emitter during component unmount. iOS Safari queues touch events asynchronously, and handlers can fire after cleanup begins. The internal variable z becomes undefined before the emit call. The existing cleanup code in GraphUsersGeneric.tsx already implements best practices but cannot prevent this race condition in library code.

**Sentry Issue:** [THENINJARPG-2ER](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2ER)

## Test plan
- Verified locally
- Code review passed

Closes #1065

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sentry-only client filter change; primary risk is over-filtering and hiding real Cytoscape-related errors if the message/stack match is too broad.
> 
> **Overview**
> Filters out a specific Cytoscape.js internal `TypeError` from client-side Sentry reporting by adding `isCytoscapeEmitError` and wiring it into `beforeSend`.
> 
> The filter matches the iOS Safari-style “undefined is not an object (evaluating …emit…)” message and confirms the stack trace originates from Cytoscape before dropping the event, reducing noise from a known third-party race condition during graph unmount.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e583955a3718eb60192ac275eba1fd4398e79244. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error reporting quality by filtering out known framework-level errors that occur on iOS Safari, reducing noise in error tracking and allowing focus on genuine issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->