### PR TITLE
banned and silenced users cannot create concept art

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -889,7 +889,7 @@ export const COST_EXTRA_JUTSU_SLOT = 50;
 export const COST_REROLL_ELEMENT = 10;
 export const COST_SKILL_RESET = 30;
 export const COST_CONCEPT_IMAGE = 1;
-export const COST_CONCEPT_VIDEO = 10;
+export const COST_CONCEPT_VIDEO = 15;
 export const COST_STREAK_CATCHUP_DAY = 1;
 export const MAX_EXTRA_JUTSU_SLOTS = 2;
 export const BATTLE_LOG_FULL_LIMIT = 1000;
@@ -1571,6 +1571,14 @@ export const SECTOR_TYPES = [
 
 // Conversation config
 export const CONVERSATION_QUIET_MINS = 5;
+export const MESSAGING_MIN_LEVEL = 3;
+export const FORUM_MIN_LEVEL = 3;
+export const AUCTION_HOUSE_MIN_LEVEL = 15;
+export const REP_TRADE_MIN_LEVEL = 15;
+export const messagingLevelMessage = `You must reach level ${MESSAGING_MIN_LEVEL} to send messages`;
+export const forumLevelMessage = `You must reach level ${FORUM_MIN_LEVEL} to post in the forum`;
+export const auctionHouseLevelMessage = `You must reach level ${AUCTION_HOUSE_MIN_LEVEL} to use the auction house`;
+export const repTradeLevelMessage = `You must reach level ${REP_TRADE_MIN_LEVEL} to buy or sell reputation with other players`;
 export const REPORT_CONTEXT_WINDOW = 20;
 
 // Kage config

--- a/app/src/app/auctionhouse/page.tsx
+++ b/app/src/app/auctionhouse/page.tsx
@@ -80,8 +80,10 @@ import { Separator } from "@/components/ui/separator";
 import {
   AUCTION_BIDDER_LEVEL_MAX,
   AUCTION_BIDDER_LEVEL_MIN,
+  AUCTION_HOUSE_MIN_LEVEL,
   AUCTION_LISTING_STATES,
   AUCTION_LISTING_TYPES,
+  auctionHouseLevelMessage,
   IMG_AVATAR_DEFAULT,
   ItemRarities,
   TRADEABLE_CURRENCY_TYPES,
@@ -158,6 +160,8 @@ export default function AuctionHousePage() {
   if (!userData) return <Loader explanation="Loading userdata" />;
   if (!access) return <Loader explanation="Accessing Auction House" />;
 
+  const belowAuctionMinLevel = userData.level < AUCTION_HOUSE_MIN_LEVEL;
+
   return (
     <ContentBox
       title="Auction House"
@@ -178,10 +182,15 @@ export default function AuctionHousePage() {
               ))}
             </SelectContent>
           </Select>
-          <NewAuctionListingDialog />
+          {!belowAuctionMinLevel && <NewAuctionListingDialog />}
         </div>
       }
     >
+      {belowAuctionMinLevel && (
+        <p className="border-b px-4 py-3 text-center text-muted-foreground text-sm">
+          {auctionHouseLevelMessage}
+        </p>
+      )}
       <AuctionListing selectedStatus={selectedStatus} />
     </ContentBox>
   );
@@ -549,7 +558,7 @@ const AuctionLotCard: React.FC<AuctionLotCardProps> = ({
               {bidStanding === "winning" && (
                 <Badge
                   variant="outline"
-                  className="gap-1 border-emerald-500/50 bg-emerald-500/10 font-medium text-emerald-900 text-[10px] dark:text-emerald-100"
+                  className="gap-1 border-emerald-500/50 bg-emerald-500/10 font-medium text-[10px] text-emerald-900 dark:text-emerald-100"
                 >
                   <TrendingUp className="h-3 w-3" />
                   Winning
@@ -558,7 +567,7 @@ const AuctionLotCard: React.FC<AuctionLotCardProps> = ({
               {bidStanding === "outbid" && (
                 <Badge
                   variant="outline"
-                  className="gap-1 border-amber-500/50 bg-amber-500/10 font-medium text-amber-950 text-[10px] dark:text-amber-100"
+                  className="gap-1 border-amber-500/50 bg-amber-500/10 font-medium text-[10px] text-amber-950 dark:text-amber-100"
                 >
                   <TrendingDown className="h-3 w-3" />
                   Outbid
@@ -586,7 +595,7 @@ const AuctionLotCard: React.FC<AuctionLotCardProps> = ({
           ) : null}
           <div className="mt-1.5 space-y-1.5 text-xs">
             <div>
-              <p className="mb-0.5 text-muted-foreground text-[10px] uppercase tracking-wide">
+              <p className="mb-0.5 text-[10px] text-muted-foreground uppercase tracking-wide">
                 Seller
               </p>
               <div className="flex min-w-0 items-center gap-2">
@@ -604,13 +613,13 @@ const AuctionLotCard: React.FC<AuctionLotCardProps> = ({
               </div>
             </div>
             {showBidderLevelHint ? (
-              <p className="text-muted-foreground text-[10px] leading-snug">
+              <p className="text-[10px] text-muted-foreground leading-snug">
                 Bidders: levels {bidderMinLevel}–{bidderMaxLevel}
               </p>
             ) : null}
             {listing.listingType === "DIRECT" && (
               <div>
-                <p className="mb-0.5 text-muted-foreground text-[10px] uppercase tracking-wide">
+                <p className="mb-0.5 text-[10px] text-muted-foreground uppercase tracking-wide">
                   Offered to
                 </p>
                 <div className="flex min-w-0 items-center gap-2">
@@ -645,7 +654,7 @@ const AuctionLotCard: React.FC<AuctionLotCardProps> = ({
       <Separator className="shrink-0 opacity-60" />
       <div className="flex shrink-0 items-end justify-between gap-2 p-3 pt-2">
         <div className="min-h-[4.25rem]">
-          <p className="text-muted-foreground text-[10px] uppercase tracking-wider">
+          <p className="text-[10px] text-muted-foreground uppercase tracking-wider">
             Current
           </p>
           <p className="font-bold text-base text-emerald-700 tabular-nums dark:text-emerald-400">
@@ -655,7 +664,7 @@ const AuctionLotCard: React.FC<AuctionLotCardProps> = ({
             </span>
           </p>
           {showPerUnitPricing ? (
-            <p className="mt-0.5 text-muted-foreground text-[10px] leading-tight tabular-nums">
+            <p className="mt-0.5 text-[10px] text-muted-foreground tabular-nums leading-tight">
               {formatAuctionPerUnitLine(
                 listing.currentPrice,
                 stackQuantity,
@@ -675,7 +684,7 @@ const AuctionLotCard: React.FC<AuctionLotCardProps> = ({
               : "—"}
           </p>
           {listing.buyoutPrice != null && showPerUnitPricing ? (
-            <p className="mt-0.5 text-muted-foreground text-[10px] leading-tight tabular-nums">
+            <p className="mt-0.5 text-[10px] text-muted-foreground tabular-nums leading-tight">
               {formatAuctionPerUnitLine(
                 listing.buyoutPrice,
                 stackQuantity,
@@ -685,7 +694,7 @@ const AuctionLotCard: React.FC<AuctionLotCardProps> = ({
           ) : null}
         </div>
         <div className="flex min-h-[4.25rem] flex-col items-end justify-end gap-0.5 text-right">
-          <div className="flex items-center gap-1 text-muted-foreground text-[10px] uppercase tracking-wide">
+          <div className="flex items-center gap-1 text-[10px] text-muted-foreground uppercase tracking-wide">
             <Timer className="h-3 w-3" />
             Ends
           </div>
@@ -787,7 +796,7 @@ const AuctionDetailsDialog: React.FC<AuctionDetailsDialogProps> = ({
       </Modal2>
     );
   }
-  if (!listing.userItem || !listing.userItem.item) {
+  if (!listing.userItem?.item) {
     return (
       <Modal2 title="Auction Details" isOpen={isOpen} setIsOpen={setIsOpen}>
         <div className="p-4 text-center">
@@ -815,13 +824,15 @@ const AuctionDetailsDialog: React.FC<AuctionDetailsDialogProps> = ({
   const isActive = listing.status === "ACTIVE";
   const stackQuantity = listing.userItem.quantity;
   const showPerUnitPricing = listing.userItem.item.canStack && stackQuantity > 1;
-  const canSellerCancel = isOwner && isActive && listing.bids.length === 0;
 
   const bidderMinLevel = listing.bidderMinLevel ?? AUCTION_BIDDER_LEVEL_MIN;
   const bidderMaxLevel = listing.bidderMaxLevel ?? AUCTION_BIDDER_LEVEL_MAX;
+  const meetsAuctionHouseMinLevel = userData.level >= AUCTION_HOUSE_MIN_LEVEL;
   const canBidByLevel =
     listing.listingType !== "AUCTION" ||
     (userData.level >= bidderMinLevel && userData.level <= bidderMaxLevel);
+  const canBid = meetsAuctionHouseMinLevel && canBidByLevel;
+  const canSellerCancel = isOwner && isActive && listing.bids.length === 0;
 
   const minIntegerBid = Math.floor(listing.currentPrice) + 1;
   const parsedBidAmount = bidAmount.trim() === "" ? Number.NaN : Number(bidAmount);
@@ -903,7 +914,7 @@ const AuctionDetailsDialog: React.FC<AuctionDetailsDialogProps> = ({
         <Card className="overflow-hidden border-amber-500/25 bg-linear-to-br from-amber-950/10 via-card to-card shadow-sm">
           <CardHeader className="space-y-0.5 p-3 pb-2">
             <div className="flex flex-wrap items-center justify-between gap-1.5">
-              <CardTitle className="flex items-center gap-1.5 text-xs font-semibold">
+              <CardTitle className="flex items-center gap-1.5 font-semibold text-xs">
                 <Gavel className="h-3 w-3 text-amber-600" />
                 Lot & pricing
               </CardTitle>
@@ -938,7 +949,7 @@ const AuctionDetailsDialog: React.FC<AuctionDetailsDialogProps> = ({
             <div className="flex flex-col gap-2 rounded-md border bg-background/60 p-2 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
               <div className="flex min-w-0 flex-1 flex-col gap-1.5 sm:flex-row sm:flex-wrap sm:items-center sm:gap-x-4 sm:gap-y-0">
                 <div className="flex min-w-0 items-center gap-1.5">
-                  <span className="shrink-0 text-muted-foreground text-[10px] uppercase tracking-wide">
+                  <span className="shrink-0 text-[10px] text-muted-foreground uppercase tracking-wide">
                     Seller
                   </span>
                   <Image
@@ -955,7 +966,7 @@ const AuctionDetailsDialog: React.FC<AuctionDetailsDialogProps> = ({
                 </div>
                 {listing.listingType === "DIRECT" && listing.targetUser ? (
                   <div className="flex min-w-0 items-center gap-1.5">
-                    <span className="shrink-0 text-muted-foreground text-[10px] uppercase tracking-wide">
+                    <span className="shrink-0 text-[10px] text-muted-foreground uppercase tracking-wide">
                       Buyer
                     </span>
                     <Image
@@ -972,15 +983,15 @@ const AuctionDetailsDialog: React.FC<AuctionDetailsDialogProps> = ({
                   </div>
                 ) : null}
               </div>
-              <div className="shrink-0 border-t border-emerald-500/20 pt-1.5 sm:border-t-0 sm:border-l sm:pl-3 sm:pt-0">
-                <p className="text-muted-foreground text-[10px] uppercase tracking-wide">
+              <div className="shrink-0 border-emerald-500/20 border-t pt-1.5 sm:border-t-0 sm:border-l sm:pt-0 sm:pl-3">
+                <p className="text-[10px] text-muted-foreground uppercase tracking-wide">
                   Current
                 </p>
-                <p className="font-bold text-base leading-tight text-emerald-800 tabular-nums sm:text-right dark:text-emerald-300">
+                <p className="font-bold text-base text-emerald-800 tabular-nums leading-tight sm:text-right dark:text-emerald-300">
                   {formatAuctionCurrency(listing.currentPrice, listing.currencyType)}
                 </p>
                 {showPerUnitPricing ? (
-                  <p className="mt-0.5 text-muted-foreground text-[10px] leading-tight sm:text-right">
+                  <p className="mt-0.5 text-[10px] text-muted-foreground leading-tight sm:text-right">
                     {formatAuctionPerUnitLine(
                       listing.currentPrice,
                       stackQuantity,
@@ -989,13 +1000,13 @@ const AuctionDetailsDialog: React.FC<AuctionDetailsDialogProps> = ({
                   </p>
                 ) : null}
                 {listing.buyoutPrice != null ? (
-                  <p className="mt-0.5 text-muted-foreground text-[11px] sm:text-right">
+                  <p className="mt-0.5 text-[11px] text-muted-foreground sm:text-right">
                     Buyout{" "}
                     {formatAuctionCurrency(listing.buyoutPrice, listing.currencyType)}
                   </p>
                 ) : null}
                 {listing.buyoutPrice != null && showPerUnitPricing ? (
-                  <p className="mt-0.5 text-muted-foreground text-[10px] leading-tight sm:text-right">
+                  <p className="mt-0.5 text-[10px] text-muted-foreground leading-tight sm:text-right">
                     {formatAuctionPerUnitLine(
                       listing.buyoutPrice,
                       stackQuantity,
@@ -1046,7 +1057,7 @@ const AuctionDetailsDialog: React.FC<AuctionDetailsDialogProps> = ({
           !isExpired &&
           !isOwner &&
           (!listing.targetUserId || listing.targetUserId === userData.userId) &&
-          canBidByLevel && (
+          canBid && (
             <Card className="border-primary/20 bg-muted/20">
               <CardHeader className="space-y-0.5 p-3 pb-1.5">
                 <CardTitle className="text-sm">Raise your bid</CardTitle>
@@ -1121,7 +1132,7 @@ const AuctionDetailsDialog: React.FC<AuctionDetailsDialogProps> = ({
               </p>
             </div>
             {!canSellerCancel && isActive ? (
-              <p className="text-center text-muted-foreground text-[10px]">
+              <p className="text-center text-[10px] text-muted-foreground">
                 Bids have been placed — this listing can no longer be cancelled.
               </p>
             ) : null}
@@ -1154,7 +1165,21 @@ const AuctionDetailsDialog: React.FC<AuctionDetailsDialogProps> = ({
         {isActive &&
           !isExpired &&
           !isOwner &&
+          !meetsAuctionHouseMinLevel &&
+          (!listing.targetUserId || listing.targetUserId === userData.userId) && (
+            <div className="flex gap-2 rounded-lg border border-amber-200 bg-amber-50/90 p-2.5 dark:border-amber-900 dark:bg-amber-950/40">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-800 dark:text-amber-200" />
+              <p className="text-amber-950 text-xs leading-snug dark:text-amber-100">
+                {auctionHouseLevelMessage}
+              </p>
+            </div>
+          )}
+
+        {isActive &&
+          !isExpired &&
+          !isOwner &&
           listing.listingType === "AUCTION" &&
+          meetsAuctionHouseMinLevel &&
           (!listing.targetUserId || listing.targetUserId === userData.userId) &&
           !canBidByLevel && (
             <div className="flex gap-2 rounded-lg border border-amber-200 bg-amber-50/90 p-2.5 dark:border-amber-900 dark:bg-amber-950/40">
@@ -1488,7 +1513,7 @@ export const NewAuctionListingDialog: React.FC = () => {
                           className="h-9"
                         />
                         <CommandList
-                          className="w-full max-h-[300px] overflow-y-auto"
+                          className="max-h-[300px] w-full overflow-y-auto"
                           onWheel={(e) => {
                             const LINE_HEIGHT = 18;
                             const PAGE_HEIGHT = e.currentTarget.clientHeight;

--- a/app/src/app/blackmarket/page.tsx
+++ b/app/src/app/blackmarket/page.tsx
@@ -28,7 +28,9 @@ import { Label } from "@/components/ui/label";
 import {
   PITY_BLOODLINE_ROLLS,
   PITY_SYSTEM_ENABLED,
+  REP_TRADE_MIN_LEVEL,
   RYO_FOR_REP_DAYS_FROZEN,
+  repTradeLevelMessage,
 } from "@/drizzle/constants";
 import { useLocalStorage } from "@/hooks/localstorage";
 import AvatarImage from "@/layout/Avatar";
@@ -320,6 +322,7 @@ const RyoShop: React.FC<{ userData: NonNullable<UserWithRelations> }> = ({
     });
 
   const isLoading = isCreating || isDelisting || isAccepting;
+  const belowRepTradeMinLevel = userData.level < REP_TRADE_MIN_LEVEL;
 
   // Creator search
   const maxUsers = 1;
@@ -423,7 +426,7 @@ const RyoShop: React.FC<{ userData: NonNullable<UserWithRelations> }> = ({
         ),
         actions: (
           <div className="flex flex-row gap-1">
-            {showActive && hasRyo && !owner && (
+            {showActive && hasRyo && !owner && !belowRepTradeMinLevel && (
               <Button onClick={() => accept({ offerId: offer.id })}>
                 <ShoppingCart className="mr-2 h-5 w-5" />
                 Buy
@@ -510,7 +513,12 @@ const RyoShop: React.FC<{ userData: NonNullable<UserWithRelations> }> = ({
       }
     >
       {/* CREATE OFFERS */}
-      {tradeableReps > 0 && (
+      {belowRepTradeMinLevel && (
+        <p className="border-b px-3 py-3 text-center text-muted-foreground text-sm">
+          {repTradeLevelMessage}
+        </p>
+      )}
+      {tradeableReps > 0 && !belowRepTradeMinLevel && (
         <div className="pb-5">
           <p className="p-3">
             You have <b>{tradeableReps.toLocaleString()} reputation points</b> and{" "}

--- a/app/src/app/conceptart/page.tsx
+++ b/app/src/app/conceptart/page.tsx
@@ -58,7 +58,7 @@ import Confirm2 from "@/layout/Confirm2";
 import ContentBox from "@/layout/ContentBox";
 import { useInfinitePagination } from "@/libs/pagination";
 import { showMutationToast } from "@/libs/toast";
-import { canCreateConceptArt } from "@/utils/permissions";
+import { getConceptArtCreateRestriction } from "@/utils/permissions";
 import { useUserData } from "@/utils/UserContext";
 import { UploadDropzone } from "@/utils/uploadthing";
 import {
@@ -164,7 +164,9 @@ export default function ConceptArt() {
     });
 
   const isPending = isImagePending || isVideoPending;
-  const conceptArtCreateRestriction = userData ? canCreateConceptArt(userData) : null;
+  const conceptArtCreateRestriction = userData
+    ? getConceptArtCreateRestriction(userData)
+    : null;
 
   // Filters
   const only_own = useWatch({ control: filterForm.control, name: "only_own" });

--- a/app/src/app/conceptart/page.tsx
+++ b/app/src/app/conceptart/page.tsx
@@ -2,6 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
+  BellOff,
   ImageIcon,
   ImagePlus,
   Loader2,
@@ -45,12 +46,19 @@ import {
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { COST_CONCEPT_IMAGE, COST_CONCEPT_VIDEO } from "@/drizzle/constants";
 import ConceptImage from "@/layout/ConceptImage";
 import Confirm2 from "@/layout/Confirm2";
 import ContentBox from "@/layout/ContentBox";
 import { useInfinitePagination } from "@/libs/pagination";
 import { showMutationToast } from "@/libs/toast";
+import { canCreateConceptArt } from "@/utils/permissions";
 import { useUserData } from "@/utils/UserContext";
 import { UploadDropzone } from "@/utils/uploadthing";
 import {
@@ -156,6 +164,7 @@ export default function ConceptArt() {
     });
 
   const isPending = isImagePending || isVideoPending;
+  const conceptArtCreateRestriction = userData ? canCreateConceptArt(userData) : null;
 
   // Filters
   const only_own = useWatch({ control: filterForm.control, name: "only_own" });
@@ -273,7 +282,29 @@ export default function ConceptArt() {
               ))}
             </SelectContent>
           </Select>
-          {userData && (
+          {userData && conceptArtCreateRestriction && (
+            <TooltipProvider delayDuration={50}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex">
+                    <Button
+                      id="new-art"
+                      disabled
+                      variant="outline"
+                      aria-label={`${conceptArtCreateRestriction}. You cannot create concept art.`}
+                    >
+                      <BellOff className="mr-2 h-6 w-6 text-red-500" />
+                      {userData.isBanned ? "Banned" : "Silenced"}
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {conceptArtCreateRestriction}. You cannot create concept art.
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+          {userData && !conceptArtCreateRestriction && (
             <Confirm2
               title="Create New"
               button={

--- a/app/src/app/forum/[boardid]/[threadid]/page.tsx
+++ b/app/src/app/forum/[boardid]/[threadid]/page.tsx
@@ -5,6 +5,7 @@ import { use, useState } from "react";
 import { useForm } from "react-hook-form";
 import { api } from "@/app/_trpc/client";
 import NotFoundPage from "@/app/[...not-found]/page";
+import { FORUM_MIN_LEVEL, forumLevelMessage } from "@/drizzle/constants";
 import { CommentOnForum } from "@/layout/Comment";
 import ContentBox from "@/layout/ContentBox";
 import Loader from "@/layout/Loader";
@@ -38,6 +39,7 @@ export default function Thread(props: { params: Promise<{ threadid: string }> })
   const allComments = comments?.data;
   const totalPages = comments?.totalPages ?? 0;
   const totalComments = comments?.totalComments ?? 0;
+  const belowForumMinLevel = (userData?.level ?? 0) < FORUM_MIN_LEVEL;
 
   const {
     handleSubmit,
@@ -70,7 +72,13 @@ export default function Thread(props: { params: Promise<{ threadid: string }> })
     });
 
   const handleSubmitComment = handleSubmit(
-    (data) => createComment(data),
+    (data) => {
+      if (belowForumMinLevel) {
+        showMutationToast({ success: false, message: forumLevelMessage });
+        return;
+      }
+      createComment(data);
+    },
     (errors) => console.error(errors),
   );
 
@@ -110,7 +118,18 @@ export default function Thread(props: { params: Promise<{ threadid: string }> })
             userData &&
             !thread.isLocked &&
             !userData.isBanned &&
-            !userData.isSilenced && (
+            !userData.isSilenced &&
+            belowForumMinLevel && (
+              <p className="mb-3 text-center text-muted-foreground text-sm">
+                {forumLevelMessage}
+              </p>
+            )}
+          {thread &&
+            userData &&
+            !thread.isLocked &&
+            !userData.isBanned &&
+            !userData.isSilenced &&
+            !belowForumMinLevel && (
               <div className="relative mb-3">
                 <RichInput
                   id="comment"

--- a/app/src/app/forum/[boardid]/page.tsx
+++ b/app/src/app/forum/[boardid]/page.tsx
@@ -19,7 +19,12 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { FORUM_BOARD_THREADS_PER_PAGE, IMG_ICON_FORUM } from "@/drizzle/constants";
+import {
+  FORUM_BOARD_THREADS_PER_PAGE,
+  FORUM_MIN_LEVEL,
+  forumLevelMessage,
+  IMG_ICON_FORUM,
+} from "@/drizzle/constants";
 import Confirm2 from "@/layout/Confirm2";
 import ContentBox from "@/layout/ContentBox";
 import ContentImageSelector from "@/layout/ContentImageSelector";
@@ -95,6 +100,7 @@ function Board(properties: { params: Promise<{ boardid: string }> }) {
   const canUserPostAsAi = userData && canPostAsAi(userData.role);
   const isNewsBoard = board?.name === "News";
   const canPostNews = userData && canCreateNews(userData.role);
+  const belowForumMinLevel = (userData?.level ?? 0) < FORUM_MIN_LEVEL;
 
   const { mutate: createThread, isPending: isCreatingThread } =
     api.forum.createThread.useMutation({
@@ -157,7 +163,8 @@ function Board(properties: { params: Promise<{ boardid: string }> }) {
         topRightContent={
           userData &&
           !userData.isBanned &&
-          !userData.isSilenced && (
+          !userData.isSilenced &&
+          !belowForumMinLevel && (
             <div className="flex flex-row items-center">
               <Confirm2
                 title="Create a new thread"
@@ -238,6 +245,14 @@ function Board(properties: { params: Promise<{ boardid: string }> }) {
           )
         }
       >
+        {userData &&
+          belowForumMinLevel &&
+          !userData.isBanned &&
+          !userData.isSilenced && (
+            <p className="mb-4 text-center text-muted-foreground text-sm">
+              {forumLevelMessage}
+            </p>
+          )}
         {allThreads?.length === 0 && <div>No threads found</div>}
         {allThreads?.map((thread, i) => {
           // Icons, which have to be clickable for moderators+, but just shown otherwise

--- a/app/src/app/inbox/page.tsx
+++ b/app/src/app/inbox/page.tsx
@@ -32,7 +32,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import type { FederalStatus, UserRank } from "@/drizzle/constants";
-import { MESSAGING_MIN_LEVEL, messagingLevelMessage } from "@/drizzle/constants";
+import { MESSAGING_MIN_LEVEL } from "@/drizzle/constants";
 import AvatarImage from "@/layout/Avatar";
 import Confirm2 from "@/layout/Confirm2";
 import ContentBox from "@/layout/ContentBox";
@@ -42,7 +42,7 @@ import RichInput from "@/layout/RichInput";
 import UserBlacklistControl from "@/layout/UserBlacklistControl";
 import UserSearchSelect from "@/layout/UserSearchSelect";
 import { showMutationToast } from "@/libs/toast";
-import { canPostAsAi } from "@/utils/permissions";
+import { canPostAsAi, getMessagingRestriction } from "@/utils/permissions";
 import { useRequiredUserData } from "@/utils/UserContext";
 import {
   type CreateConversationSchema,
@@ -285,14 +285,7 @@ export const NewConversationPrompt: React.FC<NewConversationPromptProps> = (prop
   });
   const senderUser = watchedSenderUsers?.[0];
   const canPostAsAI = userData && canPostAsAi(userData.role);
-  const belowMessagingMinLevel = (userData?.level ?? 0) < MESSAGING_MIN_LEVEL;
-  const composeRestriction = userData?.isBanned
-    ? "You are banned"
-    : userData?.isSilenced
-      ? "You are silenced"
-      : belowMessagingMinLevel
-        ? messagingLevelMessage
-        : null;
+  const composeRestriction = userData ? getMessagingRestriction(userData) : null;
 
   const users = useWatch({
     control: userSearchMethods.control,

--- a/app/src/app/inbox/page.tsx
+++ b/app/src/app/inbox/page.tsx
@@ -25,7 +25,14 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import type { FederalStatus, UserRank } from "@/drizzle/schema";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { FederalStatus, UserRank } from "@/drizzle/constants";
+import { MESSAGING_MIN_LEVEL, messagingLevelMessage } from "@/drizzle/constants";
 import AvatarImage from "@/layout/Avatar";
 import Confirm2 from "@/layout/Confirm2";
 import ContentBox from "@/layout/ContentBox";
@@ -278,6 +285,14 @@ export const NewConversationPrompt: React.FC<NewConversationPromptProps> = (prop
   });
   const senderUser = watchedSenderUsers?.[0];
   const canPostAsAI = userData && canPostAsAi(userData.role);
+  const belowMessagingMinLevel = (userData?.level ?? 0) < MESSAGING_MIN_LEVEL;
+  const composeRestriction = userData?.isBanned
+    ? "You are banned"
+    : userData?.isSilenced
+      ? "You are silenced"
+      : belowMessagingMinLevel
+        ? messagingLevelMessage
+        : null;
 
   const users = useWatch({
     control: userSearchMethods.control,
@@ -295,10 +310,10 @@ export const NewConversationPrompt: React.FC<NewConversationPromptProps> = (prop
 
   const createConversation = api.comments.createConversation.useMutation({
     onSuccess: (data) => {
-      showMutationToast({ success: true, message: "Message sent." });
-      create.reset();
-      if (data.conversationId) {
-        props.setSelectedConvo?.(data.conversationId);
+      showMutationToast(data);
+      if (data.success) {
+        create.reset();
+        if (data.conversationId) props.setSelectedConvo?.(data.conversationId);
       }
     },
   });
@@ -320,14 +335,33 @@ export const NewConversationPrompt: React.FC<NewConversationPromptProps> = (prop
 
   return (
     <div className="flex flex-row items-center">
-      {userData && (userData.isBanned || userData.isSilenced) && (
-        <Button id="conversation">
-          <BellOff className="mr-2 h-6 w-6 text-red-500" />
-          {userData.isBanned && "Banned"}
-          {userData.isSilenced && "Silenced"}
-        </Button>
+      {userData && composeRestriction && (
+        <TooltipProvider delayDuration={50}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex">
+                <Button
+                  id="conversation"
+                  disabled
+                  variant="outline"
+                  aria-label={`${composeRestriction}. You cannot start a conversation.`}
+                >
+                  <BellOff className="mr-2 h-6 w-6 text-red-500" />
+                  {userData.isBanned
+                    ? "Banned"
+                    : userData.isSilenced
+                      ? "Silenced"
+                      : `Level ${MESSAGING_MIN_LEVEL} Required`}
+                </Button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              {composeRestriction}. You cannot start a conversation.
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       )}
-      {userData && !userData.isBanned && !userData.isSilenced && (
+      {userData && !composeRestriction && (
         <Confirm2
           title="Create a new conversation"
           proceed_label="Submit"

--- a/app/src/app/register/page.tsx
+++ b/app/src/app/register/page.tsx
@@ -360,6 +360,9 @@ const RegisterForm: React.FC = () => {
                       </div>
                     </div>
                     <div className="flex w-full flex-wrap items-center gap-4 px-10">
+                      <p className="w-full basis-full text-center font-bold">
+                        You can only have two accounts per person.
+                      </p>
                       <FormField
                         control={form.control}
                         name="username"

--- a/app/src/layout/Conversation.tsx
+++ b/app/src/layout/Conversation.tsx
@@ -13,11 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Quote } from "@/components/ui/quote";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  CONVERSATION_QUIET_MINS,
-  MESSAGING_MIN_LEVEL,
-  messagingLevelMessage,
-} from "@/drizzle/constants";
+import { CONVERSATION_QUIET_MINS } from "@/drizzle/constants";
 import { CommentOnConversation } from "@/layout/Comment";
 import ContentBox from "@/layout/ContentBox";
 import Loader from "@/layout/Loader";
@@ -27,7 +23,7 @@ import { useInfinitePagination } from "@/libs/pagination";
 import { showMutationToast } from "@/libs/toast";
 import { getNewReactions, processMentions } from "@/utils/chat";
 import { parseHtml } from "@/utils/parse";
-import { canPostAsAi } from "@/utils/permissions";
+import { canPostAsAi, getMessagingRestriction } from "@/utils/permissions";
 import { stripBlockquotes } from "@/utils/sanitize";
 import { secondsFromNow } from "@/utils/time";
 import type { ArrayElement } from "@/utils/typeutils";
@@ -87,14 +83,7 @@ const Conversation: React.FC<ConversationProps> = (props) => {
     secondsFromNow(CONVERSATION_QUIET_MINS * 60),
   );
   const silence = new Date() > quietTime;
-  const belowMessagingMinLevel = (userData?.level ?? 0) < MESSAGING_MIN_LEVEL;
-  const composeRestriction = userData?.isBanned
-    ? "You are banned"
-    : userData?.isSilenced
-      ? "You are silenced"
-      : belowMessagingMinLevel
-        ? messagingLevelMessage
-        : null;
+  const composeRestriction = userData ? getMessagingRestriction(userData) : null;
 
   // Typing indicator state
   type TypingUser = { username: string; timestamp: number };
@@ -126,9 +115,7 @@ const Conversation: React.FC<ConversationProps> = (props) => {
   const allComments = comments?.pages.flatMap((page) => page.data);
   const conversation = comments?.pages[0]?.convo;
   const canComposeMessage =
-    !!userData &&
-    (conversation?.isStaffAvailable ||
-      (!userData.isBanned && !userData.isSilenced && !belowMessagingMinLevel));
+    !!userData && (conversation?.isStaffAvailable || !composeRestriction);
   type ReturnedComment = ArrayElement<typeof allComments>;
 
   // Search functionality

--- a/app/src/layout/Conversation.tsx
+++ b/app/src/layout/Conversation.tsx
@@ -13,7 +13,11 @@ import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Quote } from "@/components/ui/quote";
 import { Skeleton } from "@/components/ui/skeleton";
-import { CONVERSATION_QUIET_MINS } from "@/drizzle/constants";
+import {
+  CONVERSATION_QUIET_MINS,
+  MESSAGING_MIN_LEVEL,
+  messagingLevelMessage,
+} from "@/drizzle/constants";
 import { CommentOnConversation } from "@/layout/Comment";
 import ContentBox from "@/layout/ContentBox";
 import Loader from "@/layout/Loader";
@@ -83,6 +87,14 @@ const Conversation: React.FC<ConversationProps> = (props) => {
     secondsFromNow(CONVERSATION_QUIET_MINS * 60),
   );
   const silence = new Date() > quietTime;
+  const belowMessagingMinLevel = (userData?.level ?? 0) < MESSAGING_MIN_LEVEL;
+  const composeRestriction = userData?.isBanned
+    ? "You are banned"
+    : userData?.isSilenced
+      ? "You are silenced"
+      : belowMessagingMinLevel
+        ? messagingLevelMessage
+        : null;
 
   // Typing indicator state
   type TypingUser = { username: string; timestamp: number };
@@ -113,6 +125,10 @@ const Conversation: React.FC<ConversationProps> = (props) => {
   });
   const allComments = comments?.pages.flatMap((page) => page.data);
   const conversation = comments?.pages[0]?.convo;
+  const canComposeMessage =
+    !!userData &&
+    (conversation?.isStaffAvailable ||
+      (!userData.isBanned && !userData.isSilenced && !belowMessagingMinLevel));
   type ReturnedComment = ArrayElement<typeof allComments>;
 
   // Search functionality
@@ -585,13 +601,10 @@ const Conversation: React.FC<ConversationProps> = (props) => {
    * Submit comment
    */
   const handleSubmitComment = handleSubmit((data) => {
-    if (
-      (userData?.isSilenced || userData?.isBanned) &&
-      !conversation?.isStaffAvailable
-    ) {
+    if (composeRestriction && !conversation?.isStaffAvailable) {
       showMutationToast({
         success: false,
-        message: "You are silenced and cannot send a message.",
+        message: composeRestriction,
       });
       return;
     }
@@ -653,82 +666,87 @@ const Conversation: React.FC<ConversationProps> = (props) => {
           {conversation &&
             !conversation.isLocked &&
             userData &&
-            ((!userData.isBanned && !userData.isSilenced) ||
-              conversation.isStaffAvailable) && (
-              <div className="relative mb-2">
-                {canPostAsAI && (
-                  <div className="mb-3">
-                    <UserSearchSelect
-                      useFormMethods={userSearchMethods}
-                      label="Post as (leave empty to post as yourself)"
-                      selectedUsers={[]}
-                      showYourself={true}
-                      showAi={true}
-                      inline={true}
-                      maxUsers={maxUsers}
-                    />
-                  </div>
-                )}
-                {quoteIds &&
-                  quoteIds.length > 0 &&
-                  quoteIds.map((quoteId) => {
-                    const quote = allComments?.find((c) => c.id === quoteId);
-                    if (!quote) return null;
-                    return (
-                      <Quote
-                        key={quoteId}
-                        author={quote.username || "Unknown"}
-                        date={format(quote.createdAt, "MM/dd/yyyy")}
-                        onRemove={() => {
-                          setValue(
-                            "quoteIds",
-                            quoteIds.filter((id) => id !== quoteId),
-                          );
-                        }}
-                      >
-                        {stripBlockquotes(quote.content)}
-                      </Quote>
-                    );
-                  })}
-                <div className="relative">
-                  <RichInput
-                    id="comment"
-                    refreshKey={editorKey}
-                    height="120"
-                    disabled={isCommenting}
-                    placeholder="Write comment..."
-                    control={control}
-                    error={errors.comment?.message}
-                    onSubmit={handleSubmitComment}
-                    enableMentions={true}
-                    allowClipboardPaste={true}
-                  />
-                  <div className="absolute top-1/2 left-1/2 flex -translate-x-1/2 -translate-y-1/2 transform flex-row-reverse">
-                    {isCommenting && <Loader />}
-                  </div>
-                  <RefreshCw
-                    className="absolute top-[50%] right-24 z-20 h-8 w-8 translate-y-[-50%] text-gray-400 opacity-50 hover:cursor-pointer hover:text-gray-600"
-                    onClick={invalidateComments}
+            !canComposeMessage &&
+            composeRestriction && (
+              <p className="mb-2 text-center text-muted-foreground text-sm">
+                {composeRestriction}
+              </p>
+            )}
+          {conversation && !conversation.isLocked && canComposeMessage && (
+            <div className="relative mb-2">
+              {canPostAsAI && (
+                <div className="mb-3">
+                  <UserSearchSelect
+                    useFormMethods={userSearchMethods}
+                    label="Post as (leave empty to post as yourself)"
+                    selectedUsers={[]}
+                    showYourself={true}
+                    showAi={true}
+                    inline={true}
+                    maxUsers={maxUsers}
                   />
                 </div>
-                {conversation?.isPublic && typingUsers.size > 0 && (
-                  <div className="mt-1 text-muted-foreground text-xs italic">
-                    {(() => {
-                      const names = Array.from(typingUsers.values()).map(
-                        (u) => u.username,
-                      );
-                      if (names.length === 1) {
-                        return `${names[0]} is typing...`;
-                      } else if (names.length === 2) {
-                        return `${names[0]} and ${names[1]} are typing...`;
-                      } else {
-                        return `${names.slice(0, 2).join(", ")} and ${names.length - 2} more are typing...`;
-                      }
-                    })()}
-                  </div>
-                )}
+              )}
+              {quoteIds &&
+                quoteIds.length > 0 &&
+                quoteIds.map((quoteId) => {
+                  const quote = allComments?.find((c) => c.id === quoteId);
+                  if (!quote) return null;
+                  return (
+                    <Quote
+                      key={quoteId}
+                      author={quote.username || "Unknown"}
+                      date={format(quote.createdAt, "MM/dd/yyyy")}
+                      onRemove={() => {
+                        setValue(
+                          "quoteIds",
+                          quoteIds.filter((id) => id !== quoteId),
+                        );
+                      }}
+                    >
+                      {stripBlockquotes(quote.content)}
+                    </Quote>
+                  );
+                })}
+              <div className="relative">
+                <RichInput
+                  id="comment"
+                  refreshKey={editorKey}
+                  height="120"
+                  disabled={isCommenting}
+                  placeholder="Write comment..."
+                  control={control}
+                  error={errors.comment?.message}
+                  onSubmit={handleSubmitComment}
+                  enableMentions={true}
+                  allowClipboardPaste={true}
+                />
+                <div className="absolute top-1/2 left-1/2 flex -translate-x-1/2 -translate-y-1/2 transform flex-row-reverse">
+                  {isCommenting && <Loader />}
+                </div>
+                <RefreshCw
+                  className="absolute top-[50%] right-24 z-20 h-8 w-8 translate-y-[-50%] text-gray-400 opacity-50 hover:cursor-pointer hover:text-gray-600"
+                  onClick={invalidateComments}
+                />
               </div>
-            )}
+              {conversation?.isPublic && typingUsers.size > 0 && (
+                <div className="mt-1 text-muted-foreground text-xs italic">
+                  {(() => {
+                    const names = Array.from(typingUsers.values()).map(
+                      (u) => u.username,
+                    );
+                    if (names.length === 1) {
+                      return `${names[0]} is typing...`;
+                    } else if (names.length === 2) {
+                      return `${names[0]} and ${names[1]} are typing...`;
+                    } else {
+                      return `${names.slice(0, 2).join(", ")} and ${names.length - 2} more are typing...`;
+                    }
+                  })()}
+                </div>
+              )}
+            </div>
+          )}
           {allComments
             ?.filter((c) => c.conversationId === conversation?.id)
             .filter((c) => {

--- a/app/src/server/api/routers/auction.ts
+++ b/app/src/server/api/routers/auction.ts
@@ -19,6 +19,8 @@ import { z } from "zod";
 import {
   AUCTION_BIDDER_LEVEL_MAX,
   AUCTION_BIDDER_LEVEL_MIN,
+  AUCTION_HOUSE_MIN_LEVEL,
+  auctionHouseLevelMessage,
 } from "@/drizzle/constants";
 import {
   actionLog,
@@ -335,6 +337,9 @@ export const auctionRouter = createTRPCRouter({
       if (user.isTradeBanned) {
         return errorResponse("You are banned from trading");
       }
+      if (user.level < AUCTION_HOUSE_MIN_LEVEL) {
+        return errorResponse(auctionHouseLevelMessage);
+      }
       if (userItemData.equipped !== "NONE") {
         return errorResponse("Item is currently equipped");
       }
@@ -503,6 +508,9 @@ export const auctionRouter = createTRPCRouter({
       }
       if (user.isTradeBanned) {
         return errorResponse("You are banned from trading");
+      }
+      if (user.level < AUCTION_HOUSE_MIN_LEVEL) {
+        return errorResponse(auctionHouseLevelMessage);
       }
       if (auction.listingType === "AUCTION") {
         if (

--- a/app/src/server/api/routers/blackmarket.ts
+++ b/app/src/server/api/routers/blackmarket.ts
@@ -13,10 +13,12 @@ import {
   COST_RESET_STATS,
   ElementNames,
   MAX_EXTRA_JUTSU_SLOTS,
+  REP_TRADE_MIN_LEVEL,
   RYO_CAP,
   RYO_FOR_REP_DAYS_FROZEN,
   RYO_FOR_REP_MAX_LISTINGS,
   RYO_FOR_REP_MIN_REPS,
+  repTradeLevelMessage,
 } from "@/drizzle/constants";
 import { actionLog, ryoTrade, userData } from "@/drizzle/schema";
 import { filterValidElementsTypeguard } from "@/libs/train";
@@ -147,6 +149,9 @@ export const blackMarketRouter = createTRPCRouter({
       }
       if (user.isBanned) return errorResponse("You are banned");
       if (user.isTradeBanned) return errorResponse("You are banned from trading");
+      if (user.level < REP_TRADE_MIN_LEVEL) {
+        return errorResponse(repTradeLevelMessage);
+      }
       if (input.reps <= 0) return errorResponse("Reps must be greater than 0");
       if (input.ryo <= 0) return errorResponse("Ryo must be greater than 0");
       if (input.ryo < input.reps) return errorResponse("Ryo must be greater than reps");
@@ -227,6 +232,9 @@ export const blackMarketRouter = createTRPCRouter({
       }
       if (user.isBanned) return errorResponse("You are banned");
       if (user.isTradeBanned) return errorResponse("You are banned from trading");
+      if (user.level < REP_TRADE_MIN_LEVEL) {
+        return errorResponse(repTradeLevelMessage);
+      }
       if (user.money < offer.requestedRyo) {
         return errorResponse("Insufficient funds");
       }

--- a/app/src/server/api/routers/comments.ts
+++ b/app/src/server/api/routers/comments.ts
@@ -3,7 +3,13 @@ import { and, asc, desc, eq, inArray, isNull, notInArray, or, sql } from "drizzl
 import { alias } from "drizzle-orm/mysql-core";
 import { nanoid } from "nanoid";
 import { z } from "zod";
-import { IMG_AVATAR_DEFAULT } from "@/drizzle/constants";
+import {
+  FORUM_MIN_LEVEL,
+  forumLevelMessage,
+  IMG_AVATAR_DEFAULT,
+  MESSAGING_MIN_LEVEL,
+  messagingLevelMessage,
+} from "@/drizzle/constants";
 import {
   conversation,
   conversationComment,
@@ -207,8 +213,10 @@ export const commentsRouter = createTRPCRouter({
       // Resolve effective poster (allow staff to post as AI)
       const effectiveUserId = resolveSenderId(user, sender);
       // Guard
-      if (user.isBanned || user.isSilenced) {
-        return errorResponse("You are banned");
+      if (user.isBanned) return errorResponse("You are banned");
+      if (user.isSilenced) return errorResponse("You are silenced");
+      if (user.level < FORUM_MIN_LEVEL) {
+        return errorResponse(forumLevelMessage);
       }
       if (!thread) {
         return errorResponse("Thread not found");
@@ -370,6 +378,7 @@ export const commentsRouter = createTRPCRouter({
     .use(ratelimitMiddleware)
     .use(hasUserMiddleware)
     .input(createConversationSchema)
+    .output(baseServerResponse.extend({ conversationId: z.string().optional() }))
     .mutation(async ({ ctx, input }) => {
       // Query
       const [user, sender] = await Promise.all([
@@ -377,8 +386,10 @@ export const commentsRouter = createTRPCRouter({
         input.senderId ? fetchUser(ctx.drizzle, input.senderId) : null,
       ]);
       // Guard
-      if (user.isBanned || user.isSilenced) {
-        throw serverError("UNAUTHORIZED", "You are banned");
+      if (user.isBanned) return errorResponse("You are banned");
+      if (user.isSilenced) return errorResponse("You are silenced");
+      if (user.level < MESSAGING_MIN_LEVEL) {
+        return errorResponse(messagingLevelMessage);
       }
       const effectiveUserId = resolveSenderId(user, sender);
       // Mutate
@@ -390,7 +401,7 @@ export const commentsRouter = createTRPCRouter({
         title: input.title,
         content: input.comment,
       });
-      return { conversationId: convoId };
+      return { success: true, message: "Message sent.", conversationId: convoId };
     }),
   exitConversation: protectedProcedure
     .meta({ mcp: { enabled: true, description: "Leave a conversation" } })
@@ -676,6 +687,9 @@ export const commentsRouter = createTRPCRouter({
       if (!convo) return errorResponse("Conversation not found");
       if ((user.isBanned || user.isSilenced) && !convo.isStaffAvailable) {
         return errorResponse("You are banned");
+      }
+      if (user.level < MESSAGING_MIN_LEVEL && !convo.isStaffAvailable) {
+        return errorResponse(messagingLevelMessage);
       }
       if (!canViewConversation(convo, ctx.userId, user.role)) {
         return errorResponse("You are not allowed to view this conversation");

--- a/app/src/server/api/routers/comments.ts
+++ b/app/src/server/api/routers/comments.ts
@@ -7,8 +7,6 @@ import {
   FORUM_MIN_LEVEL,
   forumLevelMessage,
   IMG_AVATAR_DEFAULT,
-  MESSAGING_MIN_LEVEL,
-  messagingLevelMessage,
 } from "@/drizzle/constants";
 import {
   conversation,
@@ -47,6 +45,7 @@ import {
   canSeeReport,
   canSeeSecretData,
   canViewConversation,
+  getMessagingRestriction,
 } from "@/utils/permissions";
 import { checkForBadWords } from "@/utils/profanity";
 import sanitize, { stripBlockquotes } from "@/utils/sanitize";
@@ -386,11 +385,8 @@ export const commentsRouter = createTRPCRouter({
         input.senderId ? fetchUser(ctx.drizzle, input.senderId) : null,
       ]);
       // Guard
-      if (user.isBanned) return errorResponse("You are banned");
-      if (user.isSilenced) return errorResponse("You are silenced");
-      if (user.level < MESSAGING_MIN_LEVEL) {
-        return errorResponse(messagingLevelMessage);
-      }
+      const messagingRestriction = getMessagingRestriction(user);
+      if (messagingRestriction) return errorResponse(messagingRestriction);
       const effectiveUserId = resolveSenderId(user, sender);
       // Mutate
       const convoId = await createConvo({
@@ -685,11 +681,9 @@ export const commentsRouter = createTRPCRouter({
         sender && effectiveUserId === sender.userId ? sender.username : user.username;
       // Guard
       if (!convo) return errorResponse("Conversation not found");
-      if ((user.isBanned || user.isSilenced) && !convo.isStaffAvailable) {
-        return errorResponse("You are banned");
-      }
-      if (user.level < MESSAGING_MIN_LEVEL && !convo.isStaffAvailable) {
-        return errorResponse(messagingLevelMessage);
+      const messagingRestriction = getMessagingRestriction(user);
+      if (messagingRestriction && !convo.isStaffAvailable) {
+        return errorResponse(messagingRestriction);
       }
       if (!canViewConversation(convo, ctx.userId, user.role)) {
         return errorResponse("You are not allowed to view this conversation");

--- a/app/src/server/api/routers/conceptart.ts
+++ b/app/src/server/api/routers/conceptart.ts
@@ -16,7 +16,10 @@ import {
   uploadCompletedVideo,
 } from "@/libs/replicate";
 import { fetchUser } from "@/routers/profile";
-import { canCreateConceptArt, canDeleteConceptArt } from "@/utils/permissions";
+import {
+  canDeleteConceptArt,
+  getConceptArtCreateRestriction,
+} from "@/utils/permissions";
 import {
   conceptArtFilterSchema,
   conceptArtPromptSchema,
@@ -103,7 +106,7 @@ export const conceptartRouter = createTRPCRouter({
       // Query
       const user = await fetchUser(ctx.drizzle, ctx.userId);
       // Guard
-      const createRestriction = canCreateConceptArt(user);
+      const createRestriction = getConceptArtCreateRestriction(user);
       if (createRestriction) return errorResponse(createRestriction);
       if (user.reputationPoints < COST_CONCEPT_IMAGE) {
         return errorResponse("Not enough reputation points");
@@ -157,7 +160,7 @@ export const conceptartRouter = createTRPCRouter({
       // Query
       const user = await fetchUser(ctx.drizzle, ctx.userId);
       // Guard
-      const createRestriction = canCreateConceptArt(user);
+      const createRestriction = getConceptArtCreateRestriction(user);
       if (createRestriction) return errorResponse(createRestriction);
       if (user.reputationPoints < COST_CONCEPT_VIDEO) {
         return errorResponse(

--- a/app/src/server/api/routers/conceptart.ts
+++ b/app/src/server/api/routers/conceptart.ts
@@ -16,7 +16,7 @@ import {
   uploadCompletedVideo,
 } from "@/libs/replicate";
 import { fetchUser } from "@/routers/profile";
-import { canDeleteConceptArt } from "@/utils/permissions";
+import { canCreateConceptArt, canDeleteConceptArt } from "@/utils/permissions";
 import {
   conceptArtFilterSchema,
   conceptArtPromptSchema,
@@ -103,6 +103,8 @@ export const conceptartRouter = createTRPCRouter({
       // Query
       const user = await fetchUser(ctx.drizzle, ctx.userId);
       // Guard
+      const createRestriction = canCreateConceptArt(user);
+      if (createRestriction) return errorResponse(createRestriction);
       if (user.reputationPoints < COST_CONCEPT_IMAGE) {
         return errorResponse("Not enough reputation points");
       }
@@ -155,6 +157,8 @@ export const conceptartRouter = createTRPCRouter({
       // Query
       const user = await fetchUser(ctx.drizzle, ctx.userId);
       // Guard
+      const createRestriction = canCreateConceptArt(user);
+      if (createRestriction) return errorResponse(createRestriction);
       if (user.reputationPoints < COST_CONCEPT_VIDEO) {
         return errorResponse(
           `Not enough reputation points. Video generation costs ${COST_CONCEPT_VIDEO} reputation points.`,

--- a/app/src/server/api/routers/forum.ts
+++ b/app/src/server/api/routers/forum.ts
@@ -1,6 +1,7 @@
 import { asc, eq, ne, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
+import { FORUM_MIN_LEVEL, forumLevelMessage } from "@/drizzle/constants";
 import { forumBoard, forumPost, forumThread, userData } from "@/drizzle/schema";
 import { resolveSenderId } from "@/libs/comments";
 import { fetchBoard, getInfiniteThreads, readNews } from "@/libs/forum";
@@ -85,8 +86,10 @@ export const forumRouter = createTRPCRouter({
       if (isNews && !canCreateNews(user.role)) {
         return errorResponse("You are not authorized to create news");
       }
-      if (user.isBanned || user.isSilenced) {
-        return errorResponse("You are banned");
+      if (user.isBanned) return errorResponse("You are banned");
+      if (user.isSilenced) return errorResponse("You are silenced");
+      if (user.level < FORUM_MIN_LEVEL) {
+        return errorResponse(forumLevelMessage);
       }
       // Mutate
       const sanitized = sanitize(input.content);

--- a/app/src/utils/permissions.ts
+++ b/app/src/utils/permissions.ts
@@ -4,6 +4,8 @@ import type {
   UserRole,
 } from "@/drizzle/constants";
 import {
+  MESSAGING_MIN_LEVEL,
+  messagingLevelMessage,
   StaffApprovalGroups,
   SUPPORT_TICKET_STATUS_TRANSITIONS,
   UserRoles,
@@ -374,11 +376,21 @@ export const canDeleteConceptArt = (role: UserRole) => {
 };
 
 /** Returns a restriction message if the user cannot create concept art, otherwise null. */
-export const canCreateConceptArt = (
+export const getConceptArtCreateRestriction = (
   user: Pick<UserData, "isBanned" | "isSilenced">,
 ): string | null => {
   if (user.isBanned) return "You are banned";
   if (user.isSilenced) return "You are silenced";
+  return null;
+};
+
+/** Returns a restriction message if the user cannot use messaging, otherwise null. */
+export const getMessagingRestriction = (
+  user: Pick<UserData, "isBanned" | "isSilenced" | "level">,
+): string | null => {
+  if (user.isBanned) return "You are banned";
+  if (user.isSilenced) return "You are silenced";
+  if ((user.level ?? 0) < MESSAGING_MIN_LEVEL) return messagingLevelMessage;
   return null;
 };
 

--- a/app/src/utils/permissions.ts
+++ b/app/src/utils/permissions.ts
@@ -373,6 +373,15 @@ export const canDeleteConceptArt = (role: UserRole) => {
   ].includes(role);
 };
 
+/** Returns a restriction message if the user cannot create concept art, otherwise null. */
+export const canCreateConceptArt = (
+  user: Pick<UserData, "isBanned" | "isSilenced">,
+): string | null => {
+  if (user.isBanned) return "You are banned";
+  if (user.isSilenced) return "You are silenced";
+  return null;
+};
+
 export const canEscalateBan = (user: UserData, report: UserReport) => {
   return (
     !report.adminResolved &&


### PR DESCRIPTION
# Pull Request

Adjust the price of concept art videos from 10 rep to 15 rep
Users who are banned and silence cannot create concept art
Users must be level 3 to send inbox messages as well as send tavern messages.
Users must be level 3 to send forum posts.
Users must be level 15 to buy or sell on the auction house or buy/sell rep using ryo on the black market

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added minimum-level gating for messaging, forum posting, auction-house actions, and reputation-trade actions, including server-side enforcement.
  * Banned/silenced users are blocked from creating concept art/videos.

* **UI**
  * Disabled composer/thread/create actions with tooltip/inline notices across inbox, forum, auction house, black market, and concept art.
  * Auction dialogs show “level requirement” and “no longer available” when items can’t be found.
  * Registration now shows a “two accounts per person” notice.

* **Economy Adjustments**
  * Concept video cost increased from 10 to 15.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->