### PR TITLE
Fix THENINJARPG-2EY: Filter Zod validation errors from Sentry

### DIFF
--- a/app/src/app/_trpc/Provider.tsx
+++ b/app/src/app/_trpc/Provider.tsx
@@ -196,6 +196,18 @@ export const onError = (err: unknown) => {
       showMutationToast({ success: false, message: err.message });
       return;
     }
+    // Filter Zod input validation errors - these are expected user input errors, not bugs.
+    // Zod errors from tRPC input validation have BAD_REQUEST code and a JSON array message
+    // containing error objects like: [{"code":"too_small","minimum":1,"path":["power"],...}]
+    // UX note: Users see these errors via the validation toast below.
+    if (errorCode === "BAD_REQUEST" && err.message.startsWith("[")) {
+      toast({
+        variant: "destructive",
+        title: "Validation Error",
+        description: "Please check your input values",
+      });
+      return;
+    }
     Sentry.captureException(err, { extra: { message: "TRPC Client Error" } });
     toast({
       variant: "destructive",


### PR DESCRIPTION
## Summary

Filter Zod validation errors from being reported to Sentry in the tRPC error handler. These are expected user input errors, not bugs.

## Why

**Sentry Issue**: [THENINJARPG-2EY](https://studie-tech-aps.sentry.io/issues/89766469/)

**Error observed**: `TRPCClientError` with Zod validation message `"Number must be greater than or equal to 1"` for the `power` field

**Frequency**: 7 events on 2026-01-20

**Key insight from Sentry**: The error message format (JSON array starting with `[`) and error code (`BAD_REQUEST`) are characteristic of Zod input validation errors. These occur when users submit forms with invalid values (e.g., empty fields that coerce to 0).

**Root cause**: Zod validation errors from tRPC input validation were being captured by Sentry as exceptions. The specific error traced to the `actSchema` in the damage simulator form (`/manual/damage_calcs`).

## Changes

- Added a filter in `Provider.tsx` to catch Zod validation errors (identified by `BAD_REQUEST` code and JSON array message format)
- Users still see a friendly "Validation Error" toast
- Follows existing pattern used for rate limiting errors

## Test plan

- [x] Verify validation toast appears when submitting invalid form data
- [x] Verify Sentry does not receive these validation errors

Closes #1070

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to client-side error handling; risk is limited to potentially misclassifying some `BAD_REQUEST` errors and altering which issues get reported to Sentry.
> 
> **Overview**
> Prevents tRPC Zod input-validation failures from being sent to Sentry by adding a guard in `Provider.tsx` that detects `TRPCClientError` cases with `code === "BAD_REQUEST"` and a JSON-array-style message.
> 
> When this condition is hit, the handler now shows a generic *Validation Error* toast and returns early, leaving Sentry capture for other client/server error cases unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67e432c3151f71381103fa9b2e2ec00bb9cc03ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form validation error handling to display clearer, more specific feedback when users submit invalid input. Validation errors now show targeted error messages instead of generic error notifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->