### PR TITLE
feat: restrict hand slots to single armor item

### DIFF
--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -1352,8 +1352,20 @@ export const itemRouter = createTRPCRouter({
         (!info.bloodlineId || !hasBloodlineItemEquipped);
 
       if (canAutoEquip) {
+        // Check if hand armor restriction applies
+        const isHandArmor = info.itemType === "ARMOR" && info.slot === "HAND";
+        const hasHandArmorEquipped = useritems.some(
+          (ui) =>
+            (ui.equipped === "HAND_1" || ui.equipped === "HAND_2") &&
+            ui.item.itemType === "ARMOR",
+        );
+
         ItemSlots.forEach((slot) => {
           if (slot.includes(info.slot) && !useritems.find((i) => i.equipped === slot)) {
+            // Skip auto-equip for hand armors if one is already equipped
+            if (isHandArmor && hasHandArmorEquipped) {
+              return;
+            }
             equipped = slot;
           }
         });


### PR DESCRIPTION
Add validation in toggleEquipItem to prevent users from equipping more than one armor item in hand slots (HAND_1 and HAND_2). This uses soft enforcement - only future equips are restricted, existing setups and loadouts with two hand armors remain functional.

Fixes #1142

# Pull Request

**Please fill: what was implemented, why, possibly include screenshots, are any of the changes breaking, etc.**

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that allowed multiple hand armor pieces to be equipped simultaneously. The system now properly enforces a constraint preventing hand armor equips when another hand armor is already equipped, both during item purchases and manual equip actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->