### PR TITLE
Fix/tavern quote fix

### DIFF
--- a/app/src/layout/Conversation.tsx
+++ b/app/src/layout/Conversation.tsx
@@ -24,6 +24,7 @@ import { showMutationToast } from "@/libs/toast";
 import { getNewReactions, processMentions } from "@/utils/chat";
 import { parseHtml } from "@/utils/parse";
 import { canPostAsAi } from "@/utils/permissions";
+import { stripBlockquotes } from "@/utils/sanitize";
 import { secondsFromNow } from "@/utils/time";
 import type { ArrayElement } from "@/utils/typeutils";
 import { useUserData } from "@/utils/UserContext";
@@ -388,7 +389,7 @@ const Conversation: React.FC<ConversationProps> = (props) => {
           ?.map((id) => {
             const quote = allComments?.find((c) => c.id === id);
             return quote
-              ? `<blockquote author="${quote.username || "Unknown"}" date="${format(quote.createdAt, "MM/dd/yyyy")}">${quote.content}</blockquote>`
+              ? `<blockquote author="${quote.username || "Unknown"}" date="${format(quote.createdAt, "MM/dd/yyyy")}">${stripBlockquotes(quote.content)}</blockquote>`
               : "";
           })
           .join("") || "";
@@ -685,7 +686,7 @@ const Conversation: React.FC<ConversationProps> = (props) => {
                           );
                         }}
                       >
-                        {quote.content}
+                        {stripBlockquotes(quote.content)}
                       </Quote>
                     );
                   })}

--- a/app/src/server/api/routers/comments.ts
+++ b/app/src/server/api/routers/comments.ts
@@ -42,7 +42,7 @@ import {
   canViewConversation,
 } from "@/utils/permissions";
 import { checkForBadWords } from "@/utils/profanity";
-import sanitize from "@/utils/sanitize";
+import sanitize, { stripBlockquotes } from "@/utils/sanitize";
 import {
   createConversationSchema,
   deleteCommentSchema,
@@ -694,7 +694,7 @@ export const commentsRouter = createTRPCRouter({
         const quoteContent = quotes
           .map(
             (q) =>
-              `<blockquote author="${q.user?.username || "Unknown"}" date="${format(q.createdAt, "MM/dd/yyyy")}">${q.content}</blockquote>`,
+              `<blockquote author="${q.user?.username || "Unknown"}" date="${format(q.createdAt, "MM/dd/yyyy")}">${stripBlockquotes(q.content)}</blockquote>`,
           )
           .join("");
         content = `${quoteContent}\n\n${content}`;

--- a/app/src/utils/sanitize.ts
+++ b/app/src/utils/sanitize.ts
@@ -30,6 +30,11 @@ const sanitize = (html: string) => {
 
 export default sanitize;
 
+/**
+ * Removes quote wrappers and everything inside them from already-sanitized HTML.
+ * Do not call this on raw user input; it intentionally allows all tags so it can
+ * operate as a narrow post-processing step before re-wrapping quotes.
+ */
 export const stripBlockquotes = (html: string) => {
   return sanitizeHtml(html, {
     allowedTags: false,

--- a/app/src/utils/sanitize.ts
+++ b/app/src/utils/sanitize.ts
@@ -30,6 +30,15 @@ const sanitize = (html: string) => {
 
 export default sanitize;
 
+export const stripBlockquotes = (html: string) => {
+  return sanitizeHtml(html, {
+    allowedTags: false,
+    allowedAttributes: false,
+    allowVulnerableTags: true,
+    exclusiveFilter: (frame) => frame.tag === "blockquote",
+  });
+};
+
 export const capitalizeFirstLetter = (string: string) => {
   return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();
 };

--- a/app/src/utils/sanitize.ts
+++ b/app/src/utils/sanitize.ts
@@ -1,48 +1,40 @@
 import sanitizeHtml from "sanitize-html";
 
-const sanitize = (html: string) => {
-  return sanitizeHtml(html, {
-    allowedTags: sanitizeHtml.defaults.allowedTags.concat([
-      "img",
-      "blockquote",
-      "iframe",
-    ]),
-    allowedAttributes: {
-      ...sanitizeHtml.defaults.allowedAttributes,
-      img: ["src"],
-      span: ["style"],
-      blockquote: ["author", "date"],
-      iframe: [
-        "src",
-        "width",
-        "height",
-        "title",
-        "allow",
-        "allowfullscreen",
-        "frameborder",
-        "class",
-        "id",
-        "style",
-      ],
-    },
-  });
+const sanitizeOptions: sanitizeHtml.IOptions = {
+  allowedTags: sanitizeHtml.defaults.allowedTags.concat([
+    "img",
+    "blockquote",
+    "iframe",
+  ]),
+  allowedAttributes: {
+    ...sanitizeHtml.defaults.allowedAttributes,
+    img: ["src"],
+    span: ["style"],
+    blockquote: ["author", "date"],
+    iframe: [
+      "src",
+      "width",
+      "height",
+      "title",
+      "allow",
+      "allowfullscreen",
+      "frameborder",
+      "class",
+      "id",
+      "style",
+    ],
+  },
 };
+
+const sanitize = (html: string) => sanitizeHtml(html, sanitizeOptions);
 
 export default sanitize;
 
-/**
- * Removes quote wrappers and everything inside them from already-sanitized HTML.
- * Do not call this on raw user input; it intentionally allows all tags so it can
- * operate as a narrow post-processing step before re-wrapping quotes.
- */
-export const stripBlockquotes = (html: string) => {
-  return sanitizeHtml(html, {
-    allowedTags: false,
-    allowedAttributes: false,
-    allowVulnerableTags: true,
+export const stripBlockquotes = (html: string) =>
+  sanitizeHtml(html, {
+    ...sanitizeOptions,
     exclusiveFilter: (frame) => frame.tag === "blockquote",
   });
-};
 
 export const capitalizeFirstLetter = (string: string) => {
   return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();

--- a/app/tests/utils/sanitize.test.ts
+++ b/app/tests/utils/sanitize.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "vitest";
+import { stripBlockquotes } from "@/utils/sanitize";
+
+test("stripBlockquotes removes blockquotes and their nested content", () => {
+  expect(
+    stripBlockquotes(
+      'Intro <blockquote author="A">Parent <blockquote author="B">Child</blockquote></blockquote> More',
+    ),
+  ).toBe("Intro  More");
+});
+
+test("stripBlockquotes preserves non-quote sanitized html", () => {
+  expect(stripBlockquotes("<p>Hello <strong>there</strong></p>")).toBe(
+    "<p>Hello <strong>there</strong></p>",
+  );
+});

--- a/app/tests/utils/sanitize.test.ts
+++ b/app/tests/utils/sanitize.test.ts
@@ -1,16 +1,55 @@
 import { expect, test } from "vitest";
 import { stripBlockquotes } from "@/utils/sanitize";
 
+const normalizeWhitespace = (value: string) => value.replace(/\s+/g, " ").trim();
+
 test("stripBlockquotes removes blockquotes and their nested content", () => {
   expect(
-    stripBlockquotes(
-      'Intro <blockquote author="A">Parent <blockquote author="B">Child</blockquote></blockquote> More',
+    normalizeWhitespace(
+      stripBlockquotes(
+        'Intro <blockquote author="A">Parent <blockquote author="B">Child</blockquote></blockquote> More',
+      ),
     ),
-  ).toBe("Intro  More");
+  ).toBe("Intro More");
+});
+
+test("stripBlockquotes removes multiple sibling blockquotes", () => {
+  expect(
+    normalizeWhitespace(
+      stripBlockquotes(
+        'Start <blockquote author="A">First</blockquote><blockquote author="B">Second</blockquote> End',
+      ),
+    ),
+  ).toBe("Start End");
+});
+
+test("stripBlockquotes returns an empty string for empty or quote-only input", () => {
+  expect(stripBlockquotes("")).toBe("");
+  expect(
+    stripBlockquotes('<blockquote author="A" date="04/12/2026">Only quote</blockquote>'),
+  ).toBe("");
+});
+
+test("stripBlockquotes preserves text adjacent to removed quotes", () => {
+  expect(
+    normalizeWhitespace(
+      stripBlockquotes('Before<blockquote author="A">Quote</blockquote>After'),
+    ),
+  ).toBe("BeforeAfter");
 });
 
 test("stripBlockquotes preserves non-quote sanitized html", () => {
   expect(stripBlockquotes("<p>Hello <strong>there</strong></p>")).toBe(
     "<p>Hello <strong>there</strong></p>",
+  );
+});
+
+test("stripBlockquotes preserves non-quote media tags around blockquotes", () => {
+  expect(
+    stripBlockquotes(
+      '<img src="avatar.png" /><blockquote author="A">Quoted</blockquote><iframe src="https://example.com/embed"></iframe>',
+    ),
+  ).toBe(
+    '<img src="avatar.png" /><iframe src="https://example.com/embed"></iframe>',
   );
 });


### PR DESCRIPTION
# Pull Request

  Fixes nested blockquotes stacking up when a user quotes a comment that already contains a quote in the tavern (and anywhere else `Conversation` / the comments router renders quoted content).

  **What changed**
  - Added `stripBlockquotes` helper in `app/src/utils/sanitize.ts` that post-processes already-sanitized HTML and removes `<blockquote>` tags along with their contents, so a quoted reply never carries the
  previous quote chain forward.
  - Applied `stripBlockquotes` at the three sites that wrap a comment's content in a new `<blockquote>`:
    - `app/src/layout/Conversation.tsx` — client-side quote insertion when composing a reply.
    - `app/src/layout/Conversation.tsx` — rendering of inline quoted previews.
    - `app/src/server/api/routers/comments.ts` — server-side quote assembly in the comments router.
  - Added unit tests in `app/tests/utils/sanitize.test.ts` covering the new helper.

  **Why**
  Previously, quoting a comment that already contained a quote nested the old quote inside the new one, and repeated quoting produced deeply stacked blockquotes that were noisy to read and bloated the stored
  HTML. Stripping prior blockquotes before re-wrapping keeps each quote a single level deep.

  **Breaking changes**
  None. The helper only runs against content that is about to be wrapped in a fresh `<blockquote>`, so existing stored comments are untouched; only newly composed quotes collapse their nesting.

  ## License

  By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I
  acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Quotes in conversations and the composer no longer include nested blockquote wrappers—quoted text displays cleanly without redundant formatting.
  * Quoted content inserted when posting comments is now stripped of extra blockquote markup to prevent nested quoting.

* **Tests**
  * Added tests to ensure blockquote stripping behaves consistently across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->