### PR TITLE
fix: use raw power for vamp heal calculation

### DIFF
--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -1839,7 +1839,8 @@ export const vamp = (
       (e.rounds === undefined || e.rounds > 0),
   );
   if (casterHealPrevented) return preventResponse(effect, target, "cannot vamp");
-  const { power, qualifier } = getPower(effect);
+  const power = effect.power ?? 0;
+  const qualifier = effect.calculation === "percentage" ? `${power}%` : power;
   if (effect.isNew && effect.castThisRound) {
     let totalDamage = 0;
     consequences.forEach((c) => {


### PR DESCRIPTION
# Pull Request

Fixes a bug in the `vamp` combat tag where healing was scaled by the caster's offensive stat efficiency ratio instead of being a flat percentage of damage dealt.

## Problem 
 `vamp()` was calling `getPower(effect)` to retrieve the power value. `getPower()` applies the caster's offensive stat efficiency ratio correct for damage tags where your ninjutsu/taijutsu stats determine effectiveness, but wrong for vamp. Vamp heals a flat percentage of damage already dealt, so stat scaling is irrelevant.  The bug was invisible when testing with maxed/perfect stats because the efficiency ratio approaches 1.0 and the wrong formula accidentally produces approximately correct results. It only becomes visible on characters with lower stats where the ratio is far from 1.0.  

**Example:** - Vamp power configured: 30% - Damage dealt: 505 - Expected heal: `505 × 0.30 = 151` (correct) Actual heal before fix: `~34` (efficiency ratio ~0.22 applied)  

## Fix  
Replace `getPower(effect)` with `effect.power ?? 0` directly in `vamp()`. The `?? 0` guards against `power` being undefined, which would otherwise produce `NaN` that silently propagates through the heal calculation.  

## Testing 
 Verified in-game with two test accounts at identical stats: - Damage dealt: 505 - Vamp at 30%: heals 151  (`Math.floor(505 × 0.30) = 151`) - Lifesteal at 50.4%: heals 254 .

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vamp ability power calculation to use direct effect values instead of derived calculations, ensuring consistent damage-to-heal conversion and accurate power percentage display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->