### PR TITLE
Increase jutsu/item loadouts

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -1174,10 +1174,12 @@ export const FED_GOLD_INVENTORY_SLOTS = 10;
 export const FED_NORMAL_JUTSU_SLOTS = 1;
 export const FED_SILVER_JUTSU_SLOTS = 2;
 export const FED_GOLD_JUTSU_SLOTS = 3;
+export const FED_JUTSU_LOADOUTS_BASE = 2;
 export const FED_NORMAL_JUTSU_LOADOUTS = 1;
 export const FED_SILVER_JUTSU_LOADOUTS = 2;
 export const FED_GOLD_JUTSU_LOADOUTS = 3;
 
+export const FED_ITEM_LOADOUTS_BASE = 2;
 export const FED_NORMAL_ITEM_LOADOUTS = 1;
 export const FED_SILVER_ITEM_LOADOUTS = 2;
 export const FED_GOLD_ITEM_LOADOUTS = 3;

--- a/app/src/app/points/page.tsx
+++ b/app/src/app/points/page.tsx
@@ -52,9 +52,11 @@ import { FED_EVENT_ITEMS_NORMAL } from "@/drizzle/constants";
 import { FED_EVENT_ITEMS_SILVER } from "@/drizzle/constants";
 import { FED_EVENT_ITEMS_GOLD } from "@/drizzle/constants";
 import { FED_EVENT_ITEMS_DEFAULT } from "@/drizzle/constants";
+import { FED_JUTSU_LOADOUTS_BASE } from "@/drizzle/constants";
 import { FED_NORMAL_JUTSU_LOADOUTS } from "@/drizzle/constants";
 import { FED_SILVER_JUTSU_LOADOUTS } from "@/drizzle/constants";
 import { FED_GOLD_JUTSU_LOADOUTS } from "@/drizzle/constants";
+import { FED_ITEM_LOADOUTS_BASE } from "@/drizzle/constants";
 import { FED_NORMAL_ITEM_LOADOUTS } from "@/drizzle/constants";
 import { FED_SILVER_ITEM_LOADOUTS } from "@/drizzle/constants";
 import { FED_GOLD_ITEM_LOADOUTS } from "@/drizzle/constants";
@@ -477,8 +479,8 @@ const PayPalSubscriptionButton = (props: {
         </li>
         <li>+{FED_NORMAL_JUTSU_SLOTS} Jutsu slot</li>
         <li>+{FED_NORMAL_BANK_INTEREST}% bank interest</li>
-        <li>{FED_NORMAL_JUTSU_LOADOUTS} jutsu loadouts</li>
-        <li>{FED_NORMAL_ITEM_LOADOUTS} item loadouts</li>
+        <li>{FED_JUTSU_LOADOUTS_BASE + FED_NORMAL_JUTSU_LOADOUTS} jutsu loadouts</li>
+        <li>{FED_ITEM_LOADOUTS_BASE + FED_NORMAL_ITEM_LOADOUTS} item loadouts</li>
         <li>+{SKILL_TREE_RESET_FREE_NORMAL} skill tree resets per month</li>
         <li>Custom avatar (512KB)</li>
       </ul>
@@ -496,8 +498,8 @@ const PayPalSubscriptionButton = (props: {
         </li>
         <li>+{FED_SILVER_JUTSU_SLOTS} Jutsu slots</li>
         <li>+{FED_SILVER_BANK_INTEREST}% bank interest</li>
-        <li>{FED_SILVER_JUTSU_LOADOUTS} jutsu loadouts</li>
-        <li>{FED_SILVER_ITEM_LOADOUTS} item loadouts</li>
+        <li>{FED_JUTSU_LOADOUTS_BASE + FED_SILVER_JUTSU_LOADOUTS} jutsu loadouts</li>
+        <li>{FED_ITEM_LOADOUTS_BASE + FED_SILVER_ITEM_LOADOUTS} item loadouts</li>
         <li>+{SKILL_TREE_RESET_FREE_SILVER} skill tree resets per month</li>
         <li>Custom avatar (1MB)</li>
       </ul>
@@ -513,8 +515,8 @@ const PayPalSubscriptionButton = (props: {
         <li>+{FED_EVENT_ITEMS_GOLD - FED_EVENT_ITEMS_DEFAULT} Event inventory space</li>
         <li>+{FED_GOLD_JUTSU_SLOTS} Jutsu slots</li>
         <li>+{FED_GOLD_BANK_INTEREST}% bank interest</li>
-        <li>{FED_GOLD_JUTSU_LOADOUTS} jutsu loadouts</li>
-        <li>{FED_GOLD_ITEM_LOADOUTS} item loadouts</li>
+        <li>{FED_JUTSU_LOADOUTS_BASE + FED_GOLD_JUTSU_LOADOUTS} jutsu loadouts</li>
+        <li>{FED_ITEM_LOADOUTS_BASE + FED_GOLD_ITEM_LOADOUTS} item loadouts</li>
         <li>+{SKILL_TREE_RESET_FREE_GOLD} skill tree resets per month</li>
         <li>Custom avatar (2MB)</li>
       </ul>

--- a/app/src/utils/paypal.ts
+++ b/app/src/utils/paypal.ts
@@ -1,9 +1,11 @@
 import { FED_NORMAL_REPS_COST } from "@/drizzle/constants";
 import { FED_SILVER_REPS_COST } from "@/drizzle/constants";
 import { FED_GOLD_REPS_COST } from "@/drizzle/constants";
+import { FED_JUTSU_LOADOUTS_BASE } from "@/drizzle/constants";
 import { FED_NORMAL_JUTSU_LOADOUTS } from "@/drizzle/constants";
 import { FED_SILVER_JUTSU_LOADOUTS } from "@/drizzle/constants";
 import { FED_GOLD_JUTSU_LOADOUTS } from "@/drizzle/constants";
+import { FED_ITEM_LOADOUTS_BASE } from "@/drizzle/constants";
 import { FED_NORMAL_ITEM_LOADOUTS } from "@/drizzle/constants";
 import { FED_SILVER_ITEM_LOADOUTS } from "@/drizzle/constants";
 import { FED_GOLD_ITEM_LOADOUTS } from "@/drizzle/constants";
@@ -25,7 +27,7 @@ export const getUserFederalStatus = (
 export const fedJutsuLoadouts = (
   user?: Pick<UserData, "staffAccount" | "federalStatus">,
 ) => {
-  const base = 0;
+  const base = FED_JUTSU_LOADOUTS_BASE;
   if (!user) return base;
   const status = getUserFederalStatus(user);
   switch (status) {
@@ -42,7 +44,7 @@ export const fedJutsuLoadouts = (
 export const fedItemLoadouts = (
   user?: Pick<UserData, "staffAccount" | "federalStatus">,
 ) => {
-  const base = 0;
+  const base = FED_ITEM_LOADOUTS_BASE;
   if (!user) return base;
   const status = getUserFederalStatus(user);
   switch (status) {


### PR DESCRIPTION
# Pull Request

With the addition of pve items and jutsu, it was decided that player should have a base count of 2 loadouts so they can use one for each.  This also increases the number of loadouts for each fed level by a total of 2.

No Fed: 2 loadouts
Normal Fed: 3 loadouts
Silver Fed: 4 loadouts
Gold Fed: 5 loadouts

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added base loadout allocations for Jutsu and Item categories across all subscription tiers.
  * Updated subscription displays to show total available loadouts, combining base allocations with earned loadouts from each tier.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->