### PR TITLE
Fix #1077: Prevent players from getting stuck in raid queues

### DIFF
--- a/app/src/layout/RaidBrowser.tsx
+++ b/app/src/layout/RaidBrowser.tsx
@@ -22,6 +22,7 @@ import {
   History,
   Skull,
   TimerOff,
+  AlertTriangle,
 } from "lucide-react";
 import { useState, useEffect, useMemo } from "react";
 import { useRequiredUserData } from "@/utils/UserContext";
@@ -139,6 +140,16 @@ const RaidBrowser: React.FC<RaidBrowserProps> = (props) => {
       },
     });
 
+  const { mutate: selfUnstuck, isPending: unstuckPending } =
+    api.raids.selfUnstuckFromRaid.useMutation({
+      onSuccess: (data) => {
+        showMutationToast(data);
+        void util.raids.getUserRaidQueue.invalidate();
+        void util.raids.getActiveRaidTeams.invalidate();
+        void util.profile.getUser.invalidate();
+      },
+    });
+
   // Event handlers
   const handleRaidSelect = (raidId: string) => {
     setSelectedRaidId((prev) => (prev === raidId ? null : raidId));
@@ -185,6 +196,9 @@ const RaidBrowser: React.FC<RaidBrowserProps> = (props) => {
   const leaderboard = leaderboardData?.participations ?? [];
   const activeTeams = activeTeamsData?.teams ?? [];
   const maxTeams = activeTeamsData?.maxTeams ?? 5;
+
+  // Determine if user appears stuck in raid queue (status is QUEUED but not in any queue)
+  const appearStuck = userData?.status === "QUEUED" && !userQueueData?.inQueue;
 
   // Auto-select the only raid when sectorFilter is provided and there's exactly one raid
   useEffect(() => {
@@ -286,6 +300,40 @@ const RaidBrowser: React.FC<RaidBrowserProps> = (props) => {
                 ? "Raids are cooperative boss battles where multiple teams fight to deal damage to a shared boss. Damage-based rewards are available to participants."
                 : "View completed raids, check leaderboards, and claim any unclaimed rewards from raids you participated in."}
             </p>
+
+            {/* Stuck State Warning Banner */}
+            {appearStuck && (
+              <div className="mb-4 p-3 rounded-lg bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800">
+                <div className="flex items-start gap-3">
+                  <AlertTriangle className="h-5 w-5 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
+                  <div className="flex-1">
+                    <p className="font-medium text-amber-900 dark:text-amber-100">
+                      Stuck in Raid Queue
+                    </p>
+                    <p className="text-sm text-amber-800 dark:text-amber-200 mt-1">
+                      Your status shows you are in a queue, but no active queue entry was
+                      found. This can happen due to connection issues or server errors.
+                    </p>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="mt-2 border-amber-600 text-amber-700 hover:bg-amber-100 dark:border-amber-500 dark:text-amber-300 dark:hover:bg-amber-900"
+                      onClick={() => selfUnstuck()}
+                      disabled={unstuckPending}
+                    >
+                      {unstuckPending ? (
+                        <>
+                          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                          Resetting...
+                        </>
+                      ) : (
+                        "Reset Raid Status"
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            )}
 
             {displayedRaids.length > 0 ? (
               <div className="grid gap-3">

--- a/app/src/server/api/routers/raids.ts
+++ b/app/src/server/api/routers/raids.ts
@@ -23,6 +23,7 @@ import {
   bloodline,
   badge,
   war,
+  battle,
 } from "@/drizzle/schema";
 import {
   RAID_BATTLE_MAX_USERS_PER_TEAM,
@@ -38,7 +39,11 @@ import type { RaidObjectiveType } from "@/validators/objectives";
 import { postProcessRewards } from "@/libs/quest";
 import { getRaidObjectiveData, validateRaidIsActive } from "@/libs/raids";
 import { secondsFromDate } from "@/utils/time";
-import { getServerPusher, updateRaidTeamsOnSector } from "@/libs/pusher";
+import {
+  getServerPusher,
+  updateRaidTeamsOnSector,
+  updateUserOnMap,
+} from "@/libs/pusher";
 import type { DrizzleClient } from "@/server/db";
 import { canChangeContent } from "@/utils/permissions";
 import { AllTags } from "@/validators/combat";
@@ -624,7 +629,7 @@ export const raidsRouter = createTRPCRouter({
     .output(baseServerResponse.extend({ teamId: z.string().optional() }))
     .mutation(async ({ ctx, input }) => {
       // Query - parallel fetch all required data upfront
-      const [{ user }, raid, teamData] = await Promise.all([
+      const [{ user }, raid, teamData, existingQueueEntry] = await Promise.all([
         fetchUpdatedUser({ client: ctx.drizzle, userId: ctx.userId }),
         ctx.drizzle.query.quest.findFirst({
           where: and(eq(quest.id, input.questId), eq(quest.questType, "raid")),
@@ -641,6 +646,10 @@ export const raidsRouter = createTRPCRouter({
               with: { queue: true },
             })
           : Promise.resolve(null),
+        // Check if user already has a queue entry (prevents duplicate entries)
+        ctx.drizzle.query.mpvpBattleUser.findFirst({
+          where: eq(mpvpBattleUser.userId, ctx.userId),
+        }),
       ]);
 
       // Guard - basic validations
@@ -648,6 +657,11 @@ export const raidsRouter = createTRPCRouter({
       if (!raid) return errorResponse("Raid not found");
       if (user.status !== "AWAKE") {
         return errorResponse("You cannot join a raid queue in your current status");
+      }
+      if (existingQueueEntry) {
+        return errorResponse(
+          "You are already in a queue. Please leave your current queue first.",
+        );
       }
 
       // Guard - raid active state
@@ -899,7 +913,15 @@ export const raidsRouter = createTRPCRouter({
       const isClaimingState =
         queueEntry.clanBattle.battleId?.startsWith("claiming-") ?? false;
       if (queueEntry.clanBattle.battleId !== null && !isClaimingState) {
-        return errorResponse("Battle has already started");
+        // Verify the battle actually exists before blocking leave
+        const battleExists = await ctx.drizzle.query.battle.findFirst({
+          where: eq(battle.id, queueEntry.clanBattle.battleId),
+          columns: { id: true },
+        });
+        if (battleExists) {
+          return errorResponse("Battle has already started");
+        }
+        // Battle doesn't exist - treat as stale, allow leave to proceed
       }
 
       // Store sector before operations for Pusher notification
@@ -910,8 +932,8 @@ export const raidsRouter = createTRPCRouter({
         ctx.drizzle.delete(mpvpBattleUser).where(eq(mpvpBattleUser.id, queueEntry.id)),
         ctx.drizzle
           .update(userData)
-          .set({ status: "AWAKE" })
-          .where(and(eq(userData.userId, ctx.userId), eq(userData.status, "QUEUED"))),
+          .set({ status: "AWAKE", battleId: null })
+          .where(eq(userData.userId, ctx.userId)),
         // Clean up claiming ID if present
         isClaimingState
           ? ctx.drizzle
@@ -941,6 +963,115 @@ export const raidsRouter = createTRPCRouter({
         success: true,
         message: "Left raid queue",
       };
+    }),
+
+  /**
+   * Self-service unstuck from raid queue
+   */
+  selfUnstuckFromRaid: protectedProcedure
+    .use(ratelimitMiddleware)
+    .use(hasUserMiddleware)
+    .output(baseServerResponse)
+    .mutation(async ({ ctx }) => {
+      // Query - fetch user and all queue entries in parallel
+      const [{ user }, queueEntries] = await Promise.all([
+        fetchUpdatedUser({ client: ctx.drizzle, userId: ctx.userId }),
+        ctx.drizzle.query.mpvpBattleUser.findMany({
+          where: eq(mpvpBattleUser.userId, ctx.userId),
+        }),
+      ]);
+
+      // Guard - user must exist
+      if (!user) return errorResponse("User not found");
+
+      // Guard - prevent abuse when user is in a real active battle
+      if (user.status === "BATTLE" && user.battleId) {
+        const battleExists = await ctx.drizzle.query.battle.findFirst({
+          where: eq(battle.id, user.battleId),
+          columns: { id: true },
+        });
+        if (battleExists) {
+          return errorResponse(
+            "You are in an active battle. Complete the battle first.",
+          );
+        }
+      }
+
+      // Guard - don't allow if user is in a normal state with no queue entries
+      if (user.status === "AWAKE" && queueEntries.length === 0 && !user.battleId) {
+        return errorResponse("You are not stuck in a raid queue.");
+      }
+
+      // Store clanBattleIds for cleanup
+      const clanBattleIds = [...new Set(queueEntries.map((e) => e.clanBattleId))];
+
+      // Mutation - clean up all queue entries and reset user status
+      await Promise.all([
+        ctx.drizzle
+          .delete(mpvpBattleUser)
+          .where(eq(mpvpBattleUser.userId, ctx.userId)),
+        ctx.drizzle
+          .update(userData)
+          .set({ status: "AWAKE", battleId: null })
+          .where(eq(userData.userId, ctx.userId)),
+      ]);
+
+      // Clean up empty teams or reset claiming state for remaining members
+      if (clanBattleIds.length > 0) {
+        // Fetch all remaining members for all affected teams in one query
+        const remainingMembers = await ctx.drizzle.query.mpvpBattleUser.findMany({
+          where: inArray(mpvpBattleUser.clanBattleId, clanBattleIds),
+          columns: { clanBattleId: true },
+        });
+
+        // Determine which teams still have members
+        const teamsWithMembers = new Set(remainingMembers.map((m) => m.clanBattleId));
+        const emptyTeamIds = clanBattleIds.filter((id) => !teamsWithMembers.has(id));
+        const teamsToResetClaiming = clanBattleIds.filter((id) =>
+          teamsWithMembers.has(id),
+        );
+
+        // Execute bulk operations in parallel
+        await Promise.all([
+          // Delete empty teams
+          emptyTeamIds.length > 0
+            ? ctx.drizzle
+                .delete(mpvpBattleQueue)
+                .where(inArray(mpvpBattleQueue.id, emptyTeamIds))
+            : Promise.resolve(),
+          // Reset claiming state for teams that still have members
+          teamsToResetClaiming.length > 0
+            ? ctx.drizzle
+                .update(mpvpBattleQueue)
+                .set({ battleId: null })
+                .where(
+                  and(
+                    inArray(mpvpBattleQueue.id, teamsToResetClaiming),
+                    sql`${mpvpBattleQueue.battleId} LIKE 'claiming-%'`,
+                  ),
+                )
+            : Promise.resolve(),
+        ]);
+      }
+
+      // Pusher - notify sector about user status change
+      const pusher = getServerPusher();
+      void updateUserOnMap(pusher, user.sector, {
+        longitude: user.longitude,
+        latitude: user.latitude,
+        sector: user.sector,
+        avatar: user.avatar,
+        avatarLight: user.avatarLight,
+        level: user.level,
+        villageId: user.villageId,
+        battleId: null,
+        username: user.username,
+        status: "AWAKE",
+        location: "",
+        userId: ctx.userId,
+      });
+
+      return { success: true, message: "Successfully reset your raid queue state." };
     }),
 
   /**
@@ -1125,13 +1256,8 @@ export const raidsRouter = createTRPCRouter({
               ),
             ctx.drizzle
               .update(userData)
-              .set({ status: "AWAKE" })
-              .where(
-                and(
-                  inArray(userData.userId, attackerUserIds),
-                  eq(userData.status, "QUEUED"),
-                ),
-              ),
+              .set({ status: "AWAKE", battleId: null })
+              .where(inArray(userData.userId, attackerUserIds)),
             ctx.drizzle
               .delete(mpvpBattleUser)
               .where(eq(mpvpBattleUser.clanBattleId, input.teamId)),
@@ -1153,13 +1279,8 @@ export const raidsRouter = createTRPCRouter({
             ),
           ctx.drizzle
             .update(userData)
-            .set({ status: "AWAKE" })
-            .where(
-              and(
-                inArray(userData.userId, attackerUserIds),
-                eq(userData.status, "QUEUED"),
-              ),
-            ),
+            .set({ status: "AWAKE", battleId: null })
+            .where(inArray(userData.userId, attackerUserIds)),
           ctx.drizzle
             .delete(mpvpBattleUser)
             .where(eq(mpvpBattleUser.clanBattleId, input.teamId)),


### PR DESCRIPTION
## Summary
Add duplicate queue entry check in joinRaidQueue to prevent multiple team membership. Fix leaveRaidQueue to validate battle existence before blocking leave and remove conditional WHERE clause on status updates. Fix rollback status updates in startRaidBattle to unconditionally reset user status. Add selfUnstuckFromRaid endpoint for self-service recovery. Add Reset Raid Status button in RaidBrowser UI when user appears stuck.

## Why
**Problem**: Players were getting stuck in raid queue/battle states with errors like 'Battle already started' or 'You cannot join a raid queue in your current status'. This required staff intervention via Force User Awake.

**Key insights from issue**: The root causes were identified as:
1. Conditional WHERE clause in leaveRaidQueue only updated status when status=QUEUED, silently failing during race conditions
2. No guard against duplicate queue entries allowed users to be in multiple teams
3. battleId not being cleared when leaving queue left users in limbo
4. Stale battleId blocked leaving even when the battle no longer existed

**Solution**: Added server-side guards, removed conditional status updates, added battle existence validation, and provided a self-service Unstuck button for users who get into stuck states.

## Test plan
- Verified locally
- Code review passed

Closes #1077

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches raid queue/battle lifecycle and state cleanup (status/battleId, queue/team rows), so mistakes could incorrectly remove users from queues or reset battle state, but changes are localized and include battle-existence checks/guards.
> 
> **Overview**
> **Prevents players getting stuck in raid queue states** by tightening server-side queue/battle cleanup and adding a self-service recovery path.
> 
> Backend changes in `raidsRouter` add a duplicate-queue-entry guard in `joinRaidQueue`, make `leaveRaidQueue` resilient to stale `battleId`s by checking actual `battle` existence and always clearing `userData.battleId`/resetting status, and ensure `startRaidBattle` rollback unconditionally resets affected users’ status/battle fields.
> 
> Adds a new `selfUnstuckFromRaid` mutation that purges the user’s raid queue entries, resets their status/battleId, cleans up affected teams (delete empty teams / clear `claiming-*`), and broadcasts updated user state via Pusher; the `RaidBrowser` UI surfaces a “Stuck in Raid Queue” banner with a “Reset Raid Status” button when the client detects `QUEUED` status without an active queue entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05870219108cf61c5ecad960783351f6dc115eb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Stuck in Raid Queue" warning banner to alert users when queued but not actively present
  * Added "Reset Raid Status" button to clear stuck queue status

* **Bug Fixes**
  * Improved validation to prevent users from joining multiple raid queues simultaneously
  * Enhanced cleanup of raid queue and team status during queue operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->