### PR TITLE
Fix raid bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ bun: install ## Execute bun command in local development.
 start: loadEnv # Run Next.js server, access at http://127.0.0.1:PORT
 	@echo "${GREEN}start on port $(PORT)${RESET}"
 	rm -rf app/.next
-	@make bun -- OPENAI_API_KEY=$(OPENAI_API_KEY) dev -p $(PORT)
+	@FORCE_COLOR=1 make bun -- OPENAI_API_KEY=$(OPENAI_API_KEY) dev -p $(PORT) 2>&1 | grep -v "Ignoring Unsecure message event"
 
 .PHONY: build
 build: # Build Next.js app

--- a/app/bun.lock
+++ b/app/bun.lock
@@ -1,6 +1,6 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "tnr",
@@ -2423,6 +2423,22 @@
 
     "@sentry/node/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "@types/connect/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@types/htmlparser2/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
@@ -2593,6 +2609,16 @@
 
     "@prisma/instrumentation/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/runtime/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "log-update/wrap-ansi/string-width/get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
 
     "react-html-parser/htmlparser2/domutils/dom-serializer": ["dom-serializer@0.2.2", "", { "dependencies": { "domelementtype": "^2.0.1", "entities": "^2.0.0" } }, "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g=="],
@@ -2600,6 +2626,8 @@
     "react-html-parser/htmlparser2/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "replicate/readable-stream/string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "react-html-parser/htmlparser2/domutils/dom-serializer/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -43,9 +43,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <TrpcClientProvider>
               <UserContextProvider>
                 <InstallPromptProvider>
-                  {env.NEXT_PUBLIC_MEASUREMENT_ID && (
-                    <GoogleTagManager gtmId={env.NEXT_PUBLIC_MEASUREMENT_ID} />
-                  )}
+                  {env.NEXT_PUBLIC_MEASUREMENT_ID &&
+                    process.env.NODE_ENV === "production" && (
+                      <GoogleTagManager gtmId={env.NEXT_PUBLIC_MEASUREMENT_ID} />
+                    )}
                   <LayoutSwitcher>{children}</LayoutSwitcher>
                   <Toaster />
                   <AcceptWarning />

--- a/app/src/layout/PusherHandler.tsx
+++ b/app/src/layout/PusherHandler.tsx
@@ -91,6 +91,10 @@ export const usePusherHandler = (
             router.push("/combat");
             void utils.combat.getBattle.invalidate();
           }
+        } else if (data.type === "battleEnded") {
+          await utils.profile.getUser.cancel();
+          void utils.profile.getUser.invalidate();
+          void utils.combat.getBattle.invalidate();
         } else if (data.type === "newInbox") {
           if (!pathname.includes("/inbox")) {
             showMutationToast({

--- a/app/src/layout/RaidBrowser.tsx
+++ b/app/src/layout/RaidBrowser.tsx
@@ -787,12 +787,17 @@ const RaidChatPanel: React.FC<RaidChatPanelProps> = ({ conversationId }) => {
     util.comments.getConversationComments,
   ]);
 
-  const comments =
-    commentsData?.pages
+  const comments = useMemo(() => {
+    if (!commentsData?.pages) return [];
+    const seen = new Set<string>();
+    return commentsData.pages
       .flatMap((page) => page.data)
-      .filter((comment, index, all) => {
-        return all.findIndex((candidate) => candidate.id === comment.id) === index;
-      }) ?? [];
+      .filter((comment) => {
+        if (seen.has(comment.id)) return false;
+        seen.add(comment.id);
+        return true;
+      });
+  }, [commentsData?.pages]);
 
   const handleSendMessage = () => {
     if (!conversationId) return;

--- a/app/src/layout/RaidBrowser.tsx
+++ b/app/src/layout/RaidBrowser.tsx
@@ -642,7 +642,10 @@ const RaidBrowser: React.FC<RaidBrowserProps> = (props) => {
             )}
 
             {!isViewingCompletedRaid && raidDetails.raidChatConversationId && (
-              <RaidChatPanel conversationId={raidDetails.raidChatConversationId} />
+              <RaidChatPanel
+                key={raidDetails.raidChatConversationId}
+                conversationId={raidDetails.raidChatConversationId}
+              />
             )}
 
             {/* Leaderboard */}

--- a/app/src/layout/RaidBrowser.tsx
+++ b/app/src/layout/RaidBrowser.tsx
@@ -742,7 +742,6 @@ const RaidChatPanel: React.FC<RaidChatPanelProps> = ({ conversationId }) => {
     () => ({
       convo_id: conversationId,
       limit: 15,
-      refreshKey: 0,
     }),
     [conversationId],
   );

--- a/app/src/layout/RaidBrowser.tsx
+++ b/app/src/layout/RaidBrowser.tsx
@@ -19,6 +19,7 @@ import { useEffect, useMemo, useState } from "react";
 import { api } from "@/app/_trpc/client";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
+import { Textarea } from "@/components/ui/textarea";
 import {
   RAID_BATTLE_LOBBY_SECONDS,
   RAID_BATTLE_MAX_USERS_PER_TEAM,
@@ -33,6 +34,7 @@ import { getRewardArray } from "@/libs/objectives";
 import { cn } from "@/libs/shadui";
 import { showMutationToast, showRewardToast } from "@/libs/toast";
 import { calculatePercent } from "@/utils/math";
+import { parseHtml } from "@/utils/parse";
 import { secondsFromDate } from "@/utils/time";
 import { useRequiredUserData } from "@/utils/UserContext";
 
@@ -639,6 +641,10 @@ const RaidBrowser: React.FC<RaidBrowserProps> = (props) => {
               </div>
             )}
 
+            {!isViewingCompletedRaid && raidDetails.raidChatConversationId && (
+              <RaidChatPanel conversationId={raidDetails.raidChatConversationId} />
+            )}
+
             {/* Leaderboard */}
             {leaderboard.length > 0 && (
               <div className="rounded-lg border p-3">
@@ -717,6 +723,161 @@ interface RaidTeamMember {
   username: string;
   avatar: string | null;
 }
+
+interface RaidChatPanelProps {
+  conversationId: string;
+}
+
+const RaidChatPanel: React.FC<RaidChatPanelProps> = ({ conversationId }) => {
+  const { data: userData, pusher } = useRequiredUserData();
+  const util = api.useUtils();
+  const [message, setMessage] = useState("");
+
+  const queryKey = useMemo(
+    () => ({
+      convo_id: conversationId,
+      limit: 15,
+      refreshKey: 0,
+    }),
+    [conversationId],
+  );
+
+  const { data: commentsData, isPending } =
+    api.comments.getConversationComments.useInfiniteQuery(queryKey, {
+      enabled: !!conversationId,
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+    });
+
+  const { mutate: sendMessage, isPending: isSending } =
+    api.comments.createConversationComment.useMutation({
+      onSuccess: async (data) => {
+        if (!data.success) {
+          showMutationToast(data);
+          return;
+        }
+
+        setMessage("");
+        await util.comments.getConversationComments.invalidate(queryKey);
+      },
+    });
+
+  useEffect(() => {
+    if (!pusher || !conversationId) return;
+
+    const channel = pusher.subscribe(conversationId);
+    channel.bind("event", (data: { message?: string }) => {
+      if (data.message === "new") {
+        void util.comments.getConversationComments.invalidate(queryKey);
+      }
+    });
+
+    return () => {
+      pusher.unsubscribe(conversationId);
+    };
+  }, [conversationId, pusher, queryKey, util.comments.getConversationComments]);
+
+  const comments =
+    commentsData?.pages
+      .flatMap((page) => page.data)
+      .filter((comment, index, all) => {
+        return all.findIndex((candidate) => candidate.id === comment.id) === index;
+      }) ?? [];
+
+  const handleSendMessage = () => {
+    if (!conversationId) return;
+    const trimmedMessage = message.trim();
+    if (trimmedMessage.length < 4) {
+      showMutationToast({
+        success: false,
+        message: "Raid chat messages must be at least 4 characters long.",
+      });
+      return;
+    }
+
+    sendMessage({
+      object_id: conversationId,
+      comment: trimmedMessage,
+      quoteIds: null,
+      senderId: null,
+    });
+  };
+
+  return (
+    <div className="rounded-lg border p-3">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h4 className="font-medium">Raid Chat</h4>
+        <span className="text-muted-foreground text-xs">
+          Messages are shared live for this raid.
+        </span>
+      </div>
+
+      <div className="mb-3 max-h-72 space-y-2 overflow-y-auto rounded-md border bg-muted/30 p-3">
+        {isPending ? (
+          <div className="flex items-center gap-2 text-muted-foreground text-sm">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading chat...
+          </div>
+        ) : comments.length > 0 ? (
+          comments
+            .slice()
+            .reverse()
+            .map((comment) => (
+              <div
+                key={comment.id}
+                className={cn(
+                  "rounded-md border bg-background p-2 text-sm",
+                  comment.userId === userData?.userId && "border-primary/40",
+                )}
+              >
+                <div className="mb-1 flex items-center justify-between gap-2">
+                  <span className="font-medium">{comment.username}</span>
+                  <span className="text-muted-foreground text-xs">
+                    {new Date(comment.createdAt).toLocaleTimeString()}
+                  </span>
+                </div>
+                <div className="break-words text-foreground">
+                  {parseHtml(comment.content)}
+                </div>
+              </div>
+            ))
+        ) : (
+          <p className="text-muted-foreground text-sm">
+            No messages yet. Coordinate your team here.
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Textarea
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          placeholder={
+            userData?.isBanned || userData?.isSilenced
+              ? "You cannot send messages while banned or silenced."
+              : "Write a message to everyone in this raid..."
+          }
+          disabled={isSending || userData?.isBanned || userData?.isSilenced}
+          className="min-h-24"
+          maxLength={5000}
+        />
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-muted-foreground text-xs">Minimum 4 characters.</span>
+          <Button
+            onClick={handleSendMessage}
+            disabled={
+              isSending ||
+              userData?.isBanned ||
+              userData?.isSilenced ||
+              message.trim().length < 4
+            }
+          >
+            {isSending ? "Sending..." : "Send"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
 
 interface RaidTeam {
   id: string;

--- a/app/src/layout/RaidBrowser.tsx
+++ b/app/src/layout/RaidBrowser.tsx
@@ -117,6 +117,7 @@ const RaidBrowser: React.FC<RaidBrowserProps> = (props) => {
         setIsReadyToQueue(false);
         void util.raids.getUserRaidQueue.invalidate();
         void util.raids.getActiveRaidTeams.invalidate();
+        void util.raids.getRaidDetails.invalidate();
         void util.profile.getUser.invalidate();
       },
     });

--- a/app/src/layout/RaidBrowser.tsx
+++ b/app/src/layout/RaidBrowser.tsx
@@ -553,6 +553,7 @@ const RaidBrowser: React.FC<RaidBrowserProps> = (props) => {
                   userId={userData.userId}
                   userInQueue={userInSelectedRaidQueue}
                   userTeamIsClaiming={userQueueIsClaiming}
+                  isBanned={userData.isBanned}
                   onJoinTeam={handleJoinQueue}
                   onCreateTeam={() => handleJoinQueue()}
                   onLeave={handleLeaveQueue}
@@ -567,7 +568,15 @@ const RaidBrowser: React.FC<RaidBrowserProps> = (props) => {
                     Click the button below to prepare for battle. This will clear any
                     stuck status before joining the queue.
                   </p>
-                  <Button onClick={() => readyToQueue()} disabled={readyPending}>
+                  <Button
+                    onClick={() => readyToQueue()}
+                    disabled={readyPending || userData.isBanned}
+                    title={
+                      userData.isBanned
+                        ? "You are banned and cannot queue for raids"
+                        : undefined
+                    }
+                  >
                     <Swords className="mr-2 h-4 w-4" />
                     {readyPending ? "Preparing..." : "Ready to Queue"}
                   </Button>
@@ -909,6 +918,7 @@ interface RaidTeamsDisplayProps {
   userId: string;
   userInQueue: boolean;
   userTeamIsClaiming: boolean;
+  isBanned: boolean;
   onJoinTeam: (teamId: string) => void;
   onCreateTeam: () => void;
   onLeave: () => void;
@@ -924,6 +934,7 @@ const RaidTeamsDisplay: React.FC<RaidTeamsDisplayProps> = ({
   userId,
   userInQueue,
   userTeamIsClaiming,
+  isBanned,
   onJoinTeam,
   onCreateTeam,
   onLeave,
@@ -934,6 +945,9 @@ const RaidTeamsDisplay: React.FC<RaidTeamsDisplayProps> = ({
 }) => {
   // Check if user can create a new team
   const canCreateNewTeam = activeTeams.length < maxTeams && !userInQueue;
+  const banTooltip = isBanned
+    ? "You are banned and cannot participate in raids"
+    : undefined;
 
   return (
     <div className="space-y-4">
@@ -946,7 +960,12 @@ const RaidTeamsDisplay: React.FC<RaidTeamsDisplayProps> = ({
           </span>
         </div>
         {canCreateNewTeam && (
-          <Button size="sm" onClick={onCreateTeam} disabled={isJoining}>
+          <Button
+            size="sm"
+            onClick={onCreateTeam}
+            disabled={isJoining || isBanned}
+            title={banTooltip}
+          >
             <Swords className="mr-2 h-4 w-4" />
             {isJoining ? "Creating..." : "Create Team"}
           </Button>
@@ -960,7 +979,11 @@ const RaidTeamsDisplay: React.FC<RaidTeamsDisplayProps> = ({
             No active teams. Create a team to start fighting the raid boss!
           </p>
           {!userInQueue && (
-            <Button onClick={onCreateTeam} disabled={isJoining}>
+            <Button
+              onClick={onCreateTeam}
+              disabled={isJoining || isBanned}
+              title={banTooltip}
+            >
               <Swords className="mr-2 h-4 w-4" />
               {isJoining ? "Creating..." : "Create Team"}
             </Button>
@@ -1013,7 +1036,7 @@ const RaidTeamsDisplay: React.FC<RaidTeamsDisplayProps> = ({
                   {Array.from({ length: emptySlots }).map((_, emptyIdx) => (
                     <RaidEmptySlot
                       key={`empty-slot-${team.id}-${emptyIdx}`}
-                      canJoin={team.canJoin && !userInQueue}
+                      canJoin={team.canJoin && !userInQueue && !isBanned}
                       onJoin={() => onJoinTeam(team.id)}
                       isJoining={isJoining}
                     />
@@ -1042,7 +1065,12 @@ const RaidTeamsDisplay: React.FC<RaidTeamsDisplayProps> = ({
                       </Button>
 
                       {isUserLeader && !userTeamIsClaiming && (
-                        <Button size="sm" onClick={onStart} disabled={isStarting}>
+                        <Button
+                          size="sm"
+                          onClick={onStart}
+                          disabled={isStarting || isBanned}
+                          title={banTooltip}
+                        >
                           {isStarting ? (
                             <Loader2 className="mr-1 h-4 w-4 animate-spin" />
                           ) : (
@@ -1062,7 +1090,8 @@ const RaidTeamsDisplay: React.FC<RaidTeamsDisplayProps> = ({
                       size="sm"
                       variant="secondary"
                       onClick={() => onJoinTeam(team.id)}
-                      disabled={isJoining}
+                      disabled={isJoining || isBanned}
+                      title={banTooltip}
                     >
                       <Users className="mr-1 h-4 w-4" />
                       {isJoining ? "Joining..." : "Join Team"}

--- a/app/src/layout/RaidBrowser.tsx
+++ b/app/src/layout/RaidBrowser.tsx
@@ -105,6 +105,7 @@ const RaidBrowser: React.FC<RaidBrowserProps> = (props) => {
         showMutationToast(data);
         void util.raids.getUserRaidQueue.invalidate();
         void util.raids.getActiveRaidTeams.invalidate();
+        void util.raids.getRaidDetails.invalidate();
         void util.profile.getUser.invalidate();
       },
     });

--- a/app/src/layout/RaidBrowser.tsx
+++ b/app/src/layout/RaidBrowser.tsx
@@ -768,8 +768,9 @@ const RaidChatPanel: React.FC<RaidChatPanelProps> = ({ conversationId }) => {
     if (!pusher || !conversationId) return;
 
     const channel = pusher.subscribe(conversationId);
-    channel.bind("event", (data: { message?: string }) => {
-      if (data.message === "new") {
+    channel.bind("event", (data: { message?: string; fromId?: string }) => {
+      // Skip the echo of our own send — onSuccess already invalidated.
+      if (data.message === "new" && data.fromId !== userData?.userId) {
         void util.comments.getConversationComments.invalidate(queryKey);
       }
     });
@@ -777,7 +778,13 @@ const RaidChatPanel: React.FC<RaidChatPanelProps> = ({ conversationId }) => {
     return () => {
       pusher.unsubscribe(conversationId);
     };
-  }, [conversationId, pusher, queryKey, util.comments.getConversationComments]);
+  }, [
+    conversationId,
+    pusher,
+    queryKey,
+    userData?.userId,
+    util.comments.getConversationComments,
+  ]);
 
   const comments =
     commentsData?.pages

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -29,6 +29,7 @@ import {
   quest,
   raidParticipation,
   tournamentMatch,
+  user2conversation,
   userData,
   userItem,
   userItemImbuement,
@@ -134,6 +135,31 @@ export const updateBattle = async (
                 ),
               ),
           ]
+        : []),
+      // Purge raid-chat memberships on boss kill. The conversation ID is stable
+      // across raid resets (`raid-chat-${raidQuestId}`), so stale memberships
+      // would let former participants read the next team's private channel.
+      ...(raidBossDefeated && newBattle.extraState.raidQuestId
+        ? (() => {
+            const humanUserIds = newBattle.usersState
+              .filter((u) => !u.isAi && !u.isSummon)
+              .map((u) => u.userId);
+            return humanUserIds.length > 0
+              ? [
+                  client
+                    .delete(user2conversation)
+                    .where(
+                      and(
+                        eq(
+                          user2conversation.conversationId,
+                          `raid-chat-${newBattle.extraState.raidQuestId}`,
+                        ),
+                        inArray(user2conversation.userId, humanUserIds),
+                      ),
+                    ),
+                ]
+              : [];
+          })()
         : []),
       // When raid boss is defeated, release all non-acting teammates from BATTLE status.
       // updateUser only handles the acting player, so teammates would be stuck otherwise.

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -138,15 +138,18 @@ export const updateBattle = async (
       // updateUser only handles the acting player, so teammates would be stuck otherwise.
       // Mirror the pool sync (curHealth/curStamina/curChakra) the acting user gets so
       // teammates who took damage don't revert to pre-battle pool values on release.
+      // Mirror the HOSPITALIZED handling from updateUser: teammates whose curHealth
+      // dropped to 0 from boss AoE must be sent to the hospital, not released as AWAKE.
       ...(raidBossDefeated
         ? newBattle.usersState
             .filter((u) => !u.isAi && !u.isSummon && u.userId !== userId)
-            .map((teammate) =>
-              client
+            .map((teammate) => {
+              const sendToHospital =
+                !newBattle.forceKeepPools && teammate.curHealth <= 0;
+              return client
                 .update(userData)
                 .set({
                   battleId: null,
-                  status: "AWAKE",
                   regenAt: new Date(),
                   curHealth: teammate.curHealth,
                   curStamina: teammate.curStamina,
@@ -154,14 +157,24 @@ export const updateBattle = async (
                   stealthActive: false,
                   stealthActivatedAt: null,
                   stealthCooldownAt: sql`NOW() + INTERVAL ${STEALTH_POST_COMBAT_COOLDOWN_SECONDS} SECOND`,
+                  ...(sendToHospital
+                    ? {
+                        status: "HOSPITALIZED",
+                        longitude: HOSPITAL_LONG,
+                        latitude: HOSPITAL_LAT,
+                        sector: teammate.allyVillage
+                          ? teammate.sector
+                          : getVillage(newBattle, teammate.villageId)?.sector,
+                      }
+                    : { status: "AWAKE" }),
                 })
                 .where(
                   and(
                     eq(userData.userId, teammate.userId),
                     eq(userData.battleId, newBattle.id),
                   ),
-                ),
-            )
+                );
+            })
         : []),
     ]);
 

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -77,6 +77,7 @@ export const updateBattle = async (
   const raidBossDefeated =
     result &&
     newBattle.battleType === "RAID" &&
+    newBattle.usersState.some((u) => u.isAi && !u.isSummon) &&
     !newBattle.usersState.some(
       (u) => u.isAi && !u.isSummon && stillInBattle(u, newBattle.usersEffects),
     );

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -184,13 +184,15 @@ export const updateBattle = async (
             ),
           ]
         : []),
-      // When raid boss is defeated, release all non-acting teammates from BATTLE status.
-      // updateUser only handles the acting player, so teammates would be stuck otherwise.
+      // When a raid ends (boss defeated OR team wipe), release all non-acting
+      // teammates from BATTLE status. updateUser only handles the acting player,
+      // so teammates would be stuck pointing at a deleted battle row otherwise —
+      // readyToQueue hard-blocks BATTLE status and would lock them out.
       // Mirror the pool sync (curHealth/curStamina/curChakra) the acting user gets so
       // teammates who took damage don't revert to pre-battle pool values on release.
       // Mirror the HOSPITALIZED handling from updateUser: teammates whose curHealth
       // dropped to 0 from boss AoE must be sent to the hospital, not released as AWAKE.
-      ...(raidBossDefeated ? humanTeammates : [])
+      ...(raidBossDefeated || raidTeamWiped ? humanTeammates : [])
         .filter((u) => u.userId !== userId)
         .map((teammate) => {
           const sendToHospital = !newBattle.forceKeepPools && teammate.curHealth <= 0;

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -136,32 +136,32 @@ export const updateBattle = async (
         : []),
       // When raid boss is defeated, release all non-acting teammates from BATTLE status.
       // updateUser only handles the acting player, so teammates would be stuck otherwise.
+      // Mirror the pool sync (curHealth/curStamina/curChakra) the acting user gets so
+      // teammates who took damage don't revert to pre-battle pool values on release.
       ...(raidBossDefeated
-        ? (() => {
-            const teammateIds = newBattle.usersState
-              .filter((u) => !u.isAi && !u.isSummon && u.userId !== userId)
-              .map((u) => u.userId);
-            return teammateIds.length > 0
-              ? [
-                  client
-                    .update(userData)
-                    .set({
-                      battleId: null,
-                      status: "AWAKE",
-                      regenAt: new Date(),
-                      stealthActive: false,
-                      stealthActivatedAt: null,
-                      stealthCooldownAt: sql`NOW() + INTERVAL ${STEALTH_POST_COMBAT_COOLDOWN_SECONDS} SECOND`,
-                    })
-                    .where(
-                      and(
-                        inArray(userData.userId, teammateIds),
-                        eq(userData.battleId, newBattle.id),
-                      ),
-                    ),
-                ]
-              : [];
-          })()
+        ? newBattle.usersState
+            .filter((u) => !u.isAi && !u.isSummon && u.userId !== userId)
+            .map((teammate) =>
+              client
+                .update(userData)
+                .set({
+                  battleId: null,
+                  status: "AWAKE",
+                  regenAt: new Date(),
+                  curHealth: teammate.curHealth,
+                  curStamina: teammate.curStamina,
+                  curChakra: teammate.curChakra,
+                  stealthActive: false,
+                  stealthActivatedAt: null,
+                  stealthCooldownAt: sql`NOW() + INTERVAL ${STEALTH_POST_COMBAT_COOLDOWN_SECONDS} SECOND`,
+                })
+                .where(
+                  and(
+                    eq(userData.userId, teammate.userId),
+                    eq(userData.battleId, newBattle.id),
+                  ),
+                ),
+            )
         : []),
     ]);
 

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -256,6 +256,18 @@ export const updateBattle = async (
           });
         });
     }
+
+    // Nudge each human teammate's user channel so any open /combat tab
+    // invalidates getBattle/getUser immediately on raid end. Without this the
+    // acting user (and any teammate not the one who pressed an action) keeps
+    // showing the old battle map and `Status: BATTLE` until the next poll.
+    if (pusher && raidEnded) {
+      humanTeammates
+        .filter((u) => !u.fledBattle)
+        .forEach((teammate) => {
+          void pusher.trigger(teammate.userId, "event", { type: "battleEnded" });
+        });
+    }
   } else {
     const result = await client
       .update(battle)

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -1149,7 +1149,9 @@ export const updateUser = async (
   if (result && user) {
     // Check if user has active PvP quests with pvp_kills or defeat_opponents objectives
     // Get user quests from extraState (static data that doesn't change during battle)
-    const activeQuests = getUserQuestsFromBattle(curBattle, user.controllerId);
+    const activeQuests = getUserQuestsFromBattle(curBattle, user.controllerId).filter(
+      (q) => q.quest?.content !== null,
+    );
     const activePvpQuests = activeQuests.filter((q) => q.questType === "pvp");
     const hasPvpKillsInPvpQuest = activePvpQuests.some((uq) =>
       uq.quest.content.objectives.some((obj) => obj.task === "pvp_kills"),

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -37,6 +37,7 @@ import {
   war,
   warKill,
 } from "@/drizzle/schema";
+import { stillInBattle } from "@/libs/combat/actions";
 import type { ActionEffect, CombatResult, CompleteBattle } from "@/libs/combat/types";
 import {
   getItem,
@@ -73,7 +74,14 @@ export const updateBattle = async (
   fetchedVersion: number,
 ) => {
   // Calculations
-  const battleOver = result && result.friendsLeft + result.targetsLeft === 0;
+  const raidBossDefeated =
+    result &&
+    newBattle.battleType === "RAID" &&
+    !newBattle.usersState.some(
+      (u) => u.isAi && !u.isSummon && stillInBattle(u, newBattle.usersEffects),
+    );
+  const battleOver =
+    !!result && (result.friendsLeft + result.targetsLeft === 0 || raidBossDefeated);
 
   // Get user and other user
   const user = newBattle.usersState.find((u) => u.userId === userId && !u.isSummon);

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -134,6 +134,35 @@ export const updateBattle = async (
               ),
           ]
         : []),
+      // When raid boss is defeated, release all non-acting teammates from BATTLE status.
+      // updateUser only handles the acting player, so teammates would be stuck otherwise.
+      ...(raidBossDefeated
+        ? (() => {
+            const teammateIds = newBattle.usersState
+              .filter((u) => !u.isAi && !u.isSummon && u.userId !== userId)
+              .map((u) => u.userId);
+            return teammateIds.length > 0
+              ? [
+                  client
+                    .update(userData)
+                    .set({
+                      battleId: null,
+                      status: "AWAKE",
+                      regenAt: new Date(),
+                      stealthActive: false,
+                      stealthActivatedAt: null,
+                      stealthCooldownAt: sql`NOW() + INTERVAL ${STEALTH_POST_COMBAT_COOLDOWN_SECONDS} SECOND`,
+                    })
+                    .where(
+                      and(
+                        inArray(userData.userId, teammateIds),
+                        eq(userData.battleId, newBattle.id),
+                      ),
+                    ),
+                ]
+              : [];
+          })()
+        : []),
     ]);
 
     // Delete queue entries AFTER the Promise.all to ensure mpvpBattleUser

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -218,9 +218,12 @@ export const updateBattle = async (
     // Notify the sector that surviving raid teammates are back on the map.
     // Mirrors the `result.curHealth > 0` gate in updateUser so other clients
     // see them transition out of BATTLE without waiting for the next poll.
+    // Skip teammates who already fled: their DB UPDATE above no-ops via the
+    // battleId guard, so broadcasting here would overwrite their actual
+    // sector/coords in other clients' map views with stale battle data.
     if (pusher && raidBossDefeated) {
       humanTeammates
-        .filter((u) => u.userId !== userId)
+        .filter((u) => u.userId !== userId && !u.fledBattle)
         .forEach((teammate) => {
           const sendToHospital = !newBattle.forceKeepPools && teammate.curHealth <= 0;
           if (sendToHospital) return;

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -29,7 +29,6 @@ import {
   quest,
   raidParticipation,
   tournamentMatch,
-  user2conversation,
   userData,
   userItem,
   userItemImbuement,
@@ -58,6 +57,7 @@ import { battleJutsuExp } from "@/libs/train";
 import { findWarsWithUser } from "@/libs/war";
 import type { UserWithRelations } from "@/routers/profile";
 import type { DrizzleClient } from "@/server/db";
+import { purgeRaidChatMembership } from "@/server/utils/raidChat";
 
 type DataBattleAction = {
   type: (typeof BattleDataEntryType)[number];
@@ -66,6 +66,18 @@ type DataBattleAction = {
   battleWon: number;
   relatedBloodlineId?: string;
 };
+
+/**
+ * A raid is "boss defeated" when the boss AI exists in the battle and no
+ * remaining boss AI is still in fighting condition. Summons don't count as
+ * the boss; teammates' AI summons must not block the defeat condition.
+ */
+const isRaidBossDefeated = (battle: CompleteBattle) =>
+  battle.battleType === "RAID" &&
+  battle.usersState.some((u) => u.isAi && !u.isSummon) &&
+  battle.usersState.every(
+    (u) => !u.isAi || u.isSummon || !stillInBattle(u, battle.usersEffects),
+  );
 
 /**
  * Update the battle state with raw queries for speed
@@ -79,13 +91,7 @@ export const updateBattle = async (
   pusher?: PusherClient,
 ) => {
   // Calculations
-  const raidBossDefeated =
-    result &&
-    newBattle.battleType === "RAID" &&
-    newBattle.usersState.some((u) => u.isAi && !u.isSummon) &&
-    !newBattle.usersState.some(
-      (u) => u.isAi && !u.isSummon && stillInBattle(u, newBattle.usersEffects),
-    );
+  const raidBossDefeated = !!result && isRaidBossDefeated(newBattle);
   const battleOver =
     !!result && (result.friendsLeft + result.targetsLeft === 0 || raidBossDefeated);
   const isRaidBattleOver = battleOver && newBattle.battleType === "RAID";
@@ -156,17 +162,11 @@ export const updateBattle = async (
       newBattle.extraState.raidQuestId &&
       humanUserIds.length > 0
         ? [
-            client
-              .delete(user2conversation)
-              .where(
-                and(
-                  eq(
-                    user2conversation.conversationId,
-                    getRaidChatConversationId(newBattle.extraState.raidQuestId),
-                  ),
-                  inArray(user2conversation.userId, humanUserIds),
-                ),
-              ),
+            purgeRaidChatMembership(
+              client,
+              getRaidChatConversationId(newBattle.extraState.raidQuestId),
+              humanUserIds,
+            ),
           ]
         : []),
       // When raid boss is defeated, release all non-acting teammates from BATTLE status.

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -72,6 +72,7 @@ export const updateBattle = async (
   userId: string,
   newBattle: CompleteBattle,
   fetchedVersion: number,
+  pusher?: PusherClient,
 ) => {
   // Calculations
   const raidBossDefeated =
@@ -184,6 +185,25 @@ export const updateBattle = async (
       await client
         .delete(mpvpBattleQueue)
         .where(eq(mpvpBattleQueue.battleId, newBattle.id));
+    }
+
+    // Notify the sector that surviving raid teammates are back on the map.
+    // Mirrors the `result.curHealth > 0` gate in updateUser so other clients
+    // see them transition out of BATTLE without waiting for the next poll.
+    if (pusher && raidBossDefeated) {
+      newBattle.usersState
+        .filter((u) => !u.isAi && !u.isSummon && u.userId !== userId)
+        .forEach((teammate) => {
+          const sendToHospital = !newBattle.forceKeepPools && teammate.curHealth <= 0;
+          if (sendToHospital) return;
+          void updateUserOnMap(pusher, teammate.sector, {
+            ...teammate,
+            longitude: teammate.originalLongitude,
+            latitude: teammate.originalLatitude,
+            status: "AWAKE",
+            battleId: null,
+          });
+        });
     }
   } else {
     const result = await client

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -88,6 +88,7 @@ export const updateBattle = async (
     );
   const battleOver =
     !!result && (result.friendsLeft + result.targetsLeft === 0 || raidBossDefeated);
+  const isRaidBattleOver = battleOver && newBattle.battleType === "RAID";
 
   // Get user and other user
   const user = newBattle.usersState.find((u) => u.userId === userId && !u.isSummon);
@@ -103,9 +104,10 @@ export const updateBattle = async (
     }
   }
 
-  // Surviving non-summon humans, used both to purge raid-chat memberships
-  // and to release/notify teammates when the raid boss is defeated.
-  const humanTeammates = raidBossDefeated
+  // Non-summon humans in this raid battle. Used to purge raid-chat memberships
+  // on any raid battle-over (boss kill OR team wipe) and to release/notify
+  // teammates when the raid boss is defeated.
+  const humanTeammates = isRaidBattleOver
     ? newBattle.usersState.filter((u) => !u.isAi && !u.isSummon)
     : [];
   const humanUserIds = humanTeammates.map((u) => u.userId);
@@ -146,10 +148,11 @@ export const updateBattle = async (
               ),
           ]
         : []),
-      // Purge raid-chat memberships on boss kill. The conversation ID is stable
-      // across raid resets, so stale memberships would let former participants
-      // read the next team's private channel.
-      ...(raidBossDefeated &&
+      // Purge raid-chat memberships on any raid battle-over (boss kill OR team
+      // wipe). The conversation ID is stable across raid resets, so stale
+      // memberships would let former participants read the next team's private
+      // channel.
+      ...(isRaidBattleOver &&
       newBattle.extraState.raidQuestId &&
       humanUserIds.length > 0
         ? [
@@ -172,7 +175,7 @@ export const updateBattle = async (
       // teammates who took damage don't revert to pre-battle pool values on release.
       // Mirror the HOSPITALIZED handling from updateUser: teammates whose curHealth
       // dropped to 0 from boss AoE must be sent to the hospital, not released as AWAKE.
-      ...humanTeammates
+      ...(raidBossDefeated ? humanTeammates : [])
         .filter((u) => u.userId !== userId)
         .map((teammate) => {
           const sendToHospital = !newBattle.forceKeepPools && teammate.curHealth <= 0;

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -50,7 +50,10 @@ import {
 import type { PusherClient } from "@/libs/pusher";
 import { broadcastRaidAvailability, updateUserOnMap } from "@/libs/pusher";
 import { filterQuestTrackersForDbPersist, getNewTrackers } from "@/libs/quest";
-import { prepareExclusiveRaidActivation } from "@/libs/raids";
+import {
+  getRaidChatConversationId,
+  prepareExclusiveRaidActivation,
+} from "@/libs/raids";
 import { battleJutsuExp } from "@/libs/train";
 import { findWarsWithUser } from "@/libs/war";
 import type { UserWithRelations } from "@/routers/profile";
@@ -100,6 +103,13 @@ export const updateBattle = async (
     }
   }
 
+  // Surviving non-summon humans, used both to purge raid-chat memberships
+  // and to release/notify teammates when the raid boss is defeated.
+  const humanTeammates = raidBossDefeated
+    ? newBattle.usersState.filter((u) => !u.isAi && !u.isSummon)
+    : [];
+  const humanUserIds = humanTeammates.map((u) => u.userId);
+
   // Update the battle, return undefined if the battle was updated by another process
   if (battleOver) {
     await Promise.all([
@@ -137,29 +147,24 @@ export const updateBattle = async (
           ]
         : []),
       // Purge raid-chat memberships on boss kill. The conversation ID is stable
-      // across raid resets (`raid-chat-${raidQuestId}`), so stale memberships
-      // would let former participants read the next team's private channel.
-      ...(raidBossDefeated && newBattle.extraState.raidQuestId
-        ? (() => {
-            const humanUserIds = newBattle.usersState
-              .filter((u) => !u.isAi && !u.isSummon)
-              .map((u) => u.userId);
-            return humanUserIds.length > 0
-              ? [
-                  client
-                    .delete(user2conversation)
-                    .where(
-                      and(
-                        eq(
-                          user2conversation.conversationId,
-                          `raid-chat-${newBattle.extraState.raidQuestId}`,
-                        ),
-                        inArray(user2conversation.userId, humanUserIds),
-                      ),
-                    ),
-                ]
-              : [];
-          })()
+      // across raid resets, so stale memberships would let former participants
+      // read the next team's private channel.
+      ...(raidBossDefeated &&
+      newBattle.extraState.raidQuestId &&
+      humanUserIds.length > 0
+        ? [
+            client
+              .delete(user2conversation)
+              .where(
+                and(
+                  eq(
+                    user2conversation.conversationId,
+                    getRaidChatConversationId(newBattle.extraState.raidQuestId),
+                  ),
+                  inArray(user2conversation.userId, humanUserIds),
+                ),
+              ),
+          ]
         : []),
       // When raid boss is defeated, release all non-acting teammates from BATTLE status.
       // updateUser only handles the acting player, so teammates would be stuck otherwise.
@@ -167,42 +172,39 @@ export const updateBattle = async (
       // teammates who took damage don't revert to pre-battle pool values on release.
       // Mirror the HOSPITALIZED handling from updateUser: teammates whose curHealth
       // dropped to 0 from boss AoE must be sent to the hospital, not released as AWAKE.
-      ...(raidBossDefeated
-        ? newBattle.usersState
-            .filter((u) => !u.isAi && !u.isSummon && u.userId !== userId)
-            .map((teammate) => {
-              const sendToHospital =
-                !newBattle.forceKeepPools && teammate.curHealth <= 0;
-              return client
-                .update(userData)
-                .set({
-                  battleId: null,
-                  regenAt: new Date(),
-                  curHealth: teammate.curHealth,
-                  curStamina: teammate.curStamina,
-                  curChakra: teammate.curChakra,
-                  stealthActive: false,
-                  stealthActivatedAt: null,
-                  stealthCooldownAt: sql`NOW() + INTERVAL ${STEALTH_POST_COMBAT_COOLDOWN_SECONDS} SECOND`,
-                  ...(sendToHospital
-                    ? {
-                        status: "HOSPITALIZED",
-                        longitude: HOSPITAL_LONG,
-                        latitude: HOSPITAL_LAT,
-                        sector: teammate.allyVillage
-                          ? teammate.sector
-                          : getVillage(newBattle, teammate.villageId)?.sector,
-                      }
-                    : { status: "AWAKE" }),
-                })
-                .where(
-                  and(
-                    eq(userData.userId, teammate.userId),
-                    eq(userData.battleId, newBattle.id),
-                  ),
-                );
+      ...humanTeammates
+        .filter((u) => u.userId !== userId)
+        .map((teammate) => {
+          const sendToHospital = !newBattle.forceKeepPools && teammate.curHealth <= 0;
+          return client
+            .update(userData)
+            .set({
+              battleId: null,
+              regenAt: new Date(),
+              curHealth: teammate.curHealth,
+              curStamina: teammate.curStamina,
+              curChakra: teammate.curChakra,
+              stealthActive: false,
+              stealthActivatedAt: null,
+              stealthCooldownAt: sql`NOW() + INTERVAL ${STEALTH_POST_COMBAT_COOLDOWN_SECONDS} SECOND`,
+              ...(sendToHospital
+                ? {
+                    status: "HOSPITALIZED",
+                    longitude: HOSPITAL_LONG,
+                    latitude: HOSPITAL_LAT,
+                    sector: teammate.allyVillage
+                      ? teammate.sector
+                      : getVillage(newBattle, teammate.villageId)?.sector,
+                  }
+                : { status: "AWAKE" }),
             })
-        : []),
+            .where(
+              and(
+                eq(userData.userId, teammate.userId),
+                eq(userData.battleId, newBattle.id),
+              ),
+            );
+        }),
     ]);
 
     // Delete queue entries AFTER the Promise.all to ensure mpvpBattleUser
@@ -217,8 +219,8 @@ export const updateBattle = async (
     // Mirrors the `result.curHealth > 0` gate in updateUser so other clients
     // see them transition out of BATTLE without waiting for the next poll.
     if (pusher && raidBossDefeated) {
-      newBattle.usersState
-        .filter((u) => !u.isAi && !u.isSummon && u.userId !== userId)
+      humanTeammates
+        .filter((u) => u.userId !== userId)
         .forEach((teammate) => {
           const sendToHospital = !newBattle.forceKeepPools && teammate.curHealth <= 0;
           if (sendToHospital) return;

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -92,10 +92,25 @@ export const updateBattle = async (
 ) => {
   // Calculations
   // raidBossDefeated: the boss specifically died (kill).
+  // raidTeamWiped: every human in this raid is out of stillInBattle while the
+  // boss is still alive. `result.friendsLeft` is keyed on the per-user
+  // `leftBattle` flag which is only set when each user's own action triggers
+  // calcBattleResult, so a teammate killed by boss AoE on someone else's turn
+  // is not yet counted. Checking stillInBattle directly catches the wipe in
+  // the same tick.
   // raidEnded: raid is over for ANY reason on this battle — boss kill OR full team wipe.
   const raidBossDefeated = !!result && isRaidBossDefeated(newBattle);
+  const raidTeamWiped =
+    !!result &&
+    newBattle.battleType === "RAID" &&
+    newBattle.usersState
+      .filter((u) => !u.isAi && !u.isSummon)
+      .every((u) => !stillInBattle(u, newBattle.usersEffects));
   const battleOver =
-    !!result && (result.friendsLeft + result.targetsLeft === 0 || raidBossDefeated);
+    !!result &&
+    (result.friendsLeft + result.targetsLeft === 0 ||
+      raidBossDefeated ||
+      raidTeamWiped);
   const raidEnded = battleOver && newBattle.battleType === "RAID";
 
   // Get user and other user
@@ -160,9 +175,7 @@ export const updateBattle = async (
       // wipe). The conversation ID is stable across raid resets, so stale
       // memberships would let former participants read the next team's private
       // channel.
-      ...(raidEnded &&
-      newBattle.extraState.raidQuestId &&
-      humanUserIds.length > 0
+      ...(raidEnded && newBattle.extraState.raidQuestId && humanUserIds.length > 0
         ? [
             purgeRaidChatMembership(
               client,

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -100,12 +100,12 @@ export const updateBattle = async (
   // the same tick.
   // raidEnded: raid is over for ANY reason on this battle — boss kill OR full team wipe.
   const raidBossDefeated = !!result && isRaidBossDefeated(newBattle);
+  const humanFighters = newBattle.usersState.filter((u) => !u.isAi && !u.isSummon);
   const raidTeamWiped =
     !!result &&
     newBattle.battleType === "RAID" &&
-    newBattle.usersState
-      .filter((u) => !u.isAi && !u.isSummon)
-      .every((u) => !stillInBattle(u, newBattle.usersEffects));
+    humanFighters.length > 0 &&
+    humanFighters.every((u) => !stillInBattle(u, newBattle.usersEffects));
   const battleOver =
     !!result &&
     (result.friendsLeft + result.targetsLeft === 0 ||

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -204,6 +204,8 @@ export const updateBattle = async (
       throw new Error(`Failure. Version: ${fetchedVersion}, Battle: ${newBattle.id}`);
     }
   }
+
+  return { battleOver };
 };
 
 /**

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -91,10 +91,12 @@ export const updateBattle = async (
   pusher?: PusherClient,
 ) => {
   // Calculations
+  // raidBossDefeated: the boss specifically died (kill).
+  // raidEnded: raid is over for ANY reason on this battle — boss kill OR full team wipe.
   const raidBossDefeated = !!result && isRaidBossDefeated(newBattle);
   const battleOver =
     !!result && (result.friendsLeft + result.targetsLeft === 0 || raidBossDefeated);
-  const isRaidBattleOver = battleOver && newBattle.battleType === "RAID";
+  const raidEnded = battleOver && newBattle.battleType === "RAID";
 
   // Get user and other user
   const user = newBattle.usersState.find((u) => u.userId === userId && !u.isSummon);
@@ -113,7 +115,7 @@ export const updateBattle = async (
   // Non-summon humans in this raid battle. Used to purge raid-chat memberships
   // on any raid battle-over (boss kill OR team wipe) and to release/notify
   // teammates when the raid boss is defeated.
-  const humanTeammates = isRaidBattleOver
+  const humanTeammates = raidEnded
     ? newBattle.usersState.filter((u) => !u.isAi && !u.isSummon)
     : [];
   const humanUserIds = humanTeammates.map((u) => u.userId);
@@ -158,7 +160,7 @@ export const updateBattle = async (
       // wipe). The conversation ID is stable across raid resets, so stale
       // memberships would let former participants read the next team's private
       // channel.
-      ...(isRaidBattleOver &&
+      ...(raidEnded &&
       newBattle.extraState.raidQuestId &&
       humanUserIds.length > 0
         ? [

--- a/app/src/libs/raids.ts
+++ b/app/src/libs/raids.ts
@@ -2,6 +2,14 @@ import type { Quest } from "@/drizzle/schema";
 import type { RaidObjectiveType } from "@/validators/objectives";
 import { RaidObjective } from "@/validators/objectives";
 
+const RAID_CHAT_CONVERSATION_PREFIX = "raid-chat-";
+
+export const getRaidChatConversationId = (raidId: string) =>
+  `${RAID_CHAT_CONVERSATION_PREFIX}${raidId}`;
+
+export const isRaidChatConversationId = (conversationId: string) =>
+  conversationId.startsWith(RAID_CHAT_CONVERSATION_PREFIX);
+
 /**
  * Helper to extract raid objective data from a quest.
  * Raid type is implicit from the objective task (open_raid or exclusive_raid).

--- a/app/src/libs/raids.ts
+++ b/app/src/libs/raids.ts
@@ -2,7 +2,9 @@ import type { Quest } from "@/drizzle/schema";
 import type { RaidObjectiveType } from "@/validators/objectives";
 import { RaidObjective } from "@/validators/objectives";
 
-const RAID_CHAT_CONVERSATION_PREFIX = "raid-chat-";
+export const RAID_CHAT_CONVERSATION_PREFIX = "raid-chat-";
+
+export const RAID_CHAT_CONVERSATION_LIKE_PATTERN = `${RAID_CHAT_CONVERSATION_PREFIX}%`;
 
 export const getRaidChatConversationId = (raidId: string) =>
   `${RAID_CHAT_CONVERSATION_PREFIX}${raidId}`;

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -699,9 +699,6 @@ export const combatRouter = createTRPCRouter({
             return { notification: `Battle state was not changed` };
           }
 
-          // Optimistic update for all other users before we process request. Also increment version
-          const battleOver = result && result.friendsLeft + result.targetsLeft === 0;
-
           // Only keep visual tags that are newer than original round
           newBattle.groundEffects = newBattle.groundEffects.filter(
             (e) => e.type !== "visual" || e.createdRound >= originalRound,
@@ -712,7 +709,16 @@ export const combatRouter = createTRPCRouter({
            */
           try {
             newBattle.version = newBattle.version + nActions;
-            await updateBattle(db, result, suid, newBattle, battle.version);
+            // updateBattle returns the authoritative battleOver — it covers raid
+            // boss defeats where surviving teammates exist as friends, which the
+            // simple friendsLeft + targetsLeft check would miss.
+            const { battleOver } = await updateBattle(
+              db,
+              result,
+              suid,
+              newBattle,
+              battle.version,
+            );
             const [logEntries, { updatedQuestIds }] = await Promise.all([
               createAction(db, newBattle, history),
               updateUser(db, pusher, newBattle, result, suid),

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -275,6 +275,7 @@ export const combatRouter = createTRPCRouter({
                   ctx.userId,
                   newBattle,
                   fetchedVersion,
+                  pusher,
                 ),
                 createAction(ctx.drizzle, newBattle, [
                   {
@@ -294,6 +295,7 @@ export const combatRouter = createTRPCRouter({
                 ctx.userId,
                 userBattle,
                 fetchedVersion,
+                pusher,
               );
             }
           }

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -718,6 +718,7 @@ export const combatRouter = createTRPCRouter({
               suid,
               newBattle,
               battle.version,
+              pusher,
             );
             const [logEntries, { updatedQuestIds }] = await Promise.all([
               createAction(db, newBattle, history),

--- a/app/src/server/api/routers/comments.ts
+++ b/app/src/server/api/routers/comments.ts
@@ -18,6 +18,7 @@ import {
 import { resolveSenderId } from "@/libs/comments";
 import { moderateContent } from "@/libs/moderator";
 import { getServerPusher } from "@/libs/pusher";
+import { isRaidChatConversationId } from "@/libs/raids";
 import { fetchThread } from "@/routers/forum";
 import { fetchUser } from "@/routers/profile";
 import { fetchUserReport } from "@/routers/reports";
@@ -706,6 +707,10 @@ export const commentsRouter = createTRPCRouter({
 
       // Derived
       const usersIdsInConvo = convo.users.map((u) => u.userId);
+      // Raid-chat conversations use user2conversation only for read scoping;
+      // messages are ephemeral team coordination and must not bump teammates'
+      // inboxNews counter or fan out `newInbox` pusher events.
+      const skipInboxNotifications = isRaidChatConversationId(convo.id);
 
       // Extract quoted user IDs - filter out null/undefined values
       const quotedUserIds = quotes
@@ -737,7 +742,7 @@ export const commentsRouter = createTRPCRouter({
           .set({ updatedAt: new Date() })
           .where(eq(conversation.id, convo.id)),
         // Inbox news (database update)
-        ...(usersIdsInConvo.length > 0 && !convo.isPublic
+        ...(usersIdsInConvo.length > 0 && !convo.isPublic && !skipInboxNotifications
           ? [
               ctx.drizzle
                 .update(userData)
@@ -779,7 +784,7 @@ export const commentsRouter = createTRPCRouter({
           commentId: commentId,
         }),
         // Inbox news (pusher notifications)
-        ...(usersIdsInConvo.length > 0 && !convo.isPublic
+        ...(usersIdsInConvo.length > 0 && !convo.isPublic && !skipInboxNotifications
           ? usersIdsInConvo
               .filter((id) => id !== effectiveUserId)
               .map((userId) => pusher.trigger(userId, "event", { type: "newInbox" }))

--- a/app/src/server/api/routers/comments.ts
+++ b/app/src/server/api/routers/comments.ts
@@ -500,7 +500,7 @@ export const commentsRouter = createTRPCRouter({
           convo_title: z.string().min(1).max(30).optional(),
           cursor: z.number().nullish(),
           limit: z.number().min(1).max(100),
-          refreshKey: z.number(),
+          refreshKey: z.number().optional(),
           searchQuery: z.string().optional(),
         })
         .refine(

--- a/app/src/server/api/routers/comments.ts
+++ b/app/src/server/api/routers/comments.ts
@@ -410,6 +410,15 @@ export const commentsRouter = createTRPCRouter({
       if (!canViewConversation(convo, ctx.userId, user.role)) {
         return errorResponse("You are not allowed to view this conversation");
       }
+      // Raid-chat membership is managed by joinRaidQueue / leaveRaidQueue /
+      // updateBattle purges, not from the inbox UI. Allowing a manual exit
+      // would silently revoke the user's mid-raid chat access and, if they are
+      // the last member, hard-delete the deterministic conversation row and
+      // all comments — wiping chat history for future raid runs of the same
+      // questId since the conversation ID is stable across raid resets.
+      if (isRaidChatConversationId(convo.id)) {
+        return errorResponse("Raid chat membership is managed by the raid queue");
+      }
       // Mutate
       await ctx.drizzle
         .delete(user2conversation)

--- a/app/src/server/api/routers/raids.ts
+++ b/app/src/server/api/routers/raids.ts
@@ -23,6 +23,7 @@ import {
 import {
   badge,
   bloodline,
+  conversation,
   item,
   jutsu,
   mpvpBattleQueue,
@@ -311,6 +312,11 @@ export const raidsRouter = createTRPCRouter({
 
       // Derived
       const raidData = getRaidObjectiveData(raid);
+      const raidChatConversationId = await ensureRaidChatConversation(
+        ctx.drizzle,
+        raid,
+        ctx.userId,
+      );
 
       return {
         raid: {
@@ -323,6 +329,7 @@ export const raidsRouter = createTRPCRouter({
           raidBossCurrentHealth: raid.raidBossCurrentHealth,
           raidEndsAt: raid.raidEndsAt,
           raidSector: raidData?.sector ?? null,
+          raidChatConversationId,
         },
         participation,
         thresholds,
@@ -703,6 +710,9 @@ export const raidsRouter = createTRPCRouter({
       ]);
       // Guard
       if (!user) return errorResponse("User not found");
+      if (user.isBanned) {
+        return errorResponse("You are banned and cannot queue for raids");
+      }
       if (user.status === "HOSPITALIZED") {
         return errorResponse("You cannot ready up while hospitalized");
       }
@@ -878,6 +888,9 @@ export const raidsRouter = createTRPCRouter({
 
       // Guard - basic validations
       if (!user) return errorResponse("User not found");
+      if (user.isBanned) {
+        return errorResponse("You are banned and cannot queue for raids");
+      }
       if (!raid) return errorResponse("Raid not found");
       if (existingQueueEntries.length > 0) {
         return errorResponse("Already in a battle queue");
@@ -1208,6 +1221,9 @@ export const raidsRouter = createTRPCRouter({
 
       // Guard - basic validations
       if (!user) return errorResponse("User not found");
+      if (user.isBanned) {
+        return errorResponse("You are banned and cannot queue for raids");
+      }
       if (!team) return errorResponse("Team not found");
 
       // Check battleId state - handle stale claiming states or already started battles
@@ -1693,4 +1709,34 @@ export const checkAndCleanupExpiredRaid = async (
   }
 
   return { wasExpired: true, sectorCleaned: false };
+};
+
+const getRaidChatConversationId = (raidId: string) => `raid-chat-${raidId}`;
+
+const ensureRaidChatConversation = async (
+  client: DrizzleClient,
+  raid: { id: string; name: string },
+  userId: string,
+) => {
+  const conversationId = getRaidChatConversationId(raid.id);
+  await client
+    .insert(conversation)
+    .values({
+      id: conversationId,
+      title: `${raid.name} Raid Chat`,
+      createdById: userId,
+      isPublic: true,
+      isLocked: false,
+      isEnabled: true,
+    })
+    .onDuplicateKeyUpdate({
+      set: {
+        title: `${raid.name} Raid Chat`,
+        isPublic: true,
+        isLocked: false,
+        isEnabled: true,
+      },
+    });
+
+  return conversationId;
 };

--- a/app/src/server/api/routers/raids.ts
+++ b/app/src/server/api/routers/raids.ts
@@ -781,9 +781,7 @@ export const raidsRouter = createTRPCRouter({
             ]
           : []),
         // Clear ranked PVP queue — being in it sets status to QUEUED which blocks raid joining
-        ctx.drizzle
-          .delete(rankedPvpQueue)
-          .where(eq(rankedPvpQueue.userId, userId)),
+        ctx.drizzle.delete(rankedPvpQueue).where(eq(rankedPvpQueue.userId, userId)),
         // Cancel spar requests the user sent
         ctx.drizzle
           .update(userRequest)
@@ -1229,7 +1227,7 @@ export const raidsRouter = createTRPCRouter({
       // Guard - basic validations
       if (!user) return errorResponse("User not found");
       if (user.isBanned) {
-        return errorResponse("You are banned and cannot queue for raids");
+        return errorResponse("You are banned and cannot start raid battles");
       }
       if (!team) return errorResponse("Team not found");
 

--- a/app/src/server/api/routers/raids.ts
+++ b/app/src/server/api/routers/raids.ts
@@ -1100,10 +1100,29 @@ export const raidsRouter = createTRPCRouter({
       }
 
       // Only the first user of a new team creates the chat conversation;
-      // joiners of existing teams reuse the row created previously. Fire-and-forget
-      // so the response doesn't block on a write whose result we don't read.
+      // joiners of existing teams reuse the row created previously. Await so a
+      // transient insert failure can be rolled back instead of leaving the raid
+      // permanently without a chat row.
       if (createdNewTeam) {
-        void ensureRaidChatConversation(ctx.drizzle, raid, ctx.userId);
+        try {
+          await ensureRaidChatConversation(ctx.drizzle, raid, ctx.userId);
+        } catch {
+          await Promise.all([
+            ctx.drizzle
+              .delete(mpvpBattleUser)
+              .where(eq(mpvpBattleUser.userId, ctx.userId)),
+            ctx.drizzle
+              .update(userData)
+              .set({ status: "AWAKE" })
+              .where(eq(userData.userId, ctx.userId)),
+            teamId
+              ? ctx.drizzle
+                  .delete(mpvpBattleQueue)
+                  .where(eq(mpvpBattleQueue.id, teamId))
+              : Promise.resolve(),
+          ]);
+          return errorResponse("Failed to create raid chat - please try again");
+        }
       }
 
       // Pusher - notify sector about team changes

--- a/app/src/server/api/routers/raids.ts
+++ b/app/src/server/api/routers/raids.ts
@@ -51,6 +51,10 @@ import { initiateBattle } from "@/routers/combat";
 import { fetchUpdatedUser, fetchUser } from "@/routers/profile";
 import { updateRewards } from "@/routers/quests";
 import type { DrizzleClient } from "@/server/db";
+import {
+  purgeAllRaidChatMembershipsForUser,
+  purgeRaidChatMembership,
+} from "@/server/utils/raidChat";
 import { canChangeContent } from "@/utils/permissions";
 import { secondsFromDate } from "@/utils/time";
 import { AllTags } from "@/validators/combat";
@@ -801,14 +805,11 @@ export const raidsRouter = createTRPCRouter({
           : []),
         ...(clearedRaidChatConversationId
           ? [
-              ctx.drizzle
-                .delete(user2conversation)
-                .where(
-                  and(
-                    eq(user2conversation.conversationId, clearedRaidChatConversationId),
-                    eq(user2conversation.userId, userId),
-                  ),
-                ),
+              purgeRaidChatMembership(
+                ctx.drizzle,
+                clearedRaidChatConversationId,
+                userId,
+              ),
             ]
           : []),
         // Clear ranked PVP queue — being in it sets status to QUEUED which blocks raid joining
@@ -1182,14 +1183,7 @@ export const raidsRouter = createTRPCRouter({
             .update(userData)
             .set({ status: "AWAKE" })
             .where(and(eq(userData.userId, ctx.userId), eq(userData.status, "QUEUED"))),
-          ctx.drizzle
-            .delete(user2conversation)
-            .where(
-              and(
-                eq(user2conversation.userId, ctx.userId),
-                like(user2conversation.conversationId, "raid-chat-%"),
-              ),
-            ),
+          purgeAllRaidChatMembershipsForUser(ctx.drizzle, ctx.userId),
         ]);
         return { success: true, message: "Left the queue" };
       }
@@ -1216,14 +1210,7 @@ export const raidsRouter = createTRPCRouter({
           .update(userData)
           .set({ status: "AWAKE" })
           .where(and(eq(userData.userId, ctx.userId), eq(userData.status, "QUEUED"))),
-        ctx.drizzle
-          .delete(user2conversation)
-          .where(
-            and(
-              eq(user2conversation.conversationId, raidChatConversationId),
-              eq(user2conversation.userId, ctx.userId),
-            ),
-          ),
+        purgeRaidChatMembership(ctx.drizzle, raidChatConversationId, ctx.userId),
         // Clean up claiming ID if present
         isClaimingState
           ? ctx.drizzle
@@ -1712,16 +1699,7 @@ export const checkAndCleanupExpiredRaid = async (
       // Drop chat memberships for all queued users on this raid so they lose
       // access once cleanup yanks them out of the queue.
       ...(userIds.length > 0
-        ? [
-            client
-              .delete(user2conversation)
-              .where(
-                and(
-                  eq(user2conversation.conversationId, raidChatConversationId),
-                  inArray(user2conversation.userId, userIds),
-                ),
-              ),
-          ]
+        ? [purgeRaidChatMembership(client, raidChatConversationId, userIds)]
         : []),
       ...(userIds.length > 0
         ? [
@@ -1785,14 +1763,7 @@ const rollbackJoinRaidQueue = async ({
             ),
         ]
       : []),
-    client
-      .delete(user2conversation)
-      .where(
-        and(
-          eq(user2conversation.conversationId, raidChatConversationId),
-          eq(user2conversation.userId, userId),
-        ),
-      ),
+    purgeRaidChatMembership(client, raidChatConversationId, userId),
     client
       .update(userData)
       .set({ status: "AWAKE" })
@@ -1844,14 +1815,7 @@ const rollbackStartRaidBattle = async ({
         and(inArray(userData.userId, attackerUserIds), eq(userData.status, "QUEUED")),
       ),
     client.delete(mpvpBattleUser).where(eq(mpvpBattleUser.clanBattleId, teamId)),
-    client
-      .delete(user2conversation)
-      .where(
-        and(
-          eq(user2conversation.conversationId, raidChatConversationId),
-          inArray(user2conversation.userId, attackerUserIds),
-        ),
-      ),
+    purgeRaidChatMembership(client, raidChatConversationId, attackerUserIds),
   ]);
 };
 

--- a/app/src/server/api/routers/raids.ts
+++ b/app/src/server/api/routers/raids.ts
@@ -1169,14 +1169,28 @@ export const raidsRouter = createTRPCRouter({
       if (!user) return errorResponse("User not found");
       if (!queueEntry) return errorResponse("You are not in a queue");
       if (!queueEntry.clanBattle) {
-        // Queue entry exists but clan battle was deleted - clean up orphaned entry
-        await ctx.drizzle
-          .delete(mpvpBattleUser)
-          .where(eq(mpvpBattleUser.id, queueEntry.id));
-        await ctx.drizzle
-          .update(userData)
-          .set({ status: "AWAKE" })
-          .where(and(eq(userData.userId, ctx.userId), eq(userData.status, "QUEUED")));
+        // Queue entry exists but clan battle was deleted - clean up orphaned entry.
+        // The deterministic raid-chat conversation id is not recoverable from
+        // here (the parent queue row holding attackerEntityId is gone), so purge
+        // every raid-chat membership row this user owns to drop access to any
+        // stale conversation that survived a prior raid reset.
+        await Promise.all([
+          ctx.drizzle
+            .delete(mpvpBattleUser)
+            .where(eq(mpvpBattleUser.id, queueEntry.id)),
+          ctx.drizzle
+            .update(userData)
+            .set({ status: "AWAKE" })
+            .where(and(eq(userData.userId, ctx.userId), eq(userData.status, "QUEUED"))),
+          ctx.drizzle
+            .delete(user2conversation)
+            .where(
+              and(
+                eq(user2conversation.userId, ctx.userId),
+                like(user2conversation.conversationId, "raid-chat-%"),
+              ),
+            ),
+        ]);
         return { success: true, message: "Left the queue" };
       }
       if (queueEntry.clanBattle.battleType !== "RAID_BATTLE") {
@@ -1416,58 +1430,24 @@ export const raidsRouter = createTRPCRouter({
             battleId: result.battleId,
           };
         } else {
-          // Rollback - release claim, reset statuses, delete users in parallel
-          await Promise.all([
-            ctx.drizzle
-              .update(mpvpBattleQueue)
-              .set({ battleId: null })
-              .where(
-                and(
-                  eq(mpvpBattleQueue.id, input.teamId),
-                  eq(mpvpBattleQueue.battleId, claimId),
-                ),
-              ),
-            ctx.drizzle
-              .update(userData)
-              .set({ status: "AWAKE" })
-              .where(
-                and(
-                  inArray(userData.userId, attackerUserIds),
-                  eq(userData.status, "QUEUED"),
-                ),
-              ),
-            ctx.drizzle
-              .delete(mpvpBattleUser)
-              .where(eq(mpvpBattleUser.clanBattleId, input.teamId)),
-          ]);
+          await rollbackStartRaidBattle({
+            client: ctx.drizzle,
+            teamId: input.teamId,
+            claimId,
+            attackerUserIds,
+            raidId: raid.id,
+          });
 
           return errorResponse(result.message ?? "Failed to start battle");
         }
       } catch (err) {
-        // Rollback - release claim, reset statuses, delete users in parallel
-        await Promise.all([
-          ctx.drizzle
-            .update(mpvpBattleQueue)
-            .set({ battleId: null })
-            .where(
-              and(
-                eq(mpvpBattleQueue.id, input.teamId),
-                eq(mpvpBattleQueue.battleId, claimId),
-              ),
-            ),
-          ctx.drizzle
-            .update(userData)
-            .set({ status: "AWAKE" })
-            .where(
-              and(
-                inArray(userData.userId, attackerUserIds),
-                eq(userData.status, "QUEUED"),
-              ),
-            ),
-          ctx.drizzle
-            .delete(mpvpBattleUser)
-            .where(eq(mpvpBattleUser.clanBattleId, input.teamId)),
-        ]);
+        await rollbackStartRaidBattle({
+          client: ctx.drizzle,
+          teamId: input.teamId,
+          claimId,
+          attackerUserIds,
+          raidId: raid.id,
+        });
 
         throw err;
       }
@@ -1831,6 +1811,48 @@ const rollbackJoinRaidQueue = async ({
       await client.delete(mpvpBattleQueue).where(eq(mpvpBattleQueue.id, teamId));
     }
   }
+};
+
+const rollbackStartRaidBattle = async ({
+  client,
+  teamId,
+  claimId,
+  attackerUserIds,
+  raidId,
+}: {
+  client: DrizzleClient;
+  teamId: string;
+  claimId: string;
+  attackerUserIds: string[];
+  raidId: string;
+}) => {
+  // Release claim, reset statuses, drop queue rows, and purge chat memberships
+  // for every attacker so a failed battle start doesn't leave anyone with
+  // lingering access to the stable raid-chat conversation across raid resets.
+  const raidChatConversationId = getRaidChatConversationId(raidId);
+  await Promise.all([
+    client
+      .update(mpvpBattleQueue)
+      .set({ battleId: null })
+      .where(
+        and(eq(mpvpBattleQueue.id, teamId), eq(mpvpBattleQueue.battleId, claimId)),
+      ),
+    client
+      .update(userData)
+      .set({ status: "AWAKE" })
+      .where(
+        and(inArray(userData.userId, attackerUserIds), eq(userData.status, "QUEUED")),
+      ),
+    client.delete(mpvpBattleUser).where(eq(mpvpBattleUser.clanBattleId, teamId)),
+    client
+      .delete(user2conversation)
+      .where(
+        and(
+          eq(user2conversation.conversationId, raidChatConversationId),
+          inArray(user2conversation.userId, attackerUserIds),
+        ),
+      ),
+  ]);
 };
 
 const ensureRaidChatConversation = async (

--- a/app/src/server/api/routers/raids.ts
+++ b/app/src/server/api/routers/raids.ts
@@ -33,6 +33,7 @@ import {
   raidParticipation,
   rankedPvpQueue,
   sector,
+  user2conversation,
   userData,
   userRaidBuff,
   userRequest,
@@ -288,9 +289,12 @@ export const raidsRouter = createTRPCRouter({
     })
     .input(z.object({ questId: z.string() }))
     .query(async ({ ctx, input }) => {
-      // Query - parallel fetch (single round-trip)
+      // Query - parallel fetch (single round-trip). chatMembership is the
+      // user's user2conversation row for the raid chat — the chat ID is only
+      // exposed to members so non-team users cannot eavesdrop on or post to
+      // raid coordination via the public conversation endpoints.
       const raidChatConversationId = getRaidChatConversationId(input.questId);
-      const [raid, participation, thresholds, existingConvo] = await Promise.all([
+      const [raid, participation, thresholds, chatMembership] = await Promise.all([
         ctx.drizzle.query.quest.findFirst({
           where: and(eq(quest.id, input.questId), eq(quest.questType, "raid")),
         }),
@@ -304,9 +308,12 @@ export const raidsRouter = createTRPCRouter({
           where: eq(raidDamageThreshold.questId, input.questId),
           orderBy: raidDamageThreshold.sortOrder,
         }),
-        ctx.drizzle.query.conversation.findFirst({
-          where: eq(conversation.id, raidChatConversationId),
-          columns: { id: true },
+        ctx.drizzle.query.user2conversation.findFirst({
+          where: and(
+            eq(user2conversation.conversationId, raidChatConversationId),
+            eq(user2conversation.userId, ctx.userId),
+          ),
+          columns: { conversationId: true },
         }),
       ]);
 
@@ -329,7 +336,7 @@ export const raidsRouter = createTRPCRouter({
           raidBossCurrentHealth: raid.raidBossCurrentHealth,
           raidEndsAt: raid.raidEndsAt,
           raidSector: raidData?.sector ?? null,
-          raidChatConversationId: existingConvo ? raidChatConversationId : null,
+          raidChatConversationId: chatMembership ? raidChatConversationId : null,
         },
         participation,
         thresholds,
@@ -705,7 +712,11 @@ export const raidsRouter = createTRPCRouter({
         fetchUser(ctx.drizzle, ctx.userId),
         ctx.drizzle.query.mpvpBattleUser.findFirst({
           where: eq(mpvpBattleUser.userId, ctx.userId),
-          with: { clanBattle: { columns: { sector: true, battleType: true } } },
+          with: {
+            clanBattle: {
+              columns: { sector: true, battleType: true, attackerEntityId: true },
+            },
+          },
         }),
       ]);
       // Guard
@@ -764,6 +775,12 @@ export const raidsRouter = createTRPCRouter({
       }
       // Step 1: remove user from team + other independent cleanups in parallel.
       // mpvpBattleUser must be deleted before the NOT EXISTS team-cleanup check in step 2.
+      // If the cleared queue entry was a raid, also drop the user's raid chat
+      // membership so they lose access to that team's coordination chat.
+      const clearedRaidChatConversationId =
+        queueEntry?.clanBattle?.battleType === "RAID_BATTLE"
+          ? getRaidChatConversationId(queueEntry.clanBattle.attackerEntityId)
+          : null;
       await Promise.all([
         // Only delete the exact mpvpBattleUser row we read — no broad userId fallback
         ...(queueEntry
@@ -774,6 +791,18 @@ export const raidsRouter = createTRPCRouter({
                   and(
                     eq(mpvpBattleUser.userId, userId),
                     eq(mpvpBattleUser.id, queueEntry.id),
+                  ),
+                ),
+            ]
+          : []),
+        ...(clearedRaidChatConversationId
+          ? [
+              ctx.drizzle
+                .delete(user2conversation)
+                .where(
+                  and(
+                    eq(user2conversation.conversationId, clearedRaidChatConversationId),
+                    eq(user2conversation.userId, userId),
                   ),
                 ),
             ]
@@ -1090,29 +1119,31 @@ export const raidsRouter = createTRPCRouter({
           client: ctx.drizzle,
           userId: ctx.userId,
           teamId,
+          raidQuestId: input.questId,
           deleteTeam: createdNewTeam,
           deleteUserRow: false,
         });
         return errorResponse("Failed to join team - slot may have been taken");
       }
 
-      // Only the first user of a new team creates the chat conversation;
-      // joiners of existing teams reuse the row created previously. Await so a
-      // transient insert failure can be rolled back instead of leaving the raid
-      // permanently without a chat row.
-      if (createdNewTeam) {
-        try {
-          await ensureRaidChatConversation(ctx.drizzle, raid, ctx.userId);
-        } catch {
-          await rollbackJoinRaidQueue({
-            client: ctx.drizzle,
-            userId: ctx.userId,
-            teamId,
-            deleteTeam: true,
-            deleteUserRow: true,
-          });
-          return errorResponse("Failed to create raid chat - please try again");
-        }
+      // Ensure the chat conversation exists and grant this joiner membership
+      // (user2conversation) so they pass canViewConversation. The first joiner
+      // of a new team creates the row; subsequent joiners only insert their
+      // own membership row (idempotent on conflict). Await so a transient
+      // failure can be rolled back instead of leaving the user queued without
+      // chat access.
+      try {
+        await ensureRaidChatConversation(ctx.drizzle, raid, ctx.userId);
+      } catch {
+        await rollbackJoinRaidQueue({
+          client: ctx.drizzle,
+          userId: ctx.userId,
+          teamId,
+          raidQuestId: input.questId,
+          deleteTeam: createdNewTeam,
+          deleteUserRow: true,
+        });
+        return errorResponse("Failed to create raid chat - please try again");
       }
 
       // Pusher - notify sector about team changes
@@ -1170,14 +1201,25 @@ export const raidsRouter = createTRPCRouter({
 
       // Store sector before operations for Pusher notification
       const teamSector = queueEntry.clanBattle.sector;
+      const raidQuestId = queueEntry.clanBattle.attackerEntityId;
+      const raidChatConversationId = getRaidChatConversationId(raidQuestId);
 
-      // Mutation - delete queue entry, update user status, and cleanup claiming ID in parallel
+      // Mutation - delete queue entry, update user status, drop chat
+      // membership, and cleanup claiming ID in parallel.
       await Promise.all([
         ctx.drizzle.delete(mpvpBattleUser).where(eq(mpvpBattleUser.id, queueEntry.id)),
         ctx.drizzle
           .update(userData)
           .set({ status: "AWAKE" })
           .where(and(eq(userData.userId, ctx.userId), eq(userData.status, "QUEUED"))),
+        ctx.drizzle
+          .delete(user2conversation)
+          .where(
+            and(
+              eq(user2conversation.conversationId, raidChatConversationId),
+              eq(user2conversation.userId, ctx.userId),
+            ),
+          ),
         // Clean up claiming ID if present
         isClaimingState
           ? ctx.drizzle
@@ -1682,6 +1724,7 @@ export const checkAndCleanupExpiredRaid = async (
   if (queuedTeams.length > 0) {
     const teamIds = queuedTeams.map((t) => t.id);
     const userIds = queuedTeams.flatMap((t) => t.queue.map((u) => u.userId));
+    const raidChatConversationId = getRaidChatConversationId(raidId);
 
     await Promise.all([
       client
@@ -1696,6 +1739,20 @@ export const checkAndCleanupExpiredRaid = async (
             sql`(${mpvpBattleQueue.battleId} IS NULL OR ${mpvpBattleQueue.battleId} LIKE 'claiming-%')`,
           ),
         ),
+      // Drop chat memberships for all queued users on this raid so they lose
+      // access once cleanup yanks them out of the queue.
+      ...(userIds.length > 0
+        ? [
+            client
+              .delete(user2conversation)
+              .where(
+                and(
+                  eq(user2conversation.conversationId, raidChatConversationId),
+                  inArray(user2conversation.userId, userIds),
+                ),
+              ),
+          ]
+        : []),
       ...(userIds.length > 0
         ? [
             client
@@ -1731,17 +1788,20 @@ const rollbackJoinRaidQueue = async ({
   client,
   userId,
   teamId,
+  raidQuestId,
   deleteTeam,
   deleteUserRow,
 }: {
   client: DrizzleClient;
   userId: string;
   teamId: string;
+  raidQuestId: string;
   deleteTeam: boolean;
   deleteUserRow: boolean;
 }) => {
-  // Delete our user row and reset status first, so the team-empty check below
-  // sees the row we may have inserted as already gone.
+  // Delete our user row, drop chat membership, and reset status first, so the
+  // team-empty check below sees the row we may have inserted as already gone.
+  const raidChatConversationId = getRaidChatConversationId(raidQuestId);
   await Promise.all([
     ...(deleteUserRow
       ? [
@@ -1755,6 +1815,14 @@ const rollbackJoinRaidQueue = async ({
             ),
         ]
       : []),
+    client
+      .delete(user2conversation)
+      .where(
+        and(
+          eq(user2conversation.conversationId, raidChatConversationId),
+          eq(user2conversation.userId, userId),
+        ),
+      ),
     client.update(userData).set({ status: "AWAKE" }).where(eq(userData.userId, userId)),
   ]);
   // Only delete the team if no other queue rows still reference it. A concurrent
@@ -1780,6 +1848,9 @@ const ensureRaidChatConversation = async (
   userId: string,
 ) => {
   const conversationId = getRaidChatConversationId(raid.id);
+  // Chat is scoped to the raid team via user2conversation membership rows
+  // (isPublic: false), so canViewConversation falls through to the
+  // inConversation branch and only joined users can read or post.
   // No-op self-assignment on conflict — title/state never changes after the
   // first insert, so subsequent calls must not rewrite the row.
   await client
@@ -1788,11 +1859,18 @@ const ensureRaidChatConversation = async (
       id: conversationId,
       title: `${raid.name} Raid Chat`,
       createdById: userId,
-      isPublic: true,
+      isPublic: false,
       isLocked: false,
       isEnabled: true,
     })
     .onDuplicateKeyUpdate({ set: { id: sql`id` } });
+
+  // Membership grant for the joining user. Idempotent on the composite PK so
+  // re-joins / retries don't fail.
+  await client
+    .insert(user2conversation)
+    .values({ conversationId, userId })
+    .onDuplicateKeyUpdate({ set: { conversationId: sql`conversationId` } });
 
   return conversationId;
 };

--- a/app/src/server/api/routers/raids.ts
+++ b/app/src/server/api/routers/raids.ts
@@ -41,7 +41,11 @@ import {
 } from "@/drizzle/schema";
 import { getServerPusher, updateRaidTeamsOnSector } from "@/libs/pusher";
 import { postProcessRewards } from "@/libs/quest";
-import { getRaidObjectiveData, validateRaidIsActive } from "@/libs/raids";
+import {
+  getRaidChatConversationId,
+  getRaidObjectiveData,
+  validateRaidIsActive,
+} from "@/libs/raids";
 import { fetchActiveUserMpvpBattles } from "@/routers/clan";
 import { initiateBattle } from "@/routers/combat";
 import { fetchUpdatedUser, fetchUser } from "@/routers/profile";
@@ -1840,8 +1844,6 @@ const rollbackJoinRaidQueue = async ({
   }
 };
 
-const getRaidChatConversationId = (raidId: string) => `raid-chat-${raidId}`;
-
 const ensureRaidChatConversation = async (
   client: DrizzleClient,
   raid: { id: string; name: string },
@@ -1851,26 +1853,26 @@ const ensureRaidChatConversation = async (
   // Chat is scoped to the raid team via user2conversation membership rows
   // (isPublic: false), so canViewConversation falls through to the
   // inConversation branch and only joined users can read or post.
-  // No-op self-assignment on conflict — title/state never changes after the
-  // first insert, so subsequent calls must not rewrite the row.
-  await client
-    .insert(conversation)
-    .values({
-      id: conversationId,
-      title: `${raid.name} Raid Chat`,
-      createdById: userId,
-      isPublic: false,
-      isLocked: false,
-      isEnabled: true,
-    })
-    .onDuplicateKeyUpdate({ set: { id: sql`id` } });
-
-  // Membership grant for the joining user. Idempotent on the composite PK so
-  // re-joins / retries don't fail.
-  await client
-    .insert(user2conversation)
-    .values({ conversationId, userId })
-    .onDuplicateKeyUpdate({ set: { conversationId: sql`conversationId` } });
+  // PlanetScale doesn't enforce FKs, so user2conversation does not need to
+  // wait for the conversation row — both upserts are idempotent and target
+  // different tables, so run them in parallel to halve the latency.
+  await Promise.all([
+    client
+      .insert(conversation)
+      .values({
+        id: conversationId,
+        title: `${raid.name} Raid Chat`,
+        createdById: userId,
+        isPublic: false,
+        isLocked: false,
+        isEnabled: true,
+      })
+      .onDuplicateKeyUpdate({ set: { id: sql`id` } }),
+    client
+      .insert(user2conversation)
+      .values({ conversationId, userId })
+      .onDuplicateKeyUpdate({ set: { conversationId: sql`conversationId` } }),
+  ]);
 
   return conversationId;
 };

--- a/app/src/server/api/routers/raids.ts
+++ b/app/src/server/api/routers/raids.ts
@@ -729,9 +729,8 @@ export const raidsRouter = createTRPCRouter({
       ]);
       // Guard
       if (!user) return errorResponse("User not found");
-      if (user.isBanned) {
-        return errorResponse("You are banned and cannot queue for raids");
-      }
+      const bannedReady = guardNotBannedFromRaids(user, "queue for raids");
+      if (bannedReady) return bannedReady;
       if (user.status === "HOSPITALIZED") {
         return errorResponse("You cannot ready up while hospitalized");
       }
@@ -922,9 +921,8 @@ export const raidsRouter = createTRPCRouter({
 
       // Guard - basic validations
       if (!user) return errorResponse("User not found");
-      if (user.isBanned) {
-        return errorResponse("You are banned and cannot queue for raids");
-      }
+      const bannedJoin = guardNotBannedFromRaids(user, "queue for raids");
+      if (bannedJoin) return bannedJoin;
       if (!raid) return errorResponse("Raid not found");
       if (existingQueueEntries.length > 0) {
         return errorResponse("Already in a battle queue");
@@ -1270,9 +1268,8 @@ export const raidsRouter = createTRPCRouter({
 
       // Guard - basic validations
       if (!user) return errorResponse("User not found");
-      if (user.isBanned) {
-        return errorResponse("You are banned and cannot start raid battles");
-      }
+      const bannedStart = guardNotBannedFromRaids(user, "start raid battles");
+      if (bannedStart) return bannedStart;
       if (!team) return errorResponse("Team not found");
 
       // Check battleId state - handle stale claiming states or already started battles
@@ -1782,6 +1779,22 @@ const rollbackJoinRaidQueue = async ({
       await client.delete(mpvpBattleQueue).where(eq(mpvpBattleQueue.id, teamId));
     }
   }
+};
+
+/**
+ * Centralized ban-policy guard for raid participation endpoints.
+ * Returns an errorResponse when the user is banned, or null to continue.
+ * Keeps the policy in one place so future changes (ban-expiry, silenced
+ * users, etc.) only need to be made here.
+ */
+const guardNotBannedFromRaids = (
+  user: { isBanned: boolean },
+  action: string,
+) => {
+  if (user.isBanned) {
+    return errorResponse(`You are banned and cannot ${action}`);
+  }
+  return null;
 };
 
 const rollbackStartRaidBattle = async ({

--- a/app/src/server/api/routers/raids.ts
+++ b/app/src/server/api/routers/raids.ts
@@ -1787,10 +1787,7 @@ const rollbackJoinRaidQueue = async ({
  * Keeps the policy in one place so future changes (ban-expiry, silenced
  * users, etc.) only need to be made here.
  */
-const guardNotBannedFromRaids = (
-  user: { isBanned: boolean },
-  action: string,
-) => {
+const guardNotBannedFromRaids = (user: { isBanned: boolean }, action: string) => {
   if (user.isBanned) {
     return errorResponse(`You are banned and cannot ${action}`);
   }
@@ -1813,11 +1810,12 @@ const rollbackStartRaidBattle = async ({
   // Release claim, reset statuses, drop queue rows, and purge chat memberships
   // for every attacker so a failed battle start doesn't leave anyone with
   // lingering access to the stable raid-chat conversation across raid resets.
+  // The parent mpvpBattleQueue row is deleted (gated on the claim ID) so a
+  // failed start doesn't leave a phantom empty team behind in getActiveRaidTeams.
   const raidChatConversationId = getRaidChatConversationId(raidId);
   await Promise.all([
     client
-      .update(mpvpBattleQueue)
-      .set({ battleId: null })
+      .delete(mpvpBattleQueue)
       .where(
         and(eq(mpvpBattleQueue.id, teamId), eq(mpvpBattleQueue.battleId, claimId)),
       ),

--- a/app/src/server/api/routers/raids.ts
+++ b/app/src/server/api/routers/raids.ts
@@ -1813,7 +1813,10 @@ const rollbackJoinRaidQueue = async ({
           eq(user2conversation.userId, userId),
         ),
       ),
-    client.update(userData).set({ status: "AWAKE" }).where(eq(userData.userId, userId)),
+    client
+      .update(userData)
+      .set({ status: "AWAKE" })
+      .where(and(eq(userData.userId, userId), eq(userData.status, "QUEUED"))),
   ]);
   // Only delete the team if no other queue rows still reference it. A concurrent
   // joiner could have inserted into mpvpBattleUser during the await window

--- a/app/src/server/api/routers/raids.ts
+++ b/app/src/server/api/routers/raids.ts
@@ -312,11 +312,13 @@ export const raidsRouter = createTRPCRouter({
 
       // Derived
       const raidData = getRaidObjectiveData(raid);
-      const raidChatConversationId = await ensureRaidChatConversation(
-        ctx.drizzle,
-        raid,
-        ctx.userId,
-      );
+      const raidChatConversationId = getRaidChatConversationId(raid.id);
+
+      // Check if conversation exists (created during joinRaidQueue)
+      const existingConvo = await ctx.drizzle.query.conversation.findFirst({
+        where: eq(conversation.id, raidChatConversationId),
+        columns: { id: true },
+      });
 
       return {
         raid: {
@@ -329,7 +331,7 @@ export const raidsRouter = createTRPCRouter({
           raidBossCurrentHealth: raid.raidBossCurrentHealth,
           raidEndsAt: raid.raidEndsAt,
           raidSector: raidData?.sector ?? null,
-          raidChatConversationId,
+          raidChatConversationId: existingConvo ? raidChatConversationId : null,
         },
         participation,
         thresholds,
@@ -779,7 +781,9 @@ export const raidsRouter = createTRPCRouter({
             ]
           : []),
         // Clear ranked PVP queue — being in it sets status to QUEUED which blocks raid joining
-        ctx.drizzle.delete(rankedPvpQueue).where(eq(rankedPvpQueue.userId, userId)),
+        ctx.drizzle
+          .delete(rankedPvpQueue)
+          .where(eq(rankedPvpQueue.userId, userId)),
         // Cancel spar requests the user sent
         ctx.drizzle
           .update(userRequest)
@@ -1098,6 +1102,9 @@ export const raidsRouter = createTRPCRouter({
         ]);
         return errorResponse("Failed to join team - slot may have been taken");
       }
+
+      // Ensure raid chat conversation exists (idempotent, only writes on first call)
+      await ensureRaidChatConversation(ctx.drizzle, raid, ctx.userId);
 
       // Pusher - notify sector about team changes
       const pusher = getServerPusher();
@@ -1732,9 +1739,6 @@ const ensureRaidChatConversation = async (
     .onDuplicateKeyUpdate({
       set: {
         title: `${raid.name} Raid Chat`,
-        isPublic: true,
-        isLocked: false,
-        isEnabled: true,
       },
     });
 

--- a/app/src/server/api/routers/raids.ts
+++ b/app/src/server/api/routers/raids.ts
@@ -1086,16 +1086,13 @@ export const raidsRouter = createTRPCRouter({
           slot: availableSlot,
         });
       } catch {
-        // Rollback - status and team on failure
-        await Promise.all([
-          ctx.drizzle
-            .update(userData)
-            .set({ status: "AWAKE" })
-            .where(eq(userData.userId, ctx.userId)),
-          createdNewTeam && teamId
-            ? ctx.drizzle.delete(mpvpBattleQueue).where(eq(mpvpBattleQueue.id, teamId))
-            : Promise.resolve(),
-        ]);
+        await rollbackJoinRaidQueue({
+          client: ctx.drizzle,
+          userId: ctx.userId,
+          teamId,
+          deleteTeam: createdNewTeam,
+          deleteUserRow: false,
+        });
         return errorResponse("Failed to join team - slot may have been taken");
       }
 
@@ -1107,20 +1104,13 @@ export const raidsRouter = createTRPCRouter({
         try {
           await ensureRaidChatConversation(ctx.drizzle, raid, ctx.userId);
         } catch {
-          await Promise.all([
-            ctx.drizzle
-              .delete(mpvpBattleUser)
-              .where(eq(mpvpBattleUser.userId, ctx.userId)),
-            ctx.drizzle
-              .update(userData)
-              .set({ status: "AWAKE" })
-              .where(eq(userData.userId, ctx.userId)),
-            teamId
-              ? ctx.drizzle
-                  .delete(mpvpBattleQueue)
-                  .where(eq(mpvpBattleQueue.id, teamId))
-              : Promise.resolve(),
-          ]);
+          await rollbackJoinRaidQueue({
+            client: ctx.drizzle,
+            userId: ctx.userId,
+            teamId,
+            deleteTeam: true,
+            deleteUserRow: true,
+          });
           return errorResponse("Failed to create raid chat - please try again");
         }
       }
@@ -1735,6 +1725,39 @@ export const checkAndCleanupExpiredRaid = async (
   }
 
   return { wasExpired: true, sectorCleaned: false };
+};
+
+const rollbackJoinRaidQueue = async ({
+  client,
+  userId,
+  teamId,
+  deleteTeam,
+  deleteUserRow,
+}: {
+  client: DrizzleClient;
+  userId: string;
+  teamId: string;
+  deleteTeam: boolean;
+  deleteUserRow: boolean;
+}) => {
+  await Promise.all([
+    ...(deleteUserRow
+      ? [
+          client
+            .delete(mpvpBattleUser)
+            .where(
+              and(
+                eq(mpvpBattleUser.userId, userId),
+                eq(mpvpBattleUser.clanBattleId, teamId),
+              ),
+            ),
+        ]
+      : []),
+    client.update(userData).set({ status: "AWAKE" }).where(eq(userData.userId, userId)),
+    ...(deleteTeam
+      ? [client.delete(mpvpBattleQueue).where(eq(mpvpBattleQueue.id, teamId))]
+      : []),
+  ]);
 };
 
 const getRaidChatConversationId = (raidId: string) => `raid-chat-${raidId}`;

--- a/app/src/server/api/routers/raids.ts
+++ b/app/src/server/api/routers/raids.ts
@@ -1740,6 +1740,8 @@ const rollbackJoinRaidQueue = async ({
   deleteTeam: boolean;
   deleteUserRow: boolean;
 }) => {
+  // Delete our user row and reset status first, so the team-empty check below
+  // sees the row we may have inserted as already gone.
   await Promise.all([
     ...(deleteUserRow
       ? [
@@ -1754,10 +1756,20 @@ const rollbackJoinRaidQueue = async ({
         ]
       : []),
     client.update(userData).set({ status: "AWAKE" }).where(eq(userData.userId, userId)),
-    ...(deleteTeam
-      ? [client.delete(mpvpBattleQueue).where(eq(mpvpBattleQueue.id, teamId))]
-      : []),
   ]);
+  // Only delete the team if no other queue rows still reference it. A concurrent
+  // joiner could have inserted into mpvpBattleUser during the await window
+  // before this rollback fired; deleting the team unconditionally would orphan
+  // that joiner.
+  if (deleteTeam) {
+    const remaining = await client.query.mpvpBattleUser.findFirst({
+      where: eq(mpvpBattleUser.clanBattleId, teamId),
+      columns: { id: true },
+    });
+    if (!remaining) {
+      await client.delete(mpvpBattleQueue).where(eq(mpvpBattleQueue.id, teamId));
+    }
+  }
 };
 
 const getRaidChatConversationId = (raidId: string) => `raid-chat-${raidId}`;

--- a/app/src/server/api/routers/raids.ts
+++ b/app/src/server/api/routers/raids.ts
@@ -288,8 +288,9 @@ export const raidsRouter = createTRPCRouter({
     })
     .input(z.object({ questId: z.string() }))
     .query(async ({ ctx, input }) => {
-      // Query - parallel fetch
-      const [raid, participation, thresholds] = await Promise.all([
+      // Query - parallel fetch (single round-trip)
+      const raidChatConversationId = getRaidChatConversationId(input.questId);
+      const [raid, participation, thresholds, existingConvo] = await Promise.all([
         ctx.drizzle.query.quest.findFirst({
           where: and(eq(quest.id, input.questId), eq(quest.questType, "raid")),
         }),
@@ -303,6 +304,10 @@ export const raidsRouter = createTRPCRouter({
           where: eq(raidDamageThreshold.questId, input.questId),
           orderBy: raidDamageThreshold.sortOrder,
         }),
+        ctx.drizzle.query.conversation.findFirst({
+          where: eq(conversation.id, raidChatConversationId),
+          columns: { id: true },
+        }),
       ]);
 
       // Guard
@@ -312,13 +317,6 @@ export const raidsRouter = createTRPCRouter({
 
       // Derived
       const raidData = getRaidObjectiveData(raid);
-      const raidChatConversationId = getRaidChatConversationId(raid.id);
-
-      // Check if conversation exists (created during joinRaidQueue)
-      const existingConvo = await ctx.drizzle.query.conversation.findFirst({
-        where: eq(conversation.id, raidChatConversationId),
-        columns: { id: true },
-      });
 
       return {
         raid: {
@@ -1101,8 +1099,12 @@ export const raidsRouter = createTRPCRouter({
         return errorResponse("Failed to join team - slot may have been taken");
       }
 
-      // Ensure raid chat conversation exists (idempotent, only writes on first call)
-      await ensureRaidChatConversation(ctx.drizzle, raid, ctx.userId);
+      // Only the first user of a new team creates the chat conversation;
+      // joiners of existing teams reuse the row created previously. Fire-and-forget
+      // so the response doesn't block on a write whose result we don't read.
+      if (createdNewTeam) {
+        void ensureRaidChatConversation(ctx.drizzle, raid, ctx.userId);
+      }
 
       // Pusher - notify sector about team changes
       const pusher = getServerPusher();
@@ -1724,6 +1726,8 @@ const ensureRaidChatConversation = async (
   userId: string,
 ) => {
   const conversationId = getRaidChatConversationId(raid.id);
+  // No-op self-assignment on conflict — title/state never changes after the
+  // first insert, so subsequent calls must not rewrite the row.
   await client
     .insert(conversation)
     .values({
@@ -1734,11 +1738,7 @@ const ensureRaidChatConversation = async (
       isLocked: false,
       isEnabled: true,
     })
-    .onDuplicateKeyUpdate({
-      set: {
-        title: `${raid.name} Raid Chat`,
-      },
-    });
+    .onDuplicateKeyUpdate({ set: { id: sql`id` } });
 
   return conversationId;
 };

--- a/app/src/server/api/routers/raids.ts
+++ b/app/src/server/api/routers/raids.ts
@@ -1109,45 +1109,31 @@ export const raidsRouter = createTRPCRouter({
         }
       }
 
-      // Mutation - insert user into queue
-      try {
-        await ctx.drizzle.insert(mpvpBattleUser).values({
+      // Mutation - insert user into queue and ensure chat conversation in parallel.
+      // ensureRaidChatConversation targets different tables (conversation,
+      // user2conversation) and has no data dependency on the mpvpBattleUser
+      // insert, so we run them concurrently to avoid a sequential round-trip.
+      const [userInsertResult, chatResult] = await Promise.allSettled([
+        ctx.drizzle.insert(mpvpBattleUser).values({
           id: nanoid(),
           clanBattleId: teamId,
           userId: ctx.userId,
           side: "ATTACKER",
           slot: availableSlot,
-        });
-      } catch {
-        await rollbackJoinRaidQueue({
-          client: ctx.drizzle,
-          userId: ctx.userId,
-          teamId,
-          raidQuestId: input.questId,
-          deleteTeam: createdNewTeam,
-          deleteUserRow: false,
-        });
-        return errorResponse("Failed to join team - slot may have been taken");
-      }
+        }),
+        ensureRaidChatConversation(ctx.drizzle, raid, ctx.userId),
+      ]);
 
-      // Ensure the chat conversation exists and grant this joiner membership
-      // (user2conversation) so they pass canViewConversation. The first joiner
-      // of a new team creates the row; subsequent joiners only insert their
-      // own membership row (idempotent on conflict). Await so a transient
-      // failure can be rolled back instead of leaving the user queued without
-      // chat access.
-      try {
-        await ensureRaidChatConversation(ctx.drizzle, raid, ctx.userId);
-      } catch {
+      if (userInsertResult.status === "rejected" || chatResult.status === "rejected") {
         await rollbackJoinRaidQueue({
           client: ctx.drizzle,
           userId: ctx.userId,
           teamId,
           raidQuestId: input.questId,
           deleteTeam: createdNewTeam,
-          deleteUserRow: true,
+          deleteUserRow: userInsertResult.status === "fulfilled",
         });
-        return errorResponse("Failed to create raid chat - please try again");
+        return errorResponse("Failed to join raid - please try again");
       }
 
       // Pusher - notify sector about team changes

--- a/app/src/server/utils/raidChat.ts
+++ b/app/src/server/utils/raidChat.ts
@@ -1,0 +1,42 @@
+import { and, eq, inArray, like } from "drizzle-orm";
+import { user2conversation } from "@/drizzle/schema";
+import type { DrizzleClient } from "@/server/db";
+
+/**
+ * Delete user2conversation rows for a single raid-chat conversation,
+ * scoped to one user or a set of users. Returns the Drizzle query so callers
+ * can batch it inside their own `Promise.all`.
+ */
+export const purgeRaidChatMembership = (
+  client: DrizzleClient,
+  conversationId: string,
+  userIds: string | string[],
+) => {
+  const ids = Array.isArray(userIds) ? userIds : [userIds];
+  return client
+    .delete(user2conversation)
+    .where(
+      and(
+        eq(user2conversation.conversationId, conversationId),
+        inArray(user2conversation.userId, ids),
+      ),
+    );
+};
+
+/**
+ * Drop every raid-chat membership owned by a single user. Used when the
+ * specific raid id is not recoverable (orphaned queue rows) and we have to
+ * conservatively clear all stale raid-chat access.
+ */
+export const purgeAllRaidChatMembershipsForUser = (
+  client: DrizzleClient,
+  userId: string,
+) =>
+  client
+    .delete(user2conversation)
+    .where(
+      and(
+        eq(user2conversation.userId, userId),
+        like(user2conversation.conversationId, "raid-chat-%"),
+      ),
+    );

--- a/app/src/server/utils/raidChat.ts
+++ b/app/src/server/utils/raidChat.ts
@@ -1,5 +1,6 @@
 import { and, eq, inArray, like } from "drizzle-orm";
 import { user2conversation } from "@/drizzle/schema";
+import { RAID_CHAT_CONVERSATION_LIKE_PATTERN } from "@/libs/raids";
 import type { DrizzleClient } from "@/server/db";
 
 /**
@@ -37,6 +38,6 @@ export const purgeAllRaidChatMembershipsForUser = (
     .where(
       and(
         eq(user2conversation.userId, userId),
-        like(user2conversation.conversationId, "raid-chat-%"),
+        like(user2conversation.conversationId, RAID_CHAT_CONVERSATION_LIKE_PATTERN),
       ),
     );

--- a/app/src/server/utils/raidChat.ts
+++ b/app/src/server/utils/raidChat.ts
@@ -7,6 +7,11 @@ import type { DrizzleClient } from "@/server/db";
  * Delete user2conversation rows for a single raid-chat conversation,
  * scoped to one user or a set of users. Returns the Drizzle query so callers
  * can batch it inside their own `Promise.all`.
+ *
+ * Guards against an empty `userIds` array — Drizzle's `inArray` emits invalid
+ * `IN ()` SQL on an empty list, which MySQL rejects. Callers (e.g. rollback
+ * paths) may legitimately pass an empty attacker list, so resolve to undefined
+ * in that case to keep the call site's `Promise.all` shape intact.
  */
 export const purgeRaidChatMembership = (
   client: DrizzleClient,
@@ -14,6 +19,7 @@ export const purgeRaidChatMembership = (
   userIds: string | string[],
 ) => {
   const ids = Array.isArray(userIds) ? userIds : [userIds];
+  if (ids.length === 0) return Promise.resolve(undefined);
   return client
     .delete(user2conversation)
     .where(


### PR DESCRIPTION
## Summary
- block banned users from preparing for, joining, or starting raid queues
- end raid battle cleanup when the boss AI is no longer alive in combat
- add a compact live raid chat panel backed by the existing conversation system

Fixes #1305

## Test plan
- Open an active raid and confirm banned users now get blocked from readying, joining, and starting raid queues.
- Finish a raid battle by killing the boss and confirm the raid combat instance is cleaned up and the raid boss is marked defeated.
- Open an active raid and confirm the new Raid Chat panel loads recent messages and can send live updates.

## Verification
- `npx -y @biomejs/biome check app/src/libs/combat/database.ts app/src/server/api/routers/raids.ts app/src/layout/RaidBrowser.tsx`
- `npx -y -p typescript tsc --noEmit -p app/tsconfig.json` blocked here because this workspace has no installed project dependencies, so TypeScript resolves into repo-wide missing-module errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-raid chat panel with real-time messages, live push updates, message sending, deduplicated display, HTML-rendered message bodies, and client-side validation (minimum 4 chars). Input disables while sending or when silenced/banned.

* **Improvements**
  * Server ensures a persistent raid chat is created so chat appears reliably and creation failures roll back queue/team changes.
  * More accurate raid completion detection to better recognize raid-boss defeat.
  * Banned accounts are blocked from joining raid queues or starting raids.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/studie-tech/TheNinjaRPG/pull/1316)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->