### PR TITLE
Add customizable mobile navigation bar

### DIFF
--- a/app/src/app/profile/edit/page.tsx
+++ b/app/src/app/profile/edit/page.tsx
@@ -51,6 +51,7 @@ import {
   COST_SWAP_VILLAGE,
 } from "@/drizzle/constants";
 import type { Bloodline, Village } from "@/drizzle/schema";
+import { useLocalStorage } from "@/hooks/localstorage";
 import Accordion from "@/layout/Accordion";
 import ActivityStreakPanel from "@/layout/ActivityStreakPanel";
 import AiProfileEdit from "@/layout/AiProfileEdit";
@@ -67,6 +68,15 @@ import DistributeStatsForm from "@/layout/StatsDistributionForm";
 import UserBlacklistControl from "@/layout/UserBlacklistControl";
 import UserRequestSystem from "@/layout/UserRequestSystem";
 import UserSearchSelect from "@/layout/UserSearchSelect";
+import {
+  DEFAULT_MOBILE_NAV_CONFIG,
+  getMobileNavIcon,
+  getNavOptionById,
+  MOBILE_NAV_OPTIONS,
+  MOBILE_NAV_STORAGE_KEY,
+  type MobileNavConfig,
+  normalizeMobileNavConfig,
+} from "@/libs/mobileNavConfig";
 import { useInfinitePagination } from "@/libs/pagination";
 import { showMutationToast } from "@/libs/toast";
 import type { UserWithRelations } from "@/routers/profile";
@@ -302,6 +312,15 @@ export default function EditProfile() {
           onClick={setActiveElement}
         >
           <BattleSettingsEdit userId={userData.userId} />
+        </Accordion>
+        <Accordion
+          title="Mobile Navigation"
+          selectedTitle={activeElement}
+          unselectedSubtitle="Customize mobile navigation bar buttons"
+          selectedSubtitle="Choose which shortcuts appear on mobile"
+          onClick={setActiveElement}
+        >
+          <MobileNavSettings />
         </Accordion>
         {canSwapBloodline(userData.role) && (
           <Accordion
@@ -2244,6 +2263,116 @@ const ResetSkills: React.FC = () => {
           : ` for ${COST_SKILL_RESET} reputation points`}
         . This action cannot be undone. Are you sure you want to continue?
       </Confirm2>
+    </div>
+  );
+};
+
+/**
+ * Mobile Navigation Settings component
+ */
+const MobileNavSettings: React.FC = () => {
+  const [config, setConfig] = useLocalStorage<MobileNavConfig>(
+    MOBILE_NAV_STORAGE_KEY,
+    DEFAULT_MOBILE_NAV_CONFIG,
+  );
+
+  const normalizedConfig = normalizeMobileNavConfig(config);
+
+  // Get all selected IDs to filter duplicates
+  const selectedIds = [...normalizedConfig.left, ...normalizedConfig.right];
+
+  const handleLeftChange = (index: number, newId: string) => {
+    const newLeft = [...normalizedConfig.left];
+    newLeft[index] = newId;
+    setConfig({ ...normalizedConfig, left: newLeft });
+  };
+
+  const handleRightChange = (index: number, newId: string) => {
+    const newRight = [...normalizedConfig.right];
+    newRight[index] = newId;
+    setConfig({ ...normalizedConfig, right: newRight });
+  };
+
+  const handleReset = () => {
+    setConfig(DEFAULT_MOBILE_NAV_CONFIG);
+  };
+
+  const renderSlotSelector = (
+    currentId: string,
+    onChange: (newId: string) => void,
+    label: string,
+  ) => {
+    const Icon = getMobileNavIcon(currentId);
+    return (
+      <div className="flex items-center gap-2">
+        <Label className="w-16 text-sm">{label}</Label>
+        <Select value={currentId} onValueChange={onChange}>
+          <SelectTrigger className="w-full">
+            <SelectValue>
+              <div className="flex items-center gap-2">
+                <Icon className="h-4 w-4" />
+                <span>{getNavOptionById(currentId)?.name}</span>
+              </div>
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {MOBILE_NAV_OPTIONS.map((option) => {
+              const OptionIcon = getMobileNavIcon(option.id);
+              const isDisabled =
+                selectedIds.includes(option.id) && option.id !== currentId;
+              return (
+                <SelectItem key={option.id} value={option.id} disabled={isDisabled}>
+                  <div className="flex items-center gap-2">
+                    <OptionIcon className="h-4 w-4" />
+                    <span>{option.name}</span>
+                  </div>
+                </SelectItem>
+              );
+            })}
+          </SelectContent>
+        </Select>
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-4 p-3">
+      <p className="text-muted-foreground text-sm">
+        Customize the 5 buttons shown in your mobile navigation bar. The center button
+        automatically shows Village or Travel based on your location. Note: If you
+        configure Travel in a slot, it will be hidden when outside the village (since
+        the center button already shows Travel in that case).
+      </p>
+
+      <div className="space-y-3">
+        <div className="font-semibold text-sm">Left Side (2 buttons)</div>
+        {normalizedConfig.left.map((id, index) => (
+          <div key={`left-${index}`}>
+            {renderSlotSelector(
+              id,
+              (newId) => handleLeftChange(index, newId),
+              `Slot ${index + 1}`,
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="space-y-3">
+        <div className="font-semibold text-sm">Right Side (3 buttons)</div>
+        {normalizedConfig.right.map((id, index) => (
+          <div key={`right-${index}`}>
+            {renderSlotSelector(
+              id,
+              (newId) => handleRightChange(index, newId),
+              `Slot ${index + 1}`,
+            )}
+          </div>
+        ))}
+      </div>
+
+      <Button variant="outline" size="sm" onClick={handleReset}>
+        Reset to Default
+      </Button>
     </div>
   );
 };

--- a/app/src/components/layout/core4_default.tsx
+++ b/app/src/components/layout/core4_default.tsx
@@ -8,22 +8,17 @@ import {
   ChevronDown,
   ChevronRight,
   CircleHelp,
-  CircleUserRound,
-  Cog,
   Compass,
   Earth,
   Eclipse,
   Eye,
   EyeOff,
   House,
-  Inbox,
   Info,
   Link2,
   LogIn,
   Menu,
   MessageCircleWarning,
-  MessagesSquare,
-  Milk,
   Music,
   ShieldAlert,
   ShieldCheck,
@@ -85,6 +80,14 @@ import MenuBoxProfile from "@/layout/MenuBoxProfile";
 import TutorialAssistant from "@/layout/TutorialAssistant";
 import type { NavBarDropdownLink } from "@/libs/menus";
 import { getMainNavbarLinks, useGameMenu } from "@/libs/menus";
+import {
+  DEFAULT_MOBILE_NAV_CONFIG,
+  getMobileNavIcon,
+  getNavOptionById,
+  MOBILE_NAV_STORAGE_KEY,
+  type MobileNavConfig,
+  normalizeMobileNavConfig,
+} from "@/libs/mobileNavConfig";
 import { cn } from "@/libs/shadui";
 import type { UserWithRelations } from "@/routers/profile";
 import { groupBy } from "@/utils/grouping";
@@ -368,11 +371,38 @@ const LayoutCore4: React.FC<LayoutProps> = (props) => {
     </>
   );
 
+  // Mobile navigation config from localStorage
+  const [rawMobileNavConfig] = useLocalStorage<MobileNavConfig>(
+    MOBILE_NAV_STORAGE_KEY,
+    DEFAULT_MOBILE_NAV_CONFIG,
+  );
+  const mobileNavConfig = normalizeMobileNavConfig(rawMobileNavConfig);
+
   // Styling for yellow buttons
   const yellowButtonStyle =
     "h-14 w-14 sm:h-15 sm:w-15 md:h-16 md:w-16 bg-yellow-500 hover:bg-yellow-300 transition-colors text-orange-100 rounded-full p-3 shadow-md shadow-black border-2 stroke-3";
   const mobileNavbarButtonStyle =
     "h-16 w-16  hover:text-red-300 transition-colors text-orange-100 bg-opacity-50 p-2";
+
+  // Helper to render a mobile nav button from config.
+  // When outside village (!location), skip rendering "travel" since the center button shows Travel.
+  // Returns null to hide the button but the grid wrapper div is still rendered to maintain layout.
+  const renderMobileNavButton = (optionId: string) => {
+    // Skip rendering travel button when outside village (center button shows Travel instead)
+    if (optionId === "travel" && !location) return null;
+    const option = getNavOptionById(optionId);
+    if (!option) return null;
+    const Icon = getMobileNavIcon(optionId);
+    return (
+      <Link
+        href={option.href}
+        className="relative -top-2 flex justify-center"
+        prefetch={true}
+      >
+        <Icon className={mobileNavbarButtonStyle} />
+      </Link>
+    );
+  };
 
   return (
     <GlobalAudioProvider userData={userData}>
@@ -597,74 +627,36 @@ const LayoutCore4: React.FC<LayoutProps> = (props) => {
                 {userData ? (
                   <div className="absolute top-0 right-0 bottom-0 left-0 grid grid-cols-7 items-center justify-center md:hidden">
                     <div></div>
-                    <Link
-                      href="/profile"
-                      className="relative -top-2 flex justify-center"
-                      prefetch={true}
-                    >
-                      <CircleUserRound className={mobileNavbarButtonStyle} />
-                    </Link>
-                    <Link
-                      href="/inbox"
-                      className="relative -top-2 flex justify-center"
-                      prefetch={true}
-                    >
-                      <Inbox className={mobileNavbarButtonStyle} />
-                    </Link>
+                    {/* Left buttons from config */}
+                    {mobileNavConfig.left.map((optionId) => (
+                      <div key={optionId}>{renderMobileNavButton(optionId)}</div>
+                    ))}
+                    {/* CENTER button - unchanged conditional logic */}
                     {location ? (
-                      <>
-                        <Link
-                          href="/village"
-                          className="relative -top-8 flex justify-center"
-                          prefetch={true}
-                        >
-                          <div className="rounded-full bg-linear-to-b from-black/5 to-black/50 p-4">
-                            <House className={cn(yellowButtonStyle)} />
-                          </div>
-                        </Link>
-                        <Link
-                          href="/travel"
-                          className="relative -top-2 flex justify-center"
-                          prefetch={true}
-                        >
-                          <Compass className={mobileNavbarButtonStyle} />
-                        </Link>
-                      </>
+                      <Link
+                        href="/village"
+                        className="relative -top-8 flex justify-center"
+                        prefetch={true}
+                      >
+                        <div className="rounded-full bg-linear-to-b from-black/5 to-black/50 p-4">
+                          <House className={cn(yellowButtonStyle)} />
+                        </div>
+                      </Link>
                     ) : (
-                      <>
-                        <Link
-                          href="/travel"
-                          className="relative -top-8 flex justify-center"
-                          prefetch={true}
-                        >
-                          <div className="rounded-full bg-linear-to-b from-black/5 to-black/50 p-4">
-                            <Compass className={mobileNavbarButtonStyle} />
-                          </div>
-                        </Link>
-                        <Link
-                          href="/items"
-                          className="relative -top-2 flex justify-center"
-                          prefetch={true}
-                        >
-                          <Milk className={mobileNavbarButtonStyle} />
-                        </Link>
-                      </>
+                      <Link
+                        href="/travel"
+                        className="relative -top-8 flex justify-center"
+                        prefetch={true}
+                      >
+                        <div className="rounded-full bg-linear-to-b from-black/5 to-black/50 p-4">
+                          <Compass className={mobileNavbarButtonStyle} />
+                        </div>
+                      </Link>
                     )}
-
-                    <Link
-                      href="/tavern"
-                      className="relative -top-2 flex justify-center"
-                      prefetch={true}
-                    >
-                      <MessagesSquare className={mobileNavbarButtonStyle} />
-                    </Link>
-                    <Link
-                      href="/profile/edit"
-                      className="relative -top-2 flex justify-center"
-                      prefetch={true}
-                    >
-                      <Cog className={mobileNavbarButtonStyle} />
-                    </Link>
+                    {/* Right buttons from config */}
+                    {mobileNavConfig.right.map((optionId) => (
+                      <div key={optionId}>{renderMobileNavButton(optionId)}</div>
+                    ))}
                   </div>
                 ) : (
                   <div className="absolute top-4 right-0 left-0 block md:hidden">

--- a/app/src/libs/mobileNavConfig.ts
+++ b/app/src/libs/mobileNavConfig.ts
@@ -1,0 +1,133 @@
+import {
+  Banknote,
+  Bed,
+  CircleUserRound,
+  Cog,
+  Compass,
+  Dumbbell,
+  HeartPulse,
+  Inbox,
+  Landmark,
+  type LucideIcon,
+  MessagesSquare,
+  Package,
+  ScrollText,
+  Shield,
+  ShoppingBag,
+  Store,
+  Swords,
+  Users,
+  UtensilsCrossed,
+} from "lucide-react";
+
+// Mobile navigation option definition
+export interface MobileNavOption {
+  id: string;
+  name: string;
+  href: string;
+}
+
+// All available options (12 village pages + 6 existing defaults)
+export const MOBILE_NAV_OPTIONS: MobileNavOption[] = [
+  // Village pages (from requirements)
+  { id: "traininggrounds", name: "Training", href: "/traininggrounds" },
+  { id: "townhall", name: "Town Hall", href: "/townhall" },
+  { id: "ramenshop", name: "Ramen Shop", href: "/ramenshop" },
+  { id: "missionhall", name: "Mission Hall", href: "/missionhall" },
+  { id: "itemshop", name: "Item Shop", href: "/itemshop" },
+  { id: "hospital", name: "Hospital", href: "/hospital" },
+  { id: "home", name: "Home", href: "/home" },
+  { id: "clanhall", name: "Clan Hall", href: "/clanhall" },
+  { id: "blackmarket", name: "Black Market", href: "/blackmarket" },
+  { id: "battlearena", name: "Arena", href: "/battlearena" },
+  { id: "bank", name: "Bank", href: "/bank" },
+  { id: "anbu", name: "ANBU", href: "/anbu" },
+  // Current default pages (must be included)
+  { id: "profile", name: "Profile", href: "/profile" },
+  { id: "inbox", name: "Inbox", href: "/inbox" },
+  { id: "travel", name: "Travel", href: "/travel" },
+  { id: "tavern", name: "Tavern", href: "/tavern" },
+  { id: "settings", name: "Settings", href: "/profile/edit" },
+  { id: "items", name: "Items", href: "/items" },
+];
+
+export interface MobileNavConfig {
+  left: string[]; // 2 item IDs
+  right: string[]; // 3 item IDs
+}
+
+// Default configuration for mobile navigation slots.
+// The center button dynamically shows Village (when in village) or Travel (when not).
+// When outside village, any "travel" buttons in user config are hidden (but grid layout preserved).
+export const DEFAULT_MOBILE_NAV_CONFIG: MobileNavConfig = {
+  left: ["profile", "inbox"],
+  right: ["items", "tavern", "settings"],
+};
+
+export const MOBILE_NAV_STORAGE_KEY = "mobile-nav-config";
+
+export const getNavOptionById = (id: string): MobileNavOption | undefined => {
+  return MOBILE_NAV_OPTIONS.find((opt) => opt.id === id);
+};
+
+// Icon mapping function - returns the appropriate icon component for each option ID
+export const getMobileNavIcon = (id: string): LucideIcon => {
+  const iconMap: Record<string, LucideIcon> = {
+    traininggrounds: Dumbbell,
+    townhall: Landmark,
+    ramenshop: UtensilsCrossed,
+    missionhall: ScrollText,
+    itemshop: ShoppingBag,
+    hospital: HeartPulse,
+    home: Bed,
+    clanhall: Users,
+    blackmarket: Store,
+    battlearena: Swords,
+    bank: Banknote,
+    anbu: Shield,
+    profile: CircleUserRound,
+    inbox: Inbox,
+    travel: Compass,
+    tavern: MessagesSquare,
+    settings: Cog,
+    items: Package,
+  };
+  return iconMap[id] ?? CircleUserRound;
+};
+
+// Validate and normalize config from localStorage
+export const normalizeMobileNavConfig = (
+  config: unknown,
+  defaults: MobileNavConfig = DEFAULT_MOBILE_NAV_CONFIG,
+): MobileNavConfig => {
+  if (!config || typeof config !== "object") return defaults;
+
+  const c = config as Record<string, unknown>;
+  const validIds = new Set(MOBILE_NAV_OPTIONS.map((o) => o.id));
+
+  const validateArray = (
+    arr: unknown,
+    expectedLength: number,
+    fallback: string[],
+  ): string[] => {
+    if (!Array.isArray(arr)) return fallback;
+    const valid = arr.filter(
+      (id): id is string => typeof id === "string" && validIds.has(id),
+    );
+    // Reject arrays with duplicate IDs
+    if (new Set(valid).size !== valid.length) return fallback;
+    if (valid.length !== expectedLength) return fallback;
+    return valid;
+  };
+
+  const left = validateArray(c.left, 2, defaults.left);
+  const right = validateArray(c.right, 3, defaults.right);
+
+  // Reject config if there are duplicate IDs across left and right
+  const allIds = [...left, ...right];
+  if (new Set(allIds).size !== allIds.length) {
+    return defaults;
+  }
+
+  return { left, right };
+};


### PR DESCRIPTION
## Summary
- Allow users to customize the 5 configurable slots in the mobile navigation bar
- Add new settings UI in the edit profile page with dropdown selectors for each slot
- Configuration persists to localStorage and validates/falls back to defaults when invalid

## Changes
- **New file**: `app/src/libs/mobileNavConfig.ts` - Navigation options, types, icon mapping, and validation helpers
- **Modified**: `app/src/components/layout/core4_default.tsx` - Render nav buttons dynamically from localStorage config
- **Modified**: `app/src/app/profile/edit/page.tsx` - Add MobileNavSettings component and Accordion section

## Test plan
- [ ] Verify default configuration matches current hardcoded behavior (Profile, Inbox | Village/Travel | Travel, Tavern, Settings)
- [ ] Test changing individual slots and verify mobile nav updates immediately
- [ ] Test that changes persist after page refresh (localStorage)
- [ ] Test reset to default functionality
- [ ] Verify center button still behaves correctly (Village when in village, Travel when not)
- [ ] Test with invalid/corrupted localStorage data (should fallback to defaults)
- [ ] Test on mobile viewport to verify correct rendering and spacing
- [ ] Test that duplicate selection is prevented (same option can't be in multiple slots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change that persists preferences to `localStorage` and adjusts mobile nav rendering; main risk is regressions in mobile navigation layout/links if config validation or option mappings are incorrect.
> 
> **Overview**
> Enables **user-customizable mobile bottom navigation** by replacing the previously hardcoded button set with a config-driven renderer in `core4_default.tsx`, reading a validated config from `localStorage` and mapping option IDs to routes/icons.
> 
> Adds a new **“Mobile Navigation”** accordion section on `/profile/edit` with dropdown selectors for the 2 left and 3 right slots, duplicate-prevention in the UI, and a reset-to-default action.
> 
> Introduces `libs/mobileNavConfig.ts` to centralize available nav options, defaults, icon mapping, and normalization/validation (invalid/duplicate/malformed configs fall back to defaults; configured `travel` is hidden when outside the village since the center button already shows Travel).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc1094280d7abd213361a00dff8aba50ba2c6d91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customize mobile navigation from Profile → Edit: choose 2 left and 3 right slots with icons.
  * New settings panel exposed as an accordion in Edit Profile; changes persist in browser and apply immediately to the mobile bar.
  * Option to reset layout to defaults.

* **Bug Fixes**
  * Prevents duplicate selections across slots.
  * Invalid or unsupported choices now fall back to sensible defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->