### PR TITLE
Don't clear Inject & GCD on Shield

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -111,6 +111,7 @@ export const SHARED_COOLDOWN_TAGS = [
   "pierce",
   "poison",
   "seal",
+  "shield",
   "stun",
   "summon",
   "vamp",

--- a/app/src/validators/combat.ts
+++ b/app/src/validators/combat.ts
@@ -917,7 +917,7 @@ export const isPositiveUserEffect = (tag: ZodAllTags) => {
       "stunprevent",
       "summon",
       "timedilation",
-      "injectjutsus",
+      //"injectjutsus",
       "immunity",
     ].includes(tag.type)
   ) {


### PR DESCRIPTION
# Pull Request

- Commented out the inject tag from positive effects so it can't be cleared.
- Added shield to shared cooldowns

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Game Balance**
  * Shield-related abilities now share cooldown mechanics with other designated ability types.
  * Adjusted classification of injutsus effects within the combat system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->