### PR TITLE
Fix THENINJARPG-29N: Filter Chrome/Android network error from Sentry

### DIFF
--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -56,6 +56,7 @@ Sentry.init({
     "Can not send postrobot", // PayPal SDK postrobot error - alternate format
     "Cannot set properties of undefined (setting 'iframeReady')", // Usercentrics (uc.js) consent management error - third-party script timing issue
     "Failed to fetch", // Network errors during navigation - occurs when user navigates away while fetch is in-flight (common on mobile)
+    "network error", // Chrome/Android network error - occurs when fetch fails due to network issues on mobile devices
     /^Load failed/, // iOS Safari network error - occurs when device goes to sleep, network changes, or CDN requests fail (may include domain suffix)
     "Clerk: Failed to load Clerk", // Clerk script load failure - typically on very old browsers (Android 5.x, Chrome 95) that don't support modern JS
     "failed to load script", // Clerk's underlying script loading error (cause of the above) - network issues on mobile devices
@@ -195,7 +196,7 @@ function isLocalStorageAccessError(err: unknown): boolean {
 function isNetworkFetchError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   const msg = err.message ?? "";
-  return msg.startsWith("Load failed") || msg === "Failed to fetch";
+  return msg.startsWith("Load failed") || msg === "Failed to fetch" || msg === "network error";
 }
 
 /**
@@ -454,11 +455,14 @@ const isNetworkLoadError = (event: Sentry.ErrorEvent): boolean => {
   // Also check for "Failed to fetch" as a related network error
   const isFailedToFetch = message === "Failed to fetch";
 
+  // Check for Chrome/Android "network error" message
+  const isNetworkError = message === "network error";
+
   // These errors typically have no stack trace and are TypeError
   const isNetworkErrorShape =
     !hasStackTrace && (errorType === "TypeError" || errorType === "");
 
-  return (isLoadFailed || isFailedToFetch) && isNetworkErrorShape;
+  return (isLoadFailed || isFailedToFetch || isNetworkError) && isNetworkErrorShape;
 };
 
 /**


### PR DESCRIPTION
## Summary
Add "network error" to Sentry ignoreErrors array and update isNetworkFetchError and isNetworkLoadError filters to catch Chrome/Android-specific network error format.

## Why
**Sentry Issue**: [THENINJARPG-29N](https://studie-tech-aps.sentry.io/issues/81870485/)

**Error observed**: TypeError: network error on /profile page

**Frequency**: 3 events over ~2 months affecting 3 users (Chrome Mobile on Android)

**Key insight from Sentry**: The error has no stack trace and is caught by the global onunhandledrejection handler. Breadcrumbs show the user was interacting with Clerk authentication UI. Device is Chrome Mobile 144.0.0 on Android 10, indicating transient mobile network connectivity issues.

**Root cause**: Chrome/Android-specific fetch network error message ("network error") that was not being filtered alongside existing similar patterns ("Failed to fetch", "Load failed"). This is a transient browser-level network error that cannot be prevented and doesn't affect user experience since Clerk SDK has built-in retry mechanisms.

**Sentry Issue:** [THENINJARPG-29N](https://studie-tech-aps.sentry.io/issues/THENINJARPG-29N)

## Test plan
- Verified locally
- Code review passed

Closes #1112

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only expands client-side Sentry filtering for a known transient network error string, with minimal chance of hiding actionable errors beyond this specific message.
> 
> **Overview**
> Filters Chrome/Android fetch failures from Sentry by treating the `"network error"` message as a suppressible network error.
> 
> This adds `"network error"` to the Sentry `ignoreErrors` list and updates both `isNetworkFetchError` (unhandled rejections) and `isNetworkLoadError` (`beforeSend`) to drop these stackless `TypeError`-shaped events alongside existing `"Failed to fetch"`/`"Load failed"` patterns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c9b0fb31ec0996e77d5938c4bf22209427477f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced network error detection to more comprehensively identify and handle network-related failures, improving overall error reporting and app stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->