### PR TITLE
Fix Issue# 1302: Dialog Quest Options

### DIFF
--- a/app/src/layout/Logbook.tsx
+++ b/app/src/layout/Logbook.tsx
@@ -1,4 +1,4 @@
-import { Sparkles, X } from "lucide-react";
+import { Loader2, Sparkles, X } from "lucide-react";
 import type React from "react";
 import { useEffect, useState } from "react";
 import { api } from "@/app/_trpc/client";
@@ -482,26 +482,35 @@ export const LogbookEntry: React.FC<LogbookEntryProps> = (props) => {
           </div>
         )}
         {/* Dialog options */}
-        {activeObjective?.task === "dialog" && !isCheckingRewards && (
+        {activeObjective?.task === "dialog" && (
           <div className="w-full">
-            <h2 className="pl-2 font-bold text-lg">Dialog Options</h2>
+            <h2 className="flex items-center pl-2 font-bold text-lg">
+              Dialog Options
+              {isCheckingRewards && (
+                <Loader2
+                  className="ml-2 inline h-4 w-4 shrink-0 animate-spin"
+                  aria-label="Loading"
+                />
+              )}
+            </h2>
             <div className="pointer-events-auto flex w-full flex-wrap gap-1 px-2 pb-1">
-              {activeObjective.nextObjectiveId.map((entry) => (
-                <div key={entry.nextObjectiveId} className="flex justify-end">
-                  <button
-                    type="button"
-                    className="max-w-full cursor-pointer break-words rounded-lg border-2 bg-popover px-2 py-1 text-right text-xs shadow-lg hover:bg-poppopover sm:text-sm"
-                    onClick={() =>
-                      checkRewards({
-                        questId: quest.id,
-                        nextObjectiveId: entry.nextObjectiveId,
-                      })
-                    }
-                  >
-                    {entry.text}
-                  </button>
-                </div>
-              ))}
+              {!isCheckingRewards &&
+                activeObjective.nextObjectiveId.map((entry) => (
+                  <div key={entry.nextObjectiveId} className="flex justify-end">
+                    <button
+                      type="button"
+                      className="max-w-full cursor-pointer break-words rounded-lg border-2 bg-popover px-2 py-1 text-right text-xs shadow-lg hover:bg-poppopover sm:text-sm"
+                      onClick={() =>
+                        checkRewards({
+                          questId: quest.id,
+                          nextObjectiveId: entry.nextObjectiveId,
+                        })
+                      }
+                    >
+                      {entry.text}
+                    </button>
+                  </div>
+                ))}
             </div>
           </div>
         )}

--- a/app/src/layout/Logbook.tsx
+++ b/app/src/layout/Logbook.tsx
@@ -1,4 +1,4 @@
-import { Loader2, Sparkles, X } from "lucide-react";
+import { Sparkles, X } from "lucide-react";
 import type React from "react";
 import { useEffect, useState } from "react";
 import { api } from "@/app/_trpc/client";
@@ -482,7 +482,7 @@ export const LogbookEntry: React.FC<LogbookEntryProps> = (props) => {
           </div>
         )}
         {/* Dialog options */}
-        {activeObjective?.task === "dialog" && (
+        {activeObjective?.task === "dialog" && !isCheckingRewards && (
           <div className="w-full">
             <h2 className="pl-2 font-bold text-lg">Dialog Options</h2>
             <div className="pointer-events-auto flex w-full flex-wrap gap-1 px-2 pb-1">
@@ -492,18 +492,13 @@ export const LogbookEntry: React.FC<LogbookEntryProps> = (props) => {
                     type="button"
                     className="max-w-full cursor-pointer break-words rounded-lg border-2 bg-popover px-2 py-1 text-right text-xs shadow-lg hover:bg-poppopover sm:text-sm"
                     onClick={() =>
-                      !isCheckingRewards &&
                       checkRewards({
                         questId: quest.id,
                         nextObjectiveId: entry.nextObjectiveId,
                       })
                     }
                   >
-                    {isCheckingRewards ? (
-                      <Loader2 className="mr-1 h-4 w-4 animate-spin" />
-                    ) : (
-                      entry.text
-                    )}
+                    {entry.text}
                   </button>
                 </div>
               ))}

--- a/app/src/layout/TutorialAssistant.tsx
+++ b/app/src/layout/TutorialAssistant.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
-import { ArrowRight, Settings2, Sparkles, X } from "lucide-react";
+import { ArrowRight, Loader2, Settings2, Sparkles, X } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import React, { useEffect, useState } from "react";
 import { api } from "@/app/_trpc/client";
@@ -1068,28 +1068,37 @@ const TutorialAssistant: React.FC<TutorialAssistantProps> = ({
                 </Button>
               </div>
             )}
-            {dialogOptions && !isCheckingRewards && (
+            {dialogOptions && (
               <div className="mt-3 md:mt-4">
-                <h3 className="mb-2 font-semibold text-sm">Dialog Options</h3>
+                <h3 className="mb-2 flex items-center font-semibold text-sm">
+                  Dialog Options
+                  {isCheckingRewards && (
+                    <Loader2
+                      className="ml-2 inline h-4 w-4 shrink-0 animate-spin"
+                      aria-label="Loading"
+                    />
+                  )}
+                </h3>
                 <div className="flex flex-wrap gap-2">
-                  {dialogOptions.options.map((entry) => (
-                    <Button
-                      key={entry.nextObjectiveId}
-                      variant="outline"
-                      size="sm"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        checkRewards({
-                          questId: dialogOptions.questId,
-                          nextObjectiveId: entry.nextObjectiveId,
-                        });
-                      }}
-                      className="min-w-[120px] flex-1"
-                    >
-                      {entry.text}
-                    </Button>
-                  ))}
+                  {!isCheckingRewards &&
+                    dialogOptions.options.map((entry) => (
+                      <Button
+                        key={entry.nextObjectiveId}
+                        variant="outline"
+                        size="sm"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          checkRewards({
+                            questId: dialogOptions.questId,
+                            nextObjectiveId: entry.nextObjectiveId,
+                          });
+                        }}
+                        className="min-w-[120px] flex-1"
+                      >
+                        {entry.text}
+                      </Button>
+                    ))}
                 </div>
               </div>
             )}

--- a/app/src/layout/TutorialAssistant.tsx
+++ b/app/src/layout/TutorialAssistant.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
-import { ArrowRight, Loader2, Settings2, Sparkles, X } from "lucide-react";
+import { ArrowRight, Settings2, Sparkles, X } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import React, { useEffect, useState } from "react";
 import { api } from "@/app/_trpc/client";
@@ -1068,7 +1068,7 @@ const TutorialAssistant: React.FC<TutorialAssistantProps> = ({
                 </Button>
               </div>
             )}
-            {dialogOptions && (
+            {dialogOptions && !isCheckingRewards && (
               <div className="mt-3 md:mt-4">
                 <h3 className="mb-2 font-semibold text-sm">Dialog Options</h3>
                 <div className="flex flex-wrap gap-2">
@@ -1077,24 +1077,17 @@ const TutorialAssistant: React.FC<TutorialAssistantProps> = ({
                       key={entry.nextObjectiveId}
                       variant="outline"
                       size="sm"
-                      disabled={isCheckingRewards}
                       onClick={(e) => {
                         e.preventDefault();
                         e.stopPropagation();
-                        if (!isCheckingRewards) {
-                          checkRewards({
-                            questId: dialogOptions.questId,
-                            nextObjectiveId: entry.nextObjectiveId,
-                          });
-                        }
+                        checkRewards({
+                          questId: dialogOptions.questId,
+                          nextObjectiveId: entry.nextObjectiveId,
+                        });
                       }}
                       className="min-w-[120px] flex-1"
                     >
-                      {isCheckingRewards ? (
-                        <Loader2 className="mr-1 h-4 w-4 animate-spin" />
-                      ) : (
-                        entry.text
-                      )}
+                      {entry.text}
                     </Button>
                   ))}
                 </div>


### PR DESCRIPTION
# Pull Request

This PR makes it so when a dialog option is picked for the quest, the spinner is hidden instead of persistent

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated dialog options UI: the header now shows a central loading spinner while reward checks run; the entire options list is hidden during that time (instead of showing disabled buttons with per-button loaders). When visible, option buttons always display their labels and consistently trigger the reward-check action. This yields a clearer, more predictable loading/interaction experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->