### PR TITLE
fix: allow material withdrawal when regular inventory is full

### DIFF
--- a/app/src/server/api/routers/home.ts
+++ b/app/src/server/api/routers/home.ts
@@ -280,7 +280,11 @@ export const homeRouter = createTRPCRouter({
           nonStoredNonMaterials.filter((ui) => ui.item.isEventItem).length || 0;
         const nMaterials =
           nonStoredItems.filter((ui) => ui.item.itemType === "MATERIAL").length || 0;
-        if (!userItemResult.item.isEventItem && nRegularItems >= calcMaxItems(user)) {
+        if (
+          !userItemResult.item.isEventItem &&
+          userItemResult.item.itemType !== "MATERIAL" &&
+          nRegularItems >= calcMaxItems(user)
+        ) {
           return errorResponse("Inventory is full");
         }
         if (userItemResult.item.isEventItem && nEventItems >= calcMaxEventItems(user)) {


### PR DESCRIPTION
## Summary

- Fixed bug where players couldn't withdraw materials from home storage when their regular item inventory was full
- Added check for `itemType !== "MATERIAL"` to the regular item capacity check

Fixes #1091

---
Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small conditional change in home item withdrawal capacity checks; low risk but could affect edge cases around item-type counting and inventory limits.
> 
> **Overview**
> Fixes a bug in `homeRouter.toggleStoreItem` where withdrawing a `MATERIAL` from home storage could be blocked by the *regular* inventory capacity check.
> 
> The regular-item “Inventory is full” guard now explicitly excludes materials (`itemType !== "MATERIAL"`), leaving event-item and materials capacity limits to their respective checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edafe5b389c139f02e02ce64544968f90e424f35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where retrieving materials from storage could incorrectly trigger inventory full errors when at capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->