### PR TITLE
Fix issue# 1141: Reset skill tree in batches

### DIFF
--- a/app/src/server/api/routers/skillTree.ts
+++ b/app/src/server/api/routers/skillTree.ts
@@ -476,6 +476,15 @@ export const skillTreeRouter = createTRPCRouter({
       }
 
       if (hadUndeletedRows) {
+        await ctx.drizzle.insert(actionLog).values({
+          id: nanoid(),
+          userId: ctx.userId,
+          tableName: "userSkill",
+          changes: [`Partial mass reset of users' skill trees`],
+          relatedId: null,
+          relatedMsg: `Partial skill tree reset by ${user.username} (${totalDeleted} entries cleared, some remained)`,
+          relatedImage: user.avatarLight,
+        });
         return errorResponse(
           `Partial reset: ${totalDeleted} entries cleared, but some entries could not be deleted`,
         );


### PR DESCRIPTION
# Pull Request

When an admin attempts to reset all skill trees on the live database, they are met with "vttablet: rpc error: code = Unavailable desc = error reading from server: EOF".  In order to mitigate timeouts, I adjusted the code so it would do the deletes in batches rather than trying to delete everything at once.

This issue does not occur on the dev database, so I'm thinking the issue is a timeout due to the number of deletes.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized skill tree reset to use batched operations for more reliable and efficient clearing.
  * Kept audit logging for mass resets; message updated to reflect batched process.

* **Bug Fixes**
  * Improved error handling and messages: explicitly reports when nothing was cleared and preserves failure reporting when some entries remain.
  * Success message now shows the exact number of entries cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->