### PR TITLE
fix: Calculate wound, afterburn, and related effects on post-mitigated damage

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -1154,6 +1154,19 @@ export const BATTLE_TAG_STACKING = true;
 export const RANKS_RESTRICTED_FROM_PVP = ["STUDENT", "GENIN"];
 export const STREAK_LEVEL_DIFF = 10;
 
+/**
+ * Effect types that depend on post-mitigated damage values.
+ * These must be processed AFTER damage modifiers and pierce have been applied.
+ */
+export const POST_DAMAGE_MODIFIER_TYPES: string[] = [
+  "wound",
+  "afterburn",
+  "reflect",
+  "recoil",
+  "lifesteal",
+  "absorb",
+];
+
 // Black market config
 export const RYO_FOR_REP_DAYS_FROZEN = 3;
 export const RYO_FOR_REP_DAYS_AUTO_DELIST = 30;

--- a/app/src/libs/combat/constants.ts
+++ b/app/src/libs/combat/constants.ts
@@ -125,21 +125,3 @@ export const damageModifierTypes: string[] = [
   "increasedamagetaken",
   "increasedamagegiven",
 ];
-
-/**
- * Post-pierce tags that must run AFTER pierce effects (per sortEffects ordering).
- * These tags read damage consequences that pierce creates, so they must run after pierce.
- * This constant is shared between process.ts and util.ts (sortEffects) to ensure consistency.
- */
-export const POST_PIERCE_TAGS: string[] = [
-  "lifesteal",
-  "drain",
-  "poison",
-  "afterburn",
-  "absorb",
-  "recoil",
-  "reflect",
-  "wound",
-  "decreaseheal",
-  "increaseheal",
-];

--- a/app/src/libs/combat/process.ts
+++ b/app/src/libs/combat/process.ts
@@ -4,14 +4,11 @@ import {
   DURABILITY_USABILITY_THR,
   ID_ANIMATION_SMOKE,
   NO_DURABILITY_LOSS_COMBATS,
+  POST_DAMAGE_MODIFIER_TYPES,
 } from "@/drizzle/constants";
 import type { ShieldTagType } from "@/validators/combat";
 import { VisualTag } from "@/validators/combat";
-import {
-  dmgConfig as config,
-  damageModifierTypes,
-  POST_PIERCE_TAGS,
-} from "./constants";
+import { dmgConfig as config, damageModifierTypes } from "./constants";
 import {
   absorb,
   afterburn,
@@ -318,21 +315,34 @@ export const applyEffects = (
       );
     });
 
-
   // Separate non-damage-modifier effects from damage modifier effects
-  // Note: pierce and post-pierce tags are explicitly excluded here to maintain
-  // the sortEffects ordering where damage modifiers run BEFORE pierce
+  // Note: pierce is explicitly excluded here to maintain the sortEffects ordering
+  // where damage modifiers run BEFORE pierce (pierce bypasses damage reduction)
+  // Note: POST_DAMAGE_MODIFIER_TYPES (wound, afterburn, reflect, recoil, lifesteal, absorb)
+  // are excluded here because they must read post-mitigated damage values
+  // Note: increaseheal/decreaseheal are excluded because they modify lifesteal_hp/absorb_hp
+  // which are set by post-damage modifiers
   const nonDamageModifierEffects = usersEffects
     .filter((e) => e.type !== "mirror" && e.type !== "copy")
     .filter((e) => !damageModifierTypes.includes(e.type))
+    .filter((e) => !POST_DAMAGE_MODIFIER_TYPES.includes(e.type))
     .filter((e) => e.type !== "pierce")
-    .filter((e) => !POST_PIERCE_TAGS.includes(e.type));
+    .filter((e) => e.type !== "increaseheal" && e.type !== "decreaseheal");
 
-  // Separate pierce effects (must run AFTER damage modifiers per sortEffects ordering)
+  // Separate pierce effects (must run AFTER damage modifiers, BEFORE post-damage modifiers)
   const pierceEffects = usersEffects.filter((e) => e.type === "pierce");
 
-  // Separate post-pierce effects (must run AFTER pierce per sortEffects ordering)
-  const postPierceEffects = usersEffects.filter((e) => POST_PIERCE_TAGS.includes(e.type));
+  // Separate post-damage-modifier effects (wound, afterburn, reflect, recoil, lifesteal, absorb)
+  // These depend on post-mitigated damage values, so they must run after pierce
+  const postDamageModifierEffects = usersEffects.filter((e) =>
+    POST_DAMAGE_MODIFIER_TYPES.includes(e.type),
+  );
+
+  // Separate heal adjustment effects (increaseheal/decreaseheal)
+  // These modify lifesteal_hp/absorb_hp so they must run AFTER post-damage modifiers set those values
+  const healAdjustmentEffects = usersEffects.filter(
+    (e) => e.type === "increaseheal" || e.type === "decreaseheal",
+  );
 
   // Separate damage modifier effects by stage
   const stage1DamageModifiers = usersEffects
@@ -399,8 +409,8 @@ export const applyEffects = (
     );
   });
 
-  // Apply pierce effects AFTER all damage modifiers
-  // This maintains the sortEffects ordering where pierce bypasses damage reduction
+  // Apply pierce effects AFTER damage modifiers but BEFORE post-damage modifiers
+  // Pierce adds damage that should be included in post-damage calculations (lifesteal, etc.)
   pierceEffects.sort(sortEffects).forEach((effect) => {
     applySingleEffect(
       consequences,
@@ -416,9 +426,27 @@ export const applyEffects = (
     );
   });
 
-  // Apply post-pierce effects AFTER pierce (lifesteal, wound, absorb, etc.)
-  // These tags read damage consequences from pierce, so they must run after pierce
-  postPierceEffects.sort(sortEffects).forEach((effect) => {
+  // Apply post-damage-modifier effects (wound, afterburn, reflect, recoil, lifesteal, absorb)
+  // These read consequence.damage to calculate their effect, so they must run after pierce
+  // to include pierce damage in their calculations
+  postDamageModifierEffects.sort(sortEffects).forEach((effect) => {
+    applySingleEffect(
+      consequences,
+      newUsersState,
+      newUsersEffects,
+      newGroundEffects,
+      actionEffects,
+      appliedEffects,
+      battle,
+      actorId,
+      effect,
+      action,
+    );
+  });
+
+  // Apply heal adjustment effects (increaseheal/decreaseheal) AFTER post-damage modifiers
+  // These modify lifesteal_hp/absorb_hp values that are set by lifesteal/absorb effects
+  healAdjustmentEffects.sort(sortEffects).forEach((effect) => {
     applySingleEffect(
       consequences,
       newUsersState,


### PR DESCRIPTION
## Summary

- Fix wound, afterburn, reflect, recoil, lifesteal, and absorb effects to calculate based on post-mitigated damage
- Add `postDamageModifierTypes` constant for effects that depend on post-mitigated damage values
- Add new processing stage for these effects that runs after all damage modifiers

Fixes #1090

## Test plan

- [ ] Apply Afterburn to a player, verify damage is based on post-mitigated damage
- [ ] Apply Wound effect, verify damage is based on post-mitigated damage
- [ ] Test with damage reduction effects active to confirm reduced damage is used

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes combat effect processing order and introduces a new staged phase, which can alter damage/heal outcomes across many interactions and has potential balance/regression risk in core combat logic.
> 
> **Overview**
> Adjusts combat effect ordering so `wound`, `afterburn`, `reflect`, `recoil`, `lifesteal`, and `absorb` compute from **post-mitigated** damage (including pierce) rather than pre-mitigation values.
> 
> This introduces `POST_DAMAGE_MODIFIER_TYPES` (moved to global `drizzle/constants.ts`), removes the older `POST_PIERCE_TAGS` list from combat constants, and updates `applyEffects` to run phases in this order: non-modifiers → staged damage modifiers → `pierce` → post-damage modifiers → heal adjustments (`increaseheal`/`decreaseheal`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2bcddb0c4a0f0402d814b580c5de59f91207b1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for post-damage effect types (wound, afterburn, reflect, recoil, lifesteal, absorb) and new processing slots to handle them and heal adjustments.

* **Bug Fixes**
  * Corrected processing order so post-damage effects run after mitigation and pierce, ensuring accurate outcomes.

* **Improvements**
  * Heal adjustments now run after post-damage effects for consistent healing calculations while preserving existing damage results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->