### PR TITLE
Add delete concept art perm

### DIFF
--- a/app/src/layout/ConceptImage.tsx
+++ b/app/src/layout/ConceptImage.tsx
@@ -32,6 +32,7 @@ import Image from "@/layout/Image";
 import ReportUser from "@/layout/Report";
 import { showMutationToast } from "@/libs/toast";
 import type { ImageWithRelations } from "@/routers/conceptart";
+import { canDeleteConceptArt } from "@/utils/permissions";
 import { secondsPassed } from "@/utils/time";
 import { useUserData } from "@/utils/UserContext";
 
@@ -241,9 +242,10 @@ const ConceptImage: React.FC<InputProps> = (props) => {
           </div>
         )}
         <div className="absolute top-2 right-2">
-          {image.userId === user?.userId && (
+          {(image.userId === user?.userId ||
+            (user && canDeleteConceptArt(user.role))) && (
             <Trash2
-              className={`cursor-pointer text-white hover:fill-red-500 ${showDetails ? "h-6 w-6" : "h-4 w-4"}`}
+              className={`cursor-pointer text-white hover:fill-red-500 ${showDetails ? "h-7 w-7" : "h-5 w-5"}`}
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();

--- a/app/src/server/api/routers/conceptart.ts
+++ b/app/src/server/api/routers/conceptart.ts
@@ -16,6 +16,7 @@ import {
   uploadCompletedVideo,
 } from "@/libs/replicate";
 import { fetchUser } from "@/routers/profile";
+import { canDeleteConceptArt } from "@/utils/permissions";
 import {
   conceptArtFilterSchema,
   conceptArtPromptSchema,
@@ -82,10 +83,15 @@ export const conceptartRouter = createTRPCRouter({
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
       // Query
-      const result = await fetchImage(ctx.drizzle, input.id, ctx.userId);
+      const [result, user] = await Promise.all([
+        fetchImage(ctx.drizzle, input.id, ctx.userId),
+        fetchUser(ctx.drizzle, ctx.userId),
+      ]);
       // Guard
       if (!result) return errorResponse("Image not found");
-      if (result.userId !== ctx.userId) return errorResponse("Not authorized");
+      if (result.userId !== ctx.userId && !canDeleteConceptArt(user.role)) {
+        return errorResponse("Not authorized");
+      }
       // Mutate
       await ctx.drizzle.delete(conceptImage).where(eq(conceptImage.id, input.id));
       return { success: true, message: "Image deleted" };

--- a/app/src/utils/permissions.ts
+++ b/app/src/utils/permissions.ts
@@ -362,6 +362,17 @@ export const canDeleteComment = (user: UserData, commentAuthorId: string) => {
   );
 };
 
+export const canDeleteConceptArt = (role: UserRole) => {
+  return [
+    "OWNER",
+    "HEAD_MODERATOR",
+    "CODING-ADMIN",
+    "CONTENT-ADMIN",
+    "EVENT-ADMIN",
+    "MODERATOR-ADMIN",
+  ].includes(role);
+};
+
 export const canEscalateBan = (user: UserData, report: UserReport) => {
   return (
     !report.adminResolved &&

--- a/app/tests/utils/permissions.test.ts
+++ b/app/tests/utils/permissions.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 import {
   canApproveApplications,
+  canDeleteConceptArt,
   canViewAllApplications,
   getApprovalGroup,
 } from "@/utils/permissions";
@@ -36,6 +37,17 @@ test("head leads may view all applications but cannot approve", () => {
   expect(canApproveApplications("HEAD_CONTENT")).toBe(false);
   expect(canApproveApplications("HEAD_EVENT")).toBe(false);
   expect(canApproveApplications("HEAD_MODERATOR")).toBe(false);
+});
+
+test("concept art delete permission is owner and admin roles only", () => {
+  expect(canDeleteConceptArt("USER")).toBe(false);
+  expect(canDeleteConceptArt("OWNER")).toBe(true);
+  expect(canDeleteConceptArt("CODING-ADMIN")).toBe(true);
+  expect(canDeleteConceptArt("CONTENT-ADMIN")).toBe(true);
+  expect(canDeleteConceptArt("EVENT-ADMIN")).toBe(true);
+  expect(canDeleteConceptArt("MODERATOR-ADMIN")).toBe(true);
+  expect(canDeleteConceptArt("HEAD_MODERATOR")).toBe(true);
+  expect(canDeleteConceptArt("MODERATOR")).toBe(false);
 });
 
 test("non-approval staff do not get application approval access", () => {


### PR DESCRIPTION
# Pull Request

Allows owner, all admins, and head moderator to delete concept art

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Concept art deletion now supports role-based permissions; users with permitted roles can delete images in addition to image owners. Delete control visibility updated in the UI so eligible users see the action.

* **Tests**
  * Added tests verifying concept art deletion authorization across roles and owners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->