### PR TITLE
Fix multiple Sentry issues for theninjarpg

### DIFF
--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -72,6 +72,8 @@ Sentry.init({
     "ResizeObserver loop limit exceeded", // Benign browser warning from ResizeObserver specification - occurs when Radix UI components (Popover, Select) trigger layout changes during positioning
     "ResizeObserver loop completed with undelivered notifications", // Alternative format of the same benign ResizeObserver warning (used by some browsers)
     "undefined is not an object (evaluating 'window.webkit.messageHandlers')", // iOS WebKit bridge error - third-party scripts attempting to use iOS native bridge APIs that aren't available in web browser context
+    "TransformStream is not defined", // Older browser compatibility error (Firefox Mobile <102, some Android browsers) - AI chat feature uses @ai-sdk/react which requires TransformStream for SSE parsing. Users see fallback UX (chat unavailable).
+    /No ack for postMessage .* in \d+ms/, // Third-party SDK postMessage timeout - occurs when Clerk or similar services fail to receive acknowledgment for cross-origin frame communication (THENINJARPG-2FV)
   ],
 
   // Filter out third-party errors that slip through ignoreErrors
@@ -120,6 +122,9 @@ Sentry.init({
     }
     if (isWebKitMessageHandlersError(event)) {
       return null; // Drop iOS WebKit bridge errors from third-party scripts
+    }
+    if (isSpacetimeDBWebSocketConnectingError(event)) {
+      return null; // Drop SpacetimeDB WebSocket timing errors (transient)
     }
     return event;
   },
@@ -352,7 +357,23 @@ function isThirdPartyInjectedError(event: Sentry.ErrorEvent): boolean {
       frame.abs_path?.includes("cc.js"),
   );
 
-  return isInjectedScript && message.includes("Illegal invocation");
+  // Filter Illegal invocation errors from any injected script
+  if (isInjectedScript && message.includes("Illegal invocation")) {
+    return true;
+  }
+
+  // Filter Cookiebot-specific errors (cc.js) when manipulating DOM elements
+  // THENINJARPG-23Y: sortBannerButtons tries to set innerHTML on null element
+  const isCookiebotScript = stackFrames.some(
+    (frame) =>
+      frame.filename?.includes("cc.js") || frame.abs_path?.includes("cc.js"),
+  );
+
+  if (isCookiebotScript && message.includes("Cannot set properties of null")) {
+    return true;
+  }
+
+  return false;
 }
 
 /**
@@ -706,6 +727,48 @@ const isWebKitMessageHandlersError = (event: Sentry.ErrorEvent): boolean => {
     message.includes("window.webkit.messageHandlers") ||
     message.includes("webkit.messageHandlers")
   );
+};
+
+/**
+ * Check if an error is a SpacetimeDB WebSocket "Still in CONNECTING state" error.
+ * These occur when the SpacetimeDB SDK tries to send a message on a WebSocket that
+ * hasn't fully transitioned to the OPEN state yet. This is a race condition in the
+ * SDK's internal connection handling that can occur on slower networks or mobile devices.
+ *
+ * UX note: These errors are transient and handled gracefully:
+ * - The useTowerDefense hook shows a "Connecting..." state during connection
+ * - Connection errors trigger a mode change back to "lobby" with an error message
+ * - Users can retry by clicking the "Start Game" button again
+ * - The SpacetimeDB client has waitForWebSocketReady() checks for critical operations
+ *
+ * We cannot fix this in the SpacetimeDB SDK itself as it's a third-party library.
+ * The error originates from the SDK's websocket_decompress_adapter.ts send() method.
+ *
+ * THENINJARPG-2CN: Filter SpacetimeDB WebSocket timing errors from Sentry.
+ */
+const isSpacetimeDBWebSocketConnectingError = (event: Sentry.ErrorEvent): boolean => {
+  const message = event.exception?.values?.[0]?.value ?? "";
+  const errorType = event.exception?.values?.[0]?.type ?? "";
+  const stackFrames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
+
+  // Must be an InvalidStateError with the specific WebSocket CONNECTING message
+  if (errorType !== "InvalidStateError" && errorType !== "DOMException") return false;
+  if (!message.includes("Still in CONNECTING state")) return false;
+
+  // Additional check: verify it's from SpacetimeDB SDK (websocket_decompress_adapter or db_connection_impl)
+  const isFromSpacetimeDB = stackFrames.some(
+    (frame) =>
+      frame.filename?.includes("spacetimedb") ||
+      frame.filename?.includes("websocket_decompress_adapter") ||
+      frame.filename?.includes("db_connection_impl") ||
+      frame.abs_path?.includes("spacetimedb") ||
+      frame.abs_path?.includes("websocket_decompress_adapter") ||
+      frame.abs_path?.includes("db_connection_impl"),
+  );
+
+  // If we can verify it's from SpacetimeDB, filter it
+  // If stack trace is empty/anonymized (production builds), still filter based on message
+  return isFromSpacetimeDB || stackFrames.length === 0;
 };
 
 function ensureBrowserErrorHandler() {

--- a/app/src/server/api/routers/avatar.ts
+++ b/app/src/server/api/routers/avatar.ts
@@ -23,9 +23,16 @@ export const avatarRouter = createTRPCRouter({
     .meta({ mcp: { enabled: true, description: "Generate a new AI avatar" } })
     .output(baseServerResponse)
     .mutation(async ({ ctx }) => {
-      // Fetch
-      const user = await fetchUser(ctx.drizzle, ctx.userId);
+      // Fetch user directly with a query that returns null if not found
+      // This handles the case where the user was just created and the record
+      // may not be immediately available due to database replication lag
+      const user = await ctx.drizzle.query.userData.findFirst({
+        where: eq(userData.userId, ctx.userId),
+      });
       // Guard
+      if (!user) {
+        return errorResponse("User not found. Please try again in a moment.");
+      }
       if (user.reputationPoints < 1) {
         return errorResponse("Not enough reputation points");
       }

--- a/app/src/server/api/routers/staff.ts
+++ b/app/src/server/api/routers/staff.ts
@@ -1011,15 +1011,58 @@ export const staffRouter = createTRPCRouter({
 export type staffRouter = inferRouterOutputs<typeof staffRouter>;
 
 /**
+ * Check if an error is a MySQL deadlock error (errno 1213).
+ * @param error - The error to check.
+ * @returns True if the error is a deadlock error.
+ */
+const isDeadlockError = (error: unknown): boolean => {
+  if (error instanceof Error) {
+    return error.message.includes("Deadlock") || error.message.includes("errno 1213");
+  }
+  return false;
+};
+
+/**
+ * Delay execution for a specified number of milliseconds.
+ * @param ms - The number of milliseconds to delay.
+ */
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
  * Delete a user from the database.
+ * Implements retry logic for MySQL deadlock errors (errno 1213) as recommended by MySQL.
  * @param client - The database client.
  * @param userId - The ID of the user to delete.
  */
 export const deleteUser = async (client: DrizzleClient, userId: string) => {
-  // Sequential batches to prevent MySQL deadlock (errno 1213)
-  // Operations within each batch run in parallel, but batches execute sequentially
-  // This follows the pattern established in war.ts for avoiding deadlocks
+  const MAX_RETRIES = 3;
+  const BASE_DELAY_MS = 100;
 
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      await deleteUserInternal(client, userId);
+      return;
+    } catch (error) {
+      if (isDeadlockError(error) && attempt < MAX_RETRIES) {
+        // Exponential backoff: 100ms, 200ms, 400ms
+        const delayMs = BASE_DELAY_MS * 2 ** (attempt - 1);
+        await delay(delayMs);
+        continue;
+      }
+      throw error;
+    }
+  }
+};
+
+/**
+ * Internal implementation of user deletion.
+ * Sequential batches to prevent MySQL deadlock (errno 1213).
+ * Operations within each batch run in parallel, but batches execute sequentially.
+ * @param client - The database client.
+ * @param userId - The ID of the user to delete.
+ */
+const deleteUserInternal = async (client: DrizzleClient, userId: string) => {
   // Batch 1: Update foreign key references (must run first)
   await client
     .update(userData)
@@ -1104,8 +1147,12 @@ export const deleteUser = async (client: DrizzleClient, userId: string) => {
   // Batch 10: Battle & war
   await Promise.all([
     client.delete(mpvpBattleUser).where(eq(mpvpBattleUser.userId, userId)),
-    client.delete(kageDefendedChallenges).where(eq(kageDefendedChallenges.userId, userId)),
-    client.delete(kageDefendedChallenges).where(eq(kageDefendedChallenges.kageId, userId)),
+    client
+      .delete(kageDefendedChallenges)
+      .where(eq(kageDefendedChallenges.userId, userId)),
+    client
+      .delete(kageDefendedChallenges)
+      .where(eq(kageDefendedChallenges.kageId, userId)),
     client.delete(warKill).where(eq(warKill.killerId, userId)),
     client.delete(warKill).where(eq(warKill.victimId, userId)),
     client.delete(raidParticipation).where(eq(raidParticipation.userId, userId)),


### PR DESCRIPTION
## Summary

This PR fixes multiple Sentry issues for theninjarpg:

| Sentry Issue | Summary | Files Modified |
|--------------|---------|----------------|
| [THENINJARPG-2D1](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2D1/) | Added retry-on-deadlock logic with exponential backoff | staff.ts |
| [THENINJARPG-2CN](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2CN/) | Filter SpacetimeDB WebSocket CONNECTING state errors | instrumentation-client.ts |
| [THENINJARPG-2FQ](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2FQ/) | Fix race condition in createAvatar | avatar.ts |
| [THENINJARPG-23Y](https://studie-tech-aps.sentry.io/issues/THENINJARPG-23Y/) | Filter Cookiebot innerHTML null errors | instrumentation-client.ts |
| [THENINJARPG-1XW](https://studie-tech-aps.sentry.io/issues/THENINJARPG-1XW/) | Already fixed - existing filter handles this | (no changes) |
| [THENINJARPG-2FV](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2FV/) | Add regex for postMessage ack timeout errors | instrumentation-client.ts |
| [THENINJARPG-2FT](https://studie-tech-aps.sentry.io/issues/THENINJARPG-2FT/) | Add TransformStream not defined to ignoreErrors | instrumentation-client.ts |

## Why

### THENINJARPG-2D1: MySQL Deadlock in deleteUser

**Error**: Deadlock found when trying to get lock; try restarting transaction (errno 1213)
**Root cause**: The deleteUser function performs multiple sequential database operations that can conflict with concurrent operations
**Fix**: Added retry-on-deadlock logic with exponential backoff (100ms, 200ms, 400ms) as recommended by MySQL documentation

### THENINJARPG-2CN: WebSocket CONNECTING State Error

**Error**: InvalidStateError: Failed to execute 'send' on 'WebSocket': Still in CONNECTING state
**Root cause**: SpacetimeDB SDK race condition where send() is called before WebSocket is fully open
**Fix**: Added Sentry filter for this third-party SDK timing error (gracefully handled in UI)

### THENINJARPG-2FQ: User Not Found in createAvatar

**Error**: TRPCClientError: User not found
**Root cause**: Race condition where createAvatar is called immediately after user registration before DB replication completes
**Fix**: Changed from fetchUser (which throws) to direct query that returns graceful error response

### THENINJARPG-23Y: Cookiebot innerHTML Error

**Error**: TypeError: Cannot set properties of null (setting 'innerHTML')
**Root cause**: Cookiebot's cc.js sortBannerButtons function tries to manipulate DOM elements that don't exist
**Fix**: Added filter for Cookiebot script errors when setting properties on null elements

### THENINJARPG-2FV: postMessage Timeout

**Error**: No ack for postMessage B() in 10000ms
**Root cause**: Third-party SDK (Clerk) cross-origin communication timeout
**Fix**: Added regex pattern to ignoreErrors for postMessage ack timeout errors

### THENINJARPG-2FT: TransformStream Not Defined

**Error**: ReferenceError: TransformStream is not defined
**Root cause**: Older browsers (Firefox Mobile <102, some Android) don't support TransformStream used by AI SDK
**Fix**: Added to ignoreErrors - users see fallback UX (chat unavailable)

## Test plan

- [x] Code review passed (all 14 checks)
- [x] Each fix verified individually by subagent
- [x] TypeScript type checking passed
- [x] Lint passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user deletion and avatar creation flows plus error-reporting filters; main risk is masking actionable client errors or introducing unintended behavior during destructive delete retries.
> 
> **Overview**
> Reduces Sentry noise by expanding client-side suppression rules: adds new `ignoreErrors` patterns (including `TransformStream` missing and `postMessage` ack timeouts), extends injected-script filtering to drop Cookiebot null-DOM errors, and adds a new `beforeSend` filter for transient SpacetimeDB WebSocket “CONNECTING state” exceptions.
> 
> Hardens backend behavior in two spots: `avatarRouter.createAvatar` now queries `userData` directly and returns a friendly error when the user row isn’t yet visible (replication lag), and `staff.deleteUser` now retries the multi-step deletion on MySQL deadlocks with exponential backoff (while keeping the existing batched delete ordering).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d62b0356b2341ea5c42c0369c11035a584def87f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->