### PR TITLE
Fix/barrier aoe absorb scaling

### DIFF
--- a/app/src/libs/combat/actions.ts
+++ b/app/src/libs/combat/actions.ts
@@ -859,7 +859,8 @@ export const insertAction = (info: {
                     barrierEffect.targetId = barrierOnTile.id;
                     barrierEffect.id = nanoid();
                     if ("absorbPercentage" in barrierOnTile) {
-                      barrierEffect.barrierAbsorb = barrierOnTile.absorbPercentage;
+                      barrierEffect.barrierAbsorb =
+                        barrierOnTile.absorbPercentage / 100;
                     }
                     usersEffects.push(barrierEffect);
                   }

--- a/app/tests/libs/combat/barrier_aoe.test.ts
+++ b/app/tests/libs/combat/barrier_aoe.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression test for the AOE-vs-barrier damage scaling bug.
+ *
+ * `damageBarrier` consumes `barrierAbsorb` as a 0-1 fraction. The single-target
+ * path supplies that fraction (getBarriersBetween normalizes absorbPercentage to
+ * `value / 100`), but the AOE path used to assign the raw 1-100 `absorbPercentage`
+ * integer directly. That made AOE hits deal ~100x the intended damage to barriers,
+ * instantly destroying them. This test pins the AOE path to the fractional contract.
+ */
+
+/** Avoid executing real db/env when transitive imports touch `@/server/db`. */
+vi.mock("@/server/db", () => ({ drizzleDB: {} }));
+
+/**
+ * insertAction only needs `checkFriendlyFire` (force pass) from process; it never
+ * calls applyEffects. Mocking the module also avoids loading the Three.js graph.
+ */
+vi.mock("@/libs/combat/process", () => ({
+  applyEffects: vi.fn(() => ({ newBattle: {}, actionEffects: [] })),
+  checkFriendlyFire: vi.fn(() => true),
+}));
+
+import { insertAction } from "@/libs/combat/actions";
+import { getBattleGrid } from "@/libs/combat/util";
+import { DamageTag } from "@/validators/combat";
+import type {
+  CombatAction,
+  CompleteBattle,
+  GroundEffect,
+  ReturnedBattle,
+} from "@/libs/combat/types";
+
+const ABSORB_PERCENTAGE = 50;
+
+const makeActor = () => ({
+  userId: "actor",
+  username: "Actor",
+  gender: "Male",
+  villageId: "village-1",
+  direction: "left",
+  level: 100,
+  longitude: 0,
+  latitude: 0,
+  curHealth: 1000,
+  maxHealth: 1000,
+  curChakra: 1000,
+  curStamina: 1000,
+  actionPoints: 100,
+  highestOffence: "ninjutsuOffence",
+  highestDefence: "ninjutsuDefence",
+  highestGenerals: ["strength"],
+  fledBattle: false,
+  leftBattle: false,
+  usedActions: [],
+  items: [],
+  usedGenerals: { strength: 0, intelligence: 0, willpower: 0, speed: 0 },
+  usedStats: {
+    ninjutsuOffence: 0,
+    genjutsuOffence: 0,
+    taijutsuOffence: 0,
+    bukijutsuOffence: 0,
+    ninjutsuDefence: 0,
+    genjutsuDefence: 0,
+    taijutsuDefence: 0,
+    bukijutsuDefence: 0,
+  },
+});
+
+/** Enemy barrier sitting one tile away from the actor. */
+const makeBarrier = (): GroundEffect =>
+  ({
+    id: "barrier-1",
+    type: "barrier",
+    creatorId: "enemy",
+    longitude: 1,
+    latitude: 0,
+    level: 0,
+    power: 10,
+    absorbPercentage: ABSORB_PERCENTAGE,
+    curHealth: 100000,
+    maxHealth: 100000,
+    isNew: false,
+    castThisRound: false,
+    createdRound: 0,
+    barrierAbsorb: 0,
+    actionId: "barrier-action",
+    rounds: 10,
+  }) as unknown as GroundEffect;
+
+const makeBattle = (): CompleteBattle =>
+  ({
+    id: "battle-1",
+    battleType: "COMBAT",
+    width: 5,
+    height: 5,
+    round: 1,
+    createdAt: new Date("2020-01-01T00:00:00Z"),
+    updatedAt: new Date("2020-01-01T00:00:00Z"),
+    roundStartAt: new Date("2020-01-01T00:00:00Z"),
+    usersState: [makeActor()],
+    usersEffects: [],
+    groundEffects: [makeBarrier()],
+  }) as unknown as CompleteBattle;
+
+/** AOE damage action centered on the barrier tile. */
+const makeAoeDamageAction = (): CombatAction =>
+  ({
+    id: "aoe-jutsu",
+    name: "AOE Blast",
+    image: "/jutsu.png",
+    battleDescription: "",
+    type: "jutsu",
+    target: "OPPONENT",
+    method: "AOE_CIRCLE_SPAWN",
+    range: 3,
+    healthCost: 0,
+    chakraCost: 0,
+    staminaCost: 0,
+    actionCostPerc: 10,
+    updatedAt: new Date("2020-01-01T00:00:00Z"),
+    cooldown: 0,
+    originalCooldown: 0,
+    level: 1,
+    effects: [DamageTag.parse({})],
+  }) as unknown as CombatAction;
+
+describe("AOE barrier absorption scaling", () => {
+  it("assigns barrierAbsorb as a 0-1 fraction (absorbPercentage / 100), not the raw percentage", () => {
+    const battle = makeBattle();
+    const grid = getBattleGrid(20, battle as unknown as ReturnedBattle);
+
+    const result = insertAction({
+      battle,
+      grid,
+      action: makeAoeDamageAction(),
+      actorId: "actor",
+      longitude: 1,
+      latitude: 0,
+    });
+
+    // The AOE must actually have reached the barrier.
+    expect(result).toBe(true);
+    const barrierEffect = battle.usersEffects.find(
+      (e) => e.targetType === "barrier" && e.targetId === "barrier-1",
+    );
+    expect(barrierEffect).toBeDefined();
+
+    // The fix: AOE assigns the fraction, matching damageBarrier's contract.
+    expect(barrierEffect!.barrierAbsorb).toBeCloseTo(ABSORB_PERCENTAGE / 100, 10);
+    // Guard against the original 100x bug: the raw 1-100 percentage must never leak through.
+    expect(barrierEffect!.barrierAbsorb).toBeLessThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
# Pull Request

## What & why

Fixes a scaling bug where **barriers took ~100× the intended damage from AOE attacks and were destroyed in a single hit**, while single-target attacks behaved correctly.

### Root cause

`damageBarrier` (`app/src/libs/combat/tags.ts`) consumes `barrierAbsorb` as a **0–1 fraction**:

```ts
const damage = damageCalc(effect, origin, target, config) * effect.barrierAbsorb;
```

This is confirmed by `damageUser`, which uses `(1 - barrierAbsorb)` — only valid for a value ≤ 1.

- The **single-target** path supplies the fraction correctly: `getBarriersBetween` normalizes the barrier's `absorbPercentage` to `value / 100` before it reaches the effect.
- The **AOE** path instead read the original barrier straight from `groundEffects` via `findBarrier` and assigned the **raw 1–100 integer** (`absorbPercentage`, default `50`) directly to `barrierAbsorb`.

Result: AOE hits computed `damageCalc(...) × 50` instead of `× 0.5` — exactly 100× the intended damage. Against a barrier's default `maxHealth` of `100`, one AOE tick vaporized it. (The per-barrier `barrierAttacks` dedup means a barrier is hit only once per AOE, so the overkill was purely the bad multiplier, not repeated tile hits.)

### The fix

One line in the AOE branch of `app/src/libs/combat/actions.ts`, matching the single-target path's units:

```diff
- barrierEffect.barrierAbsorb = barrierOnTile.absorbPercentage;
+ barrierEffect.barrierAbsorb = barrierOnTile.absorbPercentage / 100;
```

Since exactly one barrier occupies a tile, there is no path-stacking remainder for AOE, so `/100` reproduces `getBarriersBetween`'s `1 × (50/100) = 0.5` correctly.

## What determines barrier durability (for reference)

Three fields on `BarrierTag` (`app/src/validators/combat.ts`):

| Field | Role | Default | Cap |
|---|---|---|---|
| `curHealth` / `maxHealth` | HP pool (in raw-damage units) | 100 | 100,000 |
| `power` | Barrier "level" — scales its defensive stats, reducing per-hit damage | — | — |
| `absorbPercentage` | Fraction of an incoming hit it soaks (and takes as HP loss) | 50 | 100 |

## Changes

- `app/src/libs/combat/actions.ts` — normalize AOE barrier `barrierAbsorb` to a 0–1 fraction.
- `app/tests/libs/combat/barrier_aoe.test.ts` — **new** regression test.

## Testing

- **New regression test** runs the real `insertAction` AOE path against a real battle grid and asserts the barrier-targeted effect's `barrierAbsorb` equals `absorbPercentage / 100`.
  - ✅ Passes with the fix.
  - ✅ **Fails without the fix** (temporarily reverting `/100` produced `expected 50 to be close to 0.5`), proving it pins the bug.
- ✅ Full combat suite green — **69 tests across 5 files** (`bun vitest run tests/libs/combat/`).
- ✅ `make typecheck` clean.
- biome ignores test files (consistent with the existing suite), so the new test is not linted.

## Breaking changes

No API/schema breaking changes.

**Gameplay impact:** barriers are now meaningfully durable against AOE instead of breaking instantly. This restores the intended behavior already in effect for single-target attacks; existing barrier `maxHealth` / `power` / `absorbPercentage` values continue to govern durability and may be retuned if desired.

## Screenshots

N/A — backend combat-logic change.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed barrier damage absorption for area-of-effect attacks. Barriers now correctly reduce damage from AOE abilities based on their absorption configuration. Previously, barrier damage reduction was not calculated properly, making barriers less effective than intended against AOE attacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->