### PR TITLE
Fix/auto travel sector validation

### DIFF
--- a/app/src/app/travel/page.tsx
+++ b/app/src/app/travel/page.tsx
@@ -657,7 +657,7 @@ export default function Travel() {
                               <FormControl>
                                 <Input
                                   className="w-full"
-                                  placeholder="Sector ID (0-492)"
+                                  placeholder="Sector ID (0-491)"
                                   type="number"
                                   {...field}
                                   value={field.value as number}
@@ -716,7 +716,7 @@ export default function Travel() {
                               <FormControl>
                                 <Input
                                   className="w-full"
-                                  placeholder="Sector ID (0-492)"
+                                  placeholder="Sector ID (0-491)"
                                   type="number"
                                   {...field}
                                   value={field.value as number}

--- a/app/src/server/api/routers/travel.ts
+++ b/app/src/server/api/routers/travel.ts
@@ -408,6 +408,10 @@ export const travelRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ input, ctx }) => {
+      const targetTile = (map as unknown as GlobalMapData).tiles[input.sector];
+      if (!targetTile) {
+        return { success: false, message: "Target sector does not exist" };
+      }
       let user = await fetchUser(ctx.drizzle, ctx.userId);
       if (!isAtEdge({ x: user.longitude, y: user.latitude })) {
         return { success: false, message: "You are not at the edge of a sector" };

--- a/app/src/validators/travel.ts
+++ b/app/src/validators/travel.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const sectorIdSchema = z.coerce.number().int().min(0).max(492);
+export const sectorIdSchema = z.coerce.number().int().min(0).max(491);
 
 export const quickTravelSchema = z.object({ sector: sectorIdSchema });
 export type QuickTravelSchemaInput = z.input<typeof quickTravelSchema>;

--- a/app/tests/validators/travel.test.ts
+++ b/app/tests/validators/travel.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "vitest";
+import { sectorIdSchema } from "@/validators/travel";
+
+test("sectorIdSchema rejects sector 492 (out of bounds)", () => {
+  const result = sectorIdSchema.safeParse(492);
+  expect(result.success).toBe(false);
+});
+
+test("sectorIdSchema accepts sector 491 (last valid index)", () => {
+  const result = sectorIdSchema.safeParse(491);
+  expect(result.success).toBe(true);
+  expect(result.data).toBe(491);
+});
+
+test("sectorIdSchema accepts sector 0 (first valid index)", () => {
+  const result = sectorIdSchema.safeParse(0);
+  expect(result.success).toBe(true);
+  expect(result.data).toBe(0);
+});
+
+test("sectorIdSchema rejects negative sectors", () => {
+  const result = sectorIdSchema.safeParse(-1);
+  expect(result.success).toBe(false);
+});
+
+test("sectorIdSchema coerces string numbers", () => {
+  const result = sectorIdSchema.safeParse("200");
+  expect(result.success).toBe(true);
+  expect(result.data).toBe(200);
+});


### PR DESCRIPTION
  # Pull Request

  ## Fix: Auto-Travel to Non-Existent Sectors (#1293)

  Players could enter a sector ID above the valid range (e.g. 492) into the Quick Travel or Find Sector inputs and be sent to a sector that doesn't exist in the hexasphere map, leaving them stuck with no way
  to travel back.

  **What was changed:**

  - **`app/src/validators/travel.ts`** — Corrected `sectorIdSchema` max from `492` to `491`. The hexasphere map has 492 tiles indexed `0–491`; the previous `max(492)` was an off-by-one that allowed an invalid
  sector through frontend validation.
  - **`app/src/server/api/routers/travel.ts`** — Added a server-side guard at the top of `startGlobalMove` that checks `map.tiles[input.sector]` exists before doing anything. This is the authoritative defence:
   even a direct API call bypassing the form schema cannot land a player on a non-existent sector.
  - **`app/src/app/travel/page.tsx`** — Updated both input placeholders from `Sector ID (0-492)` to `Sector ID (0-491)` to match the corrected valid range.
  - **`app/tests/validators/travel.test.ts`** — Added unit tests covering the boundary behaviour of `sectorIdSchema` (rejects 492, accepts 491, accepts 0, rejects negatives, coerces strings).

  **Breaking changes:** None. The only observable difference is that sector 492 is now correctly rejected rather than silently accepted.

  ## License

  By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I
  acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected the maximum allowed Sector ID range from 0–492 to 0–491 across UI inputs and validation.
  * Added validation to ensure target sectors exist before initiating travel operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->