### PR TITLE
Apply new damage formula

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -2523,7 +2523,29 @@ export const DMG_EP_NORMALIZATION = 40; // Standard EP for normalization
 export const DMG_GEN_WEIGHT = 2.0; // Weight multiplier for general stats in advantage calc
 export const DMG_ADVANTAGE_MIN = 0.01; // Minimum advantage modifier (prevents zero damage)
 export const DMG_ADVANTAGE_MAX = 10.0; // Maximum advantage modifier (prevents extreme damage spikes)
-export const DMG_REDUCTION_CAP = 0.8; // Max fraction damage can be reduced by (80% cap, so 20% always gets through)
+export const DMG_REDUCTION_CAP = 0.9; // Max fraction damage can be reduced by (90% cap, so 10% always gets through)
+export const OUT_OF_COMBAT_BASE_DAMAGE_INCREASE = 60; // Percentage points added to pre-battle damage increase pool
+export const OUT_OF_COMBAT_BASE_DAMAGE_REDUCTION = 50; // Percentage points added to pre-battle DR pool
+
+/** Armor/accessory folded into early pre-battle inc/DR pools in the damage pipeline. */
+export const preBattleGearFromTypes = ["armor", "accessory"] as const;
+export type PreBattleGearFromType = (typeof preBattleGearFromTypes)[number];
+
+/** Keystone % damage mods are consolidated at battle start but applied pre-bloodline. */
+export const preBattleKeystoneFromTypes = ["keystone"] as const;
+export type PreBattleKeystoneFromType = (typeof preBattleKeystoneFromTypes)[number];
+
+export const isPreBattleGearFromType = (
+  fromType?: string,
+): fromType is PreBattleGearFromType =>
+  fromType !== undefined &&
+  (preBattleGearFromTypes as readonly string[]).includes(fromType);
+
+export const isPreBattleKeystoneFromType = (
+  fromType?: string,
+): fromType is PreBattleKeystoneFromType =>
+  fromType !== undefined &&
+  (preBattleKeystoneFromTypes as readonly string[]).includes(fromType);
 
 // Map of DMG setting names to their default values (for gameSetting table storage)
 export const DMG_SETTING_DEFAULTS: Record<string, number> = {

--- a/app/src/libs/combat/process.ts
+++ b/app/src/libs/combat/process.ts
@@ -4,7 +4,11 @@ import {
   DMG_REDUCTION_CAP,
   DURABILITY_USABILITY_THR,
   ID_ANIMATION_SMOKE,
+  isPreBattleGearFromType,
+  isPreBattleKeystoneFromType,
   NO_DURABILITY_LOSS_COMBATS,
+  OUT_OF_COMBAT_BASE_DAMAGE_INCREASE,
+  OUT_OF_COMBAT_BASE_DAMAGE_REDUCTION,
   POST_DAMAGE_MODIFIER_TYPES,
 } from "@/drizzle/constants";
 import type { ShieldTagType } from "@/validators/combat";
@@ -18,6 +22,8 @@ import {
 } from "./constants";
 import {
   absorb,
+  adjustDamageGiven,
+  adjustDamageTaken,
   afterburn,
   buffPrevent,
   calcDmgModifier,
@@ -42,6 +48,9 @@ import {
   finalStand,
   flee,
   fleePrevent,
+  getDamageModifierPreventState,
+  getEfficiencyRatio,
+  getPower,
   heal,
   healPrevent,
   immunity,
@@ -89,7 +98,9 @@ import type {
   CombatAction,
   CompleteBattle,
   Consequence,
+  ExtraState,
   GroundEffect,
+  PreBattleGearModifiers,
   UserEffect,
 } from "./types";
 import {
@@ -352,39 +363,6 @@ export const applyEffects = (
     (e) => e.type === "increaseheal" || e.type === "decreaseheal",
   );
 
-  // Separate damage boosts (increases) from reductions (decreases)
-  // We'll apply boosts first, then capture a snapshot, then apply reductions
-  const stage1DamageBoosts = usersEffects
-    .filter((e) => damageBoostTypes.includes(e.type))
-    .filter((e) => getEffectStage(e) === 1);
-
-  // Bloodline damage boosts/decreases run last (Phase 4, after non-bloodline reductions + cap); multiplicative; exclude bloodline boosts from Stage 2
-  const bloodlineDamageBoosts = usersEffects.filter(
-    (e) =>
-      "fromType" in e &&
-      e.fromType === "bloodline" &&
-      (e.type === "increasedamagetaken" || e.type === "increasedamagegiven"),
-  );
-
-  const bloodlineDamageReductions = usersEffects.filter(
-    (e) =>
-      "fromType" in e &&
-      e.fromType === "bloodline" &&
-      (e.type === "decreasedamagetaken" || e.type === "decreasedamagegiven"),
-  );
-
-  const stage2DamageBoosts = usersEffects
-    .filter((e) => damageBoostTypes.includes(e.type))
-    .filter((e) => getEffectStage(e) === 2)
-    .filter(
-      (e) =>
-        !(
-          "fromType" in e &&
-          e.fromType === "bloodline" &&
-          (e.type === "increasedamagetaken" || e.type === "increasedamagegiven")
-        ),
-    );
-
   // Apply non-damage-modifier effects first (maintains existing ordering)
   nonDamageModifierEffects.sort(sortEffects).forEach((effect) => {
     applySingleEffect(
@@ -401,125 +379,98 @@ export const applyEffects = (
     );
   });
 
-  // Phase 1: Apply Stage 1 damage BOOSTS (equipment/pre-battle: armor, skill, village, ranked)
-  // These modify damage before in-battle effects
-  stage1DamageBoosts.sort(sortEffects).forEach((effect) => {
-    applySingleEffect(
-      consequences,
-      newUsersState,
-      newUsersEffects,
-      newGroundEffects,
-      actionEffects,
-      appliedEffects,
-      battle,
-      actorId,
-      effect,
-      action,
-    );
-  });
-
-  // Capture baseDamageAfterStage1 for all damage consequences, including DOT
-  // This becomes the base for Stage 2 percentage calculations
-  consequences.forEach((consequence) => {
-    const stagedDamage = consequence.damage ?? consequence.residual;
-    if (stagedDamage !== undefined) {
-      consequence.baseDamageAfterStage1 = stagedDamage;
-    }
-  });
-
-  // Phase 2: Apply Stage 2 damage BOOSTS (in-battle: bloodline, jutsu, item, basic)
-  // These stack on top of Stage 1 boosts
-  stage2DamageBoosts.sort(sortEffects).forEach((effect) => {
-    applySingleEffect(
-      consequences,
-      newUsersState,
-      newUsersEffects,
-      newGroundEffects,
-      actionEffects,
-      appliedEffects,
-      battle,
-      actorId,
-      effect,
-      action,
-    );
-  });
-
-  // Capture baseDamageAfterBoosts for reduction calculations, including DOT
-  // This is the fully boosted damage that reductions will use as their base
-  consequences.forEach((consequence) => {
-    const boostedDamage = consequence.damage ?? consequence.residual;
-    if (boostedDamage !== undefined) {
-      consequence.baseDamageAfterBoosts = boostedDamage;
-    }
-  });
-
-  // Phase 3: Apply non-bloodline damage REDUCTIONS (from any stage)
-  // Bloodline decreasedamagetaken / decreasedamagegiven run in Phase 4 with bloodline increases
-  // Reductions are calculated as percentages of the FULLY BOOSTED damage
-  // This ensures damage reduction is effective against amplified damage
-  // Note: reductions intentionally apply to both direct and residual (DOT) damage
-  const allDamageReductions = usersEffects.filter(
-    (e) =>
-      damageReductionTypes.includes(e.type) &&
-      !(
-        "fromType" in e &&
-        e.fromType === "bloodline" &&
-        (e.type === "decreasedamagetaken" || e.type === "decreasedamagegiven")
-      ),
+  const sealEffects = getActiveSealEffects(usersEffects);
+  const usersStateById = new Map(newUsersState.map((u) => [u.userId, u]));
+  const damageModifierEligibilityById = buildDamageModifierEligibilityById(
+    usersEffects,
+    battle.round,
+    usersStateById,
   );
 
-  allDamageReductions.sort(sortEffects).forEach((effect) => {
-    applySingleEffect(
-      consequences,
-      newUsersState,
-      newUsersEffects,
-      newGroundEffects,
-      actionEffects,
-      appliedEffects,
-      battle,
-      actorId,
-      effect,
-      action,
-    );
+  // Consolidated damage pipeline: multiplicative inc buckets, shared sequential % DR, static DR, BL inc
+  applyDamageModifierPipelineToConsequences({
+    consequences,
+    usersEffects,
+    extraState: battle.extraState,
+    battleRound: battle.round,
+    sealEffects,
+    eligibilityById: damageModifierEligibilityById,
   });
 
-  // Enforce damage reduction cap: damage cannot be reduced below (1 - DMG_REDUCTION_CAP) of boosted pre-reduction damage
-  consequences.forEach((consequence) => {
-    if (
-      consequence.damage !== undefined &&
-      consequence.baseDamageAfterBoosts !== undefined
-    ) {
-      const minDamage = consequence.baseDamageAfterBoosts * (1 - DMG_REDUCTION_CAP);
-      consequence.damage = Math.max(consequence.damage, minDamage);
-    }
-    if (
-      consequence.residual !== undefined &&
-      consequence.baseDamageAfterBoosts !== undefined
-    ) {
-      const minResidual = consequence.baseDamageAfterBoosts * (1 - DMG_REDUCTION_CAP);
-      consequence.residual = Math.max(consequence.residual, minResidual);
-    }
-  });
-
-  // Phase 4: Bloodline damage modifiers (decreasedamagetaken, decreasedamagegiven,
-  // increasedamagetaken, increasedamagegiven) apply after the cap, in sortEffects order
-  // (decreases before increases). Same timing for offensive and defensive bloodline modifiers.
-  [...bloodlineDamageReductions, ...bloodlineDamageBoosts]
+  const modifierInfoConsequences = new Map<string, Consequence>();
+  usersEffects
+    .filter((e) => damageModifierTypes.includes(e.type))
+    .filter((e) => !sealCheck(e, sealEffects))
     .sort(sortEffects)
     .forEach((effect) => {
-      applySingleEffect(
-        consequences,
-        newUsersState,
-        newUsersEffects,
-        newGroundEffects,
-        actionEffects,
-        appliedEffects,
-        battle,
-        actorId,
-        effect,
-        action,
-      );
+      const targetUser = usersStateById.get(effect.targetId);
+      if (!targetUser) return;
+
+      const eligibility = damageModifierEligibilityById.get(effect.id);
+      if (eligibility?.preventInfo) {
+        actionEffects.push(eligibility.preventInfo);
+        return;
+      }
+
+      let info: ActionEffect | undefined;
+      switch (effect.type) {
+        case "increasedamagegiven":
+          info = adjustDamageGiven(
+            effect,
+            usersEffects,
+            modifierInfoConsequences,
+            targetUser,
+          );
+          break;
+        case "decreasedamagegiven":
+          effect.power = -Math.abs(effect.power);
+          effect.powerPerLevel = -Math.abs(effect.powerPerLevel);
+          info = adjustDamageGiven(
+            effect,
+            usersEffects,
+            modifierInfoConsequences,
+            targetUser,
+          );
+          break;
+        case "increasedamagetaken":
+          info = adjustDamageTaken(
+            effect,
+            usersEffects,
+            modifierInfoConsequences,
+            targetUser,
+          );
+          break;
+        case "decreasedamagetaken":
+          effect.power = -Math.abs(effect.power);
+          effect.powerPerLevel = -Math.abs(effect.powerPerLevel);
+          info = adjustDamageTaken(
+            effect,
+            usersEffects,
+            modifierInfoConsequences,
+            targetUser,
+          );
+          break;
+        default:
+          break;
+      }
+      if (info) actionEffects.push(info);
     });
+
+  // Damage modifier tags are excluded from applySingleEffect; carry them forward so they
+  // persist in the outgoing snapshot (pierce / post-damage tags have dedicated passes later).
+  const presentEffectIds = new Set(newUsersEffects.map((e) => e.id));
+  for (const e of usersEffects) {
+    if (
+      !damageModifierTypes.includes(e.type) ||
+      presentEffectIds.has(e.id) ||
+      !((isEffectActive(e) && !e.fromGround) || e.type === "visual")
+    ) {
+      continue;
+    }
+    e.isNew = false;
+    newUsersEffects.push(e);
+    presentEffectIds.add(e.id);
+  }
 
   // Apply pierce effects AFTER damage modifiers but BEFORE post-damage modifiers
   // Pierce adds damage that should be included in post-damage calculations (lifesteal, etc.)
@@ -1011,7 +962,7 @@ export const applySingleEffect = (
     ? true
     : !appliedEffects.has(idx) ||
       effect.fromType === "bloodline" ||
-      effect.fromType === "armor";
+      isPreBattleGearFromType(effect.fromType);
   // Special cases
   if (
     BARRIER_DAMAGE_TAG_TYPES.has(effect.type) &&
@@ -1235,5 +1186,522 @@ export const applySingleEffect = (
         round,
       ),
     );
+  }
+};
+
+// ─── Consolidated damage modifier pipeline (battle damage packets) ─────────────
+
+export type { PreBattleGearModifiers };
+
+export const emptyPreBattleGearModifiers = (): PreBattleGearModifiers => ({
+  incDamageGivenFromGear: 0,
+  incDamageTakenFromGear: 0,
+  drTakenFromGear: 0,
+  drGivenFromGear: 0,
+  incDamageGivenFromKeystone: 0,
+  incDamageTakenFromKeystone: 0,
+  drTakenFromKeystone: 0,
+  drGivenFromKeystone: 0,
+});
+
+/** Armor/accessory/keystone percentage mods fold into preBattleGearModifiers at battle start. */
+export const isConsolidatedStage1PercentageModifier = (effect: UserEffect): boolean => {
+  if (
+    !damageBoostTypes.includes(effect.type) &&
+    !damageReductionTypes.includes(effect.type)
+  ) {
+    return false;
+  }
+  if (!("fromType" in effect)) {
+    return false;
+  }
+  const { fromType } = effect;
+  if (!isPreBattleGearFromType(fromType) && !isPreBattleKeystoneFromType(fromType)) {
+    return false;
+  }
+  return effect.calculation === "percentage";
+};
+
+/** True when percentage mods are folded into preBattleGearModifiers (not pipeline lists). */
+const isPreBattleConsolidatedPercentageFromType = (
+  fromType: string | undefined,
+): boolean =>
+  isPreBattleGearFromType(fromType) || isPreBattleKeystoneFromType(fromType);
+
+/** Stage-1 percentage modifiers from skill/village/ranked stay in usersEffects for the pipeline. */
+const isStage1NonGearPercentageModifier = (effect: UserEffect): boolean => {
+  if (
+    !damageBoostTypes.includes(effect.type) &&
+    !damageReductionTypes.includes(effect.type)
+  ) {
+    return false;
+  }
+  if (getEffectStage(effect) !== 1 || effect.calculation !== "percentage") {
+    return false;
+  }
+  if (
+    "fromType" in effect &&
+    isPreBattleConsolidatedPercentageFromType(effect.fromType)
+  ) {
+    return false;
+  }
+  return true;
+};
+
+const applyPercentageDrMultiplier = (damage: number, drFraction: number): number =>
+  damage * Math.max(0, 1 - drFraction);
+
+export const buildPreBattleGearModifiersForUser = (
+  userEffects: UserEffect[],
+  userId: string,
+): PreBattleGearModifiers => {
+  const mods = emptyPreBattleGearModifiers();
+
+  for (const effect of userEffects) {
+    if (effect.targetId !== userId) continue;
+    if (!isConsolidatedStage1PercentageModifier(effect)) continue;
+
+    const { power } = getPower(effect);
+    const isKeystone =
+      "fromType" in effect && isPreBattleKeystoneFromType(effect.fromType);
+    if (effect.type === "increasedamagegiven") {
+      if (isKeystone) mods.incDamageGivenFromKeystone += power;
+      else mods.incDamageGivenFromGear += power;
+    } else if (effect.type === "increasedamagetaken") {
+      if (isKeystone) mods.incDamageTakenFromKeystone += power;
+      else mods.incDamageTakenFromGear += power;
+    } else if (effect.type === "decreasedamagetaken") {
+      if (isKeystone) mods.drTakenFromKeystone += Math.abs(power);
+      else mods.drTakenFromGear += Math.abs(power);
+    } else if (effect.type === "decreasedamagegiven") {
+      if (isKeystone) mods.drGivenFromKeystone += Math.abs(power);
+      else mods.drGivenFromGear += Math.abs(power);
+    }
+  }
+
+  return mods;
+};
+
+export const consolidatePreBattleDamageModifiers = (
+  userEffects: UserEffect[],
+  userIds: string[],
+): {
+  preBattleGearModifiers: Record<string, PreBattleGearModifiers>;
+  filteredEffects: UserEffect[];
+} => {
+  const preBattleGearModifiers: Record<string, PreBattleGearModifiers> = {};
+  for (const userId of userIds) {
+    preBattleGearModifiers[userId] = buildPreBattleGearModifiersForUser(
+      userEffects,
+      userId,
+    );
+  }
+
+  const filteredEffects = userEffects.filter(
+    (e) => !isConsolidatedStage1PercentageModifier(e),
+  );
+
+  return { preBattleGearModifiers, filteredEffects };
+};
+
+const isBloodlineDamageMod = (effect: UserEffect): boolean =>
+  "fromType" in effect && effect.fromType === "bloodline";
+
+const getActiveSealEffects = (usersEffects: UserEffect[]) =>
+  usersEffects.filter((e) => e.type === "seal" && !e.isNew && isEffectActive(e));
+
+/** Which packet id field to compare against effect.targetId (pair-dependent). */
+type DamageModifierPacketSide = "attacker" | "defender";
+
+export type DamageModifierEligibility = {
+  targetId: string;
+  increaseSide: DamageModifierPacketSide | null;
+  decreaseSide: DamageModifierPacketSide | null;
+  /** Set when prevent RNG blocks the modifier; reused for combat log (no second roll). */
+  preventInfo?: ActionEffect;
+};
+
+/** Pair-independent timing + modifier type; built once per performAction round. */
+export const buildDamageModifierEligibilityById = (
+  usersEffects: UserEffect[],
+  battleRound: number,
+  usersStateById?: Map<string, BattleUserState>,
+): Map<string, DamageModifierEligibility> => {
+  const eligibilityById = new Map<string, DamageModifierEligibility>();
+  const roundCtx = { round: battleRound };
+
+  for (const effect of usersEffects) {
+    const isBoost = damageBoostTypes.includes(effect.type);
+    const isDr = damageReductionTypes.includes(effect.type);
+    if (!isBoost && !isDr) continue;
+
+    // Same condition as adjustDamageGiven / adjustDamageTaken after applySingleEffect
+    // assigns `effect.castThisRound = (startRound === curRound)`.
+    const { startRound, curRound } = calcEffectRoundInfo(effect, roundCtx);
+    const passesTiming = !effect.isNew && startRound !== curRound;
+
+    const targetUser = usersStateById?.get(effect.targetId);
+    const preventState = targetUser
+      ? getDamageModifierPreventState(effect, usersEffects, targetUser)
+      : { blocked: false, info: undefined };
+
+    let increaseSide: DamageModifierPacketSide | null = null;
+    let decreaseSide: DamageModifierPacketSide | null = null;
+    if (passesTiming && !preventState.blocked) {
+      if (effect.type === "increasedamagegiven") increaseSide = "attacker";
+      else if (effect.type === "increasedamagetaken") increaseSide = "defender";
+      if (effect.type === "decreasedamagegiven") decreaseSide = "attacker";
+      else if (effect.type === "decreasedamagetaken") decreaseSide = "defender";
+    }
+
+    eligibilityById.set(effect.id, {
+      targetId: effect.targetId,
+      increaseSide,
+      decreaseSide,
+      preventInfo: preventState.info,
+    });
+  }
+
+  return eligibilityById;
+};
+
+const modifierAppliesToDamagePacketPair = (
+  eligibility: DamageModifierEligibility | undefined,
+  attackerId: string,
+  defenderId: string,
+  kind: "increase" | "decrease",
+): boolean => {
+  if (!eligibility) return false;
+  const side =
+    kind === "increase" ? eligibility.increaseSide : eligibility.decreaseSide;
+  if (!side) return false;
+  const id = side === "attacker" ? attackerId : defenderId;
+  return id === eligibility.targetId;
+};
+
+const allowBloodlineDamageModifier = (
+  damageEffect: UserEffect,
+  modEffect: UserEffect,
+  power: number,
+): boolean => {
+  if (!isBloodlineDamageMod(modEffect)) return true;
+  if (
+    !("allowBloodlineDamageIncrease" in damageEffect) ||
+    !("allowBloodlineDamageDecrease" in damageEffect)
+  ) {
+    return true;
+  }
+  if (power > 0 && !damageEffect.allowBloodlineDamageIncrease) return false;
+  if (power < 0 && !damageEffect.allowBloodlineDamageDecrease) return false;
+  return true;
+};
+
+const getSignedDrModifierPower = (effect: UserEffect): number => {
+  const { power } = getPower(effect);
+  if (effect.type === "decreasedamagetaken" || effect.type === "decreasedamagegiven") {
+    return -Math.abs(power);
+  }
+  return power;
+};
+
+export type DamagePacketModifierLists = {
+  stage1PreBattleIncreases: UserEffect[];
+  inBattleIncreases: UserEffect[];
+  stage1PreBattleDrEffects: UserEffect[];
+  inCombatDrEffects: UserEffect[];
+  staticIncEffects: UserEffect[];
+  staticDrEffects: UserEffect[];
+  bloodlineIncreases: UserEffect[];
+  bloodlineDrEffects: UserEffect[];
+};
+
+/** Bucket damage modifiers once per attacker–defender pair (reuse across consequences). */
+export const buildDamagePacketModifierLists = (
+  usersEffects: UserEffect[],
+  attackerId: string,
+  defenderId: string,
+  eligibilityById: Map<string, DamageModifierEligibility>,
+): DamagePacketModifierLists => {
+  const applies = (effect: UserEffect, kind: "increase" | "decrease") =>
+    modifierAppliesToDamagePacketPair(
+      eligibilityById.get(effect.id),
+      attackerId,
+      defenderId,
+      kind,
+    );
+
+  const stage1PreBattleIncreases: UserEffect[] = [];
+  const inBattleIncreases: UserEffect[] = [];
+  const stage1PreBattleDrEffects: UserEffect[] = [];
+  const inCombatDrEffects: UserEffect[] = [];
+  const staticIncEffects: UserEffect[] = [];
+  const staticDrEffects: UserEffect[] = [];
+  const bloodlineIncreases: UserEffect[] = [];
+  const bloodlineDrEffects: UserEffect[] = [];
+
+  for (const effect of usersEffects) {
+    const isBoost = damageBoostTypes.includes(effect.type);
+    const isDr = damageReductionTypes.includes(effect.type);
+    if (!isBoost && !isDr) continue;
+
+    const isBloodline = isBloodlineDamageMod(effect);
+    const isStatic = effect.calculation === "static";
+    const isPercentage = effect.calculation === "percentage";
+
+    if (isBoost && applies(effect, "increase")) {
+      if (isStatic) {
+        staticIncEffects.push(effect);
+      } else if (isPercentage && isBloodline) {
+        bloodlineIncreases.push(effect);
+      } else if (isPercentage && isStage1NonGearPercentageModifier(effect)) {
+        stage1PreBattleIncreases.push(effect);
+      } else if (isPercentage && getEffectStage(effect) === 2 && !isBloodline) {
+        inBattleIncreases.push(effect);
+      }
+      continue;
+    }
+
+    if (isDr && applies(effect, "decrease")) {
+      if (isStatic) {
+        staticDrEffects.push(effect);
+      } else if (isPercentage && isBloodline) {
+        bloodlineDrEffects.push(effect);
+      } else if (isPercentage && isStage1NonGearPercentageModifier(effect)) {
+        stage1PreBattleDrEffects.push(effect);
+      } else if (isPercentage && getEffectStage(effect) !== 1 && !isBloodline) {
+        inCombatDrEffects.push(effect);
+      }
+    }
+  }
+
+  stage1PreBattleIncreases.sort(sortEffects);
+  inBattleIncreases.sort(sortEffects);
+  stage1PreBattleDrEffects.sort(sortEffects);
+  inCombatDrEffects.sort(sortEffects);
+  staticIncEffects.sort(sortEffects);
+  staticDrEffects.sort(sortEffects);
+  bloodlineIncreases.sort(sortEffects);
+  bloodlineDrEffects.sort(sortEffects);
+
+  return {
+    stage1PreBattleIncreases,
+    inBattleIncreases,
+    stage1PreBattleDrEffects,
+    inCombatDrEffects,
+    staticIncEffects,
+    staticDrEffects,
+    bloodlineIncreases,
+    bloodlineDrEffects,
+  };
+};
+
+type DamagePacketComputeContext = {
+  rawDamage: number;
+  damageEffect: UserEffect;
+  usersEffects: UserEffect[];
+  attackerId: string;
+  defenderId: string;
+  preBattleGearModifiers: Record<string, PreBattleGearModifiers>;
+  battleRound: number;
+  modifierLists?: DamagePacketModifierLists;
+  sealEffects?: UserEffect[];
+};
+
+export const computeDamagePacket = (
+  ctx: DamagePacketComputeContext,
+): { damage: number } => {
+  const {
+    damageEffect,
+    usersEffects,
+    attackerId,
+    defenderId,
+    preBattleGearModifiers,
+    battleRound,
+  } = ctx;
+  const modifierLists =
+    ctx.modifierLists ??
+    buildDamagePacketModifierLists(
+      usersEffects,
+      attackerId,
+      defenderId,
+      buildDamageModifierEligibilityById(usersEffects, battleRound),
+    );
+  const sealEffects = ctx.sealEffects ?? getActiveSealEffects(usersEffects);
+  const attackerGear =
+    preBattleGearModifiers[attackerId] ?? emptyPreBattleGearModifiers();
+  const defenderGear =
+    preBattleGearModifiers[defenderId] ?? emptyPreBattleGearModifiers();
+
+  let damage = ctx.rawDamage;
+
+  for (const effect of modifierLists.stage1PreBattleIncreases) {
+    const ratio = getEfficiencyRatio(damageEffect, effect);
+    if (ratio === 0) continue;
+    const { power } = getPower(effect);
+    damage *= 1 + (power / 100) * ratio;
+  }
+
+  const incPoints =
+    OUT_OF_COMBAT_BASE_DAMAGE_INCREASE +
+    attackerGear.incDamageGivenFromGear +
+    defenderGear.incDamageTakenFromGear;
+  damage *= 1 + incPoints / 100;
+
+  for (const effect of modifierLists.inBattleIncreases) {
+    const ratio = getEfficiencyRatio(damageEffect, effect);
+    if (ratio === 0) continue;
+    const { power } = getPower(effect);
+    if (!allowBloodlineDamageModifier(damageEffect, effect, power)) continue;
+    damage *= 1 + (power / 100) * ratio;
+  }
+
+  const baseDamageAfterBoosts = damage;
+
+  const drPoints =
+    OUT_OF_COMBAT_BASE_DAMAGE_REDUCTION +
+    defenderGear.drTakenFromGear +
+    attackerGear.drGivenFromGear;
+  damage = applyPercentageDrMultiplier(damage, drPoints / 100);
+
+  for (const effect of modifierLists.stage1PreBattleDrEffects) {
+    const ratio = getEfficiencyRatio(damageEffect, effect);
+    if (ratio === 0) continue;
+    const power = getSignedDrModifierPower(effect);
+    damage = applyPercentageDrMultiplier(damage, (Math.abs(power) / 100) * ratio);
+  }
+
+  for (const effect of modifierLists.inCombatDrEffects) {
+    const ratio = getEfficiencyRatio(damageEffect, effect);
+    if (ratio === 0) continue;
+    const power = getSignedDrModifierPower(effect);
+    if (!allowBloodlineDamageModifier(damageEffect, effect, power)) continue;
+    damage = applyPercentageDrMultiplier(damage, (Math.abs(power) / 100) * ratio);
+  }
+
+  const minDamage = baseDamageAfterBoosts * (1 - DMG_REDUCTION_CAP);
+  damage = Math.max(damage, minDamage);
+
+  let totalStaticIncrease = 0;
+  for (const effect of modifierLists.staticIncEffects) {
+    if (sealCheck(effect, sealEffects)) continue;
+    const ratio = getEfficiencyRatio(damageEffect, effect);
+    if (ratio === 0) continue;
+    const { power } = getPower(effect);
+    if (
+      isBloodlineDamageMod(effect) &&
+      !allowBloodlineDamageModifier(damageEffect, effect, power)
+    ) {
+      continue;
+    }
+    totalStaticIncrease += power * ratio;
+  }
+  damage += totalStaticIncrease;
+
+  let totalStaticReduction = 0;
+  for (const effect of modifierLists.staticDrEffects) {
+    if (sealCheck(effect, sealEffects)) continue;
+    const ratio = getEfficiencyRatio(damageEffect, effect);
+    if (ratio === 0) continue;
+    const { power } = getPower(effect);
+    totalStaticReduction += Math.abs(power) * ratio;
+  }
+  damage = Math.max(minDamage, damage - totalStaticReduction);
+
+  const keystoneIncPoints =
+    (attackerGear.incDamageGivenFromKeystone ?? 0) +
+    (defenderGear.incDamageTakenFromKeystone ?? 0);
+  damage *= 1 + keystoneIncPoints / 100;
+
+  const keystoneDrPoints =
+    (defenderGear.drTakenFromKeystone ?? 0) + (attackerGear.drGivenFromKeystone ?? 0);
+  damage = applyPercentageDrMultiplier(damage, keystoneDrPoints / 100);
+  damage = Math.max(minDamage, damage);
+
+  for (const effect of modifierLists.bloodlineIncreases) {
+    if (sealCheck(effect, sealEffects)) continue;
+    const ratio = getEfficiencyRatio(damageEffect, effect);
+    if (ratio === 0) continue;
+    const { power } = getPower(effect);
+    if (!allowBloodlineDamageModifier(damageEffect, effect, power)) continue;
+    damage *= 1 + (power / 100) * ratio;
+  }
+
+  for (const effect of modifierLists.bloodlineDrEffects) {
+    if (sealCheck(effect, sealEffects)) continue;
+    const ratio = getEfficiencyRatio(damageEffect, effect);
+    if (ratio === 0) continue;
+    const power = getSignedDrModifierPower(effect);
+    if (!allowBloodlineDamageModifier(damageEffect, effect, power)) continue;
+    damage = applyPercentageDrMultiplier(damage, (Math.abs(power) / 100) * ratio);
+  }
+
+  return { damage: Math.max(minDamage, damage) };
+};
+
+export const applyDamageModifierPipelineToConsequences = ({
+  consequences,
+  usersEffects,
+  extraState,
+  battleRound,
+  sealEffects: sealEffectsInput,
+  eligibilityById: eligibilityByIdInput,
+  usersStateById,
+}: {
+  consequences: Map<string, Consequence>;
+  usersEffects: UserEffect[];
+  extraState: ExtraState;
+  battleRound: number;
+  sealEffects?: UserEffect[];
+  eligibilityById?: Map<string, DamageModifierEligibility>;
+  /** @deprecated Prefer passing eligibilityById from applyEffects. */
+  usersStateById?: Map<string, BattleUserState>;
+}) => {
+  const preBattleGearModifiers = extraState.preBattleGearModifiers ?? {};
+  const sealEffects = sealEffectsInput ?? getActiveSealEffects(usersEffects);
+  const effectById = new Map(usersEffects.map((e) => [e.id, e]));
+  const eligibilityById =
+    eligibilityByIdInput ??
+    buildDamageModifierEligibilityById(usersEffects, battleRound, usersStateById);
+  const modifierListsByPair = new Map<string, DamagePacketModifierLists>();
+
+  for (const [effectId, consequence] of consequences) {
+    const damageKey =
+      consequence.damage !== undefined
+        ? "damage"
+        : consequence.residual !== undefined
+          ? "residual"
+          : undefined;
+    if (!damageKey) continue;
+
+    const dmgEffect = effectById.get(effectId);
+    if (!dmgEffect) continue;
+
+    const pairKey = `${consequence.userId}\0${consequence.targetId}`;
+    let modifierLists = modifierListsByPair.get(pairKey);
+    if (!modifierLists) {
+      modifierLists = buildDamagePacketModifierLists(
+        usersEffects,
+        consequence.userId,
+        consequence.targetId,
+        eligibilityById,
+      );
+      modifierListsByPair.set(pairKey, modifierLists);
+    }
+
+    const rawDamage = consequence[damageKey] ?? 0;
+    const { damage } = computeDamagePacket({
+      rawDamage,
+      damageEffect: dmgEffect,
+      usersEffects,
+      attackerId: consequence.userId,
+      defenderId: consequence.targetId,
+      preBattleGearModifiers,
+      battleRound,
+      modifierLists,
+      sealEffects,
+    });
+
+    consequence[damageKey] = damage;
+    consequence.baseDamageForModifiers ??= rawDamage;
   }
 };

--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -231,7 +231,15 @@ export const copy = (
   const primaryCheck = Math.random() < power / 100;
   if (effect.isNew && effect.rounds && effect.castThisRound) {
     if (primaryCheck) {
-      const excludedFromTypes = ["bloodline", "armor", "item", "village", "skill"];
+      const excludedFromTypes = [
+        "bloodline",
+        "armor",
+        "accessory",
+        "keystone",
+        "item",
+        "village",
+        "skill",
+      ];
       const allowedEffectTypes = [
         "increasedamagegiven",
         "increasestat",
@@ -316,7 +324,15 @@ export const mirror = (
   const primaryCheck = Math.random() < power / 100;
   if (effect.isNew && effect.rounds && effect.castThisRound) {
     if (primaryCheck) {
-      const excludedFromTypes = ["bloodline", "armor", "item", "village", "skill"];
+      const excludedFromTypes = [
+        "bloodline",
+        "armor",
+        "accessory",
+        "keystone",
+        "item",
+        "village",
+        "skill",
+      ];
       const excludedEffectTypes = [
         "damage",
         "pierce",
@@ -952,6 +968,29 @@ export const decreaseDamageTaken = (
   return adjustDamageTaken(effect, usersEffects, consequences, target);
 };
 
+/** Single prevent roll for pipeline + combat log (matches increase/decreaseDamage* wrappers). */
+export const getDamageModifierPreventState = (
+  effect: UserEffect,
+  usersEffects: UserEffect[],
+  target: BattleUserState,
+): { blocked: boolean; info: ActionEffect | undefined } => {
+  const preventType =
+    effect.type === "increasedamagegiven" || effect.type === "decreasedamagetaken"
+      ? "buffprevent"
+      : effect.type === "decreasedamagegiven" || effect.type === "increasedamagetaken"
+        ? "debuffprevent"
+        : null;
+  if (!preventType) return { blocked: false, info: undefined };
+
+  const { pass, preventTag } = preventCheck(usersEffects, preventType, target);
+  if (preventTag && preventTag.createdRound < effect.createdRound && !pass) {
+    const message =
+      preventType === "buffprevent" ? "cannot be buffed" : "cannot be debuffed";
+    return { blocked: true, info: preventResponse(effect, target, message) };
+  }
+  return { blocked: false, info: undefined };
+};
+
 /** Adjust ability to heal other of target */
 export const adjustHealGiven = (
   effect: UserEffect,
@@ -1069,6 +1108,8 @@ const removeEffects = (
       .filter((e) => e.targetId === effect.targetId)
       .filter((e) => e.fromType !== "bloodline")
       .filter((e) => e.fromType !== "armor")
+      .filter((e) => e.fromType !== "accessory")
+      .filter((e) => e.fromType !== "keystone")
       .filter((e) => e.fromType !== "skill")
       .filter((e) => e.fromType !== "ranked")
       .filter(type === "positive" ? isPositiveUserEffect : isNegativeUserEffect)
@@ -3167,7 +3208,7 @@ export const getStatTypeFromStat = (stat: (typeof StatNames)[number]) => {
  * Returns a ratio between 0 to 1, 0 indicating e.g. that none of the stats in LHS are
  * matched in the RHS, whereas a ratio of 1 means everything is matched by a value in RHS
  */
-const getEfficiencyRatio = (dmgEffect: UserEffect, effect: UserEffect) => {
+export const getEfficiencyRatio = (dmgEffect: UserEffect, effect: UserEffect) => {
   // Force reflect for pierce damage, bypassing tag matching
   if (dmgEffect.type === "pierce") return 1;
   // We need to get the list of dmgEffect stats/gens/elements and effect stats/gens/elements

--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -293,6 +293,18 @@ export type BasicActions = {
   basicFlee: CombatAction;
 };
 
+/** Per-user pre-battle armor/accessory/keystone % damage mods (percentage points). */
+export type PreBattleGearModifiers = {
+  incDamageGivenFromGear: number;
+  incDamageTakenFromGear: number;
+  drTakenFromGear: number;
+  drGivenFromGear: number;
+  incDamageGivenFromKeystone: number;
+  incDamageTakenFromKeystone: number;
+  drTakenFromKeystone: number;
+  drGivenFromKeystone: number;
+};
+
 /**
  * Extra battle state containing static data and battle settings.
  * Static data is stored once at battle initiation and looked up by ID.
@@ -318,6 +330,8 @@ export type ExtraState = {
   bountySignups: Record<string, CombatQueryBountySignup[]>; // controllerId -> array of bounty signups
   // Battle settings
   dmgConfig?: DmgConfig;
+  /** Per-user pre-battle gear/keystone % mods folded into the damage pipeline at battle start. */
+  preBattleGearModifiers?: Record<string, PreBattleGearModifiers>;
   settings?: GameSetting[];
   textureAssets?: string[];
   sfxAssets?: string[];
@@ -363,6 +377,9 @@ export type ReturnedUserState = Pick<BattleUserState, (typeof publicState)[numbe
 export type ReturnedBattle = Omit<CompleteBattle, "usersState"> & {
   usersState: ReturnedUserState[];
 };
+
+/** Minimal battle context for per-round effect logic (e.g. castThisRound). */
+export type BattleRoundContext = Pick<ReturnedBattle, "round">;
 
 /**
  * Dynamic battle state - only the fields that change during battle.
@@ -477,10 +494,6 @@ export type Consequence = {
   rawResidual?: number;
   /** Base damage value used for additive percentage modifier calculations (e.g., increaseDamageGiven) */
   baseDamageForModifiers?: number;
-  /** Base damage after Stage 1 (equipment/pre-battle) modifiers are applied */
-  baseDamageAfterStage1?: number;
-  /** Base damage after ALL boost modifiers (Stage 1 + Stage 2 increases) are applied, before any reductions */
-  baseDamageAfterBoosts?: number;
   wound?: number;
   reflect?: number;
   recoil?: number;
@@ -534,6 +547,8 @@ export type UserEffect = BattleEffect & {
   fromType?:
     | "jutsu"
     | "armor"
+    | "accessory"
+    | "keystone"
     | "item"
     | "basic"
     | "bloodline"

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -69,6 +69,7 @@ import {
 import { checkFriendlyFire } from "./process";
 import { getPower } from "./tags";
 import type {
+  BattleRoundContext,
   BattleUserState,
   BattleWar,
   CombatAction,
@@ -823,7 +824,7 @@ export const calcApplyRatio = (
  */
 export const calcEffectRoundInfo = (
   effect: UserEffect | GroundEffect,
-  battle: ReturnedBattle,
+  battle: BattleRoundContext,
 ) => {
   if (effect.rounds !== undefined && effect.createdRound !== undefined) {
     return { startRound: effect.createdRound, curRound: battle.round };
@@ -852,7 +853,7 @@ export const isEffectActive = (effect: UserEffect | GroundEffect) => {
  * apply first (Stage 1), then in-battle effects apply to the result (Stage 2).
  */
 export const getEffectStage = (effect: UserEffect | GroundEffect): 1 | 2 => {
-  const stage1Types = ["armor", "skill", "village", "ranked"];
+  const stage1Types = ["armor", "accessory", "keystone", "skill", "village", "ranked"];
   if (
     "fromType" in effect &&
     effect.fromType &&
@@ -874,34 +875,14 @@ export const getBaseDamageForModifier = (
     damage?: number;
     residual?: number;
     baseDamageForModifiers?: number;
-    baseDamageAfterStage1?: number;
-    baseDamageAfterBoosts?: number;
   },
 ): number => {
-  // For damage REDUCTIONS, use the fully boosted damage.
-  // baseDamageAfterBoosts is snapshotted in Phase 2 of process.ts and must
-  // always be present before any reduction effect reaches this function.
-  if (damageReductionTypes.includes(effect.type)) {
-    if (consequence.baseDamageAfterBoosts === undefined) {
-      console.warn(
-        "getBaseDamageForModifier: baseDamageAfterBoosts missing for reduction effect",
-      );
-    }
-    return consequence.baseDamageAfterBoosts ?? consequence.baseDamageForModifiers ?? 0;
-  }
-
-  // For damage INCREASES, use staged base
-  const effectStage = getEffectStage(effect);
-  return effectStage === 1
-    ? (consequence.baseDamageForModifiers ??
-        consequence.damage ??
-        consequence.residual ??
-        0)
-    : (consequence.baseDamageAfterStage1 ??
-        consequence.baseDamageForModifiers ??
-        consequence.damage ??
-        consequence.residual ??
-        0);
+  return (
+    consequence.baseDamageForModifiers ??
+    consequence.damage ??
+    consequence.residual ??
+    0
+  );
 };
 
 /**

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -111,7 +111,12 @@ import {
   updateVillageAnbuClan,
   updateWars,
 } from "@/libs/combat/database";
-import { applyEffects, checkFriendlyFire } from "@/libs/combat/process";
+import {
+  applyEffects,
+  checkFriendlyFire,
+  consolidatePreBattleDamageModifiers,
+  emptyPreBattleGearModifiers,
+} from "@/libs/combat/process";
 import { realizeTag } from "@/libs/combat/tags";
 import type {
   ActionEffect,
@@ -1092,9 +1097,17 @@ export const combatRouter = createTRPCRouter({
       userBattle.extraState.jutsus = userBattle.extraState.jutsus || {};
       userBattle.extraState.jutsuReskins = userBattle.extraState.jutsuReskins || {};
       userBattle.extraState.items = userBattle.extraState.items || {};
+      userBattle.extraState.preBattleGearModifiers =
+        userBattle.extraState.preBattleGearModifiers || {};
       Object.assign(userBattle.extraState.jutsus, extraState.jutsus);
       Object.assign(userBattle.extraState.jutsuReskins, extraState.jutsuReskins);
       Object.assign(userBattle.extraState.items, extraState.items);
+      const updatedBattleUserId = usersState[0]?.userId;
+      if (updatedBattleUserId) {
+        userBattle.extraState.preBattleGearModifiers[updatedBattleUserId] =
+          extraState.preBattleGearModifiers?.[updatedBattleUserId] ??
+          emptyPreBattleGearModifiers();
+      }
 
       // Mutate
       const result = await ctx.drizzle
@@ -2735,7 +2748,12 @@ export const processUsersForBattle = async (
                     level: user.level,
                   });
                   realized.isNew = false;
-                  realized.fromType = "armor";
+                  realized.fromType =
+                    itemType === "ACCESSORY"
+                      ? "accessory"
+                      : itemType === "KEYSTONE"
+                        ? "keystone"
+                        : "armor";
                   realized.castThisRound = false;
                   realized.targetId = user.userId;
                   userEffects.push(realized);
@@ -2891,33 +2909,6 @@ export const processUsersForBattle = async (
           }
         }
       }
-    }
-  }
-
-  // Apply decreasedamagetaken to all users in ranked PvP battles
-  if (battleType === "RANKED_PVP" || battleType === "RANKED_SPARRING") {
-    for (const user of usersState) {
-      const effect = DecreaseDamageTakenTag.parse({
-        target: "SELF",
-        statTypes: StatTypes,
-        generalTypes: GeneralTypes,
-        type: "decreasedamagetaken",
-        power: 150,
-        calculation: "static",
-        rounds: undefined,
-      }) as unknown as UserEffect;
-      const realized = realizeTag({
-        tag: effect,
-        user: user,
-        actionId: "ranked_pvp",
-        target: user,
-        level: user.level,
-      });
-      realized.isNew = false;
-      realized.castThisRound = false;
-      realized.targetId = user.userId;
-      realized.fromType = "ranked";
-      userEffects.push(realized);
     }
   }
 
@@ -3147,8 +3138,13 @@ export const processUsersForBattle = async (
     Object.assign(extraState.clans, summonExtraState.clans);
   }
 
+  const userIds = convertedUsersState.map((u) => u.userId);
+  const { preBattleGearModifiers, filteredEffects } =
+    consolidatePreBattleDamageModifiers(userEffects, userIds);
+  extraState.preBattleGearModifiers = preBattleGearModifiers;
+
   return {
-    userEffects,
+    userEffects: filteredEffects,
     usersState: convertedUsersState,
     extraState,
     initialDurability,

--- a/app/tests/libs/combat/damage_formula.test.ts
+++ b/app/tests/libs/combat/damage_formula.test.ts
@@ -311,8 +311,8 @@ describe("damage reduction cap", () => {
     ...overrides,
   });
 
-  it("DMG_REDUCTION_CAP is 80%", () => {
-    expect(DMG_REDUCTION_CAP).toBe(0.8);
+  it("DMG_REDUCTION_CAP is 90%", () => {
+    expect(DMG_REDUCTION_CAP).toBe(0.9);
   });
 
   it("does not alter damage that is above the floor", () => {
@@ -322,28 +322,28 @@ describe("damage reduction cap", () => {
     expect(consequences.get("e1")!.damage).toBe(60);
   });
 
-  it("caps damage at 20% of base when fully reduced to 0", () => {
+  it("caps damage at 10% of base when fully reduced to 0", () => {
     const consequences = new Map<string, Consequence>();
     consequences.set("e1", makeConsequence({ damage: 0, baseDamageForModifiers: 100 }));
     applyReductionCap(consequences);
-    expect(consequences.get("e1")!.damage).toBeCloseTo(20, 5);
+    expect(consequences.get("e1")!.damage).toBeCloseTo(10, 5);
   });
 
-  it("caps damage at 20% of base when reduced below the floor", () => {
+  it("caps damage at 10% of base when reduced below the floor", () => {
     const consequences = new Map<string, Consequence>();
     consequences.set("e1", makeConsequence({ damage: 5, baseDamageForModifiers: 100 }));
     applyReductionCap(consequences);
-    expect(consequences.get("e1")!.damage).toBeCloseTo(20, 5);
+    expect(consequences.get("e1")!.damage).toBeCloseTo(10, 5);
   });
 
-  it("caps negative damage (over-reduction) at 20% of base", () => {
+  it("caps negative damage (over-reduction) at 10% of base", () => {
     const consequences = new Map<string, Consequence>();
     consequences.set(
       "e1",
       makeConsequence({ damage: -50, baseDamageForModifiers: 100 }),
     );
     applyReductionCap(consequences);
-    expect(consequences.get("e1")!.damage).toBeCloseTo(20, 5);
+    expect(consequences.get("e1")!.damage).toBeCloseTo(10, 5);
   });
 
   it("does not affect consequences without baseDamageForModifiers", () => {
@@ -367,7 +367,7 @@ describe("damage reduction cap", () => {
       makeConsequence({ damage: 80, baseDamageForModifiers: 200 }),
     );
     applyReductionCap(consequences);
-    expect(consequences.get("e1")!.damage).toBeCloseTo(40, 5);
+    expect(consequences.get("e1")!.damage).toBeCloseTo(20, 5);
     expect(consequences.get("e2")!.damage).toBe(80);
   });
 });

--- a/app/tests/libs/combat/damage_modifiers.test.ts
+++ b/app/tests/libs/combat/damage_modifiers.test.ts
@@ -1,0 +1,776 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DMG_REDUCTION_CAP,
+  OUT_OF_COMBAT_BASE_DAMAGE_INCREASE,
+  OUT_OF_COMBAT_BASE_DAMAGE_REDUCTION,
+} from "@/drizzle/constants";
+import {
+  buildDamageModifierEligibilityById,
+  buildDamagePacketModifierLists,
+  computeDamagePacket,
+  type DamageModifierEligibility,
+  consolidatePreBattleDamageModifiers,
+  emptyPreBattleGearModifiers,
+  isConsolidatedStage1PercentageModifier,
+} from "@/libs/combat/process";
+import type {
+  BattleUserState,
+  PreBattleGearModifiers,
+  UserEffect,
+} from "@/libs/combat/types";
+import {
+  BuffPreventTag,
+  DamageTag,
+  DecreaseDamageTakenTag,
+  IncreaseDamageGivenTag,
+  SealTag,
+  type ZodAllTags,
+} from "@/validators/combat";
+
+type UserEffectRuntime = Pick<
+  UserEffect,
+  | "id"
+  | "creatorId"
+  | "targetId"
+  | "level"
+  | "isNew"
+  | "castThisRound"
+  | "createdRound"
+  | "longitude"
+  | "latitude"
+  | "barrierAbsorb"
+  | "actionId"
+> & {
+  fromType?: UserEffect["fromType"];
+};
+
+const toUserEffect = (tag: ZodAllTags, runtime: UserEffectRuntime): UserEffect => ({
+  ...tag,
+  ...runtime,
+});
+
+const makeDamageEffect = (): UserEffect =>
+  toUserEffect(
+    DamageTag.parse({
+      statTypes: ["Ninjutsu"],
+      calculation: "formula",
+    }),
+    {
+      id: "dmg-1",
+      creatorId: "attacker",
+      targetId: "defender",
+      level: 1,
+      isNew: true,
+      castThisRound: true,
+      createdRound: 1,
+      longitude: 0,
+      latitude: 0,
+      barrierAbsorb: 0,
+      actionId: "test-action",
+    },
+  );
+
+const makeModifierEffect = (params: {
+  id?: string;
+  type: "increasedamagegiven" | "decreasedamagetaken";
+  targetId: string;
+  power: number;
+  fromType?: UserEffect["fromType"];
+  calculation?: "static" | "percentage";
+}): UserEffect => {
+  const tagInput = {
+    power: params.power,
+    calculation: params.calculation ?? "percentage",
+    statTypes: ["Ninjutsu"] as const,
+  };
+
+  const tag =
+    params.type === "increasedamagegiven"
+      ? IncreaseDamageGivenTag.parse(tagInput)
+      : DecreaseDamageTakenTag.parse(tagInput);
+
+  return toUserEffect(tag, {
+    id: params.id ?? "mod-1",
+    creatorId: "attacker",
+    targetId: params.targetId,
+    level: 0,
+    isNew: false,
+    castThisRound: false,
+    createdRound: 0,
+    longitude: 0,
+    latitude: 0,
+    barrierAbsorb: 0,
+    actionId: "test-action",
+    fromType: params.fromType,
+  });
+};
+
+const gearMods = (overrides: Partial<PreBattleGearModifiers> = {}): PreBattleGearModifiers => ({
+  ...emptyPreBattleGearModifiers(),
+  ...overrides,
+});
+
+const defaultTestGearModifiers = () => ({
+  attacker: gearMods({ incDamageGivenFromGear: 18.9 }),
+  defender: gearMods({ drTakenFromGear: 5 }),
+});
+
+describe("isConsolidatedStage1PercentageModifier", () => {
+  it("consolidates equipped gear percentage damage mods only", () => {
+    const armorInc = makeModifierEffect({
+      type: "increasedamagegiven",
+      targetId: "attacker",
+      fromType: "armor",
+      power: 10,
+    });
+    const accessoryInc = makeModifierEffect({
+      id: "acc-inc",
+      type: "increasedamagegiven",
+      targetId: "attacker",
+      fromType: "accessory",
+      power: 5,
+    });
+    const keystoneDr = makeModifierEffect({
+      id: "ks-dr",
+      type: "decreasedamagetaken",
+      targetId: "attacker",
+      fromType: "keystone",
+      power: 3,
+    });
+    const skillInc = makeModifierEffect({
+      id: "skill-inc",
+      type: "increasedamagegiven",
+      targetId: "attacker",
+      fromType: "skill",
+      power: 10,
+    });
+    const bloodlineInc = makeModifierEffect({
+      id: "bl-inc",
+      type: "increasedamagegiven",
+      targetId: "attacker",
+      fromType: "bloodline",
+      power: 10,
+    });
+
+    expect(isConsolidatedStage1PercentageModifier(armorInc)).toBe(true);
+    expect(isConsolidatedStage1PercentageModifier(accessoryInc)).toBe(true);
+    expect(isConsolidatedStage1PercentageModifier(keystoneDr)).toBe(true);
+    expect(isConsolidatedStage1PercentageModifier(skillInc)).toBe(false);
+    expect(isConsolidatedStage1PercentageModifier(bloodlineInc)).toBe(false);
+  });
+});
+
+describe("consolidatePreBattleDamageModifiers", () => {
+  it("strips gear mods into preBattleGearModifiers but keeps skill mods in userEffects", () => {
+    const armorInc = makeModifierEffect({
+      id: "armor-inc",
+      type: "increasedamagegiven",
+      targetId: "attacker",
+      fromType: "armor",
+      power: 12,
+    });
+    const accessoryInc = makeModifierEffect({
+      id: "acc-inc",
+      type: "increasedamagegiven",
+      targetId: "attacker",
+      fromType: "accessory",
+      power: 4,
+    });
+    const keystoneDr = makeModifierEffect({
+      id: "ks-dr",
+      type: "decreasedamagetaken",
+      targetId: "attacker",
+      fromType: "keystone",
+      power: 6,
+    });
+    const skillInc = makeModifierEffect({
+      id: "skill-inc",
+      type: "increasedamagegiven",
+      targetId: "attacker",
+      fromType: "skill",
+      power: 8,
+    });
+
+    const { preBattleGearModifiers, filteredEffects } =
+      consolidatePreBattleDamageModifiers(
+        [armorInc, accessoryInc, keystoneDr, skillInc],
+        ["attacker"],
+      );
+
+    expect(preBattleGearModifiers.attacker?.incDamageGivenFromGear).toBe(16);
+    expect(preBattleGearModifiers.attacker?.drTakenFromKeystone).toBe(6);
+    expect(filteredEffects).toEqual([skillInc]);
+  });
+});
+
+describe("buildDamagePacketModifierLists", () => {
+  it("does not bucket keystone percentage mods into stage-1 non-gear lists", () => {
+    const keystoneInc = makeModifierEffect({
+      id: "ks-inc",
+      type: "increasedamagegiven",
+      targetId: "attacker",
+      fromType: "keystone",
+      power: 15,
+    });
+    const skillInc = makeModifierEffect({
+      id: "skill-inc",
+      type: "increasedamagegiven",
+      targetId: "attacker",
+      fromType: "skill",
+      power: 10,
+    });
+    const eligibility = new Map<string, DamageModifierEligibility>([
+      [
+        "ks-inc",
+        { targetId: "attacker", increaseSide: "attacker", decreaseSide: null },
+      ],
+      [
+        "skill-inc",
+        { targetId: "attacker", increaseSide: "attacker", decreaseSide: null },
+      ],
+    ]);
+
+    const lists = buildDamagePacketModifierLists(
+      [keystoneInc, skillInc],
+      "attacker",
+      "defender",
+      eligibility,
+    );
+
+    expect(lists.stage1PreBattleIncreases.map((e) => e.id)).toEqual(["skill-inc"]);
+    expect(lists.inBattleIncreases).toHaveLength(0);
+  });
+});
+
+describe("buildDamageModifierEligibilityById", () => {
+  it("excludes modifiers when buffprevent RNG blocks", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    const inc = makeModifierEffect({
+      id: "inc",
+      type: "increasedamagegiven",
+      targetId: "attacker",
+      power: 20,
+      fromType: "jutsu",
+    });
+    inc.createdRound = 5;
+
+    const prevent = toUserEffect(
+      BuffPreventTag.parse({ power: 100, calculation: "static" }),
+      {
+        id: "buff-prevent",
+        creatorId: "defender",
+        targetId: "attacker",
+        level: 0,
+        isNew: false,
+        castThisRound: false,
+        createdRound: 0,
+        longitude: 0,
+        latitude: 0,
+        barrierAbsorb: 0,
+        actionId: "prevent-action",
+      },
+    );
+
+    const attacker = { userId: "attacker", username: "Attacker" } as BattleUserState;
+    const usersStateById = new Map([["attacker", attacker]]);
+    const eligibility = buildDamageModifierEligibilityById(
+      [inc, prevent],
+      1,
+      usersStateById,
+    );
+
+    expect(eligibility.get("inc")?.increaseSide).toBeNull();
+    expect(eligibility.get("inc")?.preventInfo?.txt).toContain("cannot be buffed");
+
+    const lists = buildDamagePacketModifierLists(
+      [inc, prevent],
+      "attacker",
+      "defender",
+      eligibility,
+    );
+    expect(lists.inBattleIncreases).toHaveLength(0);
+
+    const emptyGear = { attacker: gearMods(), defender: gearMods() };
+    const withInc = computeDamagePacket({
+      rawDamage: 100,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [inc],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: emptyGear,
+      modifierLists: buildDamagePacketModifierLists(
+        [inc],
+        "attacker",
+        "defender",
+        buildDamageModifierEligibilityById([inc], 1, usersStateById),
+      ),
+    }).damage;
+
+    const prevented = computeDamagePacket({
+      rawDamage: 100,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [inc, prevent],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: emptyGear,
+      modifierLists: lists,
+    }).damage;
+
+    const afterOoc =
+      100 *
+      (1 + OUT_OF_COMBAT_BASE_DAMAGE_INCREASE / 100) *
+      (1 - OUT_OF_COMBAT_BASE_DAMAGE_REDUCTION / 100);
+    expect(withInc).toBeCloseTo(afterOoc * 1.2, 2);
+    expect(prevented).toBeCloseTo(afterOoc, 2);
+
+    vi.restoreAllMocks();
+  });
+});
+
+describe("computeDamagePacket", () => {
+  it("applies base 60% inc and 50% DR only", () => {
+    const { damage } = computeDamagePacket({
+      rawDamage: 505,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: {
+        attacker: gearMods(),
+        defender: gearMods(),
+      },
+    });
+
+    const expected =
+      505 *
+      (1 + OUT_OF_COMBAT_BASE_DAMAGE_INCREASE / 100) *
+      (1 - OUT_OF_COMBAT_BASE_DAMAGE_REDUCTION / 100);
+    expect(damage).toBeCloseTo(expected, 2);
+    expect(damage).toBeCloseTo(404, 2);
+  });
+
+  it("applies stage-1 skill DR after pre-battle pool without negative intermediate damage", () => {
+    const skillDr = makeModifierEffect({
+      id: "skill-dr",
+      type: "decreasedamagetaken",
+      targetId: "defender",
+      fromType: "skill",
+      power: 10,
+    });
+
+    const gearOnly = computeDamagePacket({
+      rawDamage: 100,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: {
+        attacker: gearMods(),
+        defender: gearMods({ drTakenFromGear: 30 }),
+      },
+    }).damage;
+
+    const withSkillDr = computeDamagePacket({
+      rawDamage: 100,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [skillDr],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: {
+        attacker: gearMods(),
+        defender: gearMods({ drTakenFromGear: 30 }),
+      },
+    }).damage;
+
+    expect(gearOnly).toBeCloseTo(32, 2);
+    expect(withSkillDr).toBeCloseTo(gearOnly * 0.9, 2);
+  });
+
+  it("applies stage-1 skill percentage inc before consolidated gear inc", () => {
+    const skillInc = makeModifierEffect({
+      id: "skill-inc",
+      type: "increasedamagegiven",
+      targetId: "attacker",
+      fromType: "skill",
+      power: 10,
+    });
+
+    const { damage } = computeDamagePacket({
+      rawDamage: 100,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [skillInc],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: {
+        attacker: gearMods({ incDamageGivenFromGear: 10 }),
+        defender: gearMods(),
+      },
+    });
+
+    const expected =
+      100 *
+      1.1 *
+      (1 + (OUT_OF_COMBAT_BASE_DAMAGE_INCREASE + 10) / 100) *
+      (1 - OUT_OF_COMBAT_BASE_DAMAGE_REDUCTION / 100);
+    expect(damage).toBeCloseTo(expected, 2);
+  });
+
+  it("clamps to min damage floor when keystone DR exceeds 100%", () => {
+    const blBoost = makeModifierEffect({
+      id: "bl-inc",
+      type: "increasedamagegiven",
+      targetId: "attacker",
+      fromType: "bloodline",
+      power: 50,
+    });
+
+    const { damage } = computeDamagePacket({
+      rawDamage: 100,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [blBoost],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: {
+        attacker: gearMods(),
+        defender: gearMods({ drTakenFromKeystone: 150 }),
+      },
+    });
+
+    const boosted = 100 * (1 + OUT_OF_COMBAT_BASE_DAMAGE_INCREASE / 100);
+    const floor = boosted * (1 - DMG_REDUCTION_CAP);
+    expect(damage).toBeCloseTo(floor * 1.5, 2);
+  });
+
+  it("applies keystone inc after % mitigation and before bloodline", () => {
+    const { damage } = computeDamagePacket({
+      rawDamage: 100,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: {
+        attacker: gearMods({ incDamageGivenFromKeystone: 10 }),
+        defender: gearMods(),
+      },
+    });
+
+    const afterEarlyPools =
+      100 *
+      (1 + OUT_OF_COMBAT_BASE_DAMAGE_INCREASE / 100) *
+      (1 - OUT_OF_COMBAT_BASE_DAMAGE_REDUCTION / 100);
+    const expected = afterEarlyPools * 1.1;
+    expect(damage).toBeCloseTo(expected, 2);
+    expect(damage).not.toBeCloseTo(
+      100 *
+        (1 + (OUT_OF_COMBAT_BASE_DAMAGE_INCREASE + 10) / 100) *
+        (1 - OUT_OF_COMBAT_BASE_DAMAGE_REDUCTION / 100),
+      2,
+    );
+  });
+
+  it("applies gear inc and DR points additively into base pools", () => {
+    const { damage } = computeDamagePacket({
+      rawDamage: 505,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: defaultTestGearModifiers(),
+    });
+
+    expect(damage).toBeCloseTo(406.55, 2);
+  });
+
+  it("applies defender stage-1 increasedamagetaken in pre-battle inc pool", () => {
+    const { damage } = computeDamagePacket({
+      rawDamage: 505,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: {
+        attacker: gearMods(),
+        defender: gearMods({ incDamageTakenFromGear: 10 }),
+      },
+    });
+
+    const expected =
+      505 *
+      (1 + (OUT_OF_COMBAT_BASE_DAMAGE_INCREASE + 10) / 100) *
+      (1 - OUT_OF_COMBAT_BASE_DAMAGE_REDUCTION / 100);
+    expect(damage).toBeCloseTo(expected, 2);
+    expect(damage).toBeCloseTo(429.25, 2);
+  });
+
+  it("does not apply attacker increasedamagetaken to outgoing damage", () => {
+    const baseline = computeDamagePacket({
+      rawDamage: 505,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: {
+        attacker: gearMods(),
+        defender: gearMods(),
+      },
+    }).damage;
+
+    const { damage } = computeDamagePacket({
+      rawDamage: 505,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: {
+        attacker: gearMods({ incDamageTakenFromGear: 20 }),
+        defender: gearMods(),
+      },
+    });
+
+    expect(damage).toBeCloseTo(baseline, 2);
+  });
+
+  it("applies bloodline percentage DR after the reduction cap", () => {
+    const jutsuDr = makeModifierEffect({
+      id: "jutsu-dr",
+      type: "decreasedamagetaken",
+      targetId: "defender",
+      fromType: "jutsu",
+      power: 50,
+    });
+    const blDr = makeModifierEffect({
+      id: "bl-dr",
+      type: "decreasedamagetaken",
+      targetId: "defender",
+      fromType: "bloodline",
+      power: 20,
+    });
+
+    const withoutBlDr = computeDamagePacket({
+      rawDamage: 100,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [jutsuDr],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: {
+        attacker: gearMods(),
+        defender: gearMods(),
+      },
+    }).damage;
+
+    const { damage } = computeDamagePacket({
+      rawDamage: 100,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [jutsuDr, blDr],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: {
+        attacker: gearMods(),
+        defender: gearMods(),
+      },
+    });
+
+    expect(damage).toBeCloseTo(withoutBlDr * 0.8, 2);
+  });
+
+  it("does not apply sealed bloodline damage modifiers in the pipeline", () => {
+    const blBoost = makeModifierEffect({
+      id: "bl-inc",
+      type: "increasedamagegiven",
+      targetId: "attacker",
+      fromType: "bloodline",
+      power: 40,
+    });
+    const seal = toUserEffect(SealTag.parse({ power: 100, calculation: "static" }), {
+      id: "seal-1",
+      creatorId: "defender",
+      targetId: "attacker",
+      level: 0,
+      isNew: false,
+      castThisRound: false,
+      createdRound: 0,
+      longitude: 0,
+      latitude: 0,
+      barrierAbsorb: 0,
+      actionId: "seal-action",
+    });
+
+    const baseline = computeDamagePacket({
+      rawDamage: 505,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: defaultTestGearModifiers(),
+    }).damage;
+
+    const { damage } = computeDamagePacket({
+      rawDamage: 505,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [blBoost, seal],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: defaultTestGearModifiers(),
+    });
+
+    expect(damage).toBeCloseTo(baseline, 2);
+  });
+
+  it("applies 40% bloodline boost after DR", () => {
+    const blBoost = makeModifierEffect({
+      id: "bl-inc",
+      type: "increasedamagegiven",
+      targetId: "attacker",
+      fromType: "bloodline",
+      power: 40,
+    });
+
+    const { damage } = computeDamagePacket({
+      rawDamage: 505,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [blBoost],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: defaultTestGearModifiers(),
+    });
+
+    expect(damage).toBeCloseTo(569.17, 2);
+  });
+
+  it("uses DMG_REDUCTION_CAP of 90%", () => {
+    expect(DMG_REDUCTION_CAP).toBe(0.9);
+  });
+
+  it("enforces 10% damage floor after extreme DR", () => {
+    const extremeDr = makeModifierEffect({
+      id: "extreme-dr",
+      type: "decreasedamagetaken",
+      targetId: "defender",
+      fromType: "jutsu",
+      power: 80,
+    });
+
+    const { damage } = computeDamagePacket({
+      rawDamage: 100,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [extremeDr],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: {
+        attacker: gearMods(),
+        defender: gearMods(),
+      },
+    });
+
+    const boosted = 100 * (1 + OUT_OF_COMBAT_BASE_DAMAGE_INCREASE / 100);
+    const afterOocDr = boosted * (1 - OUT_OF_COMBAT_BASE_DAMAGE_REDUCTION / 100);
+    const afterExtremeDr = afterOocDr * (1 - 0.8);
+    const floor = boosted * (1 - DMG_REDUCTION_CAP);
+    expect(damage).toBeCloseTo(Math.max(afterExtremeDr, floor), 2);
+  });
+
+  it("applies static increase as flat addition immediately before static DR", () => {
+    const staticInc = makeModifierEffect({
+      id: "static-inc",
+      type: "increasedamagegiven",
+      targetId: "attacker",
+      fromType: "jutsu",
+      calculation: "static",
+      power: 25,
+    });
+    const staticDr = makeModifierEffect({
+      id: "static-dr",
+      type: "decreasedamagetaken",
+      targetId: "defender",
+      fromType: "ranked",
+      calculation: "static",
+      power: 50,
+    });
+
+    const baseline = computeDamagePacket({
+      rawDamage: 100,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: {
+        attacker: gearMods(),
+        defender: gearMods(),
+      },
+    }).damage;
+
+    const { damage } = computeDamagePacket({
+      rawDamage: 100,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [staticInc, staticDr],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: {
+        attacker: gearMods(),
+        defender: gearMods(),
+      },
+    });
+
+    expect(damage).toBeCloseTo(baseline + 25 - 50, 2);
+  });
+
+  it("applies static DR as flat subtraction after % mitigation", () => {
+    const staticDr = makeModifierEffect({
+      id: "static-dr",
+      type: "decreasedamagetaken",
+      targetId: "defender",
+      fromType: "ranked",
+      calculation: "static",
+      power: 50,
+    });
+
+    const baseline = computeDamagePacket({
+      rawDamage: 505,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: {
+        attacker: gearMods(),
+        defender: gearMods(),
+      },
+    }).damage;
+
+    const { damage } = computeDamagePacket({
+      rawDamage: 505,
+      damageEffect: makeDamageEffect(),
+      usersEffects: [staticDr],
+      attackerId: "attacker",
+      defenderId: "defender",
+      battleRound: 1,
+      preBattleGearModifiers: {
+        attacker: gearMods(),
+        defender: gearMods(),
+      },
+    });
+
+    expect(damage).toBeCloseTo(baseline - 50, 2);
+  });
+});


### PR DESCRIPTION
# Pull Request

**Please fill: what was implemented, why, possibly include screenshots, are any of the changes breaking, etc.**

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accessories and keystones now count as pre-battle gear and affect damage calculations.
  * Out-of-combat damage tuning added (configurable base increase and reduction).
  * Combat now records detailed per-hit damage breakdowns for visibility/analysis.

* **Bug Fixes**
  * Damage reduction cap raised from 80% to 90% — minimum damage now 10% of base.

* **Tests**
  * Expanded tests covering the consolidated damage pipeline and pre-battle gear modifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/studie-tech/TheNinjaRPG/pull/1350?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->