### PR TITLE
fix: iOS double-tap delay in combat

### DIFF
--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -382,6 +382,16 @@
   }
 }
 
+/* Fix iOS double-tap delay by disabling double-tap-to-zoom on interactive elements */
+@layer base {
+  button,
+  a,
+  [role="button"],
+  .cursor-pointer {
+    touch-action: manipulation;
+  }
+}
+
 ::-webkit-scrollbar {
   @apply w-5 h-2.5;
 }


### PR DESCRIPTION
## Summary

- Adds `touch-action: manipulation` CSS rule to interactive elements
- Disables iOS Safari's 300ms delay for double-tap-to-zoom detection
- Allows single-tap actions to work immediately in combat

Fixes #1087

---
Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, global CSS change that only affects touch interaction behavior on clickable elements; low likelihood of regressions outside mobile Safari gesture handling.
> 
> **Overview**
> Reduces iOS Safari tap latency by applying `touch-action: manipulation` globally to interactive elements (`button`, `a`, `[role="button"]`, and `.cursor-pointer`) in `globals.css`, preventing the double-tap-to-zoom detection delay.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49445bd4b2df9479c2f23a09315783cb46af32c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed unintended double-tap zoom on interactive elements (buttons, links, and similar controls) to enhance mobile usability and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->