### PR TITLE
Item shop qol

### DIFF
--- a/app/src/app/blackmarket/page.tsx
+++ b/app/src/app/blackmarket/page.tsx
@@ -95,7 +95,7 @@ export default function BlackMarket() {
               <i> - Have a bloodline genetically infused.</i>
             </li>
             <li>
-              <i> - Special items with Seichi silver or Reputation points.</i>
+              <i> - Special items with silver or Reputation points.</i>
             </li>
             <li>
               <i> - Exchange ryo for reputation points.</i>
@@ -113,15 +113,31 @@ export default function BlackMarket() {
             initialBreak={true}
             minRepsCost={1}
             title="Reputation Shop"
-            subtitle="Buy rare items"
+            subtitle="Browse categories, search the catalog, then open a card to buy."
+            useItemTypeTabs
+            seichiSilverUi="silver"
+            catalogHeroTitle="Reputation catalog"
+            catalogHeroDescription="Spend reputation on rare stock. Category tabs and search match the village shop; filters refine rarity, slot, and effects."
+            catalogHeroBadgeCatalog="Reputation pricing"
+            catalogSearchId="blackmarket-rep-catalog-search"
+            catalogTutorialId={false}
+            filterPopoverTriggerId="blackmarket-rep-filter"
           />
           <Shop
             userData={userData}
             defaultType="CONSUMABLE"
             initialBreak={true}
             minSeichiSilverCost={1}
-            title="Seichi Silver Shop"
-            subtitle="Buy rare items"
+            title="Silver Shop"
+            subtitle="Browse categories, search the catalog, then open a card to buy."
+            useItemTypeTabs
+            seichiSilverUi="silver"
+            catalogHeroTitle="Silver catalog"
+            catalogHeroDescription="Spend silver on exclusive goods. Use tabs and search, then tap a card to review and purchase."
+            catalogHeroBadgeCatalog="Silver pricing"
+            catalogSearchId="blackmarket-seichi-catalog-search"
+            catalogTutorialId={false}
+            filterPopoverTriggerId="blackmarket-seichi-filter"
           />
           {PITY_SYSTEM_ENABLED && <PityBloodlineRoll userData={userData} />}
         </>

--- a/app/src/app/blackmarket/page.tsx
+++ b/app/src/app/blackmarket/page.tsx
@@ -95,7 +95,7 @@ export default function BlackMarket() {
               <i> - Have a bloodline genetically infused.</i>
             </li>
             <li>
-              <i> - Special items with silver or Reputation points.</i>
+              <i> - Buy special items with silver or reputation points.</i>
             </li>
             <li>
               <i> - Exchange ryo for reputation points.</i>
@@ -114,14 +114,16 @@ export default function BlackMarket() {
             minRepsCost={1}
             title="Reputation Shop"
             subtitle="Browse categories, search the catalog, then open a card to buy."
-            useItemTypeTabs
-            seichiSilverUi="silver"
-            catalogHeroTitle="Reputation catalog"
-            catalogHeroDescription="Spend reputation on rare stock. Category tabs and search match the village shop; filters refine rarity, slot, and effects."
-            catalogHeroBadgeCatalog="Reputation pricing"
-            catalogSearchId="blackmarket-rep-catalog-search"
-            catalogTutorialId={false}
-            filterPopoverTriggerId="blackmarket-rep-filter"
+            catalog={{
+              silverLabel: "silver",
+              heroTitle: "Reputation catalog",
+              heroDescription:
+                "Spend reputation on rare stock. Category tabs and search match the village shop; filters refine rarity, slot, and effects.",
+              heroBadge: "Reputation pricing",
+              searchId: "blackmarket-rep-catalog-search",
+              listId: false,
+              filterTriggerId: "blackmarket-rep-filter",
+            }}
           />
           <Shop
             userData={userData}
@@ -130,14 +132,16 @@ export default function BlackMarket() {
             minSeichiSilverCost={1}
             title="Silver Shop"
             subtitle="Browse categories, search the catalog, then open a card to buy."
-            useItemTypeTabs
-            seichiSilverUi="silver"
-            catalogHeroTitle="Silver catalog"
-            catalogHeroDescription="Spend silver on exclusive goods. Use tabs and search, then tap a card to review and purchase."
-            catalogHeroBadgeCatalog="Silver pricing"
-            catalogSearchId="blackmarket-seichi-catalog-search"
-            catalogTutorialId={false}
-            filterPopoverTriggerId="blackmarket-seichi-filter"
+            catalog={{
+              silverLabel: "silver",
+              heroTitle: "Silver catalog",
+              heroDescription:
+                "Spend silver on exclusive goods. Use tabs and search, then tap a card to review and purchase.",
+              heroBadge: "Silver pricing",
+              searchId: "blackmarket-seichi-catalog-search",
+              listId: false,
+              filterTriggerId: "blackmarket-seichi-filter",
+            }}
           />
           {PITY_SYSTEM_ENABLED && <PityBloodlineRoll userData={userData} />}
         </>

--- a/app/src/app/itemshop/page.tsx
+++ b/app/src/app/itemshop/page.tsx
@@ -23,7 +23,6 @@ export default function ItemShop() {
       defaultBackHref={"/village"}
       eventItems={false}
       subtitle="Browse gear and supplies — open a card to inspect and buy."
-      useItemTypeTabs
     />
   );
 }

--- a/app/src/app/itemshop/page.tsx
+++ b/app/src/app/itemshop/page.tsx
@@ -22,6 +22,8 @@ export default function ItemShop() {
       defaultType="WEAPON"
       defaultBackHref={"/village"}
       eventItems={false}
+      subtitle="Browse gear and supplies — open a card to inspect and buy."
+      useItemTypeTabs
     />
   );
 }

--- a/app/src/app/souvenirs/page.tsx
+++ b/app/src/app/souvenirs/page.tsx
@@ -26,7 +26,6 @@ export default function ItemShop() {
       defaultBackHref={"/village"}
       eventItems={true}
       subtitle="Limited-run souvenirs — search, filter, then open a card to purchase."
-      useItemTypeTabs
     />
   );
 }

--- a/app/src/app/souvenirs/page.tsx
+++ b/app/src/app/souvenirs/page.tsx
@@ -25,6 +25,8 @@ export default function ItemShop() {
       defaultType="WEAPON"
       defaultBackHref={"/village"}
       eventItems={true}
+      subtitle="Limited-run souvenirs — search, filter, then open a card to purchase."
+      useItemTypeTabs
     />
   );
 }

--- a/app/src/layout/ItemShopFiltering.tsx
+++ b/app/src/layout/ItemShopFiltering.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import {
   BattleUsageTypes,
   ItemRarities,
@@ -19,19 +20,28 @@ interface ItemShopFilteringProps {
   state: ItemShopFilteringState;
   defaultType: ItemType;
   restrictTypes?: ItemType[];
+  /** When true, item type is controlled elsewhere (e.g. shop tabs); omit Type from the filter popover. */
+  hideItemTypeField?: boolean;
+  /** Popover trigger button id (unique when several shops on one page). */
+  filterTriggerId?: string;
 }
 
-const makeItemShopSchema = (types: readonly string[]) =>
-  defineFilteringSchema({
+const makeItemShopSchema = (types: readonly string[], itemTypeDefault?: ItemType) => {
+  const first = (types[0] ?? "WEAPON") as ItemType;
+  const initialItemType =
+    itemTypeDefault && types.includes(itemTypeDefault) ? itemTypeDefault : first;
+  return defineFilteringSchema({
     fields: [
       {
         id: "itemType",
         label: "Type",
         type: "single-select",
-        defaultValue: types[0] ?? "WEAPON",
+        defaultValue: initialItemType,
         includeNone: false,
         emptyValues: [],
         options: types.map((t) => ({ value: t, label: t })),
+        visibleIf: (ctx) =>
+          !(ctx as { hideItemType?: boolean } | undefined)?.hideItemType,
       },
       { id: "name", label: "Name", type: "text", defaultValue: "" },
       {
@@ -82,17 +92,25 @@ const makeItemShopSchema = (types: readonly string[]) =>
       },
     ] as const,
   });
+};
 
 const ItemShopFiltering: React.FC<ItemShopFilteringProps> = (props) => {
-  let categories = Object.values(ItemTypes) as string[];
-  if (props.restrictTypes)
-    categories = categories.filter((t) => props.restrictTypes?.includes(t as ItemType));
-  const schema = makeItemShopSchema(categories);
+  const restrictKey = props.restrictTypes?.join() ?? "";
+  const schema = useMemo(() => {
+    let categories = Object.values(ItemTypes) as string[];
+    if (props.restrictTypes?.length) {
+      categories = categories.filter((t) =>
+        props.restrictTypes?.includes(t as ItemType),
+      );
+    }
+    return makeItemShopSchema(categories, props.defaultType);
+  }, [restrictKey, props.defaultType]);
   return (
     <ContentFiltering
       schema={schema}
       state={props.state.cf}
-      triggerButtonId="filter-item"
+      triggerButtonId={props.filterTriggerId ?? "filter-item"}
+      context={{ hideItemType: props.hideItemTypeField }}
     />
   );
 };
@@ -103,12 +121,11 @@ export const getShopFilter = (state: ItemShopFilteringState) =>
   buildFilter(state.cf, makeItemShopSchema(Object.values(ItemTypes)));
 
 export const useShopFiltering = (defaultType: ItemType) => {
-  const cf = useContentFiltering(makeItemShopSchema(Object.values(ItemTypes)));
-  if (!cf.values.itemType) {
-    (cf.setters.itemType as React.Dispatch<React.SetStateAction<ItemType>>)(
-      defaultType,
-    );
-  }
+  const schema = useMemo(
+    () => makeItemShopSchema(Object.values(ItemTypes), defaultType),
+    [defaultType],
+  );
+  const cf = useContentFiltering(schema);
   return {
     ...cf.values,
     cf,

--- a/app/src/layout/ItemShopFiltering.tsx
+++ b/app/src/layout/ItemShopFiltering.tsx
@@ -26,6 +26,8 @@ interface ItemShopFilteringProps {
   filterTriggerId?: string;
 }
 
+type ItemShopFilterContext = { hideItemType?: boolean };
+
 const makeItemShopSchema = (types: readonly string[], itemTypeDefault?: ItemType) => {
   const first = (types[0] ?? "WEAPON") as ItemType;
   const initialItemType =
@@ -40,8 +42,7 @@ const makeItemShopSchema = (types: readonly string[], itemTypeDefault?: ItemType
         includeNone: false,
         emptyValues: [],
         options: types.map((t) => ({ value: t, label: t })),
-        visibleIf: (ctx) =>
-          !(ctx as { hideItemType?: boolean } | undefined)?.hideItemType,
+        visibleIf: (ctx) => !(ctx as ItemShopFilterContext).hideItemType,
       },
       { id: "name", label: "Name", type: "text", defaultValue: "" },
       {

--- a/app/src/layout/Shop.tsx
+++ b/app/src/layout/Shop.tsx
@@ -1,3 +1,4 @@
+import type { LucideIcon } from "lucide-react";
 import {
   Check,
   CircleAlert,
@@ -26,7 +27,6 @@ import {
 } from "@/drizzle/constants";
 import type { Item, ItemType } from "@/drizzle/schema";
 import { useTutorialStep } from "@/hooks/tutorial";
-import { ActionSelector } from "@/layout/CombatActions";
 import ContentBox from "@/layout/ContentBox";
 import ContentImage from "@/layout/ContentImage";
 import Image from "@/layout/Image";
@@ -43,8 +43,20 @@ import { cn } from "@/libs/shadui";
 import { showMutationToast } from "@/libs/toast";
 import type { UserWithRelations } from "@/routers/profile";
 import { useAwake } from "@/utils/routing";
-import { capitalizeFirstLetter } from "@/utils/sanitize";
 import { getStrucBoost } from "@/utils/village";
+
+/** Optional overrides for the catalog UI (e.g. black market uses several at once). */
+export interface ShopCatalogOverrides {
+  heroTitle?: string;
+  heroDescription?: string;
+  heroBadge?: string;
+  searchId?: string;
+  /** `false` omits the catalog list wrapper id; string overrides. Default: tutorial-itemshop when not `eventItems`. */
+  listId?: string | false;
+  filterTriggerId?: string;
+  /** User-facing Seichi silver wording (`silver` on black market; default village: seichi). */
+  silverLabel?: "silver" | "seichi";
+}
 
 interface ShopProps {
   userData: NonNullable<UserWithRelations>;
@@ -59,42 +71,58 @@ interface ShopProps {
   minCost?: number;
   minRepsCost?: number;
   minSeichiSilverCost?: number;
-  /** Village item shop / souvenirs: auction-style floor layout, category tabs, card grid. */
-  useItemTypeTabs?: boolean;
-  /** When useItemTypeTabs: overrides hero headline (default: village / souvenir copy). */
-  catalogHeroTitle?: string;
-  catalogHeroDescription?: string;
-  catalogHeroBadgeCatalog?: string;
-  /** When useItemTypeTabs: id for search field + label (avoid duplicates if multiple shops on one page). */
-  catalogSearchId?: string;
-  /** Catalog list wrapper id; use `false` to omit (e.g. black market). Default village: tutorial-itemshop. */
-  catalogTutorialId?: string | false;
-  /** Id for the filter popover trigger when multiple shops share a page. */
-  filterPopoverTriggerId?: string;
-  /** User-facing label for Seichi silver (`silver` on black market, default village wording otherwise). */
-  seichiSilverUi?: "seichi" | "silver";
+  catalog?: ShopCatalogOverrides;
 }
+
+const SILVER_COPY = {
+  seichi: {
+    catalog: "seichi",
+    purchase: "seichi silver",
+    wallet: "Seichi Silver:",
+  },
+  silver: {
+    catalog: "silver",
+    purchase: "silver",
+    wallet: "Silver:",
+  },
+} as const;
+
+const SHOP_ITEM_TYPE_TAB_ICON: Partial<Record<ItemType, LucideIcon>> = {
+  WEAPON: Sword,
+  CONSUMABLE: FlaskConical,
+  ARMOR: Shield,
+  ACCESSORY: Sparkles,
+  MATERIAL: Package,
+  KEYSTONE: Gem,
+  CRYSTAL: Diamond,
+};
+
+const SHOP_ITEM_TYPE_TAB_HINT: Record<ItemType, string> = {
+  WEAPON: "Weapons — damage tags, stat scaling, and battle usage vary by piece.",
+  CONSUMABLE: "Consumables — scrolls, pills, and one-off tools for combat and travel.",
+  ARMOR: "Armor — defensive layers and resistances for your build.",
+  ACCESSORY: "Accessories — rings, charms, and extras that tweak your kit.",
+  MATERIAL: "Materials — crafting and upgrade components.",
+  KEYSTONE: "Keystones — slot upgrades and build-defining modifiers.",
+  CRYSTAL: "Crystals — special slot items and enhancements.",
+  OTHER: "Other — miscellaneous goods in stock.",
+};
+
+const SHOP_ITEM_TYPE_TAB_LABEL: Record<ItemType, string> = {
+  WEAPON: "Weapon",
+  CONSUMABLE: "Consumable",
+  ARMOR: "Armor",
+  ACCESSORY: "Accessory",
+  MATERIAL: "Material",
+  KEYSTONE: "Keystone",
+  CRYSTAL: "Crystal",
+  OTHER: "Other",
+};
 
 function categoryTabIcon(type: ItemType) {
   const cls = "h-4 w-4 shrink-0 opacity-90";
-  switch (type) {
-    case "WEAPON":
-      return <Sword className={cls} />;
-    case "CONSUMABLE":
-      return <FlaskConical className={cls} />;
-    case "ARMOR":
-      return <Shield className={cls} />;
-    case "ACCESSORY":
-      return <Sparkles className={cls} />;
-    case "MATERIAL":
-      return <Package className={cls} />;
-    case "KEYSTONE":
-      return <Gem className={cls} />;
-    case "CRYSTAL":
-      return <Diamond className={cls} />;
-    default:
-      return <LayoutGrid className={cls} />;
-  }
+  const Icon = SHOP_ITEM_TYPE_TAB_ICON[type] ?? LayoutGrid;
+  return <Icon className={cls} />;
 }
 
 function shopItemDiscountFactor(
@@ -149,7 +177,6 @@ function ShopCatalogCard({
             rarity={item.rarity ?? undefined}
             hideBorder
             className="h-full w-full max-h-full max-w-full object-contain"
-            onClick={onSelect}
           />
         </div>
       </div>
@@ -200,12 +227,9 @@ function ShopCatalogCard({
 }
 
 const Shop: React.FC<ShopProps> = (props) => {
-  const { userData, defaultType, minCost, minRepsCost, minSeichiSilverCost } = props;
-  const useModern = !!props.useItemTypeTabs;
-  const seichiUi = props.seichiSilverUi ?? "seichi";
-  const seichiCatalogWord = seichiUi === "silver" ? "silver" : "seichi";
-  const seichiPurchasePhrase = seichiUi === "silver" ? "silver" : "seichi silver";
-  const seichiWalletLabel = seichiUi === "silver" ? "Silver:" : "Seichi Silver:";
+  const { userData, defaultType, minCost, minRepsCost, minSeichiSilverCost, catalog } =
+    props;
+  const silverCopy = SILVER_COPY[catalog?.silverLabel ?? "seichi"];
 
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [item, setItem] = useState<Item | undefined>(undefined);
@@ -213,10 +237,7 @@ const Shop: React.FC<ShopProps> = (props) => {
   const filteringState = useShopFiltering(defaultType);
   const isAwake = useAwake(userData);
   const itemTypeTabOptions = useMemo(
-    () =>
-      (props.restrictTypes?.length
-        ? props.restrictTypes
-        : [...ItemTypes]) as ItemType[],
+    () => (props.restrictTypes?.length ? props.restrictTypes : ItemTypes) as ItemType[],
     [props.restrictTypes],
   );
 
@@ -236,6 +257,7 @@ const Shop: React.FC<ShopProps> = (props) => {
     },
     {
       enabled: userData !== undefined,
+      staleTime: Infinity,
       getNextPageParam: (lastPage) => lastPage.nextCursor,
       placeholderData: (previousData) => previousData,
     },
@@ -273,7 +295,9 @@ const Shop: React.FC<ShopProps> = (props) => {
   const hDiscount = item?.effects?.find((e) => e.type === "heal")
     ? MEDNIN_HEAL_ITEM_DISCOUNT_PERC
     : 0;
-  const factor = (100 - sDiscount - aDiscount - hDiscount) / 100;
+  const selectedItemFactor = item
+    ? shopItemDiscountFactor(item, sDiscount, aDiscount)
+    : 1;
 
   const discounts = [
     ...(sDiscount > 0 ? [{ label: "village structures", value: sDiscount }] : []),
@@ -282,7 +306,7 @@ const Shop: React.FC<ShopProps> = (props) => {
   ];
   const totalDiscount = discounts.reduce((acc, d) => acc + d.value, 0);
 
-  const ryoCost = Math.ceil((item?.cost ?? 0) * stacksize * factor);
+  const ryoCost = Math.ceil((item?.cost ?? 0) * stacksize * selectedItemFactor);
   const repsCost = Math.ceil((item?.repsCost ?? 0) * stacksize);
   const seichiSilverCost = Math.ceil((item?.seichiSilverCost ?? 0) * stacksize);
   const canAfford =
@@ -293,7 +317,7 @@ const Shop: React.FC<ShopProps> = (props) => {
     ...(ryoCost > 0 ? [`${ryoCost.toLocaleString()} ryo`] : []),
     ...(repsCost > 0 ? [`${repsCost.toLocaleString()} reputation points`] : []),
     ...(seichiSilverCost > 0
-      ? [`${seichiSilverCost.toLocaleString()} ${seichiPurchasePhrase}`]
+      ? [`${seichiSilverCost.toLocaleString()} ${silverCopy.purchase}`]
       : []),
   ];
   const missing = [
@@ -307,48 +331,31 @@ const Shop: React.FC<ShopProps> = (props) => {
       : []),
     ...(seichiSilverCost > userData.seichiSilver
       ? [
-          `${(seichiSilverCost - userData.seichiSilver).toLocaleString()} more ${seichiPurchasePhrase}`,
+          `${(seichiSilverCost - userData.seichiSilver).toLocaleString()} more ${silverCopy.purchase}`,
         ]
       : []),
   ];
   const costString = `Buy for ${costs.join(", ")}`;
   const missingString = `Need ${missing.join(", ")}`;
 
-  const catalogSearchId = props.catalogSearchId ?? "shop-catalog-search";
+  const catalogSearchId = catalog?.searchId ?? "shop-catalog-search";
   const catalogListDomId =
-    props.catalogTutorialId === false
+    catalog?.listId === false
       ? undefined
-      : (props.catalogTutorialId ??
-        (props.eventItems ? undefined : "tutorial-itemshop"));
+      : (catalog?.listId ?? (props.eventItems ? undefined : "tutorial-itemshop"));
 
   const catalogHeroTitle =
-    props.catalogHeroTitle ??
+    catalog?.heroTitle ??
     (props.eventItems ? "Souvenir counter" : "Village storefront");
   const catalogHeroDescription =
-    props.catalogHeroDescription ??
+    catalog?.heroDescription ??
     (props.eventItems
       ? "Limited-run goods for ryo. Use filters to narrow rarity and effects, then open a card to review and purchase."
       : "Open categories to browse village stock. Filters stack with search — your discounts apply at checkout.");
-  const catalogHeroBadgeCatalog =
-    props.catalogHeroBadgeCatalog ??
-    (props.eventItems ? "Event catalog" : "Village pricing");
+  const catalogHeroBadge =
+    catalog?.heroBadge ?? (props.eventItems ? "Event catalog" : "Village pricing");
 
-  const tabHint =
-    filteringState.itemType === "WEAPON"
-      ? "Weapons — damage tags, stat scaling, and battle usage vary by piece."
-      : filteringState.itemType === "CONSUMABLE"
-        ? "Consumables — scrolls, pills, and one-off tools for combat and travel."
-        : filteringState.itemType === "ARMOR"
-          ? "Armor — defensive layers and resistances for your build."
-          : filteringState.itemType === "ACCESSORY"
-            ? "Accessories — rings, charms, and extras that tweak your kit."
-            : filteringState.itemType === "MATERIAL"
-              ? "Materials — crafting and upgrade components."
-              : filteringState.itemType === "KEYSTONE"
-                ? "Keystones — slot upgrades and build-defining modifiers."
-                : filteringState.itemType === "CRYSTAL"
-                  ? "Crystals — special slot items and enhancements."
-                  : "Other — miscellaneous goods in stock.";
+  const tabHint = SHOP_ITEM_TYPE_TAB_HINT[filteringState.itemType];
 
   if (!isAwake) return <Loader explanation="Redirecting because not awake" />;
 
@@ -393,7 +400,7 @@ const Shop: React.FC<ShopProps> = (props) => {
             </div>
             {userData.seichiSilver > 0 && (
               <div className="flex justify-between">
-                <span>{seichiWalletLabel}</span>
+                <span>{silverCopy.wallet}</span>
                 <span className="font-mono">
                   {userData.seichiSilver.toLocaleString()}
                 </span>
@@ -451,9 +458,7 @@ const Shop: React.FC<ShopProps> = (props) => {
           title={props.title ?? "Item Shop"}
           subtitle={
             props.subtitle ??
-            (useModern
-              ? "Browse categories, search the catalog, then open a card to buy."
-              : "Buy items")
+            "Browse categories, search the catalog, then open a card to buy."
           }
           defaultBackHref={props.defaultBackHref}
           initialBreak={props.initialBreak}
@@ -464,8 +469,8 @@ const Shop: React.FC<ShopProps> = (props) => {
                 state={filteringState}
                 defaultType={defaultType}
                 restrictTypes={props.restrictTypes}
-                hideItemTypeField={useModern}
-                filterTriggerId={props.filterPopoverTriggerId}
+                hideItemTypeField
+                filterTriggerId={catalog?.filterTriggerId}
               />
             </div>
           }
@@ -481,7 +486,7 @@ const Shop: React.FC<ShopProps> = (props) => {
             />
           )}
 
-          {useModern && userData && (
+          {userData && (
             <>
               <div className="relative overflow-hidden border-b bg-linear-to-br from-amber-950/25 via-card to-card px-3 py-4 md:px-6 md:py-8">
                 <div className="pointer-events-none absolute -top-24 right-0 h-48 w-48 rounded-full bg-amber-500/10 blur-3xl" />
@@ -503,7 +508,7 @@ const Shop: React.FC<ShopProps> = (props) => {
                           className="gap-1 border-amber-500/25 bg-background/60 font-normal"
                         >
                           <Tag className="h-3 w-3" />
-                          {catalogHeroBadgeCatalog}
+                          {catalogHeroBadge}
                         </Badge>
                         <Badge
                           variant="secondary"
@@ -538,6 +543,7 @@ const Shop: React.FC<ShopProps> = (props) => {
                             : "text-muted-foreground hover:bg-background/60 hover:text-foreground",
                         )}
                         onClick={() => {
+                          if (filteringState.itemType === t) return;
                           filteringState.setItemType(t);
                           setItem(undefined);
                           setStacksize(1);
@@ -546,7 +552,7 @@ const Shop: React.FC<ShopProps> = (props) => {
                       >
                         {categoryTabIcon(t)}
                         <span className="text-center leading-tight">
-                          {capitalizeFirstLetter(t.toLowerCase())}
+                          {SHOP_ITEM_TYPE_TAB_LABEL[t]}
                         </span>
                       </button>
                     ))}
@@ -603,12 +609,13 @@ const Shop: React.FC<ShopProps> = (props) => {
                   <>
                     <ul className="mx-auto grid max-w-7xl list-none grid-cols-3 gap-1 sm:gap-2 md:grid-cols-4 md:gap-3 lg:grid-cols-6">
                       {allItems.map((row) => {
-                        const factor = shopItemDiscountFactor(
+                        const rowFactor = shopItemDiscountFactor(
                           row,
                           sDiscount,
                           aDiscount,
                         );
-                        const ryoDue = row.cost > 0 ? Math.ceil(row.cost * factor) : 0;
+                        const ryoDue =
+                          row.cost > 0 ? Math.ceil(row.cost * rowFactor) : 0;
                         const repsDue = Math.ceil(row.repsCost ?? 0);
                         const seichiDue = Math.ceil(row.seichiSilverCost ?? 0);
                         const canAffordRow =
@@ -620,9 +627,9 @@ const Shop: React.FC<ShopProps> = (props) => {
                             <ShopCatalogCard
                               item={row}
                               selected={item?.id === row.id}
-                              previewFactor={factor}
+                              previewFactor={rowFactor}
                               canAfford={canAffordRow}
-                              seichiCatalogWord={seichiCatalogWord}
+                              seichiCatalogWord={silverCopy.catalog}
                               onSelect={() => {
                                 if (item?.id === row.id) {
                                   setItem(undefined);
@@ -647,34 +654,6 @@ const Shop: React.FC<ShopProps> = (props) => {
                   </>
                 )}
               </div>
-            </>
-          )}
-
-          {!useModern && (
-            <>
-              {isFetching && <Loader explanation="Loading data" />}
-              {!isFetching && userData && (
-                <div className="p-2">
-                  <ActionSelector
-                    items={allItems}
-                    selectedId={item?.id}
-                    labelSingles={true}
-                    onClick={(id) => {
-                      if (id === item?.id) {
-                        setItem(undefined);
-                        setStacksize(1);
-                        setIsOpen(false);
-                      } else {
-                        setItem(allItems?.find((row) => row.id === id));
-                        setStacksize(1);
-                        setIsOpen(true);
-                      }
-                    }}
-                    showBgColor={false}
-                    showLabels={true}
-                  />
-                </div>
-              )}
             </>
           )}
 

--- a/app/src/layout/Shop.tsx
+++ b/app/src/layout/Shop.tsx
@@ -355,7 +355,8 @@ const Shop: React.FC<ShopProps> = (props) => {
   const catalogHeroBadge =
     catalog?.heroBadge ?? (props.eventItems ? "Event catalog" : "Village pricing");
 
-  const tabHint = SHOP_ITEM_TYPE_TAB_HINT[filteringState.itemType];
+  const selectedItemType = filteringState.itemType as ItemType;
+  const tabHint = SHOP_ITEM_TYPE_TAB_HINT[selectedItemType];
 
   if (!isAwake) return <Loader explanation="Redirecting because not awake" />;
 
@@ -535,15 +536,15 @@ const Shop: React.FC<ShopProps> = (props) => {
                         key={t}
                         type="button"
                         role="tab"
-                        aria-selected={filteringState.itemType === t}
+                        aria-selected={selectedItemType === t}
                         className={cn(
                           "flex flex-col items-center justify-center gap-0.5 rounded-md px-0.5 py-1.5 font-semibold text-[10px] transition-all sm:flex-row sm:gap-2 sm:rounded-lg sm:px-1 sm:py-3 sm:text-xs",
-                          filteringState.itemType === t
+                          selectedItemType === t
                             ? "bg-background text-foreground shadow-sm ring-1 ring-border/60"
                             : "text-muted-foreground hover:bg-background/60 hover:text-foreground",
                         )}
                         onClick={() => {
-                          if (filteringState.itemType === t) return;
+                          if (selectedItemType === t) return;
                           filteringState.setItemType(t);
                           setItem(undefined);
                           setStacksize(1);

--- a/app/src/layout/Shop.tsx
+++ b/app/src/layout/Shop.tsx
@@ -119,6 +119,8 @@ const SHOP_ITEM_TYPE_TAB_LABEL: Record<ItemType, string> = {
   OTHER: "Other",
 };
 
+const MIN_ITEM_SHOP_DISCOUNT_FACTOR = 0.05;
+
 function categoryTabIcon(type: ItemType) {
   const cls = "h-4 w-4 shrink-0 opacity-90";
   const Icon = SHOP_ITEM_TYPE_TAB_ICON[type] ?? LayoutGrid;
@@ -133,7 +135,10 @@ function shopItemDiscountFactor(
   const healDiscount = item.effects.some((e) => e.type === "heal")
     ? MEDNIN_HEAL_ITEM_DISCOUNT_PERC
     : 0;
-  return (100 - structureDiscountPerc - anbuDiscountPerc - healDiscount) / 100;
+  return Math.max(
+    MIN_ITEM_SHOP_DISCOUNT_FACTOR,
+    (100 - structureDiscountPerc - anbuDiscountPerc - healDiscount) / 100,
+  );
 }
 
 function ShopCatalogCard({

--- a/app/src/layout/Shop.tsx
+++ b/app/src/layout/Shop.tsx
@@ -1,13 +1,34 @@
-import { useState } from "react";
+import {
+  Check,
+  CircleAlert,
+  Diamond,
+  FlaskConical,
+  Gem,
+  LayoutGrid,
+  Package,
+  Search,
+  Shield,
+  ShoppingBag,
+  Sparkles,
+  Sword,
+  Tag,
+  Ticket,
+} from "lucide-react";
+import { useMemo, useState } from "react";
 import { api } from "@/app/_trpc/client";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   ANBU_ITEMSHOP_DISCOUNT_PERC,
+  ItemTypes,
   MEDNIN_HEAL_ITEM_DISCOUNT_PERC,
 } from "@/drizzle/constants";
 import type { Item, ItemType } from "@/drizzle/schema";
 import { useTutorialStep } from "@/hooks/tutorial";
 import { ActionSelector } from "@/layout/CombatActions";
 import ContentBox from "@/layout/ContentBox";
+import ContentImage from "@/layout/ContentImage";
 import Image from "@/layout/Image";
 import {
   getShopFilter,
@@ -18,9 +39,11 @@ import ItemWithEffects from "@/layout/ItemWithEffects";
 import Loader from "@/layout/Loader";
 import Modal2 from "@/layout/Modal2";
 import { UncontrolledSliderField } from "@/layout/SliderField";
+import { cn } from "@/libs/shadui";
 import { showMutationToast } from "@/libs/toast";
 import type { UserWithRelations } from "@/routers/profile";
 import { useAwake } from "@/utils/routing";
+import { capitalizeFirstLetter } from "@/utils/sanitize";
 import { getStrucBoost } from "@/utils/village";
 
 interface ShopProps {
@@ -36,23 +59,169 @@ interface ShopProps {
   minCost?: number;
   minRepsCost?: number;
   minSeichiSilverCost?: number;
+  /** Village item shop / souvenirs: auction-style floor layout, category tabs, card grid. */
+  useItemTypeTabs?: boolean;
+  /** When useItemTypeTabs: overrides hero headline (default: village / souvenir copy). */
+  catalogHeroTitle?: string;
+  catalogHeroDescription?: string;
+  catalogHeroBadgeCatalog?: string;
+  /** When useItemTypeTabs: id for search field + label (avoid duplicates if multiple shops on one page). */
+  catalogSearchId?: string;
+  /** Catalog list wrapper id; use `false` to omit (e.g. black market). Default village: tutorial-itemshop. */
+  catalogTutorialId?: string | false;
+  /** Id for the filter popover trigger when multiple shops share a page. */
+  filterPopoverTriggerId?: string;
+  /** User-facing label for Seichi silver (`silver` on black market, default village wording otherwise). */
+  seichiSilverUi?: "seichi" | "silver";
+}
+
+function categoryTabIcon(type: ItemType) {
+  const cls = "h-4 w-4 shrink-0 opacity-90";
+  switch (type) {
+    case "WEAPON":
+      return <Sword className={cls} />;
+    case "CONSUMABLE":
+      return <FlaskConical className={cls} />;
+    case "ARMOR":
+      return <Shield className={cls} />;
+    case "ACCESSORY":
+      return <Sparkles className={cls} />;
+    case "MATERIAL":
+      return <Package className={cls} />;
+    case "KEYSTONE":
+      return <Gem className={cls} />;
+    case "CRYSTAL":
+      return <Diamond className={cls} />;
+    default:
+      return <LayoutGrid className={cls} />;
+  }
+}
+
+function shopItemDiscountFactor(
+  item: Item,
+  structureDiscountPerc: number,
+  anbuDiscountPerc: number,
+) {
+  const healDiscount = item.effects.some((e) => e.type === "heal")
+    ? MEDNIN_HEAL_ITEM_DISCOUNT_PERC
+    : 0;
+  return (100 - structureDiscountPerc - anbuDiscountPerc - healDiscount) / 100;
+}
+
+function ShopCatalogCard({
+  item,
+  selected,
+  onSelect,
+  previewFactor,
+  canAfford,
+  seichiCatalogWord,
+}: {
+  item: Item;
+  selected: boolean;
+  onSelect: () => void;
+  previewFactor: number;
+  canAfford: boolean;
+  seichiCatalogWord: string;
+}) {
+  const ryo = item.cost > 0 ? Math.ceil(item.cost * previewFactor) : null;
+  const lineParts = [
+    ryo !== null ? `${ryo.toLocaleString()} ryo` : null,
+    item.repsCost > 0 ? `${item.repsCost.toLocaleString()} rep` : null,
+    item.seichiSilverCost > 0
+      ? `${item.seichiSilverCost.toLocaleString()} ${seichiCatalogWord}`
+      : null,
+  ].filter(Boolean);
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        "flex h-full min-h-0 w-full flex-col overflow-hidden rounded-lg border bg-card text-center shadow-sm transition-colors sm:rounded-xl",
+        selected ? "border-primary bg-muted/40" : "border-border hover:bg-muted/30",
+      )}
+    >
+      <div className="flex shrink-0 items-center justify-center px-1.5 pt-1.5 pb-1 sm:px-3 sm:pt-3 sm:pb-2">
+        <div className="relative aspect-square size-16 shrink-0 overflow-hidden rounded border border-border/70 bg-muted/20 sm:size-28 sm:rounded-md lg:size-32">
+          <ContentImage
+            image={item.image}
+            alt={item.name}
+            rarity={item.rarity ?? undefined}
+            hideBorder
+            className="h-full w-full max-h-full max-w-full object-contain"
+            onClick={onSelect}
+          />
+        </div>
+      </div>
+      <div className="flex min-h-0 w-full flex-1 flex-col gap-1 border-border border-t px-1.5 pt-1.5 pb-2 sm:px-2.5 sm:pt-2.5 sm:pb-3">
+        <div className="min-h-0 min-w-0 flex-1 text-balance">
+          <p className="text-[11px] font-semibold leading-tight break-words sm:text-sm">
+            {item.name}
+          </p>
+          {lineParts.length > 0 ? (
+            <p className="mt-0.5 text-[9px] text-muted-foreground sm:text-xs">
+              {lineParts.join(" · ")}
+            </p>
+          ) : (
+            <p className="mt-0.5 text-[9px] text-muted-foreground sm:text-xs">
+              Tap for details
+            </p>
+          )}
+        </div>
+        <div
+          className={cn(
+            "-mx-1.5 flex shrink-0 items-center justify-center gap-0.5 rounded px-1.5 py-0.5 font-medium text-[9px] sm:-mx-2.5 sm:gap-1 sm:rounded-md sm:px-2.5 sm:py-1 sm:text-[11px]",
+            canAfford
+              ? "bg-emerald-500/15 text-emerald-900 ring-1 ring-inset ring-emerald-600/30 dark:bg-emerald-500/20 dark:text-emerald-50 dark:ring-emerald-400/35"
+              : "bg-destructive/10 text-destructive",
+          )}
+        >
+          {canAfford ? (
+            <>
+              <Check
+                className="h-2.5 w-2.5 shrink-0 opacity-90 sm:h-3 sm:w-3"
+                aria-hidden
+              />
+              <span>Afford</span>
+            </>
+          ) : (
+            <>
+              <CircleAlert
+                className="h-2.5 w-2.5 shrink-0 opacity-90 sm:h-3 sm:w-3"
+                aria-hidden
+              />
+              <span>Can't afford</span>
+            </>
+          )}
+        </div>
+      </div>
+    </button>
+  );
 }
 
 const Shop: React.FC<ShopProps> = (props) => {
-  // Destructure
   const { userData, defaultType, minCost, minRepsCost, minSeichiSilverCost } = props;
+  const useModern = !!props.useItemTypeTabs;
+  const seichiUi = props.seichiSilverUi ?? "seichi";
+  const seichiCatalogWord = seichiUi === "silver" ? "silver" : "seichi";
+  const seichiPurchasePhrase = seichiUi === "silver" ? "silver" : "seichi silver";
+  const seichiWalletLabel = seichiUi === "silver" ? "Silver:" : "Seichi Silver:";
 
-  // Settings
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [item, setItem] = useState<Item | undefined>(undefined);
   const [stacksize, setStacksize] = useState<number>(1);
   const filteringState = useShopFiltering(defaultType);
   const isAwake = useAwake(userData);
+  const itemTypeTabOptions = useMemo(
+    () =>
+      (props.restrictTypes?.length
+        ? props.restrictTypes
+        : [...ItemTypes]) as ItemType[],
+    [props.restrictTypes],
+  );
 
-  // tRPC Utility
   const utils = api.useUtils();
 
-  // Data
   const { data: items, isFetching } = api.item.getAll.useInfiniteQuery(
     {
       minCost,
@@ -74,14 +243,11 @@ const Shop: React.FC<ShopProps> = (props) => {
   const allItems = items?.pages
     .flatMap((page) => page.data)
     .filter(
-      (item) =>
-        !item.expireFromStoreAt || new Date(item.expireFromStoreAt) > new Date(),
+      (row) => !row.expireFromStoreAt || new Date(row.expireFromStoreAt) > new Date(),
     );
 
-  // Tutorial hook
   const { currentStep, handleNextStep } = useTutorialStep();
 
-  // Mutations
   const { mutate: purchase, isPending: isPurchasing } = api.item.buy.useMutation({
     onSuccess: (data) => {
       showMutationToast(data);
@@ -98,10 +264,10 @@ const Shop: React.FC<ShopProps> = (props) => {
       document.body.style.cursor = "default";
       setIsOpen(false);
       setItem(undefined);
+      setStacksize(1);
     },
   });
 
-  // Discount factors
   const sDiscount = getStrucBoost("itemDiscountPerLvl", userData.village?.structures);
   const aDiscount = userData.anbuId ? ANBU_ITEMSHOP_DISCOUNT_PERC : 0;
   const hDiscount = item?.effects?.find((e) => e.type === "heal")
@@ -109,7 +275,6 @@ const Shop: React.FC<ShopProps> = (props) => {
     : 0;
   const factor = (100 - sDiscount - aDiscount - hDiscount) / 100;
 
-  // Collect discount information for UI
   const discounts = [
     ...(sDiscount > 0 ? [{ label: "village structures", value: sDiscount }] : []),
     ...(aDiscount > 0 ? [{ label: "ANBU membership", value: aDiscount }] : []),
@@ -117,7 +282,6 @@ const Shop: React.FC<ShopProps> = (props) => {
   ];
   const totalDiscount = discounts.reduce((acc, d) => acc + d.value, 0);
 
-  // Can user afford selected item
   const ryoCost = Math.ceil((item?.cost ?? 0) * stacksize * factor);
   const repsCost = Math.ceil((item?.repsCost ?? 0) * stacksize);
   const seichiSilverCost = Math.ceil((item?.seichiSilverCost ?? 0) * stacksize);
@@ -129,7 +293,7 @@ const Shop: React.FC<ShopProps> = (props) => {
     ...(ryoCost > 0 ? [`${ryoCost.toLocaleString()} ryo`] : []),
     ...(repsCost > 0 ? [`${repsCost.toLocaleString()} reputation points`] : []),
     ...(seichiSilverCost > 0
-      ? [`${seichiSilverCost.toLocaleString()} seichi silver`]
+      ? [`${seichiSilverCost.toLocaleString()} ${seichiPurchasePhrase}`]
       : []),
   ];
   const missing = [
@@ -143,32 +307,165 @@ const Shop: React.FC<ShopProps> = (props) => {
       : []),
     ...(seichiSilverCost > userData.seichiSilver
       ? [
-          `${(seichiSilverCost - userData.seichiSilver).toLocaleString()} more seichi silver`,
+          `${(seichiSilverCost - userData.seichiSilver).toLocaleString()} more ${seichiPurchasePhrase}`,
         ]
       : []),
   ];
-  // Simple cost string for the purchase button
   const costString = `Buy for ${costs.join(", ")}`;
   const missingString = `Need ${missing.join(", ")}`;
 
-  // Show loaders
+  const catalogSearchId = props.catalogSearchId ?? "shop-catalog-search";
+  const catalogListDomId =
+    props.catalogTutorialId === false
+      ? undefined
+      : (props.catalogTutorialId ??
+        (props.eventItems ? undefined : "tutorial-itemshop"));
+
+  const catalogHeroTitle =
+    props.catalogHeroTitle ??
+    (props.eventItems ? "Souvenir counter" : "Village storefront");
+  const catalogHeroDescription =
+    props.catalogHeroDescription ??
+    (props.eventItems
+      ? "Limited-run goods for ryo. Use filters to narrow rarity and effects, then open a card to review and purchase."
+      : "Open categories to browse village stock. Filters stack with search — your discounts apply at checkout.");
+  const catalogHeroBadgeCatalog =
+    props.catalogHeroBadgeCatalog ??
+    (props.eventItems ? "Event catalog" : "Village pricing");
+
+  const tabHint =
+    filteringState.itemType === "WEAPON"
+      ? "Weapons — damage tags, stat scaling, and battle usage vary by piece."
+      : filteringState.itemType === "CONSUMABLE"
+        ? "Consumables — scrolls, pills, and one-off tools for combat and travel."
+        : filteringState.itemType === "ARMOR"
+          ? "Armor — defensive layers and resistances for your build."
+          : filteringState.itemType === "ACCESSORY"
+            ? "Accessories — rings, charms, and extras that tweak your kit."
+            : filteringState.itemType === "MATERIAL"
+              ? "Materials — crafting and upgrade components."
+              : filteringState.itemType === "KEYSTONE"
+                ? "Keystones — slot upgrades and build-defining modifiers."
+                : filteringState.itemType === "CRYSTAL"
+                  ? "Crystals — special slot items and enhancements."
+                  : "Other — miscellaneous goods in stock.";
+
   if (!isAwake) return <Loader explanation="Redirecting because not awake" />;
+
+  const purchaseModal = userData && isOpen && item && (
+    <Modal2
+      id="tutorial-itemshop-confirmPurchase"
+      title="Confirm Purchase"
+      proceed_label={isPurchasing ? undefined : canAfford ? costString : missingString}
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
+      isValid={false}
+      onAccept={() => {
+        if (canAfford) {
+          purchase({
+            itemId: item.id,
+            stack: stacksize,
+            villageId: userData.villageId,
+          });
+        } else {
+          setIsOpen(false);
+        }
+      }}
+      confirmClassName={
+        canAfford
+          ? "bg-blue-600 text-white hover:bg-blue-700"
+          : "bg-red-600 text-white hover:bg-red-700"
+      }
+    >
+      <div className="grid grid-cols-2 gap-2 pb-3">
+        <div className="rounded-lg bg-slate-100 p-3 dark:bg-slate-800">
+          <h4 className="mb-2 font-semibold text-sm">Your Currency</h4>
+          <div className="grid grid-cols-1 gap-1 text-sm">
+            <div className="flex justify-between">
+              <span>Ryo:</span>
+              <span className="font-mono">{userData.money.toLocaleString()}</span>
+            </div>
+            <div className="flex justify-between">
+              <span>Reputation Points:</span>
+              <span className="font-mono">
+                {userData.reputationPoints.toLocaleString()}
+              </span>
+            </div>
+            {userData.seichiSilver > 0 && (
+              <div className="flex justify-between">
+                <span>{seichiWalletLabel}</span>
+                <span className="font-mono">
+                  {userData.seichiSilver.toLocaleString()}
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+        {discounts.length > 0 && (
+          <div className="rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-800 dark:bg-green-900/20">
+            <h4 className="mb-2 font-semibold text-green-800 text-sm dark:text-green-200">
+              Active Discounts ({totalDiscount}% total)
+            </h4>
+            <div className="space-y-1 text-sm">
+              {discounts.map((discount) => (
+                <div
+                  key={discount.label}
+                  className="flex justify-between text-green-700 dark:text-green-300"
+                >
+                  <span className="capitalize">{discount.label}:</span>
+                  <span className="font-mono">{discount.value}%</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+      {!isPurchasing && (
+        <>
+          <ItemWithEffects
+            item={item}
+            key={item.id}
+            showEdit="item"
+            showStatistic="item"
+          />
+          {item.canStack && item.stackSize > 1 ? (
+            <UncontrolledSliderField
+              id="stackSize"
+              label={`How many to buy: ${stacksize}`}
+              value={stacksize}
+              min={1}
+              max={item.stackSize}
+              setValue={setStacksize}
+            />
+          ) : undefined}
+        </>
+      )}
+      {isPurchasing && <Loader explanation={`Purchasing ${item.name}`} />}
+    </Modal2>
+  );
 
   return (
     <>
       {isAwake && (
         <ContentBox
           title={props.title ?? "Item Shop"}
-          subtitle={props.subtitle ?? "Buy items"}
+          subtitle={
+            props.subtitle ??
+            (useModern
+              ? "Browse categories, search the catalog, then open a card to buy."
+              : "Buy items")
+          }
           defaultBackHref={props.defaultBackHref}
           initialBreak={props.initialBreak}
           padding={false}
           topRightContent={
-            <div className="flex flex-row gap-2">
+            <div className="flex flex-row flex-wrap items-center justify-end gap-2">
               <ItemShopFiltering
                 state={filteringState}
                 defaultType={defaultType}
                 restrictTypes={props.restrictTypes}
+                hideItemTypeField={useModern}
+                filterTriggerId={props.filterPopoverTriggerId}
               />
             </div>
           }
@@ -183,122 +480,205 @@ const Shop: React.FC<ShopProps> = (props) => {
               priority={true}
             />
           )}
-          {isFetching && <Loader explanation="Loading data" />}
-          {!isFetching && userData && (
-            <div className="p-2">
-              <ActionSelector
-                items={allItems}
-                selectedId={item?.id}
-                labelSingles={true}
-                onClick={(id) => {
-                  if (id === item?.id) {
-                    setItem(undefined);
-                    setIsOpen(false);
-                  } else {
-                    setItem(allItems?.find((item) => item.id === id));
-                    setIsOpen(true);
-                  }
-                }}
-                showBgColor={false}
-                showLabels={true}
-              />
-              {isOpen && item && (
-                <Modal2
-                  id="tutorial-itemshop-confirmPurchase"
-                  title="Confirm Purchase"
-                  proceed_label={
-                    isPurchasing ? undefined : canAfford ? costString : missingString
-                  }
-                  isOpen={isOpen}
-                  setIsOpen={setIsOpen}
-                  isValid={false}
-                  onAccept={() => {
-                    if (canAfford) {
-                      purchase({
-                        itemId: item.id,
-                        stack: stacksize,
-                        villageId: userData.villageId,
-                      });
-                    } else {
-                      setIsOpen(false);
-                    }
-                  }}
-                  confirmClassName={
-                    canAfford
-                      ? "bg-blue-600 text-white hover:bg-blue-700"
-                      : "bg-red-600 text-white hover:bg-red-700"
-                  }
-                >
-                  <div className="grid grid-cols-2 gap-2 pb-3">
-                    <div className="rounded-lg bg-slate-100 p-3 dark:bg-slate-800">
-                      <h4 className="mb-2 font-semibold text-sm">Your Currency</h4>
-                      <div className="grid grid-cols-1 gap-1 text-sm">
-                        <div className="flex justify-between">
-                          <span>Ryo:</span>
-                          <span className="font-mono">
-                            {userData.money.toLocaleString()}
-                          </span>
-                        </div>
-                        <div className="flex justify-between">
-                          <span>Reputation Points:</span>
-                          <span className="font-mono">
-                            {userData.reputationPoints.toLocaleString()}
-                          </span>
-                        </div>
-                        {userData.seichiSilver > 0 && (
-                          <div className="flex justify-between">
-                            <span>Seichi Silver:</span>
-                            <span className="font-mono">
-                              {userData.seichiSilver.toLocaleString()}
-                            </span>
-                          </div>
-                        )}
+
+          {useModern && userData && (
+            <>
+              <div className="relative overflow-hidden border-b bg-linear-to-br from-amber-950/25 via-card to-card px-3 py-4 md:px-6 md:py-8">
+                <div className="pointer-events-none absolute -top-24 right-0 h-48 w-48 rounded-full bg-amber-500/10 blur-3xl" />
+                <div className="relative flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                  <div className="flex items-start gap-3">
+                    <div className="rounded-xl bg-amber-500/15 p-3 ring-1 ring-amber-500/35">
+                      <ShoppingBag className="h-7 w-7 text-amber-700 dark:text-amber-400" />
+                    </div>
+                    <div className="space-y-1">
+                      <p className="font-semibold text-lg tracking-tight md:text-xl">
+                        {catalogHeroTitle}
+                      </p>
+                      <p className="max-w-xl text-muted-foreground text-sm leading-relaxed">
+                        {catalogHeroDescription}
+                      </p>
+                      <div className="flex flex-wrap gap-2 pt-1">
+                        <Badge
+                          variant="secondary"
+                          className="gap-1 border-amber-500/25 bg-background/60 font-normal"
+                        >
+                          <Tag className="h-3 w-3" />
+                          {catalogHeroBadgeCatalog}
+                        </Badge>
+                        <Badge
+                          variant="secondary"
+                          className="gap-1 border-amber-500/25 bg-background/60 font-normal"
+                        >
+                          <Ticket className="h-3 w-3" />
+                          Tap a card to buy
+                        </Badge>
                       </div>
                     </div>
-                    {discounts.length > 0 && (
-                      <div className="rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-800 dark:bg-green-900/20">
-                        <h4 className="mb-2 font-semibold text-green-800 text-sm dark:text-green-200">
-                          Active Discounts ({totalDiscount}% total)
-                        </h4>
-                        <div className="space-y-1 text-sm">
-                          {discounts.map((discount) => (
-                            <div
-                              key={discount.label}
-                              className="flex justify-between text-green-700 dark:text-green-300"
-                            >
-                              <span className="capitalize">{discount.label}:</span>
-                              <span className="font-mono">{discount.value}%</span>
-                            </div>
-                          ))}
-                        </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="border-b bg-linear-to-b from-amber-950/10 to-muted/30 px-2 py-3 md:px-6 md:py-4">
+                <div className="mx-auto flex max-w-5xl flex-col gap-1.5 sm:gap-2">
+                  <div
+                    className="grid grid-cols-4 gap-0.5 rounded-lg bg-muted/90 p-0.5 shadow-inner ring-1 ring-border/50 sm:grid-cols-4 sm:gap-1 sm:rounded-xl sm:p-1 lg:grid-cols-8 dark:bg-muted/40"
+                    role="tablist"
+                    aria-label="Item category"
+                  >
+                    {itemTypeTabOptions.map((t) => (
+                      <button
+                        key={t}
+                        type="button"
+                        role="tab"
+                        aria-selected={filteringState.itemType === t}
+                        className={cn(
+                          "flex flex-col items-center justify-center gap-0.5 rounded-md px-0.5 py-1.5 font-semibold text-[10px] transition-all sm:flex-row sm:gap-2 sm:rounded-lg sm:px-1 sm:py-3 sm:text-xs",
+                          filteringState.itemType === t
+                            ? "bg-background text-foreground shadow-sm ring-1 ring-border/60"
+                            : "text-muted-foreground hover:bg-background/60 hover:text-foreground",
+                        )}
+                        onClick={() => {
+                          filteringState.setItemType(t);
+                          setItem(undefined);
+                          setStacksize(1);
+                          setIsOpen(false);
+                        }}
+                      >
+                        {categoryTabIcon(t)}
+                        <span className="text-center leading-tight">
+                          {capitalizeFirstLetter(t.toLowerCase())}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                  <p className="text-balance text-center text-[11px] text-muted-foreground leading-relaxed sm:text-xs">
+                    {tabHint}
+                  </p>
+                </div>
+              </div>
+
+              <div className="border-b bg-muted/25 px-2 py-3 md:px-5 md:py-4">
+                <div className="mx-auto flex max-w-5xl flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+                  <div className="min-w-0 flex-1">
+                    <Label
+                      htmlFor={catalogSearchId}
+                      className="text-muted-foreground text-xs uppercase"
+                    >
+                      Search catalog
+                    </Label>
+                    <div className="relative mt-1">
+                      <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                      <Input
+                        id={catalogSearchId}
+                        placeholder="Search by item name…"
+                        value={filteringState.name}
+                        onChange={(e) => filteringState.setName(e.target.value)}
+                        className="h-11 rounded-xl border-border/80 bg-background pl-10 shadow-sm"
+                      />
+                    </div>
+                  </div>
+                  <p className="text-muted-foreground text-xs lg:max-w-xs lg:text-right">
+                    More filters (rarity, slot, effects, …) stay in the filter button
+                    above.
+                  </p>
+                </div>
+              </div>
+
+              <div className="px-1.5 py-2 sm:px-3 sm:py-3 md:p-5" id={catalogListDomId}>
+                {isFetching && !allItems?.length ? (
+                  <div className="flex min-h-[40vh] items-center justify-center">
+                    <Loader explanation="Loading catalog…" />
+                  </div>
+                ) : !allItems?.length ? (
+                  <div className="flex min-h-[36vh] flex-col items-center justify-center rounded-2xl border border-dashed bg-muted/20 px-6 py-16 text-center">
+                    <ShoppingBag className="mb-3 h-12 w-12 text-muted-foreground opacity-60" />
+                    <p className="font-medium text-lg">No items match your filters</p>
+                    <p className="mt-1 max-w-sm text-muted-foreground text-sm">
+                      {filteringState.name.trim()
+                        ? "Try clearing the name search or opening the filter panel to reset rarity, slot, or effects."
+                        : "Try another category tab or widen filters in the panel above."}
+                    </p>
+                  </div>
+                ) : (
+                  <>
+                    <ul className="mx-auto grid max-w-7xl list-none grid-cols-3 gap-1 sm:gap-2 md:grid-cols-4 md:gap-3 lg:grid-cols-6">
+                      {allItems.map((row) => {
+                        const factor = shopItemDiscountFactor(
+                          row,
+                          sDiscount,
+                          aDiscount,
+                        );
+                        const ryoDue = row.cost > 0 ? Math.ceil(row.cost * factor) : 0;
+                        const repsDue = Math.ceil(row.repsCost ?? 0);
+                        const seichiDue = Math.ceil(row.seichiSilverCost ?? 0);
+                        const canAffordRow =
+                          userData.money >= ryoDue &&
+                          userData.reputationPoints >= repsDue &&
+                          userData.seichiSilver >= seichiDue;
+                        return (
+                          <li key={row.id} className="h-full min-h-0 min-w-0">
+                            <ShopCatalogCard
+                              item={row}
+                              selected={item?.id === row.id}
+                              previewFactor={factor}
+                              canAfford={canAffordRow}
+                              seichiCatalogWord={seichiCatalogWord}
+                              onSelect={() => {
+                                if (item?.id === row.id) {
+                                  setItem(undefined);
+                                  setStacksize(1);
+                                  setIsOpen(false);
+                                } else {
+                                  setItem(row);
+                                  setStacksize(1);
+                                  setIsOpen(true);
+                                }
+                              }}
+                            />
+                          </li>
+                        );
+                      })}
+                    </ul>
+                    {isFetching && allItems.length > 0 && (
+                      <div className="flex justify-center py-8">
+                        <Loader explanation="Updating catalog…" />
                       </div>
                     )}
-                  </div>
-                  {!isPurchasing && (
-                    <>
-                      <ItemWithEffects
-                        item={item}
-                        key={item.id}
-                        showEdit="item"
-                        showStatistic="item"
-                      />
-                      {item.canStack && item.stackSize > 1 ? (
-                        <UncontrolledSliderField
-                          id="stackSize"
-                          label={`How many to buy: ${stacksize}`}
-                          value={stacksize}
-                          min={1}
-                          max={item.stackSize}
-                          setValue={setStacksize}
-                        />
-                      ) : undefined}
-                    </>
-                  )}
-                  {isPurchasing && <Loader explanation={`Purchasing ${item.name}`} />}
-                </Modal2>
-              )}
-            </div>
+                  </>
+                )}
+              </div>
+            </>
           )}
+
+          {!useModern && (
+            <>
+              {isFetching && <Loader explanation="Loading data" />}
+              {!isFetching && userData && (
+                <div className="p-2">
+                  <ActionSelector
+                    items={allItems}
+                    selectedId={item?.id}
+                    labelSingles={true}
+                    onClick={(id) => {
+                      if (id === item?.id) {
+                        setItem(undefined);
+                        setStacksize(1);
+                        setIsOpen(false);
+                      } else {
+                        setItem(allItems?.find((row) => row.id === id));
+                        setStacksize(1);
+                        setIsOpen(true);
+                      }
+                    }}
+                    showBgColor={false}
+                    showLabels={true}
+                  />
+                </div>
+              )}
+            </>
+          )}
+
+          {purchaseModal}
         </ContentBox>
       )}
     </>

--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -69,6 +69,8 @@ import type { PostProcessedRewards } from "@/validators/rewards";
 import { ObjectiveReward, type ObjectiveRewardType } from "@/validators/rewards";
 import { updateRewards } from "./quests";
 
+const MIN_ITEM_SHOP_DISCOUNT_FACTOR = 0.05;
+
 export const itemRouter = createTRPCRouter({
   getAllNames: publicProcedure
     .meta({ mcp: { enabled: true, description: "Get all item names and images" } })
@@ -1433,7 +1435,10 @@ export const itemRouter = createTRPCRouter({
       const hDiscount = info?.effects.find((e) => e.type === "heal")
         ? MEDNIN_HEAL_ITEM_DISCOUNT_PERC
         : 0;
-      const factor = (100 - sDiscount - aDiscount - hDiscount) / 100;
+      const factor = Math.max(
+        MIN_ITEM_SHOP_DISCOUNT_FACTOR,
+        (100 - sDiscount - aDiscount - hDiscount) / 100,
+      );
       // Guard
       if (user.villageId !== input.villageId) return errorResponse("Wrong village");
       if (!info) return errorResponse("Item not found");


### PR DESCRIPTION
# Pull Request

Changes:
- Better modernizes the item shop, souvenir shop, and the blackmarket item shop

**Important note**
I checked the tutorial, and you are still able to proceed through the item shop segment with this update.  While it tells you to buy the shuriken, it doesn't not point at it for you like it does other steps, I'm not sure if that was already the case for it or not.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modern catalog UI with category tabs, card-based browsing, hero text/badges and per-shop catalog search/list controls
  * Dedicated catalog search and filter trigger for quicker item discovery
  * Affordability badges on item cards and clearer shop naming/description (Seichi → Silver where applicable)

* **Improvements**
  * Improved filtering defaults and option to hide item-type selector
  * Purchase quantity resets when switching or settling items; clearer loading/empty/update catalog messages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->