### PR TITLE
fix: prevent clan boosts from applying to outlaw factions/towns

### DIFF
--- a/app/src/layout/Clan.tsx
+++ b/app/src/layout/Clan.tsx
@@ -1182,98 +1182,101 @@ export const ClanInfo: React.FC<ClanInfoProps> = (props) => {
               )}
             </div>
           </div>
-          <div className="mt-4 grid grid-cols-2 gap-x-4">
-            <BoostRow
-              label="Training boost"
-              currentBoost={clanData.trainingBoost}
-              baseCost={CLAN_TRAINING_BOOST_BASE_COST}
-              perLevelCost={CLAN_TRAINING_BOOST_PER_LEVEL_COST}
-              clanBank={clanData.bank}
-              canPurchase={leaderLike}
-              isPending={isPurchasingBoost}
-              onPurchase={() => purchaseBoost({ clanId, boostType: "trainingBoost" })}
-            />
-            <BoostRow
-              label="Ryo gain boost"
-              currentBoost={clanData.ryoBoost}
-              baseCost={CLAN_RYO_BOOST_BASE_COST}
-              perLevelCost={CLAN_RYO_BOOST_PER_LEVEL_COST}
-              clanBank={clanData.bank}
-              canPurchase={leaderLike}
-              isPending={isPurchasingBoost}
-              onPurchase={() => purchaseBoost({ clanId, boostType: "ryoBoost" })}
-            />
-            <BoostRow
-              label="Regen boost"
-              currentBoost={clanData.regenBoost}
-              baseCost={CLAN_REGEN_BOOST_BASE_COST}
-              perLevelCost={CLAN_REGEN_BOOST_PER_LEVEL_COST}
-              clanBank={clanData.bank}
-              canPurchase={leaderLike}
-              isPending={isPurchasingBoost}
-              onPurchase={() =>
-                purchaseBoost({ clanId: clanData.id, boostType: "regenBoost" })
-              }
-            />
-            <BoostRow
-              label="Mission reward boost"
-              currentBoost={clanData.missionRewardBoost}
-              baseCost={CLAN_MISSION_BOOST_BASE_COST}
-              perLevelCost={CLAN_MISSION_BOOST_PER_LEVEL_COST}
-              clanBank={clanData.bank}
-              canPurchase={leaderLike}
-              isPending={isPurchasingBoost}
-              onPurchase={() =>
-                purchaseBoost({ clanId, boostType: "missionRewardBoost" })
-              }
-            />
-            <BoostRow
-              label="Crafting time reduction"
-              currentBoost={clanData.craftingTimeBoost}
-              baseCost={CLAN_CRAFTING_TIME_BOOST_BASE_COST}
-              perLevelCost={CLAN_CRAFTING_TIME_BOOST_PER_LEVEL_COST}
-              clanBank={clanData.bank}
-              canPurchase={leaderLike}
-              isPending={isPurchasingBoost}
-              onPurchase={() =>
-                purchaseBoost({ clanId, boostType: "craftingTimeBoost" })
-              }
-            />
-            <BoostRow
-              label="Crafting exp boost"
-              currentBoost={clanData.craftingExpBoost}
-              baseCost={CLAN_CRAFTING_EXP_BOOST_BASE_COST}
-              perLevelCost={CLAN_CRAFTING_EXP_BOOST_PER_LEVEL_COST}
-              clanBank={clanData.bank}
-              canPurchase={leaderLike}
-              isPending={isPurchasingBoost}
-              onPurchase={() =>
-                purchaseBoost({ clanId, boostType: "craftingExpBoost" })
-              }
-            />
-            <BoostRow
-              label="Hunter exp boost"
-              currentBoost={clanData.hunterExpBoost}
-              baseCost={CLAN_HUNTER_EXP_BOOST_BASE_COST}
-              perLevelCost={CLAN_HUNTER_EXP_BOOST_PER_LEVEL_COST}
-              clanBank={clanData.bank}
-              canPurchase={leaderLike}
-              isPending={isPurchasingBoost}
-              onPurchase={() => purchaseBoost({ clanId, boostType: "hunterExpBoost" })}
-            />
-            <BoostRow
-              label="Gatherer exp boost"
-              currentBoost={clanData.gathererExpBoost}
-              baseCost={CLAN_GATHERER_EXP_BOOST_BASE_COST}
-              perLevelCost={CLAN_GATHERER_EXP_BOOST_PER_LEVEL_COST}
-              clanBank={clanData.bank}
-              canPurchase={leaderLike}
-              isPending={isPurchasingBoost}
-              onPurchase={() =>
-                purchaseBoost({ clanId, boostType: "gathererExpBoost" })
-              }
-            />
-          </div>
+          {/* Clan boosts - only available for real clans, not outlaw factions/towns */}
+          {!userData?.isOutlaw && (
+            <div className="mt-4 grid grid-cols-2 gap-x-4">
+              <BoostRow
+                label="Training boost"
+                currentBoost={clanData.trainingBoost}
+                baseCost={CLAN_TRAINING_BOOST_BASE_COST}
+                perLevelCost={CLAN_TRAINING_BOOST_PER_LEVEL_COST}
+                clanBank={clanData.bank}
+                canPurchase={leaderLike}
+                isPending={isPurchasingBoost}
+                onPurchase={() => purchaseBoost({ clanId, boostType: "trainingBoost" })}
+              />
+              <BoostRow
+                label="Ryo gain boost"
+                currentBoost={clanData.ryoBoost}
+                baseCost={CLAN_RYO_BOOST_BASE_COST}
+                perLevelCost={CLAN_RYO_BOOST_PER_LEVEL_COST}
+                clanBank={clanData.bank}
+                canPurchase={leaderLike}
+                isPending={isPurchasingBoost}
+                onPurchase={() => purchaseBoost({ clanId, boostType: "ryoBoost" })}
+              />
+              <BoostRow
+                label="Regen boost"
+                currentBoost={clanData.regenBoost}
+                baseCost={CLAN_REGEN_BOOST_BASE_COST}
+                perLevelCost={CLAN_REGEN_BOOST_PER_LEVEL_COST}
+                clanBank={clanData.bank}
+                canPurchase={leaderLike}
+                isPending={isPurchasingBoost}
+                onPurchase={() =>
+                  purchaseBoost({ clanId: clanData.id, boostType: "regenBoost" })
+                }
+              />
+              <BoostRow
+                label="Mission reward boost"
+                currentBoost={clanData.missionRewardBoost}
+                baseCost={CLAN_MISSION_BOOST_BASE_COST}
+                perLevelCost={CLAN_MISSION_BOOST_PER_LEVEL_COST}
+                clanBank={clanData.bank}
+                canPurchase={leaderLike}
+                isPending={isPurchasingBoost}
+                onPurchase={() =>
+                  purchaseBoost({ clanId, boostType: "missionRewardBoost" })
+                }
+              />
+              <BoostRow
+                label="Crafting time reduction"
+                currentBoost={clanData.craftingTimeBoost}
+                baseCost={CLAN_CRAFTING_TIME_BOOST_BASE_COST}
+                perLevelCost={CLAN_CRAFTING_TIME_BOOST_PER_LEVEL_COST}
+                clanBank={clanData.bank}
+                canPurchase={leaderLike}
+                isPending={isPurchasingBoost}
+                onPurchase={() =>
+                  purchaseBoost({ clanId, boostType: "craftingTimeBoost" })
+                }
+              />
+              <BoostRow
+                label="Crafting exp boost"
+                currentBoost={clanData.craftingExpBoost}
+                baseCost={CLAN_CRAFTING_EXP_BOOST_BASE_COST}
+                perLevelCost={CLAN_CRAFTING_EXP_BOOST_PER_LEVEL_COST}
+                clanBank={clanData.bank}
+                canPurchase={leaderLike}
+                isPending={isPurchasingBoost}
+                onPurchase={() =>
+                  purchaseBoost({ clanId, boostType: "craftingExpBoost" })
+                }
+              />
+              <BoostRow
+                label="Hunter exp boost"
+                currentBoost={clanData.hunterExpBoost}
+                baseCost={CLAN_HUNTER_EXP_BOOST_BASE_COST}
+                perLevelCost={CLAN_HUNTER_EXP_BOOST_PER_LEVEL_COST}
+                clanBank={clanData.bank}
+                canPurchase={leaderLike}
+                isPending={isPurchasingBoost}
+                onPurchase={() => purchaseBoost({ clanId, boostType: "hunterExpBoost" })}
+              />
+              <BoostRow
+                label="Gatherer exp boost"
+                currentBoost={clanData.gathererExpBoost}
+                baseCost={CLAN_GATHERER_EXP_BOOST_BASE_COST}
+                perLevelCost={CLAN_GATHERER_EXP_BOOST_PER_LEVEL_COST}
+                clanBank={clanData.bank}
+                canPurchase={leaderLike}
+                isPending={isPurchasingBoost}
+                onPurchase={() =>
+                  purchaseBoost({ clanId, boostType: "gathererExpBoost" })
+                }
+              />
+            </div>
+          )}
           {/* Elder Nomination - only for non-outlaw clans */}
           {!userData?.isOutlaw &&
             leaderLike &&

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -1213,7 +1213,8 @@ export const calcBattleResult = (
         });
       }
       const userClan = getClan(battle, user.clanId);
-      if (userClan?.trainingBoost && userClan.trainingBoost > 0) {
+      // Only apply clan training boost for real clans (not outlaw factions/towns)
+      if (!user.isOutlaw && userClan?.trainingBoost && userClan.trainingBoost > 0) {
         expBoost += userClan.trainingBoost / 100;
       }
 
@@ -1305,8 +1306,8 @@ export const calcBattleResult = (
       let clanPoints = 0;
       let deltaEarnedExperience = 0;
 
-      // Money/ryo calculation
-      const moneyBoost = userClan?.ryoBoost ? 1 + userClan.ryoBoost / 100 : 1;
+      // Money/ryo calculation - only apply clan boost for real clans
+      const moneyBoost = !user.isOutlaw && userClan?.ryoBoost ? 1 + userClan.ryoBoost / 100 : 1;
       const isCombatOrWarBattle =
         battleType === "COMBAT" || battleType === "SHRINE_WAR";
       let moneyDelta = didWin
@@ -2051,7 +2052,8 @@ export const calcBattleResult = (
         outcome !== "Fled"
       ) {
         // Calculate what the user would have gotten if they won (same calculation as winner)
-        const loserMoneyBoost = userClan?.ryoBoost ? 1 + userClan.ryoBoost / 100 : 1;
+        // Only apply clan boost for real clans
+        const loserMoneyBoost = !user.isOutlaw && userClan?.ryoBoost ? 1 + userClan.ryoBoost / 100 : 1;
         let loserMoneyGain = WAR_TORN_SECTOR_BASE_MONEY * loserMoneyBoost;
         loserMoneyGain *= 1.5; // COMBAT multiplier
         loserMoneyGain *= battle.rewardScaling;

--- a/app/src/libs/profile.ts
+++ b/app/src/libs/profile.ts
@@ -260,9 +260,10 @@ export const calcActiveUserRegen = (
     regeneration = regeneration + user.bloodline.regenIncrease;
   }
 
-  // Clan boost (in percentage)
+  // Clan boost (in percentage) - only apply for real clans, not outlaw factions/towns
   const maxRegenBoost = CLAN_BOOST_MAX_LEVEL * CLAN_BOOST_PERCENT_PER_LEVEL;
   if (
+    !user.isOutlaw &&
     user.clan?.regenBoost &&
     user.clan?.regenBoost > 0 &&
     user.clan?.regenBoost <= maxRegenBoost

--- a/app/src/libs/quest.ts
+++ b/app/src/libs/quest.ts
@@ -140,7 +140,8 @@ export const getReward = (
     const errandsBoost = getShrineBoost(sectors, "Errands", user.village);
     const missionBoost = getShrineBoost(sectors, "Mission", user.village);
     // Get clan mission reward boost (percentage as decimal)
-    const clanMissionBoost = (user.clan?.missionRewardBoost ?? 0) / 100;
+    // Only apply for real clans, not outlaw factions/towns
+    const clanMissionBoost = user.isOutlaw ? 0 : (user.clan?.missionRewardBoost ?? 0) / 100;
     let boostFactor = 1;
     if (userQuest?.quest.questType) {
       if (["mission", "crime", "medical"].includes(userQuest.quest.questType)) {
@@ -262,9 +263,10 @@ export const getReward = (
     );
 
     // Apply clan experience boosts (percentages stored in clan object)
-    const clanHunterExpBoost = (user.clan?.hunterExpBoost ?? 0) / 100;
-    const clanGathererExpBoost = (user.clan?.gathererExpBoost ?? 0) / 100;
-    const clanCraftingExpBoost = (user.clan?.craftingExpBoost ?? 0) / 100;
+    // Only apply for real clans, not outlaw factions/towns
+    const clanHunterExpBoost = user.isOutlaw ? 0 : (user.clan?.hunterExpBoost ?? 0) / 100;
+    const clanGathererExpBoost = user.isOutlaw ? 0 : (user.clan?.gathererExpBoost ?? 0) / 100;
+    const clanCraftingExpBoost = user.isOutlaw ? 0 : (user.clan?.craftingExpBoost ?? 0) / 100;
     if (clanHunterExpBoost > 0 && rawRewards.reward_hunting_experience > 0) {
       rawRewards.reward_hunting_experience = Math.floor(
         rawRewards.reward_hunting_experience * (1 + clanHunterExpBoost),

--- a/app/src/server/api/routers/occupation.ts
+++ b/app/src/server/api/routers/occupation.ts
@@ -171,12 +171,12 @@ export const occupationRouter = createTRPCRouter({
       const shrineBoostFactor = shrineBoost ? 1 - shrineBoost : 1;
       // Clan crafting time reduction (percentage stored in clan object)
       // Max boost is 20% (10 levels × 2%), clamp as safety guard
+      // Only apply for real clans, not outlaw factions/towns
       const clanCraftingTimeBoostCap =
         (CLAN_BOOST_MAX_LEVEL * CLAN_BOOST_PERCENT_PER_LEVEL) / 100;
-      const clanCraftingTimeBoost = Math.min(
-        (user.clan?.craftingTimeBoost ?? 0) / 100,
-        clanCraftingTimeBoostCap,
-      );
+      const clanCraftingTimeBoost = user.isOutlaw
+        ? 0
+        : Math.min((user.clan?.craftingTimeBoost ?? 0) / 100, clanCraftingTimeBoostCap);
       const clanCraftingTimeFactor = 1 - clanCraftingTimeBoost;
       const craftSeconds = Math.round(
         craftingTime * 60 * shrineBoostFactor * clanCraftingTimeFactor * input.quantity,
@@ -254,8 +254,8 @@ export const occupationRouter = createTRPCRouter({
       }
 
       // Award crafting experience (from item config, or 0 if not set)
-      // Apply clan crafting experience boost
-      const clanCraftingExpBoost = (user.clan?.craftingExpBoost ?? 0) / 100;
+      // Apply clan crafting experience boost (only for real clans, not outlaw factions/towns)
+      const clanCraftingExpBoost = user.isOutlaw ? 0 : (user.clan?.craftingExpBoost ?? 0) / 100;
       const baseExpGain =
         (itemWithRequirements.craftingExperience ?? 0) * input.quantity;
       const expGain = Math.floor(baseExpGain * (1 + clanCraftingExpBoost));
@@ -392,8 +392,8 @@ export const occupationRouter = createTRPCRouter({
       });
 
       // Award small amount of crafting experience (half of crystal's crafting experience, or 0 if not set)
-      // Apply clan crafting experience boost
-      const clanCraftingExpBoost = (user.clan?.craftingExpBoost ?? 0) / 100;
+      // Apply clan crafting experience boost (only for real clans, not outlaw factions/towns)
+      const clanCraftingExpBoost = user.isOutlaw ? 0 : (user.clan?.craftingExpBoost ?? 0) / 100;
       const baseExpGain = Math.floor((crystalItem.craftingExperience ?? 0) / 2);
       const expGain = Math.floor(baseExpGain * (1 + clanCraftingExpBoost));
       // Update trackers with crafting experience gained

--- a/app/src/server/api/routers/train.ts
+++ b/app/src/server/api/routers/train.ts
@@ -127,7 +127,8 @@ export const trainRouter = createTRPCRouter({
       const gameFactor = trainSetting?.value ?? 1;
       const warFactor = (100 + (warSetting?.value ?? 0)) / 100;
       const boost = getStrucBoost("trainBoostPerLvl", user.village?.structures) / 100;
-      const clanBoost = (user?.clan?.trainingBoost ?? 0) / 100;
+      // Only apply clan boost for real clans (not outlaw factions/towns)
+      const clanBoost = user?.isOutlaw ? 0 : (user?.clan?.trainingBoost ?? 0) / 100;
       const factor = gameFactor * (1 + boost + clanBoost + shrineBoost) * warFactor;
       const seconds = (Date.now() - user.trainingStartedAt.getTime()) / 1000;
       const minutes = seconds / 60;


### PR DESCRIPTION
## Summary
- Added isOutlaw checks to prevent clan boosts from applying to factions
- Affected boosts: training, ryo, regen, mission reward, crafting time/exp, hunter exp, gatherer exp
- Hide boost purchase UI for faction members in Clan.tsx
- Monthly reset already correctly filters by VILLAGE type only

Fixes #1093

## Test plan
- [ ] Verify clan members (isOutlaw=false) still receive boosts
- [ ] Verify faction members (isOutlaw=true) no longer receive boosts
- [ ] Verify boost purchase UI is hidden for faction members

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly conditional checks that disable bonuses for a specific user category; risk is limited to balance regressions if `isOutlaw` is mis-set or mismatched between client/server.
> 
> **Overview**
> Prevents *outlaw factions/towns* from benefiting from clan boosts by gating boost application behind `!user.isOutlaw` in reward/efficiency calculations (combat EXP + ryo, training gains, regen, quest mission rewards, and crafting time/XP including imbuement XP).
> 
> Updates the Clan UI to hide the clan boost purchase section for outlaw users, keeping boosts as a real-clan-only mechanic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f5f0280a99be564130c088813c4f32db50be4ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Balancing Changes**
  * Outlaw clans are now restricted from receiving clan-provided boosts. Affected benefits include training experience multipliers, earnings bonuses (ryo) from combat victories and defeats, health regeneration enhancements, mission completion reward multipliers, crafting time reduction bonuses, and experience gains from hunting, gathering, and crafting activities. This change applies consistently across all game systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->