### PR TITLE
Fix war shrine points per kill and reduce raid shrine HP

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -1294,11 +1294,11 @@ export const SKILL_POINT_MIN_LEVEL = 21; // Minimum level to start gaining skill
 export const SKILL_POINT_MAX_LEVEL = 40; // Maximum level to gain skill points from leveling
 export const MAX_SKILL_POINTS_FROM_LEVELING = 20; // Maximum skill points that can be gained from leveling
 
-export const WAR_SECTORWAR_AI_SHRINE_REDUCE = 3; // KIlling AI shrine hp decrease
+export const WAR_SECTORWAR_AI_SHRINE_REDUCE = 10; // KIlling AI shrine hp decrease
 export const WAR_SECTORWAR_AI_SHRINE_RECOVER = 3; // Shrine hp recover per day
-export const WAR_SECTORWAR_PVP_SHRINE_REDUCE = 5; // Killing a player in a sector war shrine hp decrease
+export const WAR_SECTORWAR_PVP_SHRINE_REDUCE = 20; // Killing a player in a sector war shrine hp decrease
 export const WAR_SECTORWAR_PVP_SHRINE_RECOVER = 7; // Shrine hp remove per day
-export const WAR_RAID_SHRINE_HP = 1000; // Fixed HP for Village Wars and Raids (abstract mechanic)
+export const WAR_RAID_SHRINE_HP = 500; // Fixed HP for Village Wars and Raids (abstract mechanic)
 export const WAR_SHRINE_CAPTURE_WARHEALTH_DMG = 200; // Damage to war health when shrine is captured (HP <= 0)
 export const WAR_SHRINE_RECAPTURE_WARHEALTH_HEAL = 150; // Heal to war health when shrine is recaptured (HP > 25%)
 export const WAR_RECAPTURE_THRESHOLD = 0.25; // Threshold for recapture (25% of max shrine HP)

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -441,8 +441,8 @@ export const updateWars = async (
       if (["VILLAGE_WAR", "WAR_RAID"].includes(w.type)) {
         // Use the already-computed villageWarShrineInfo which includes:
         // 1. The correct shrine change constants
-        // 2. Scaling by rewardScaling
-        // 3. Level difference adjustment (reduced to ±1 when STREAK_LEVEL_DIFF exceeded)
+        // 2. Level difference adjustment (reduced to ±1 when STREAK_LEVEL_DIFF exceeded)
+        // Note: villageWarShrineInfo is NOT scaled by rewardScaling (shrine damage is a war mechanic)
         // Combine attacker and defender changes for logging purposes
         const shrineInfo = result.villageWarShrineInfo[w.id];
         logShrineHpChange = shrineInfo ? shrineInfo.attacker + shrineInfo.defender : 0;

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -1808,13 +1808,9 @@ export const calcBattleResult = (
           warHealthInfo[name] = val * battle.rewardScaling;
         }
       });
-      Object.keys(villageWarShrineInfo).forEach((warId) => {
-        const info = villageWarShrineInfo[warId];
-        if (info) {
-          info.attacker *= battle.rewardScaling;
-          info.defender *= battle.rewardScaling;
-        }
-      });
+      // Note: villageWarShrineInfo is intentionally NOT scaled by rewardScaling.
+      // Shrine HP changes are a strategic war mechanic and should not be reduced
+      // by anti-farming scaling, ensuring consistent war progress per kill.
 
       // Adjust shrine & townhall datamage based on level different
       const maxTargetLevel = Math.max(...targetUsers.map((t) => t.level), 0);


### PR DESCRIPTION
## What was implemented

Fixed a bug where **war shrine points per kill were far too low** (showing as 1 in some cases). Also reduced Village War and Raid shrine HP from 1000 to 500 as requested.

### What the fix does

- Increased `WAR_SECTORWAR_AI_SHRINE_REDUCE` from 3 → **10** (shrine HP removed per AI kill)
- Increased `WAR_SECTORWAR_PVP_SHRINE_REDUCE` from 5 → **20** (shrine HP removed per PvP kill)
- Reduced `WAR_RAID_SHRINE_HP` from 1000 → **500** (starting/max HP for Village War and Raid shrines)
- Removed `rewardScaling` multiplication from `villageWarShrineInfo` in `calcBattleResult` (`libs/combat/util.ts`)
- Updated the matching comment in `combat/database.ts` to accurately reflect that village war shrine damage is no longer scaled

### Root cause

The `rewardScaling` factor (which reduces rewards for repeated battles against the same opponent and scales by `scaleGains`) was being applied to village war shrine HP changes. With the old constant of 3 and a typical `rewardScaling` of ~0.33, a kill would only deal ~1 point of shrine damage — matching the screenshot in the issue. Simply raising the constants without removing the scaling would have partially fixed the problem but shrine damage would still be suppressed for repeated fights.

### Guard conditions

| Guard | Purpose |
|---|---|
| Level difference check (lines 1829-1859, `util.ts`) | Reduces shrine damage to ±1 when a higher-level player fights a much weaker one (pre-existing anti-farming protection, unchanged) |
| `GREATEST`/`LEAST` in DB queries (`database.ts`) | Clamps shrine HP to `[0, maxHp]`,  prevents over-healing or negative HP (pre-existing, verified correct) |
| Conditional `WHERE` on shrine capture | Shrine status transitions (ACTIVE → CAPTURED) only happen if the DB row still matches expected state, prevents double-application from parallel battles.

### Scope note

`rewardScaling` is still applied to **sector war** shrine changes (`shrineInfo`/`shrineChangeHp`). Sector war shrines have level-based HP (3000–5000) and are a different mechanic; this issue only concerns Village Wars and Raids.

## Why

The `rewardScaling` factor was designed to reduce personal rewards (XP, money, tokens) for farming the same opponent. It should not apply to war shrine damage, which is a strategic war mechanic, every kill against an enemy village should deal a consistent, predictable amount of shrine damage regardless of how many times the fight has been repeated.

## Guardrails

- Village war shrine HP is clamped to `[0, maxHp]` by all DB update queries , no overflow or underflow possible
- The pre-existing level difference guard (`STREAK_LEVEL_DIFF`) still reduces shrine damage to ±1 when fighting significantly under-leveled opponents, preventing level-bully shrine farming
- Shrine changes are accumulated per war across all kills in a single battle before being written — no double-counting

## Breaking changes

None. Existing active wars retain their current shrine HP values; only newly created wars will be initialized at 500 HP.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Balance Changes**
  * Increased shrine damage taken from kills in sector wars.
  * Reduced shrine HP pool for Village Wars and Raids.
  * Adjusted shrine damage calculations to ensure consistent scaling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->