### PR TITLE
Display if jutsu/item is bloodline boosts in damage tag

### DIFF
--- a/app/src/layout/ItemWithEffects.tsx
+++ b/app/src/layout/ItemWithEffects.tsx
@@ -846,10 +846,16 @@ const ItemWithEffects: React.FC<ItemWithEffectsProps> = (props) => {
                         )}
                         {(parsedEffect.type === "damage" ||
                           parsedEffect.type === "pierce") && (
-                          <span>
-                            <b>Bloodline boosted: </b>
-                            {parsedEffect.allowBloodlineDamageIncrease ? "Yes" : "No"}
-                          </span>
+                          <>
+                            <span>
+                              <b>Bloodline damage increase: </b>
+                              {parsedEffect.allowBloodlineDamageIncrease ? "Yes" : "No"}
+                            </span>
+                            <span>
+                              <b>Bloodline damage decrease: </b>
+                              {parsedEffect.allowBloodlineDamageDecrease ? "Yes" : "No"}
+                            </span>
+                          </>
                         )}
                         {"generalTypes" in parsedEffect &&
                           parsedEffect.generalTypes &&


### PR DESCRIPTION
# Pull Request

Jutsu and items will now display in the damage effect if it is bloodline boosted or not

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Item details for damage and pierce effects now show whether bloodline damage increase is enabled or disabled.
  * Item details for damage and pierce effects now show whether bloodline damage decrease is enabled or disabled, formatted as “Yes” or “No”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->