### PR TITLE
Fix: Form editor entry fields not rendering correctly

### DIFF
--- a/app/src/layout/EditContent.tsx
+++ b/app/src/layout/EditContent.tsx
@@ -2532,7 +2532,8 @@ export const EffectFieldInputGeneric = <E extends ZodAllTags>(opts: {
     while (
       t instanceof z.ZodDefault ||
       t instanceof z.ZodOptional ||
-      t instanceof z.ZodNullable
+      t instanceof z.ZodNullable ||
+      t instanceof z.ZodPrefault
     ) {
       t = t.unwrap() as z.ZodType;
     }
@@ -2652,7 +2653,8 @@ export const EffectFieldInputGeneric = <E extends ZodAllTags>(opts: {
     while (
       t instanceof z.ZodDefault ||
       t instanceof z.ZodOptional ||
-      t instanceof z.ZodNullable
+      t instanceof z.ZodNullable ||
+      t instanceof z.ZodPrefault
     ) {
       t = t.unwrap() as z.ZodType;
     }


### PR DESCRIPTION
## Summary
- Fixed `getInner()` function to handle `z.ZodPrefault` type
- Fields using `.prefault()` now correctly render as toggles/dropdowns

Fixes #1119

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI/schema introspection change limited to how Zod wrapper types are unwrapped; minimal risk beyond affecting which form control renders for prefaulted fields.
> 
> **Overview**
> Fixes dynamic editor field inference so schemas using `.prefault()` render the correct input controls.
> 
> `EditContent.tsx` updates all Zod-unwrapping loops/helpers (`getInner` and field renderers) to also unwrap `z.ZodPrefault`, aligning behavior with `ZodDefault`/`ZodOptional`/`ZodNullable` across effect, objective, reward, and mass-effect editor paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 242f8dfbf80cc6d9c597c65206982b4b99150aa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of default and optional values across Effect, Objective, and Reward forms, form fields, and the mass effect editor to ensure consistent validation and correct resolution of nested inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->