### PR TITLE
Don't allow an item to have two of the same imbuement

### DIFF
--- a/app/src/layout/OccupationCrafting.tsx
+++ b/app/src/layout/OccupationCrafting.tsx
@@ -403,6 +403,12 @@ export default function OccupationCrafting() {
                               const crystal = userItem.item;
                               if (!crystal) return false;
 
+                              const alreadyOnItem =
+                                selectedImbuableItem.imbuements?.some(
+                                  (imb) => imb.imbuementItemId === crystal.id,
+                                );
+                              if (alreadyOnItem) return false;
+
                               // If crystal has no target types specified, it can be used on any item
                               if (!crystal.crystalTargetTypes) {
                                 return true;

--- a/app/src/server/api/routers/occupation.ts
+++ b/app/src/server/api/routers/occupation.ts
@@ -372,6 +372,11 @@ export const occupationRouter = createTRPCRouter({
           `You have reached the maximum number of crystals for this item (${maxImbuedItems})`,
         );
       }
+      if (
+        targetUserItem.imbuements.some((imb) => imb.imbuementItemId === crystalItem.id)
+      ) {
+        return errorResponse(`This item already has a ${crystalItem.name} imbuement`);
+      }
       // Derived
       const imbuingTime = CRAFTING_TIMES_MINS[userCraftingRank][crystalItem.rarity];
       const finishTime = new Date(Date.now() + imbuingTime * 60 * 1000);


### PR DESCRIPTION
# Pull Request

Items can currently receive two of the same imbuement, this makes it so that the same imbuement cannnot be used twice on the same item.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crystal imbuement validation to prevent duplicates. Crystals already applied to an item are now automatically filtered from the selection interface and cannot be reapplied, ensuring proper item customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->