### PR TITLE
fix: Pierce not triggering Wound, Absorb, Lifesteal

### DIFF
--- a/app/src/libs/combat/constants.ts
+++ b/app/src/libs/combat/constants.ts
@@ -125,3 +125,21 @@ export const damageModifierTypes: string[] = [
   "increasedamagetaken",
   "increasedamagegiven",
 ];
+
+/**
+ * Post-pierce tags that must run AFTER pierce effects (per sortEffects ordering).
+ * These tags read damage consequences that pierce creates, so they must run after pierce.
+ * This constant is shared between process.ts and util.ts (sortEffects) to ensure consistency.
+ */
+export const POST_PIERCE_TAGS: string[] = [
+  "lifesteal",
+  "drain",
+  "poison",
+  "afterburn",
+  "absorb",
+  "recoil",
+  "reflect",
+  "wound",
+  "decreaseheal",
+  "increaseheal",
+];

--- a/app/src/libs/combat/process.ts
+++ b/app/src/libs/combat/process.ts
@@ -7,7 +7,11 @@ import {
 } from "@/drizzle/constants";
 import type { ShieldTagType } from "@/validators/combat";
 import { VisualTag } from "@/validators/combat";
-import { dmgConfig as config, damageModifierTypes } from "./constants";
+import {
+  dmgConfig as config,
+  damageModifierTypes,
+  POST_PIERCE_TAGS,
+} from "./constants";
 import {
   absorb,
   afterburn,
@@ -314,18 +318,6 @@ export const applyEffects = (
       );
     });
 
-  // Post-pierce tags that must run AFTER pierce effects (per sortEffects ordering)
-  // These tags read damage consequences that pierce creates, so they must run after pierce
-  const postPierceTags = [
-    "lifesteal",
-    "drain",
-    "poison",
-    "afterburn",
-    "absorb",
-    "recoil",
-    "reflect",
-    "wound",
-  ];
 
   // Separate non-damage-modifier effects from damage modifier effects
   // Note: pierce and post-pierce tags are explicitly excluded here to maintain
@@ -334,13 +326,13 @@ export const applyEffects = (
     .filter((e) => e.type !== "mirror" && e.type !== "copy")
     .filter((e) => !damageModifierTypes.includes(e.type))
     .filter((e) => e.type !== "pierce")
-    .filter((e) => !postPierceTags.includes(e.type));
+    .filter((e) => !POST_PIERCE_TAGS.includes(e.type));
 
   // Separate pierce effects (must run AFTER damage modifiers per sortEffects ordering)
   const pierceEffects = usersEffects.filter((e) => e.type === "pierce");
 
   // Separate post-pierce effects (must run AFTER pierce per sortEffects ordering)
-  const postPierceEffects = usersEffects.filter((e) => postPierceTags.includes(e.type));
+  const postPierceEffects = usersEffects.filter((e) => POST_PIERCE_TAGS.includes(e.type));
 
   // Separate damage modifier effects by stage
   const stage1DamageModifiers = usersEffects

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -59,7 +59,7 @@ import type { ZodAllTags } from "@/validators/combat";
 import type { PathCalculator, TerrainHex } from "../hexgrid";
 import { defineHex } from "../hexgrid";
 import { availableUserActions, calcActiveUser, stillInBattle } from "./actions";
-import { allState, publicState } from "./constants";
+import { allState, POST_PIERCE_TAGS, publicState } from "./constants";
 import { checkFriendlyFire } from "./process";
 import { getPower } from "./tags";
 import type {
@@ -910,17 +910,8 @@ export const sortEffects = (
     "increasedamagetaken",
     // Piercing damage
     "pierce",
-    // Post-modifiers after pierce
-    "lifesteal",
-    "drain",
-    "poison",
-    "afterburn",
-    "absorb",
-    "recoil",
-    "reflect",
-    "wound",
-    "decreaseheal",
-    "increaseheal",
+    // Post-modifiers after pierce (uses shared constant from constants.ts)
+    ...(POST_PIERCE_TAGS as ZodAllTags["type"][]),
     "copy",
     "mirror",
     // Time effects


### PR DESCRIPTION
## Summary
- Fix processing order for post-pierce tags (lifesteal, wound, absorb, etc.)
- These tags now run AFTER pierce effects so they can read pierce damage consequences

Fixes #1089

## Test plan
- [ ] Use a Pierce jutsu with Wound - verify wound triggers
- [ ] Use a Pierce jutsu with Lifesteal - verify lifesteal works
- [ ] Use a Pierce jutsu against enemy with Absorb - verify absorb works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes combat effect sequencing around `pierce`, which can alter damage/heal outcomes for multiple tags and may have balance/edge-case impacts across battles despite being localized.
> 
> **Overview**
> Fixes combat effect ordering so **post-pierce tags** (e.g. `lifesteal`, `wound`, `absorb`, `reflect`, `recoil`, `poison`, `afterburn`, `drain`, heal modifiers) are processed **after** `pierce`, ensuring they can read the consequences created by pierce damage.
> 
> Introduces a shared `POST_PIERCE_TAGS` constant and reuses it both in `sortEffects` ordering (`util.ts`) and in `applyEffects` (`process.ts`), where post-pierce effects are now filtered out of the main pass and applied in a dedicated post-pierce step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a87b6eac90808ee91fd4192d27a30503c563617. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures post-pierce combat effects (lifesteal, drain, poison, afterburn, absorb, recoil, reflect, wound, etc.) consistently run after pierce so they read correct damage consequences and preserve sort order.
* **Refactor**
  * Centralized post-pierce tag list into a shared definition to keep ordering and behavior consistent across effect processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->