### PR TITLE
Feature/1325 rank adjustments

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -1630,6 +1630,11 @@ export const WAR_FUNDS_COST = 10000; // Prestige cost of declaring war
 export const RANKED_REQUIRED_RANK: UserRank = "CHUNIN";
 export const RANKED_ENTRY_COST = 40000;
 export const RANKED_STREAK_BONUS = 2;
+// Max seconds a player waits in the ranked queue before rank is ignored and
+// they are matched with any other queued player.
+export const RANKED_QUEUE_MAX_WAIT_SECS = 300;
+// Minimum LP a player gains from a ranked win, regardless of the Elo delta.
+export const RANKED_MIN_LP_GAIN = 18;
 export const RANKED_SANNIN_TOP_PLAYERS = 10;
 export const RANKED_RANKS = [
   "Unranked",

--- a/app/src/libs/ranked_pvp.ts
+++ b/app/src/libs/ranked_pvp.ts
@@ -14,6 +14,8 @@ import {
   RANKED_LOADOUT_MAX_STUN_JUTSUS,
   RANKED_LOADOUT_MAX_SUMMON_JUTSUS,
   RANKED_LOADOUT_MAX_WEAPONS,
+  RANKED_MIN_LP_GAIN,
+  RANKED_QUEUE_MAX_WAIT_SECS,
   RANKED_RANKS,
   RANKED_SANNIN_TOP_PLAYERS,
   RANKED_STREAK_BONUS,
@@ -108,8 +110,34 @@ export function calculateLpEloChange(
     lpChange += RANKED_STREAK_BONUS * player.rankedStreak;
   }
 
-  return Math.round(lpChange);
+  const rounded = Math.round(lpChange);
+  // A win always grants at least RANKED_MIN_LP_GAIN, even against a much
+  // lower-rated opponent where the raw Elo delta rounds near zero.
+  return playerWon ? Math.max(rounded, RANKED_MIN_LP_GAIN) : rounded;
 }
+
+/**
+ * LP radius for ranked matchmaking, widening with time in queue. Once the
+ * player has waited RANKED_QUEUE_MAX_WAIT_SECS, rank is ignored entirely
+ * (Infinity) so they match any queued opponent.
+ * @param secondsInQueue - Seconds the player has been in the queue
+ * @returns The LP radius within which an opponent may be matched
+ */
+export const getRankedRadius = (secondsInQueue: number): number => {
+  if (secondsInQueue >= RANKED_QUEUE_MAX_WAIT_SECS) {
+    return Infinity;
+  }
+  if (secondsInQueue < 60) {
+    return 50;
+  } else if (secondsInQueue < 120) {
+    return 100;
+  } else if (secondsInQueue < 180) {
+    return 150;
+  } else if (secondsInQueue < 240) {
+    return 200;
+  }
+  return 250;
+};
 
 /**
  * Validate the jutsu loadout for ranked PvP

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -2240,11 +2240,17 @@ export const initiateBattle = async (
               ? [inArray(userData.userId, targetIds)]
               : []),
           ),
-          or(
-            eq(userData.status, "AWAKE"),
-            eq(userData.status, "QUEUED"),
-            eq(userData.status, "KAGE_QUEUED"),
-          ),
+          // Ranked participants are claimed straight from the queue, so require
+          // QUEUED specifically: a player who just left the queue (now AWAKE)
+          // must not be pulled into a ranked battle by a poll whose snapshot
+          // predated their leave.
+          battleType === "RANKED_PVP"
+            ? eq(userData.status, "QUEUED")
+            : or(
+                eq(userData.status, "AWAKE"),
+                eq(userData.status, "QUEUED"),
+                eq(userData.status, "KAGE_QUEUED"),
+              ),
           ...(battleType === "COMBAT"
             ? [
                 and(

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -3,6 +3,7 @@ import {
   and,
   desc,
   eq,
+  exists,
   gt,
   gte,
   inArray,
@@ -77,6 +78,7 @@ import {
   quest,
   questHistory,
   raidParticipation,
+  rankedPvpQueue,
   sector,
   tournamentMatch,
   userData,
@@ -2245,7 +2247,15 @@ export const initiateBattle = async (
           // must not be pulled into a ranked battle by a poll whose snapshot
           // predated their leave.
           battleType === "RANKED_PVP"
-            ? eq(userData.status, "QUEUED")
+            ? and(
+                eq(userData.status, "QUEUED"),
+                exists(
+                  client
+                    .select({ one: sql`1` })
+                    .from(rankedPvpQueue)
+                    .where(eq(rankedPvpQueue.userId, userData.userId)),
+                ),
+              )
             : or(
                 eq(userData.status, "AWAKE"),
                 eq(userData.status, "QUEUED"),
@@ -2290,7 +2300,18 @@ export const initiateBattle = async (
     await Promise.all([
       client
         .update(userData)
-        .set({ status: "AWAKE", battleId: null })
+        .set({
+          status:
+            battleType === "RANKED_PVP"
+              ? sql`CASE WHEN ${exists(
+                  client
+                    .select({ one: sql`1` })
+                    .from(rankedPvpQueue)
+                    .where(eq(rankedPvpQueue.userId, userData.userId)),
+                )} THEN "QUEUED" ELSE "AWAKE" END`
+              : "AWAKE",
+          battleId: null,
+        })
         .where(eq(userData.battleId, battleId)),
       client.delete(battle).where(eq(battle.id, battleId)),
       client.delete(battleHistory).where(eq(battleHistory.battleId, battleId)),

--- a/app/src/server/api/routers/pvprank.ts
+++ b/app/src/server/api/routers/pvprank.ts
@@ -558,10 +558,19 @@ export const pvpRankRouter = createTRPCRouter({
           .set({ status: "AWAKE" })
           .where(and(eq(userData.userId, ctx.userId), eq(userData.status, "QUEUED"))),
       ]);
-      // No row matched -> we were matched into a battle; don't report a
-      // misleading success. The battle Pusher event redirects us into the match.
+      // No row matched: status changed between the guard read and this update.
+      // That can mean a concurrent match claimed us into a battle, OR a failed
+      // match rolled us back to AWAKE. The queue row is already deleted, so we are
+      // out of the queue either way; re-read battleId (cold path) to report
+      // accurately rather than assume a battle.
       if (leaveResult.rowsAffected === 0) {
-        return errorResponse("You've been matched into a ranked battle");
+        const current = await ctx.drizzle.query.userData.findFirst({
+          columns: { battleId: true },
+          where: eq(userData.userId, ctx.userId),
+        });
+        if (current?.battleId) {
+          return errorResponse("You've been matched into a ranked battle");
+        }
       }
       return { success: true, message: "Left ranked PvP queue" };
     }),

--- a/app/src/server/api/routers/pvprank.ts
+++ b/app/src/server/api/routers/pvprank.ts
@@ -344,9 +344,7 @@ export const pvpRankRouter = createTRPCRouter({
       ]);
       // Cleanups ub case of bad queuing state
       if (user.status !== "QUEUED" && queueEntry) {
-        await ctx.drizzle
-          .delete(rankedPvpQueue)
-          .where(eq(rankedPvpQueue.userId, ctx.userId));
+        await deleteUserRankedQueueRow(ctx.drizzle, ctx.userId);
       } else if (user.status === "QUEUED" && !queueEntry) {
         await ctx.drizzle
           .update(userData)
@@ -550,7 +548,7 @@ export const pvpRankRouter = createTRPCRouter({
       }
       // Mutation
       await Promise.all([
-        ctx.drizzle.delete(rankedPvpQueue).where(eq(rankedPvpQueue.userId, ctx.userId)),
+        deleteUserRankedQueueRow(ctx.drizzle, ctx.userId),
         // Guard on QUEUED so a concurrent match that already claimed us into a
         // battle (status BATTLE) is not clobbered back to AWAKE.
         ctx.drizzle
@@ -588,9 +586,7 @@ export const pvpRankRouter = createTRPCRouter({
       // inQueue stays true (the client keeps polling) and the lost-claim restore
       // below would re-QUEUE us into unwanted matches.
       if (userEntry.user?.status !== "QUEUED") {
-        await ctx.drizzle
-          .delete(rankedPvpQueue)
-          .where(eq(rankedPvpQueue.userId, ctx.userId));
+        await deleteUserRankedQueueRow(ctx.drizzle, ctx.userId);
         return { success: false, message: "", battleId: undefined };
       }
       // Derived
@@ -741,6 +737,15 @@ export const fetchUserRankedQueue = async (client: DrizzleClient, userId: string
     },
   });
 };
+
+/**
+ * Delete a user's ranked PvP queue row. Reconciles a stale/orphaned row (one
+ * that outlived its owner's QUEUED status) and backs leaving the queue.
+ * @param client - The Drizzle client
+ * @param userId - The user's ID
+ */
+export const deleteUserRankedQueueRow = (client: DrizzleClient, userId: string) =>
+  client.delete(rankedPvpQueue).where(eq(rankedPvpQueue.userId, userId));
 
 /**
  * Fetch all ranked seasons

--- a/app/src/server/api/routers/pvprank.ts
+++ b/app/src/server/api/routers/pvprank.ts
@@ -546,8 +546,10 @@ export const pvpRankRouter = createTRPCRouter({
       if (user.status !== "QUEUED") {
         return errorResponse("Not in the queue");
       }
-      // Mutation
-      await Promise.all([
+      // Mutation. Capture the CAS result: if a concurrent match claimed us into a
+      // battle between the guard read above and this update, the QUEUED-guarded
+      // status update matches no rows.
+      const [, leaveResult] = await Promise.all([
         deleteUserRankedQueueRow(ctx.drizzle, ctx.userId),
         // Guard on QUEUED so a concurrent match that already claimed us into a
         // battle (status BATTLE) is not clobbered back to AWAKE.
@@ -556,6 +558,11 @@ export const pvpRankRouter = createTRPCRouter({
           .set({ status: "AWAKE" })
           .where(and(eq(userData.userId, ctx.userId), eq(userData.status, "QUEUED"))),
       ]);
+      // No row matched -> we were matched into a battle; don't report a
+      // misleading success. The battle Pusher event redirects us into the match.
+      if (leaveResult.rowsAffected === 0) {
+        return errorResponse("You've been matched into a ranked battle");
+      }
       return { success: true, message: "Left ranked PvP queue" };
     }),
 

--- a/app/src/server/api/routers/pvprank.ts
+++ b/app/src/server/api/routers/pvprank.ts
@@ -1,5 +1,17 @@
 import { TRPCError } from "@trpc/server";
-import { and, asc, desc, eq, gt, gte, inArray, lte, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  exists,
+  gt,
+  gte,
+  inArray,
+  isNull,
+  lte,
+  sql,
+} from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import {
@@ -28,6 +40,7 @@ import {
 } from "@/drizzle/schema";
 import { collapseRewards, postProcessRewards } from "@/libs/quest";
 import {
+  getRankedRadius,
   getRankedRank,
   validateItemLoadout,
   validateJutsuLoadout,
@@ -538,10 +551,12 @@ export const pvpRankRouter = createTRPCRouter({
       // Mutation
       await Promise.all([
         ctx.drizzle.delete(rankedPvpQueue).where(eq(rankedPvpQueue.userId, ctx.userId)),
+        // Guard on QUEUED so a concurrent match that already claimed us into a
+        // battle (status BATTLE) is not clobbered back to AWAKE.
         ctx.drizzle
           .update(userData)
           .set({ status: "AWAKE" })
-          .where(eq(userData.userId, ctx.userId)),
+          .where(and(eq(userData.userId, ctx.userId), eq(userData.status, "QUEUED"))),
       ]);
       return { success: true, message: "Left ranked PvP queue" };
     }),
@@ -573,6 +588,10 @@ export const pvpRankRouter = createTRPCRouter({
       const lpRadius = getRankedRadius(secondsInQueue);
       const opponentEntry = queuedPlayers.find((opponent) => {
         if (opponent.userId === ctx.userId) return false;
+        // Also the crash-recovery reconciler: PlanetScale has no transactions,
+        // so a crash between a successful match and the queue-row delete can
+        // leave a BATTLE player with a lingering queue row. Skipping non-QUEUED
+        // rows here (and the QUEUED-only claim in initiateBattle) excludes them.
         if (opponent.user?.status !== "QUEUED") return false;
         return Math.abs(opponent.rankedLp - userEntry.rankedLp) <= lpRadius;
       });
@@ -583,85 +602,116 @@ export const pvpRankRouter = createTRPCRouter({
       if (!userEntry.user.rankedLoadout || !opponentEntry.user.rankedLoadout) {
         return { success: false, message: "No loadout found", battleId: undefined };
       }
-      // Start battle
-      const [result] = await Promise.all([
-        initiateBattle(
-          {
-            userIds: [userEntry.userId],
-            targetIds: [opponentEntry.userId],
-            client: ctx.drizzle,
-            biome: "arena",
-            targetStatDistribution: RANKED_PVP_STATS,
-            userStatDistribution: RANKED_PVP_STATS,
-            forceLoadouts: [
-              userEntry.user.rankedLoadout,
-              opponentEntry.user.rankedLoadout,
-            ],
-          },
-          "RANKED_PVP",
-        ),
-        ctx.drizzle
-          .delete(rankedPvpQueue)
-          .where(inArray(rankedPvpQueue.userId, [ctx.userId, opponentEntry.userId])),
-        ctx.drizzle
-          .insert(logQueueLengths)
-          .values({
-            rankedRank: rankedRank,
-            ceiledMinutes: Math.ceil(secondsInQueue / 60),
-            count: 1,
-          })
-          .onDuplicateKeyUpdate({ set: { count: sql`${logQueueLengths.count} + 1` } }),
-        ctx.drizzle
-          .insert(logRankedPicks)
-          .values([
-            ...userEntry.user.rankedLoadout.loadout.jutsuIds.map((jutsuId) => ({
-              type: "jutsu" as const,
-              contentId: jutsuId,
-              battleType: "RANKED_PVP" as const,
-              count: 1,
-            })),
-            ...userEntry.user.rankedLoadout.loadout.weaponIds.map((weaponId) => ({
-              type: "item" as const,
-              contentId: weaponId,
-              battleType: "RANKED_PVP" as const,
-              count: 1,
-            })),
-            ...userEntry.user.rankedLoadout.loadout.consumableIds.map(
-              (consumableId) => ({
-                type: "consumable" as const,
-                contentId: consumableId,
-                battleType: "RANKED_PVP" as const,
-                count: 1,
-              }),
-            ),
-            ...opponentEntry.user.rankedLoadout.loadout.jutsuIds.map((jutsuId) => ({
-              type: "jutsu" as const,
-              contentId: jutsuId,
-              battleType: "RANKED_PVP" as const,
-              count: 1,
-            })),
-            ...opponentEntry.user.rankedLoadout.loadout.weaponIds.map((weaponId) => ({
-              type: "item" as const,
-              contentId: weaponId,
-              battleType: "RANKED_PVP" as const,
-              count: 1,
-            })),
-            ...opponentEntry.user.rankedLoadout.loadout.consumableIds.map(
-              (consumableId) => ({
-                type: "consumable" as const,
-                contentId: consumableId,
-                battleType: "RANKED_PVP" as const,
-                count: 1,
-              }),
-            ),
-          ])
-          .onDuplicateKeyUpdate({ set: { count: sql`${logRankedPicks.count} + 1` } }),
-      ]);
+      // The atomic claim is inside initiateBattle: it transitions both
+      // participants QUEUED -> BATTLE in one guarded UPDATE and rolls back
+      // (resetting only the rows it touched to AWAKE) if it cannot claim both.
+      // That userData status-CAS — not the queue table — is the single-winner
+      // mutex, so we call it first and gate all cleanup on its success.
+      const result = await initiateBattle(
+        {
+          userIds: [userEntry.userId],
+          targetIds: [opponentEntry.userId],
+          client: ctx.drizzle,
+          biome: "arena",
+          targetStatDistribution: RANKED_PVP_STATS,
+          userStatDistribution: RANKED_PVP_STATS,
+          forceLoadouts: [
+            userEntry.user.rankedLoadout,
+            opponentEntry.user.rankedLoadout,
+          ],
+        },
+        "RANKED_PVP",
+      );
+
       if (result.success && result.battleId) {
+        // Winner path only: remove both players from the queue and write match
+        // logs. Gating these on success stops a losing poll from deleting queue
+        // rows it never matched.
+        await Promise.all([
+          ctx.drizzle
+            .delete(rankedPvpQueue)
+            .where(inArray(rankedPvpQueue.userId, [ctx.userId, opponentEntry.userId])),
+          ctx.drizzle
+            .insert(logQueueLengths)
+            .values({
+              rankedRank: rankedRank,
+              ceiledMinutes: Math.ceil(secondsInQueue / 60),
+              count: 1,
+            })
+            .onDuplicateKeyUpdate({
+              set: { count: sql`${logQueueLengths.count} + 1` },
+            }),
+          ctx.drizzle
+            .insert(logRankedPicks)
+            .values([
+              ...userEntry.user.rankedLoadout.loadout.jutsuIds.map((jutsuId) => ({
+                type: "jutsu" as const,
+                contentId: jutsuId,
+                battleType: "RANKED_PVP" as const,
+                count: 1,
+              })),
+              ...userEntry.user.rankedLoadout.loadout.weaponIds.map((weaponId) => ({
+                type: "item" as const,
+                contentId: weaponId,
+                battleType: "RANKED_PVP" as const,
+                count: 1,
+              })),
+              ...userEntry.user.rankedLoadout.loadout.consumableIds.map(
+                (consumableId) => ({
+                  type: "consumable" as const,
+                  contentId: consumableId,
+                  battleType: "RANKED_PVP" as const,
+                  count: 1,
+                }),
+              ),
+              ...opponentEntry.user.rankedLoadout.loadout.jutsuIds.map((jutsuId) => ({
+                type: "jutsu" as const,
+                contentId: jutsuId,
+                battleType: "RANKED_PVP" as const,
+                count: 1,
+              })),
+              ...opponentEntry.user.rankedLoadout.loadout.weaponIds.map((weaponId) => ({
+                type: "item" as const,
+                contentId: weaponId,
+                battleType: "RANKED_PVP" as const,
+                count: 1,
+              })),
+              ...opponentEntry.user.rankedLoadout.loadout.consumableIds.map(
+                (consumableId) => ({
+                  type: "consumable" as const,
+                  contentId: consumableId,
+                  battleType: "RANKED_PVP" as const,
+                  count: 1,
+                }),
+              ),
+            ])
+            .onDuplicateKeyUpdate({ set: { count: sql`${logRankedPicks.count} + 1` } }),
+        ]);
         return { success: true, message: "Match found!", battleId: result.battleId };
-      } else {
-        return result;
       }
+
+      // Lost the claim (opponent taken first, or both already gone). Our queue
+      // row was left intact above, so the next 5s poll rematches us. Restore us
+      // to QUEUED only if we are exactly initiateBattle's rollback AWAKE (no real
+      // battle) and our queue row still exists, so this can never clobber a
+      // legitimate BATTLE/other state or a row a concurrent winner cleaned up.
+      await ctx.drizzle
+        .update(userData)
+        .set({ status: "QUEUED" })
+        .where(
+          and(
+            eq(userData.userId, ctx.userId),
+            eq(userData.status, "AWAKE"),
+            isNull(userData.battleId),
+            exists(
+              ctx.drizzle
+                .select({ one: sql`1` })
+                .from(rankedPvpQueue)
+                .where(eq(rankedPvpQueue.userId, ctx.userId)),
+            ),
+          ),
+        );
+      return { success: false, message: "", battleId: undefined };
     }),
 });
 
@@ -706,35 +756,6 @@ export const fetchCurrentSeason = async (client: DrizzleClient) => {
     ),
   });
   return season || null;
-};
-
-/**
- * Get the radius for a ranked PvP match
- * @param secondsInQueue - The number of seconds the player has been in the queue
- * @returns The radius for the match
- */
-export const getRankedRadius = (secondsInQueue: number) => {
-  if (secondsInQueue < 60) {
-    return 50;
-  } else if (secondsInQueue < 120) {
-    return 100;
-  } else if (secondsInQueue < 180) {
-    return 150;
-  } else if (secondsInQueue < 240) {
-    return 200;
-  } else if (secondsInQueue < 300) {
-    return 250;
-  } else if (secondsInQueue < 600) {
-    return 300;
-  } else if (secondsInQueue < 900) {
-    return 350;
-  } else if (secondsInQueue < 1200) {
-    return 400;
-  } else if (secondsInQueue < 1500) {
-    return 450;
-  } else {
-    return 500;
-  }
 };
 
 /**

--- a/app/src/server/api/routers/pvprank.ts
+++ b/app/src/server/api/routers/pvprank.ts
@@ -1,17 +1,5 @@
 import { TRPCError } from "@trpc/server";
-import {
-  and,
-  asc,
-  desc,
-  eq,
-  exists,
-  gt,
-  gte,
-  inArray,
-  isNull,
-  lte,
-  sql,
-} from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, lte, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import {
@@ -648,10 +636,47 @@ export const pvpRankRouter = createTRPCRouter({
       );
 
       if (result.success && result.battleId) {
-        // Winner path only: remove both players from the queue and write match
-        // logs. Gating these on success stops a losing poll from deleting queue
-        // rows it never matched.
-        await Promise.all([
+        const rankedPickRows = [
+          ...userEntry.user.rankedLoadout.loadout.jutsuIds.map((jutsuId) => ({
+            type: "jutsu" as const,
+            contentId: jutsuId,
+            battleType: "RANKED_PVP" as const,
+            count: 1,
+          })),
+          ...userEntry.user.rankedLoadout.loadout.weaponIds.map((weaponId) => ({
+            type: "item" as const,
+            contentId: weaponId,
+            battleType: "RANKED_PVP" as const,
+            count: 1,
+          })),
+          ...userEntry.user.rankedLoadout.loadout.consumableIds.map((consumableId) => ({
+            type: "consumable" as const,
+            contentId: consumableId,
+            battleType: "RANKED_PVP" as const,
+            count: 1,
+          })),
+          ...opponentEntry.user.rankedLoadout.loadout.jutsuIds.map((jutsuId) => ({
+            type: "jutsu" as const,
+            contentId: jutsuId,
+            battleType: "RANKED_PVP" as const,
+            count: 1,
+          })),
+          ...opponentEntry.user.rankedLoadout.loadout.weaponIds.map((weaponId) => ({
+            type: "item" as const,
+            contentId: weaponId,
+            battleType: "RANKED_PVP" as const,
+            count: 1,
+          })),
+          ...opponentEntry.user.rankedLoadout.loadout.consumableIds.map(
+            (consumableId) => ({
+              type: "consumable" as const,
+              contentId: consumableId,
+              battleType: "RANKED_PVP" as const,
+              count: 1,
+            }),
+          ),
+        ];
+        const postMatchTasks: PromiseLike<unknown>[] = [
           ctx.drizzle
             .delete(rankedPvpQueue)
             .where(inArray(rankedPvpQueue.userId, [ctx.userId, opponentEntry.userId])),
@@ -665,76 +690,27 @@ export const pvpRankRouter = createTRPCRouter({
             .onDuplicateKeyUpdate({
               set: { count: sql`${logQueueLengths.count} + 1` },
             }),
-          ctx.drizzle
-            .insert(logRankedPicks)
-            .values([
-              ...userEntry.user.rankedLoadout.loadout.jutsuIds.map((jutsuId) => ({
-                type: "jutsu" as const,
-                contentId: jutsuId,
-                battleType: "RANKED_PVP" as const,
-                count: 1,
-              })),
-              ...userEntry.user.rankedLoadout.loadout.weaponIds.map((weaponId) => ({
-                type: "item" as const,
-                contentId: weaponId,
-                battleType: "RANKED_PVP" as const,
-                count: 1,
-              })),
-              ...userEntry.user.rankedLoadout.loadout.consumableIds.map(
-                (consumableId) => ({
-                  type: "consumable" as const,
-                  contentId: consumableId,
-                  battleType: "RANKED_PVP" as const,
-                  count: 1,
-                }),
-              ),
-              ...opponentEntry.user.rankedLoadout.loadout.jutsuIds.map((jutsuId) => ({
-                type: "jutsu" as const,
-                contentId: jutsuId,
-                battleType: "RANKED_PVP" as const,
-                count: 1,
-              })),
-              ...opponentEntry.user.rankedLoadout.loadout.weaponIds.map((weaponId) => ({
-                type: "item" as const,
-                contentId: weaponId,
-                battleType: "RANKED_PVP" as const,
-                count: 1,
-              })),
-              ...opponentEntry.user.rankedLoadout.loadout.consumableIds.map(
-                (consumableId) => ({
-                  type: "consumable" as const,
-                  contentId: consumableId,
-                  battleType: "RANKED_PVP" as const,
-                  count: 1,
-                }),
-              ),
-            ])
-            .onDuplicateKeyUpdate({ set: { count: sql`${logRankedPicks.count} + 1` } }),
-        ]);
+        ];
+        if (rankedPickRows.length > 0) {
+          postMatchTasks.push(
+            ctx.drizzle
+              .insert(logRankedPicks)
+              .values(rankedPickRows)
+              .onDuplicateKeyUpdate({
+                set: { count: sql`${logRankedPicks.count} + 1` },
+              }),
+          );
+        }
+        // Winner path only: remove both players from the queue and write match
+        // logs. Gating these on success stops a losing poll from deleting queue
+        // rows it never matched.
+        await Promise.all(postMatchTasks);
         return { success: true, message: "Match found!", battleId: result.battleId };
       }
 
-      // Lost the claim (opponent taken first, or both already gone). Our queue
-      // row was left intact above, so the next 5s poll rematches us. Restore us
-      // to QUEUED only if we are exactly initiateBattle's rollback AWAKE (no real
-      // battle) and our queue row still exists, so this can never clobber a
-      // legitimate BATTLE/other state or a row a concurrent winner cleaned up.
-      await ctx.drizzle
-        .update(userData)
-        .set({ status: "QUEUED" })
-        .where(
-          and(
-            eq(userData.userId, ctx.userId),
-            eq(userData.status, "AWAKE"),
-            isNull(userData.battleId),
-            exists(
-              ctx.drizzle
-                .select({ one: sql`1` })
-                .from(rankedPvpQueue)
-                .where(eq(rankedPvpQueue.userId, ctx.userId)),
-            ),
-          ),
-        );
+      // Lost the claim (opponent taken first, the caller already left, or both
+      // already gone). Ranked rollback in initiateBattle restores any
+      // temporarily claimed queue rows, so the next 5s poll can rematch.
       return { success: false, message: "", battleId: undefined };
     }),
 });

--- a/app/src/server/api/routers/pvprank.ts
+++ b/app/src/server/api/routers/pvprank.ts
@@ -582,16 +582,28 @@ export const pvpRankRouter = createTRPCRouter({
       if (!userEntry) {
         return { success: false, message: "", battleId: undefined };
       }
+      // If we hold a queue row but are no longer QUEUED, the row is stale — e.g.
+      // a crash between a successful match start and the queue cleanup left it
+      // behind and our battle has since ended. Remove it and stop: otherwise
+      // inQueue stays true (the client keeps polling) and the lost-claim restore
+      // below would re-QUEUE us into unwanted matches.
+      if (userEntry.user?.status !== "QUEUED") {
+        await ctx.drizzle
+          .delete(rankedPvpQueue)
+          .where(eq(rankedPvpQueue.userId, ctx.userId));
+        return { success: false, message: "", battleId: undefined };
+      }
       // Derived
       const secondsInQueue = secondsPassed(userEntry.queueStartTime);
       const rankedRank = getRankedRank(userEntry.rankedLp, topPlayersLP);
       const lpRadius = getRankedRadius(secondsInQueue);
       const opponentEntry = queuedPlayers.find((opponent) => {
         if (opponent.userId === ctx.userId) return false;
-        // Also the crash-recovery reconciler: PlanetScale has no transactions,
-        // so a crash between a successful match and the queue-row delete can
-        // leave a BATTLE player with a lingering queue row. Skipping non-QUEUED
-        // rows here (and the QUEUED-only claim in initiateBattle) excludes them.
+        // Skip opponents that are no longer QUEUED: a crash between a successful
+        // match and the queue-row delete can leave a BATTLE player with a
+        // lingering queue row. This filter, with the QUEUED-only claim in
+        // initiateBattle, keeps such a stale row from being matched (our own
+        // stale row is removed by the caller-status guard above).
         if (opponent.user?.status !== "QUEUED") return false;
         return Math.abs(opponent.rankedLp - userEntry.rankedLp) <= lpRadius;
       });

--- a/app/tests/libs/ranked_pvp.test.ts
+++ b/app/tests/libs/ranked_pvp.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { calculateLpEloChange, getRankedRadius } from "@/libs/ranked_pvp";
+import { RANKED_MIN_LP_GAIN, RANKED_QUEUE_MAX_WAIT_SECS } from "@/drizzle/constants";
+
+describe("calculateLpEloChange", () => {
+  it("floors a win to RANKED_MIN_LP_GAIN when the raw Elo gain is below it", () => {
+    // High-rated player beats a far lower-rated opponent: raw gain rounds to ~0.
+    const lp = calculateLpEloChange(
+      { rankedLp: 900, rankedStreak: 0 },
+      { rankedLp: 100 },
+      true,
+      [],
+    );
+    expect(lp).toBe(RANKED_MIN_LP_GAIN);
+  });
+
+  it("does not lower a win that already exceeds the floor", () => {
+    // Low-rated player beats a far higher-rated opponent: large gain + rank bonus.
+    const lp = calculateLpEloChange(
+      { rankedLp: 100, rankedStreak: 0 },
+      { rankedLp: 900 },
+      true,
+      [],
+    );
+    expect(lp).toBeGreaterThan(RANKED_MIN_LP_GAIN);
+  });
+
+  it("does not floor a loss (stays negative)", () => {
+    const lp = calculateLpEloChange(
+      { rankedLp: 900, rankedStreak: 0 },
+      { rankedLp: 100 },
+      false,
+      [],
+    );
+    expect(lp).toBeLessThan(0);
+  });
+});
+
+describe("getRankedRadius", () => {
+  it("widens with wait time below the max wait", () => {
+    expect(getRankedRadius(0)).toBe(50);
+    expect(getRankedRadius(59)).toBe(50);
+    expect(getRankedRadius(60)).toBe(100);
+    expect(getRankedRadius(120)).toBe(150);
+    expect(getRankedRadius(180)).toBe(200);
+    expect(getRankedRadius(240)).toBe(250);
+    expect(getRankedRadius(RANKED_QUEUE_MAX_WAIT_SECS - 1)).toBe(250);
+  });
+
+  it("ignores rank (Infinity radius) once the max wait is reached", () => {
+    expect(getRankedRadius(RANKED_QUEUE_MAX_WAIT_SECS)).toBe(Infinity);
+    expect(getRankedRadius(600)).toBe(Infinity);
+    expect(getRankedRadius(5000)).toBe(Infinity);
+  });
+});


### PR DESCRIPTION
# Pull Request

Closes #1325 (Rank Adjustments).

## What was implemented

Two ranked-PvP quality-of-life changes from the issue, plus the concurrency hardening that the first change made necessary:

1. **5-minute queue cutoff — match regardless of rank.** Once a player has waited `RANKED_QUEUE_MAX_WAIT_SECS` (300s) in the ranked queue, the LP radius becomes unlimited (`getRankedRadius` returns `Infinity`), so they are matched with the oldest-waiting queued opponent regardless of rank. Below 5 minutes the existing LP-radius widening is unchanged; the previously-unreachable 5–25 min steps were removed. `getRankedRadius` was also moved from the router into the pure `ranked_pvp.ts` lib so it can be unit-tested.
2. **Minimum 18 LP per ranked win.** `calculateLpEloChange` now floors a win at `RANKED_MIN_LP_GAIN` (18): `playerWon ? Math.max(rounded, RANKED_MIN_LP_GAIN) : rounded`. The floor applies to **wins only** — draws stay at the existing flat +10 and losses are unchanged.
3. **Matchmaking concurrency hardening (PlanetScale-safe, no transactions).**
   - `checkRankedPvpMatches` now calls `initiateBattle` first and only deletes the queue rows / writes match logs when the claim succeeds; on a lost claim it restores the caller to `QUEUED` with a guarded CAS (`status='AWAKE' AND battleId IS NULL AND EXISTS(queue row)`) so it can never clobber a real battle or strand a player.
   - The ranked battle claim in `initiateBattle` now requires `status='QUEUED'`, closing a race where a player who just left the queue could be pulled into a ranked battle by a stale matchmaking poll.
   - `leaveRankedPvpQueue`'s status update is CAS-guarded on `status='QUEUED'` so a concurrent match that already moved the player to `BATTLE` is not clobbered back to `AWAKE`.
   - A caller-side stale-row guard self-heals an orphaned queue row (left behind if a crash interrupts cleanup), and the shared `deleteUserRankedQueueRow` helper de-duplicates the three single-user queue-row deletes.

**Files:** `app/drizzle/constants.ts`, `app/src/libs/ranked_pvp.ts`, `app/src/server/api/routers/pvprank.ts`, `app/src/server/api/routers/combat.ts`, `app/tests/libs/ranked_pvp.test.ts`.

## Why

The two bullets are the QoL asks in #1325 (faster matches during low population; no more demoralizing near-zero LP wins). The "match anyone after 5 minutes" rule increases the chance two long-waiting players match each other simultaneously at low population, which exposed pre-existing matchmaking races (double-match / queue-stranding / leave-queue). Those are closed here using compare-and-swap predicates and `rowsAffected`, since PlanetScale does not support multi-statement transactions.

## Screenshots

N/A — backend matchmaking and LP logic only; no UI changes.

## Breaking changes

None in the API/schema sense: **no database schema or migration changes** (new values are constants only), and no tRPC input/output contracts changed. The behavioral changes are intentional ranked-PvP gameplay adjustments scoped to #1325 (unlimited match radius after 5 min; 18-LP win floor).

## Testing

- New unit tests in `app/tests/libs/ranked_pvp.test.ts` (5/5 passing): LP win-floor (below-floor → 18, above-floor unchanged, loss stays negative) and `getRankedRadius` boundaries (just-below → 250, at/after the cutoff → `Infinity`).
- `make typecheck` clean; `make lint` clean (no new warnings in changed files).
- Concurrency changes are CAS/`rowsAffected`-guarded and were reviewed by tracing the race interleavings (no DB integration-test harness exists for matchmaking); see manual-QA notes in the design doc.

## Out of Scope

- Extract a `buildPickRows(loadout)` helper for the pre-existing `logRankedPicks` 6-way spread (unrelated match-logging duplication).
- Optionally extend the cleaner cron to delete queue rows for `BATTLE` users (the crash-orphan case is already self-healed at read/poll time).

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Ranked PvP now enforces a minimum LP gain for wins.
  * Ranked matchmaking radius increases with queue wait time, becoming effectively unbounded after the max wait threshold.

* **Bug Fixes**
  * Improved ranked battle eligibility by requiring active queue membership for ranked matches.
  * Hardened ranked queue leaving, match polling, and rollback behavior to avoid incorrect state during battle start.

* **Tests**
  * Added coverage for LP/Elo flooring and ranked radius growth up to (and beyond) the max wait limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->