### PR TITLE
Removed DR from village walls

### DIFF
--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -2493,6 +2493,10 @@ export const processUsersForBattle = async (
       user.avatarLight = user.anbuSquad.image;
     }
 
+    // For ally village check later (and formerly for village wall defence bonus)
+    const ownSector = user.sector === user.village?.sector;
+    const inVillage = calcIsInVillage({ x: user.longitude, y: user.latitude });
+
     // Add bloodline efects
     if (
       user.bloodline?.effects &&


### PR DESCRIPTION
# Pull Request

It has been requested by the content team that damage reduction be removed as a defender bonus while in village walls.  This change removes the buff from applying to players

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Village defence bonuses are no longer applied at the start of battles, affecting damage reduction for villagers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->