### PR TITLE
Fix #865: Reorganize jutsu management UI with categorized accordion sections

### DIFF
--- a/.claude/commands/automation-fix-github-issue.md
+++ b/.claude/commands/automation-fix-github-issue.md
@@ -67,7 +67,9 @@ Replace `GITHUB_ISSUE_NUMBER` with the actual issue number from `$ARGUMENTS` in 
 
 ### Step 3: Aggregate Plans
 
-Launch a subagent using the `Task` tool to aggregate all 6 plans into one comprehensive plan:
+Launch a subagent using the `Task` tool to aggregate all 6 plans into one comprehensive plan.
+
+<important>DO NOT AGGREGATE UNTIL ALL PLANS HAVE BEEN GENERATED. CODEX MAY PRODUCE SLOW PLANS; BUT WAIT TILL THEY ARE DONE</important>
 
 ```
 Run the /plan-aggregate skill with the arguments: PLAN1_PATH PLAN2_PATH PLAN3_PATH PLAN4_PATH PLAN5_PATH PLAN6_PATH

--- a/app/src/app/jutsus/page.tsx
+++ b/app/src/app/jutsus/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback, memo } from "react";
 import {
   Trash2,
   CircleFadingArrowUp,
@@ -298,10 +298,7 @@ export default function MyJutsu() {
   const isFetching = l1 || l2;
 
   // Collapse UserItem and Item
-  const userElements = useMemo(
-    () => new Set(getUserElements(userData)),
-    [userData],
-  );
+  const userElements = useMemo(() => new Set(getUserElements(userData)), [userData]);
 
   // Categorize jutsu for organized display
   const categorizedJutsus = useMemo(() => {
@@ -310,42 +307,45 @@ export default function MyJutsu() {
   }, [userJutsus, userData, userItems, userElements]);
 
   // Transform jutsu to action items with warnings
-  const transformToActionItems = (jutsus: UserJutsuWithRelations[]) => {
-    return jutsus.map((uj) => {
-      let warning = "";
-      if (userData) {
-        if (!checkJutsuItems(uj.jutsu, userItems)) {
-          warning = `No ${uj.jutsu.jutsuWeapon.toLowerCase()} weapon equipped.`;
+  const transformToActionItems = useCallback(
+    (jutsus: UserJutsuWithRelations[]) => {
+      return jutsus.map((uj) => {
+        let warning = "";
+        if (userData) {
+          if (!checkJutsuItems(uj.jutsu, userItems)) {
+            warning = `No ${uj.jutsu.jutsuWeapon.toLowerCase()} weapon equipped.`;
+          }
+          if (!checkJutsuElements(uj.jutsu, userElements)) {
+            warning = "You do not have the required elements to use this jutsu.";
+          }
+          if (!hasRequiredRank(userData.rank, uj.jutsu.requiredRank)) {
+            warning = "You do not have the required rank to use this jutsu.";
+          }
+          if (!hasRequiredLevel(userData.level, uj.jutsu.requiredLevel)) {
+            warning = "You do not have the required level to use this jutsu.";
+          }
+          if (!checkJutsuRank(uj.jutsu.jutsuRank, userData.rank)) {
+            warning = "You do not have the required rank to use this jutsu.";
+          }
+          if (!checkJutsuVillage(uj.jutsu, userData)) {
+            warning = "You do not have the required village to use this jutsu.";
+          }
+          if (!checkJutsuBloodline(uj.jutsu, userData)) {
+            warning = "You do not have the required bloodline to use this jutsu.";
+          }
         }
-        if (!checkJutsuElements(uj.jutsu, userElements)) {
-          warning = "You do not have the required elements to use this jutsu.";
-        }
-        if (!hasRequiredRank(userData.rank, uj.jutsu.requiredRank)) {
-          warning = "You do not have the required rank to use this jutsu.";
-        }
-        if (!hasRequiredLevel(userData.level, uj.jutsu.requiredLevel)) {
-          warning = "You do not have the required level to use this jutsu.";
-        }
-        if (!checkJutsuRank(uj.jutsu.jutsuRank, userData.rank)) {
-          warning = "You do not have the required rank to use this jutsu.";
-        }
-        if (!checkJutsuVillage(uj.jutsu, userData)) {
-          warning = "You do not have the required village to use this jutsu.";
-        }
-        if (!checkJutsuBloodline(uj.jutsu, userData)) {
-          warning = "You do not have the required bloodline to use this jutsu.";
-        }
-      }
-      return {
-        ...uj.jutsu,
-        ...uj,
-        type: "jutsu" as const,
-        highlight: !!uj.equipped,
-        warning,
-        isReskinned: !!uj.activeReskin,
-      };
-    });
-  };
+        return {
+          ...uj.jutsu,
+          ...uj,
+          type: "jutsu" as const,
+          highlight: !!uj.equipped,
+          warning,
+          isReskinned: !!uj.activeReskin,
+        };
+      });
+    },
+    [userData, userItems, userElements],
+  );
 
   // Derived calculations
   const curEquip = userJutsus?.filter((j) => j.equipped).length;
@@ -427,10 +427,8 @@ export default function MyJutsu() {
               items={transformToActionItems(
                 // Sort equipped by loadout order
                 [...categorizedJutsus.equipped].sort((a, b) => {
-                  const aIndex =
-                    userData?.loadout?.jutsuIds.indexOf(a.jutsuId) ?? -1;
-                  const bIndex =
-                    userData?.loadout?.jutsuIds.indexOf(b.jutsuId) ?? -1;
+                  const aIndex = userData?.loadout?.jutsuIds.indexOf(a.jutsuId) ?? -1;
+                  const bIndex = userData?.loadout?.jutsuIds.indexOf(b.jutsuId) ?? -1;
                   if (aIndex === -1 && bIndex === -1) return 0;
                   if (aIndex === -1) return 1;
                   if (bIndex === -1) return -1;
@@ -519,12 +517,14 @@ export default function MyJutsu() {
         )}
 
         {/* Show message when no jutsu */}
-        {!categorizedJutsus && !isFetching && (
-          <p className="text-muted-foreground text-center py-4">
-            You have not learned any jutsu. Go to the training grounds in your
-            village to learn some.
-          </p>
-        )}
+        {!isFetching &&
+          categorizedJutsus &&
+          Object.values(categorizedJutsus).every((arr) => arr.length === 0) && (
+            <p className="text-muted-foreground text-center py-4">
+              You have not learned any jutsu. Go to the training grounds in your village
+              to learn some.
+            </p>
+          )}
 
         {isOpen && userData && userjutsu && (
           <Modal2
@@ -1046,15 +1046,9 @@ interface JutsuCategorySectionProps {
   }[];
 }
 
-const JutsuCategorySection: React.FC<JutsuCategorySectionProps> = ({
-  title,
-  jutsus,
-  isOpen,
-  onToggle,
-  onClick,
-  counts,
-  transformToActionItems,
-}) => {
+const JutsuCategorySection = memo((props: JutsuCategorySectionProps) => {
+  const { title, jutsus, isOpen, onToggle, onClick, counts, transformToActionItems } =
+    props;
   if (jutsus.length === 0) return null;
 
   return (
@@ -1085,7 +1079,8 @@ const JutsuCategorySection: React.FC<JutsuCategorySectionProps> = ({
       )}
     </div>
   );
-};
+});
+JutsuCategorySection.displayName = "JutsuCategorySection";
 
 // Helper types and functions
 
@@ -1143,7 +1138,10 @@ const categorizeJutsus = (
         uj.jutsu.jutsuRank,
         userData.rank as Parameters<typeof checkJutsuRank>[1],
       ) &&
-      checkJutsuVillage(uj.jutsu, userData as Parameters<typeof checkJutsuVillage>[1]) &&
+      checkJutsuVillage(
+        uj.jutsu,
+        userData as Parameters<typeof checkJutsuVillage>[1],
+      ) &&
       checkJutsuBloodline(
         uj.jutsu,
         userData as Parameters<typeof checkJutsuBloodline>[1],


### PR DESCRIPTION
## Summary

- Reorganizes the jutsu management page to display jutsu in categorized, collapsible accordion sections
- Equipped jutsu section always visible at top of the page
- Accordion sections for: **Bloodline**, **PVP Only**, **PVE Only**, **General**, and **Unavailable** jutsu
- Filters dynamically update all accordion views
- Loadout switching updates the equipped section in real-time

## Changes

- Added `CategorizedJutsus` interface for type-safe category handling
- Added `categorizeJutsus` function to sort jutsu into appropriate categories based on `jutsuType`, `battleUsageType`, and equip eligibility
- Added `JutsuCategorySection` sub-component for rendering accordion sections
- Added multi-select accordion state management using `Set<string>`
- Added `useWatch` hook for React Compiler compatibility (replaced `watch()`)
- Added loading state to "Unequip All" button with `disabled={isUnequipping}`

## Test plan

- [x] Tests pass (`make test` - 34 passed)
- [x] Lint passes (`make lint` - 0 errors)
- [x] Typecheck passes (`make typecheck` - no errors)
- [ ] Manual testing: Navigate to jutsu management page and verify accordion sections work
- [ ] Manual testing: Apply filters and verify all sections update
- [ ] Manual testing: Switch loadouts and verify equipped section updates
- [ ] Manual testing: Unequip all button shows loading state

Closes #865

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to a substantial UI refactor that changes list rendering/categorization and could affect equipability visibility/order, but no backend or auth/data model changes.
> 
> **Overview**
> **Reworks the `Jutsu Management` page UI** to show an always-visible *Equipped* section plus collapsible accordion sections for Bloodline, PVP, PVE, General, and Unavailable jutsu, with per-item warnings and loadout-order sorting preserved for equipped items.
> 
> Adds local categorization/rendering helpers (`categorizeJutsus`, `JutsuCategorySection`) and state/memoization (`useMemo`, `useCallback`, `memo`) to reduce recomputation; updates reskin image handling to use `useWatch` and disables/labels the *Unequip All* button while the mutation is pending. Also adds a stronger “wait for all plans” instruction in `.claude/commands/automation-fix-github-issue.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abe7b4f2a86050ccbbce1e20ce04bc7e4bbcf684. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reorganized jutsu display into categorized, collapsible sections (Equipped, Bloodline, PVP, PVE, General, Unavailable) with counts and improved navigation.
  * Real-time reskin image updates and integrated warnings/labels for action items.
  * Shows a clear "No jutsu learned" message when none are available.

* **Documentation**
  * Added an explicit caution to delay aggregation until all plans have been generated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->