### PR TITLE
fix: honor reduced combat AP costs

### DIFF
--- a/app/src/app/combat/page.tsx
+++ b/app/src/app/combat/page.tsx
@@ -214,6 +214,8 @@ export default function CombatPage() {
         selectedId={actionId}
         combatMode={true}
         userActionPoints={user?.actionPoints}
+        battle={battle}
+        userId={userId}
         gridClassNameOverwrite={actionGridClass}
         aspectRatioClass={actionAspect}
         onClick={handleActionClick}

--- a/app/src/layout/CombatActions.tsx
+++ b/app/src/layout/CombatActions.tsx
@@ -13,6 +13,8 @@ import type { Bloodline, Item, ItemRarity, Jutsu } from "@/drizzle/schema";
 import DurabilityBar from "@/layout/DurabilityBar";
 import ElementImage from "@/layout/ElementImage";
 import ItemWithEffects from "@/layout/ItemWithEffects";
+import { getActionPointCost } from "@/libs/combat/actions";
+import type { CombatAction, ReturnedBattle } from "@/libs/combat/types";
 import { cn } from "@/libs/shadui";
 import { canChangeContent } from "@/utils/permissions";
 import { useUserData } from "@/utils/UserContext";
@@ -61,6 +63,8 @@ interface ActionSelectorSettingsProps {
   showInfoIcon?: boolean;
   combatMode?: boolean;
   userActionPoints?: number;
+  battle?: ReturnedBattle | null;
+  userId?: string;
 }
 
 interface ActionSelectorProps extends ActionSelectorSettingsProps {
@@ -119,16 +123,30 @@ export const ActionSelector: React.FC<ActionSelectorProps> = (props) => {
       selectedItem.lastUsedRound !== undefined &&
       currentRound - selectedItem.lastUsedRound < selectedItem.cooldown;
 
+    const effectiveActionCost =
+      combatMode && props.battle && props.userId
+        ? getActionPointCost(props.userId, props.battle, selectedItem as CombatAction)
+        : selectedItem.actionCostPerc;
+
     // Check if user has insufficient AP
     const insufficientAP =
       userActionPoints !== undefined &&
-      selectedItem.actionCostPerc !== undefined &&
-      userActionPoints < selectedItem.actionCostPerc;
+      effectiveActionCost !== undefined &&
+      userActionPoints < effectiveActionCost;
 
     if (isOnCooldown || insufficientAP) {
       onClick(selectedId);
     }
-  }, [combatMode, selectedId, currentRound, userActionPoints, onClick, filtered]);
+  }, [
+    combatMode,
+    selectedId,
+    currentRound,
+    userActionPoints,
+    onClick,
+    filtered,
+    props.battle,
+    props.userId,
+  ]);
 
   return (
     <>
@@ -230,13 +248,17 @@ export const ActionOption: React.FC<ActionOptionProps> = (props) => {
   const elements = item.effects
     ? item.effects.flatMap((e) => ("elements" in e && e.elements ? e.elements : []))
     : [];
+  const effectiveActionCost =
+    settings.combatMode && settings.battle && settings.userId
+      ? getActionPointCost(settings.userId, settings.battle, item as CombatAction)
+      : actionCostPerc;
 
   // Check if user has insufficient AP (only in combat mode)
   const insufficientAP =
     settings.combatMode &&
     settings.userActionPoints !== undefined &&
-    actionCostPerc !== undefined &&
-    settings.userActionPoints < actionCostPerc;
+    effectiveActionCost !== undefined &&
+    settings.userActionPoints < effectiveActionCost;
 
   // Handler that prevents selection when AP is insufficient
   const handleClick = () => {

--- a/app/src/libs/combat/actions.ts
+++ b/app/src/libs/combat/actions.ts
@@ -1151,44 +1151,6 @@ export const actionPointsAfterAction = (
     return { apAfter: 0, apAvailableAfter: 0, canAct: false, availableActionPoints: 0 };
   const stunReduction = calcApReduction(battle, user.userId);
 
-  // Helper: count applicable temporal effects and get AP delta (10 per effect)
-  const getTemporalApDelta = (type: "timecompression" | "timedilation") => {
-    if (action?.id === "wait") return 0;
-    // Time dilation and time compression should not affect basic actions or items
-    if (action?.type === "basic" || action?.type === "item") return 0;
-    const effects = battle.usersEffects.filter((e): e is UserEffect => {
-      return (
-        e.type === type &&
-        e.targetId === user.userId &&
-        !e.castThisRound &&
-        isEffectActive(e)
-      );
-    });
-    const appliesByElements = (effect: UserEffect) => {
-      // No elements specified on the effect → applies to all actions
-      if (!("elements" in effect) || !effect.elements || effect.elements.length === 0) {
-        return true;
-      }
-      // For jutsu: apply only if there is an overlap with the action's elements
-      if (action?.type === "jutsu" && action.data && "effects" in action.data) {
-        const actionElements = new Set(
-          action.data.effects.flatMap((eff) =>
-            "elements" in eff && eff.elements ? eff.elements : [],
-          ),
-        );
-        return actionElements.size === 0
-          ? false
-          : effect.elements.some((el: ElementName) => actionElements.has(el));
-      }
-      return true;
-    };
-    const applicable = effects.filter(appliesByElements);
-    return applicable.length * 10;
-  };
-
-  const timeCompressionApIncrease = getTemporalApDelta("timecompression");
-  const timeDilationApDecrease = getTemporalApDelta("timedilation");
-
   const availableActionPoints = Math.max(0, user.actionPoints - stunReduction);
 
   // If no action is provided, just return current available AP
@@ -1201,10 +1163,7 @@ export const actionPointsAfterAction = (
     };
   }
 
-  const actionCost = Math.max(
-    0,
-    (action.actionCostPerc || 0) + timeCompressionApIncrease - timeDilationApDecrease,
-  );
+  const actionCost = getActionPointCost(user.userId, battle, action);
   const apAfter = Math.max(0, user.actionPoints - actionCost); // stored AP after spending
   const apAvailableAfter = availableActionPoints - actionCost; // gating with stun etc.
   return {
@@ -1213,6 +1172,83 @@ export const actionPointsAfterAction = (
     canAct: apAvailableAfter >= 0,
     availableActionPoints,
   };
+};
+
+const elementsFromJutsuTags = (tags: CombatAction["effects"]): ElementName[] =>
+  tags.flatMap((eff) =>
+    "elements" in eff && eff.elements && eff.elements.length > 0 ? eff.elements : [],
+  );
+
+/** Union of tag elements on the action (normalized `effects` plus embedded jutsu `data.effects` when present). */
+const collectJutsuActionElements = (action: CombatAction): Set<ElementName> => {
+  const acc = new Set(elementsFromJutsuTags(action.effects));
+  if (action.data && "effects" in action.data && Array.isArray(action.data.effects)) {
+    for (const el of elementsFromJutsuTags(action.data.effects)) {
+      acc.add(el);
+    }
+  }
+  return acc;
+};
+
+const getTemporalApDelta = (
+  battle: ReturnedBattle,
+  userId: string,
+  action: CombatAction,
+  type: "timecompression" | "timedilation",
+) => {
+  if (action.id === "wait") return 0;
+  // Time dilation and time compression should not affect basic actions or items
+  if (action.type === "basic" || action.type === "item") return 0;
+  const effects = battle.usersEffects.filter((e): e is UserEffect => {
+    return (
+      e.type === type && e.targetId === userId && !e.castThisRound && isEffectActive(e)
+    );
+  });
+  const appliesByElements = (effect: UserEffect) => {
+    // No elements specified on the effect -> applies to all actions
+    if (!effect.elements || effect.elements.length === 0) {
+      return true;
+    }
+    // Element-scoped temporal effects only apply to jutsu that declare matching elements
+    if (action.type !== "jutsu") {
+      return true;
+    }
+    const actionElements = collectJutsuActionElements(action);
+    if (actionElements.size === 0) {
+      return false;
+    }
+    return effect.elements.some((el: ElementName) => actionElements.has(el));
+  };
+  const applicable = effects.filter(appliesByElements);
+  return applicable.length * 10;
+};
+
+export const getActionPointCost = (
+  userId?: string | null,
+  battle?: ReturnedBattle | null,
+  action?: CombatAction,
+) => {
+  if (!userId || !battle || !action) {
+    return Math.max(0, action?.actionCostPerc || 0);
+  }
+
+  const timeCompressionApIncrease = getTemporalApDelta(
+    battle,
+    userId,
+    action,
+    "timecompression",
+  );
+  const timeDilationApDecrease = getTemporalApDelta(
+    battle,
+    userId,
+    action,
+    "timedilation",
+  );
+
+  return Math.max(
+    0,
+    (action.actionCostPerc || 0) + timeCompressionApIncrease - timeDilationApDecrease,
+  );
 };
 
 /**

--- a/app/tests/libs/combat/actions.test.ts
+++ b/app/tests/libs/combat/actions.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from "vitest";
+
+/** Keep AP helpers testable without loading the full combat graph (process, hex, Three). */
+vi.mock("@/libs/combat/process", () => ({
+  applyEffects: vi.fn(() => ({
+    newBattle: {},
+    actionEffects: [],
+  })),
+  checkFriendlyFire: vi.fn(() => true),
+}));
+
+vi.mock("@/libs/hexgrid", () => ({
+  getPossibleActionTiles: vi.fn(() => new Set()),
+  PathCalculator: vi.fn(),
+}));
+
+/** Avoid executing real db/env when transitive imports touch `@/server/db`. */
+vi.mock("@/server/db", () => ({
+  drizzleDB: {},
+}));
+
+import {
+  actionPointsAfterAction,
+  getActionPointCost,
+} from "@/libs/combat/actions";
+import type { ElementName } from "@/drizzle/constants";
+import type { CombatAction, ReturnedBattle, ReturnedUserState, UserEffect } from "@/libs/combat/types";
+
+const makeBattle = (effects: UserEffect[]): ReturnedBattle =>
+  ({
+    id: "battle-1",
+    activeUserId: "user-1",
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    roundStartAt: new Date("2026-01-01T00:00:00Z"),
+    background: "default",
+    width: 10,
+    height: 10,
+    battleType: "COMBAT",
+    version: 1,
+    round: 1,
+    rewardScaling: 1,
+    forceKeepPools: false,
+    groundEffects: [],
+    usersEffects: effects,
+    usersState: [
+      {
+        userId: "user-1",
+        actionPoints: 50,
+        longitude: 0,
+        latitude: 0,
+      },
+    ],
+    extraState: {
+      jutsus: {},
+      jutsuReskins: {},
+      items: {},
+      bloodlines: {},
+      villages: {},
+      anbuSquads: {},
+      keystoneItems: {},
+      wars: {},
+      aiProfiles: {},
+      relations: {},
+      clans: {},
+      userQuests: {},
+      completedQuests: {},
+      questData: {},
+      bounties: {},
+      bountySignups: {},
+    },
+  }) as unknown as ReturnedBattle;
+
+const makeTimeDilation = (opts?: { elements?: ElementName[] }): UserEffect =>
+  ({
+    id: "effect-1",
+    creatorId: "user-2",
+    targetId: "user-1",
+    level: 1,
+    isNew: false,
+    castThisRound: false,
+    createdRound: 1,
+    power: 10,
+    type: "timedilation",
+    calculation: "static",
+    direction: "offence",
+    rounds: 1,
+    longitude: 0,
+    latitude: 0,
+    barrierAbsorb: 0,
+    actionId: "time-dilation",
+    ...(opts?.elements && opts.elements.length > 0 ? { elements: opts.elements } : {}),
+  }) as UserEffect;
+
+const makeJutsuAction = (): CombatAction =>
+  ({
+    id: "jutsu-1",
+    name: "Expensive Jutsu",
+    image: "/jutsu.png",
+    battleDescription: "test",
+    type: "jutsu",
+    target: "OTHER_USER",
+    method: "SINGLE",
+    range: 1,
+    healthCost: 0,
+    chakraCost: 0,
+    staminaCost: 0,
+    actionCostPerc: 60,
+    updatedAt: Date.now(),
+    cooldown: 0,
+    originalCooldown: 0,
+    effects: [],
+    data: {
+      effects: [{ type: "damage", elements: ["Fire"] }],
+    },
+  }) as unknown as CombatAction;
+
+/** Fire only on normalized top-level `effects` (no embedded `data.effects`). */
+const makeJutsuFireTopLevelOnly = (): CombatAction =>
+  ({
+    id: "jutsu-1",
+    name: "Expensive Jutsu",
+    image: "/jutsu.png",
+    battleDescription: "test",
+    type: "jutsu",
+    target: "OTHER_USER",
+    method: "SINGLE",
+    range: 1,
+    healthCost: 0,
+    chakraCost: 0,
+    staminaCost: 0,
+    actionCostPerc: 60,
+    updatedAt: Date.now(),
+    cooldown: 0,
+    originalCooldown: 0,
+    effects: [{ type: "damage", elements: ["Fire"] }],
+    data: undefined,
+  }) as unknown as CombatAction;
+
+const makeUser = (): ReturnedUserState =>
+  ({
+    userId: "user-1",
+    actionPoints: 50,
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+  }) as unknown as ReturnedUserState;
+
+describe("combat AP cost adjustments", () => {
+  it("reduces jutsu AP cost when time dilation is active", () => {
+    const battle = makeBattle([makeTimeDilation()]);
+    const action = makeJutsuAction();
+
+    expect(getActionPointCost("user-1", battle, action)).toBe(50);
+  });
+
+  it("allows a discounted jutsu when the adjusted AP cost is affordable", () => {
+    const battle = makeBattle([makeTimeDilation()]);
+    const action = makeJutsuAction();
+    const user = makeUser();
+
+    const result = actionPointsAfterAction(user, battle, action);
+
+    expect(result.apAvailableAfter).toBe(0);
+    expect(result.canAct).toBe(true);
+  });
+
+  it("uses top-level action.effects for element-scoped time dilation when data is absent", () => {
+    const battle = makeBattle([makeTimeDilation({ elements: ["Fire"] })]);
+    const action = makeJutsuFireTopLevelOnly();
+
+    expect(getActionPointCost("user-1", battle, action)).toBe(50);
+  });
+
+  it("does not apply element-scoped time dilation when action elements do not overlap", () => {
+    const battle = makeBattle([makeTimeDilation({ elements: ["Water"] })]);
+    const action = makeJutsuFireTopLevelOnly();
+
+    expect(getActionPointCost("user-1", battle, action)).toBe(60);
+  });
+
+  it("still matches elements from embedded jutsu data.effects", () => {
+    const battle = makeBattle([makeTimeDilation({ elements: ["Fire"] })]);
+    const action = makeJutsuAction();
+
+    expect(getActionPointCost("user-1", battle, action)).toBe(50);
+  });
+});


### PR DESCRIPTION
## Summary
- reuse the shared combat AP-cost calculation for the selector's usability checks
- keep Time Dilation and Time Compression UI gating aligned with the actual combat execution path
- add a regression test covering a 60 AP jutsu becoming usable at 50 AP under Time Dilation

Fixes #1015

## Test Plan
- `NEXT_PUBLIC_PUSHER_APP_KEY=test NEXT_PUBLIC_PUSHER_APP_CLUSTER=test NEXT_PUBLIC_BASE_URL=http://localhost:3000 NODE_ENV=test npx vitest run tests/libs/combat/actions.test.ts`
- `npx biome check src/libs/combat/actions.ts src/layout/CombatActions.tsx src/app/combat/page.tsx tests/libs/combat/actions.test.ts`
- `npm run check` currently fails on unrelated pre-existing Biome diagnostics elsewhere in the repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Combat action costs now reflect the current battle and the acting user, so active temporal effects (e.g., time dilation/compression) can change ability AP costs and selection behavior.
  * UI now prevents or auto-deselects actions when they become unaffordable under current battle conditions.
* **Tests**
  * Added tests covering AP cost calculations and affordability under temporal effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->