### PR TITLE
Basic Action Changes

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -194,7 +194,11 @@ export type GeneralType = (typeof GeneralTypes)[number];
 export const AdjustableBasicActions = [
   "basicAttack",
   "basicHeal",
+  "meditate",
+  "offensiveStance",
+  "defensiveStance",
   "move",
+  "replacementTechnique",
   "clear",
   "cleanse",
 ] as const;
@@ -921,7 +925,7 @@ export const BLOODLINE_ROLL_TYPES = [
 ] as const;
 
 // Bloodline swap config
-export const BLOODLINE_SWAP_COOLDOWN_HOURS = 48;
+export const BLOODLINE_SWAP_COOLDOWN_HOURS = 120;
 export const BLOODLINE_SWAP_FREE_DAYS = 30;
 export const BLOODLINE_SWAP_FREE_AMOUNT = 0;
 export const BLOODLINE_SWAP_FREE_NORMAL = 0;
@@ -2112,8 +2116,14 @@ export const IMG_ELEMENT_METAL =
 
 export const IMG_BASIC_HEAL =
   "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJnlXNSKmojJ0EqeDCvBrNmZaXVdY97gSpOWiA";
+export const IMG_BASIC_MEDITATE =
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJgt4hLTcU9cpECTimBdjaqbNn7vQsxGR1wLk4";
 export const IMG_BASIC_ATTACK =
   "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJdMXlCrP62PI3ciLaYzgVX8FopBADxSrGmvQl";
+export const IMG_BASIC_OFFENSIVE_STANCE =
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJnBZu0YmojJ0EqeDCvBrNmZaXVdY97gSpOWiA";
+export const IMG_BASIC_DEFENSIVE_STANCE =
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJFr82ddG2iOewJtjGzvNcmEX3TBnoSfMDZPH4";
 export const IMG_BASIC_FLEE =
   "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJRohRDR0udmODoNtpa0FMcwI4k2Eq7nJhyvjl";
 export const IMG_BASIC_STEALTH =
@@ -2122,6 +2132,8 @@ export const IMG_BASIC_WAIT =
   "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ8ByNJwOkkp45TvAnoIBa0rtCf1lbyXYjVKQ2";
 export const IMG_BASIC_MOVE =
   "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJnQxuGeXmojJ0EqeDCvBrNmZaXVdY97gSpOWi";
+export const IMG_BASIC_REPLACEMENT_TECHNIQUE =
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJZtjLXMaYQrBIUTu69nkMxWmS4ah0O7LVCp8b";
 export const IMG_BASIC_CLEANSE =
   "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ5oYOji797jl4ubX8xrRqTZasyMp2WA5eLGUP";
 export const IMG_BASIC_CLEAR =

--- a/app/src/app/api/chat/support/route.ts
+++ b/app/src/app/api/chat/support/route.ts
@@ -217,11 +217,19 @@ This document outlines various screens, menus, and gameplay systems available in
     - The turn automatically ends if AP drops below 20%.
 - **Basic Actions:**  
   - **Basic Attack:**  
-    - Costs 40 AP and 10 SP; scales with Taijutsu.
+    - Costs 20 AP and 10 SP; has a 1-round cooldown; scales with Highest offense.
+  - **Offensive Stance:**  
+    - Costs 20 AP; has a 1-round cooldown; increases all offence damage by 5% for 1 round.
+  - **Defensive Stance:**  
+    - Costs 20 AP; has a 1-round cooldown; reduces damage taken by 5% for 1 round.
   - **Basic Heal:**  
     - Costs 60 AP and 10 CP; has a 5-round cooldown and scales with Medical Ninja Rank.
+  - **Meditate:**  
+    - Costs 20 AP and 10 CP; has a 4-round cooldown; restores chakra and Stamina and scales with Medical Ninja Rank.
   - **Move:**  
-    - Costs 30 AP per hexagon of movement.
+    - Costs 10 AP per hexagon of movement.
+  - **Replacement Technique:**  
+    - Costs 20 AP; has a 2-round cooldown; reposition up to 5 hexes away.
   - **Clear:**  
     - Costs 60 AP, affects a 4-hex range, with a 9-turn cooldown; removes opponent’s positive effects.
   - **Cleanse:**  

--- a/app/src/app/api/chat/support/route.ts
+++ b/app/src/app/api/chat/support/route.ts
@@ -213,7 +213,7 @@ This document outlines various screens, menus, and gameplay systems available in
     - Provides a zoomed-out view of the combat area.
   - **Time Remaining and Action Gauge:**  
     - 60-second turn timer.  
-    - The action gauge (AP) determines available actions; actions drain AP by varying amounts (typically 60%, 40%, 30%, or 20%).  
+    - The action gauge (AP) determines available actions; actions drain AP by varying amounts (typically 60%, 40%, 20%, or 10%).  
     - The turn automatically ends if AP drops below 20%.
 - **Basic Actions:**  
   - **Basic Attack:**  

--- a/app/src/layout/Countdown.tsx
+++ b/app/src/layout/Countdown.tsx
@@ -18,15 +18,17 @@ const Countdown: React.FC<CountdownProps> = (props) => {
 
   // Track whether we've called onFinish for this countdown
   const hasCalledOnFinishRef = useRef(false);
-  // Track the target time to detect when countdown resets
-  const prevTargetTimeRef = useRef(targetTime);
+  // Track the actual target date to detect when countdown resets. `timeDiff` can
+  // recalibrate without representing a new countdown.
+  const targetDateTime = targetDate.getTime();
+  const prevTargetDateTimeRef = useRef(targetDateTime);
   // Store onFinish in a ref to avoid it being a dependency (inline functions change every render)
   const onFinishRef = useRef(onFinish);
   onFinishRef.current = onFinish;
 
   // Reset finish flag when target changes
-  if (prevTargetTimeRef.current !== targetTime) {
-    prevTargetTimeRef.current = targetTime;
+  if (prevTargetDateTimeRef.current !== targetDateTime) {
+    prevTargetDateTimeRef.current = targetDateTime;
     hasCalledOnFinishRef.current = false;
   }
 

--- a/app/src/layout/ElementImage.tsx
+++ b/app/src/layout/ElementImage.tsx
@@ -154,11 +154,35 @@ const ElementImage: React.FC<ElementImageProps> = (props) => {
           />
         );
         break;
+      case "offensiveStance":
+        image = (
+          <BicepsFlexed
+            strokeWidth={3}
+            className={cn(base, props.className, "bg-red-600")}
+          />
+        );
+        break;
+      case "defensiveStance":
+        image = (
+          <BrainCog
+            strokeWidth={3}
+            className={cn(base, props.className, "bg-blue-600")}
+          />
+        );
+        break;
       case "basicHeal":
         image = (
           <HeartPulse
             strokeWidth={3}
             className={cn(base, props.className, "bg-green-600")}
+          />
+        );
+        break;
+      case "meditate":
+        image = (
+          <Brain
+            strokeWidth={3}
+            className={cn(base, props.className, "bg-purple-600")}
           />
         );
         break;
@@ -191,6 +215,14 @@ const ElementImage: React.FC<ElementImageProps> = (props) => {
           <Footprints
             strokeWidth={3}
             className={cn(base, props.className, "bg-cyan-600")}
+          />
+        );
+        break;
+      case "replacementTechnique":
+        image = (
+          <LoaderPinwheel
+            strokeWidth={3}
+            className={cn(base, props.className, "bg-orange-500")}
           />
         );
         break;

--- a/app/src/libs/combat/actions.ts
+++ b/app/src/libs/combat/actions.ts
@@ -389,6 +389,8 @@ export const getDefaultBasicActions = (
 ): BasicActions => {
   const healPower = calcCombatHealPercentage(user);
   const jutsuStatTypes = ["Ninjutsu", "Genjutsu", "Taijutsu", "Bukijutsu"] as const;
+  const lastUsed = (id: string, def = -10) =>
+    user?.basicActions?.find((ba) => ba.id === id)?.lastUsedRound ?? def;
 
   return {
     basicAttack: {
@@ -407,8 +409,7 @@ export const getDefaultBasicActions = (
       updatedAt: Date.now(),
       cooldown: 1,
       originalCooldown: 1,
-      lastUsedRound:
-        user?.basicActions?.find((ba) => ba.id === "basicAttack")?.lastUsedRound ?? 0,
+      lastUsedRound: lastUsed("basicAttack"),
       level: user?.level,
       effects: [
         DamageTag.parse({
@@ -439,9 +440,7 @@ export const getDefaultBasicActions = (
       updatedAt: Date.now(),
       cooldown: 1,
       originalCooldown: 1,
-      lastUsedRound:
-        user?.basicActions?.find((ba) => ba.id === "offensiveStance")?.lastUsedRound ??
-        -10,
+      lastUsedRound: lastUsed("offensiveStance"),
       level: user?.level,
       effects: [
         IncreaseDamageGivenTag.parse({
@@ -469,9 +468,7 @@ export const getDefaultBasicActions = (
       updatedAt: Date.now(),
       cooldown: 1,
       originalCooldown: 1,
-      lastUsedRound:
-        user?.basicActions?.find((ba) => ba.id === "defensiveStance")?.lastUsedRound ??
-        -10,
+      lastUsedRound: lastUsed("defensiveStance"),
       level: user?.level,
       effects: [
         DecreaseDamageTakenTag.parse({
@@ -499,8 +496,7 @@ export const getDefaultBasicActions = (
       updatedAt: Date.now(),
       cooldown: 5,
       originalCooldown: 5,
-      lastUsedRound:
-        user?.basicActions?.find((ba) => ba.id === "basicHeal")?.lastUsedRound ?? -10,
+      lastUsedRound: lastUsed("basicHeal"),
       level: user?.level,
       effects: [
         HealTag.parse({
@@ -530,8 +526,7 @@ export const getDefaultBasicActions = (
       updatedAt: Date.now(),
       cooldown: 4,
       originalCooldown: 4,
-      lastUsedRound:
-        user?.basicActions?.find((ba) => ba.id === "meditate")?.lastUsedRound ?? -10,
+      lastUsedRound: lastUsed("meditate"),
       level: user?.level,
       effects: [
         HealTag.parse({
@@ -557,8 +552,7 @@ export const getDefaultBasicActions = (
       updatedAt: Date.now(),
       cooldown: 0,
       originalCooldown: 0,
-      lastUsedRound:
-        user?.basicActions?.find((ba) => ba.id === "move")?.lastUsedRound ?? 0,
+      lastUsedRound: lastUsed("move", 0),
       healthCost: 0,
       chakraCost: 0,
       staminaCost: 0,
@@ -578,9 +572,7 @@ export const getDefaultBasicActions = (
       updatedAt: Date.now(),
       cooldown: 2,
       originalCooldown: 2,
-      lastUsedRound:
-        user?.basicActions?.find((ba) => ba.id === "replacementTechnique")
-          ?.lastUsedRound ?? -10,
+      lastUsedRound: lastUsed("replacementTechnique"),
       healthCost: 0,
       chakraCost: 0,
       staminaCost: 0,
@@ -599,8 +591,7 @@ export const getDefaultBasicActions = (
       updatedAt: Date.now(),
       cooldown: 10,
       originalCooldown: 10,
-      lastUsedRound:
-        user?.basicActions?.find((ba) => ba.id === "cleanse")?.lastUsedRound ?? -10,
+      lastUsedRound: lastUsed("cleanse"),
       healthCost: 0,
       chakraCost: 0,
       staminaCost: 0,
@@ -619,8 +610,7 @@ export const getDefaultBasicActions = (
       updatedAt: Date.now(),
       cooldown: 10,
       originalCooldown: 10,
-      lastUsedRound:
-        user?.basicActions?.find((ba) => ba.id === "clear")?.lastUsedRound ?? -10,
+      lastUsedRound: lastUsed("clear"),
       healthCost: 0,
       chakraCost: 0,
       staminaCost: 0,
@@ -639,8 +629,7 @@ export const getDefaultBasicActions = (
       updatedAt: Date.now(),
       cooldown: 0,
       originalCooldown: 0,
-      lastUsedRound:
-        user?.basicActions?.find((ba) => ba.id === "flee")?.lastUsedRound ?? 0,
+      lastUsedRound: lastUsed("flee", 0),
       healthCost: 0.1,
       chakraCost: 0,
       staminaCost: 0,

--- a/app/src/libs/combat/actions.ts
+++ b/app/src/libs/combat/actions.ts
@@ -106,25 +106,20 @@ export const availableUserActions = (
 
   // Concatenate all actions
   let availableActions = [
-    ...(basicMoves && !isStealth
-      ? [
-          basicActions.basicAttack,
-          basicActions.basicOffensiveStance,
-          basicActions.basicDefensiveStance,
-        ]
-      : []),
-    ...(!isImmobilized
-      ? [basicActions.basicMove, basicActions.basicReplacementTechnique]
-      : []),
+    ...(basicMoves && !isStealth ? [basicActions.basicAttack] : []),
+    ...(!isImmobilized ? [basicActions.basicMove] : []),
     ...(basicMoves && !isStealth && !isStudent
       ? [
           basicActions.basicHeal,
           basicActions.basicMeditate,
           basicActions.basicClear,
           basicActions.basicCleanse,
-          basicActions.basicFlee,
+          basicActions.basicOffensiveStance,
+          basicActions.basicDefensiveStance,
         ]
       : []),
+    ...(!isImmobilized && !isStudent ? [basicActions.basicReplacementTechnique] : []),
+    ...(basicMoves && !isStealth && !isStudent ? [basicActions.basicFlee] : []),
     ...(availableActionPoints && availableActionPoints > 0
       ? [
           {

--- a/app/src/libs/combat/actions.ts
+++ b/app/src/libs/combat/actions.ts
@@ -13,9 +13,13 @@ import {
   IMG_BASIC_ATTACK,
   IMG_BASIC_CLEANSE,
   IMG_BASIC_CLEAR,
+  IMG_BASIC_DEFENSIVE_STANCE,
   IMG_BASIC_FLEE,
   IMG_BASIC_HEAL,
+  IMG_BASIC_MEDITATE,
   IMG_BASIC_MOVE,
+  IMG_BASIC_OFFENSIVE_STANCE,
+  IMG_BASIC_REPLACEMENT_TECHNIQUE,
   IMG_BASIC_WAIT,
   NO_DURABILITY_LOSS_COMBATS,
   NonActionItemTypes,
@@ -65,9 +69,11 @@ import {
   ClearTag,
   DamageTag,
   DecreaseCooldownTag,
+  DecreaseDamageTakenTag,
   FleeTag,
   HealTag,
   IncreaseCooldownTag,
+  IncreaseDamageGivenTag,
   IncreaseRangeTag,
   InjectJutsusTag,
   MoveTag,
@@ -100,11 +106,20 @@ export const availableUserActions = (
 
   // Concatenate all actions
   let availableActions = [
-    ...(basicMoves && !isStealth ? [basicActions.basicAttack] : []),
-    ...(!isImmobilized ? [basicActions.basicMove] : []),
+    ...(basicMoves && !isStealth
+      ? [
+          basicActions.basicAttack,
+          basicActions.basicOffensiveStance,
+          basicActions.basicDefensiveStance,
+        ]
+      : []),
+    ...(!isImmobilized
+      ? [basicActions.basicMove, basicActions.basicReplacementTechnique]
+      : []),
     ...(basicMoves && !isStealth && !isStudent
       ? [
           basicActions.basicHeal,
+          basicActions.basicMeditate,
           basicActions.basicClear,
           basicActions.basicCleanse,
           basicActions.basicFlee,
@@ -282,8 +297,15 @@ export const getActiveBasicActions = (
   // Build active actions using base (full CombatAction) merged with tracking data
   const active: BasicActions = {
     basicAttack: mergeTracking(base.basicAttack, "basicAttack"),
+    basicOffensiveStance: mergeTracking(base.basicOffensiveStance, "offensiveStance"),
+    basicDefensiveStance: mergeTracking(base.basicDefensiveStance, "defensiveStance"),
     basicHeal: mergeTracking(base.basicHeal, "basicHeal"),
+    basicMeditate: mergeTracking(base.basicMeditate, "meditate"),
     basicMove: mergeTracking(base.basicMove, "move"),
+    basicReplacementTechnique: mergeTracking(
+      base.basicReplacementTechnique,
+      "replacementTechnique",
+    ),
     basicClear: mergeTracking(base.basicClear, "clear"),
     basicCleanse: mergeTracking(base.basicCleanse, "cleanse"),
     basicFlee: mergeTracking(base.basicFlee, "flee"),
@@ -365,6 +387,9 @@ export const getDefaultBasicActions = (
       }
     | undefined,
 ): BasicActions => {
+  const healPower = calcCombatHealPercentage(user);
+  const jutsuStatTypes = ["Ninjutsu", "Genjutsu", "Taijutsu", "Bukijutsu"] as const;
+
   return {
     basicAttack: {
       id: "basicAttack",
@@ -377,11 +402,11 @@ export const getDefaultBasicActions = (
       healthCost: 0,
       chakraCost: 0,
       staminaCost: 10,
-      actionCostPerc: 40,
+      actionCostPerc: 20,
       range: 1,
       updatedAt: Date.now(),
-      cooldown: 0,
-      originalCooldown: 0,
+      cooldown: 1,
+      originalCooldown: 1,
       lastUsedRound:
         user?.basicActions?.find((ba) => ba.id === "basicAttack")?.lastUsedRound ?? 0,
       level: user?.level,
@@ -394,6 +419,67 @@ export const getDefaultBasicActions = (
           rounds: 0,
           appearAnimation: ID_ANIMATION_HIT,
           appearSfx: ID_SFX_HIT,
+        }),
+      ],
+    },
+    basicOffensiveStance: {
+      id: "offensiveStance",
+      name: "Offensive Stance",
+      image: IMG_BASIC_OFFENSIVE_STANCE,
+      battleDescription:
+        "%user takes an offensive stance, increasing their offence damage",
+      type: "basic" as const,
+      target: "SELF" as const,
+      method: "SINGLE" as const,
+      healthCost: 0,
+      chakraCost: 0,
+      staminaCost: 0,
+      actionCostPerc: 20,
+      range: 0,
+      updatedAt: Date.now(),
+      cooldown: 1,
+      originalCooldown: 1,
+      lastUsedRound:
+        user?.basicActions?.find((ba) => ba.id === "offensiveStance")?.lastUsedRound ??
+        -10,
+      level: user?.level,
+      effects: [
+        IncreaseDamageGivenTag.parse({
+          power: 5,
+          powerPerLevel: 0,
+          calculation: "percentage",
+          statTypes: [...jutsuStatTypes],
+          rounds: 1,
+        }),
+      ],
+    },
+    basicDefensiveStance: {
+      id: "defensiveStance",
+      name: "Defensive Stance",
+      image: IMG_BASIC_DEFENSIVE_STANCE,
+      battleDescription: "%user takes a defensive stance, reducing damage taken",
+      type: "basic" as const,
+      target: "SELF" as const,
+      method: "SINGLE" as const,
+      healthCost: 0,
+      chakraCost: 0,
+      staminaCost: 0,
+      actionCostPerc: 20,
+      range: 0,
+      updatedAt: Date.now(),
+      cooldown: 1,
+      originalCooldown: 1,
+      lastUsedRound:
+        user?.basicActions?.find((ba) => ba.id === "defensiveStance")?.lastUsedRound ??
+        -10,
+      level: user?.level,
+      effects: [
+        DecreaseDamageTakenTag.parse({
+          power: 5,
+          powerPerLevel: 0,
+          calculation: "percentage",
+          statTypes: [...jutsuStatTypes],
+          rounds: 1,
         }),
       ],
     },
@@ -418,10 +504,42 @@ export const getDefaultBasicActions = (
       level: user?.level,
       effects: [
         HealTag.parse({
-          power: calcCombatHealPercentage(user),
+          power: healPower,
           powerPerLevel: 0.0,
           calculation: "static",
           rounds: 0,
+          poolsAffected: ["Health"],
+          appearAnimation: ID_ANIMATION_HEAL,
+          appearSfx: ID_SFX_HEAL,
+        }),
+      ],
+    },
+    basicMeditate: {
+      id: "meditate",
+      name: "Meditate",
+      image: IMG_BASIC_MEDITATE,
+      battleDescription: "%user meditates to restore their chakra and stamina",
+      type: "basic" as const,
+      target: "SELF" as const,
+      method: "SINGLE" as const,
+      healthCost: 0,
+      chakraCost: 10,
+      staminaCost: 0,
+      actionCostPerc: 20,
+      range: 0,
+      updatedAt: Date.now(),
+      cooldown: 4,
+      originalCooldown: 4,
+      lastUsedRound:
+        user?.basicActions?.find((ba) => ba.id === "meditate")?.lastUsedRound ?? -10,
+      level: user?.level,
+      effects: [
+        HealTag.parse({
+          power: healPower,
+          powerPerLevel: 0.0,
+          calculation: "static",
+          rounds: 0,
+          poolsAffected: ["Chakra", "Stamina"],
           appearAnimation: ID_ANIMATION_HEAL,
           appearSfx: ID_SFX_HEAL,
         }),
@@ -444,7 +562,29 @@ export const getDefaultBasicActions = (
       healthCost: 0,
       chakraCost: 0,
       staminaCost: 0,
-      actionCostPerc: 30,
+      actionCostPerc: 10,
+      effects: [MoveTag.parse({ power: 100, appearSfx: ID_SFX_MOVE })],
+    },
+    basicReplacementTechnique: {
+      id: "replacementTechnique",
+      name: "Replacement Technique",
+      image: IMG_BASIC_REPLACEMENT_TECHNIQUE,
+      battleDescription:
+        "%user uses the replacement technique to reposition on the battlefield",
+      type: "basic" as const,
+      target: "EMPTY_GROUND" as const,
+      method: "SINGLE" as const,
+      range: 5,
+      updatedAt: Date.now(),
+      cooldown: 2,
+      originalCooldown: 2,
+      lastUsedRound:
+        user?.basicActions?.find((ba) => ba.id === "replacementTechnique")
+          ?.lastUsedRound ?? -10,
+      healthCost: 0,
+      chakraCost: 0,
+      staminaCost: 0,
+      actionCostPerc: 20,
       effects: [MoveTag.parse({ power: 100, appearSfx: ID_SFX_MOVE })],
     },
     basicCleanse: {

--- a/app/src/libs/combat/actions.ts
+++ b/app/src/libs/combat/actions.ts
@@ -383,6 +383,7 @@ export const getDefaultBasicActions = (
     | undefined,
 ): BasicActions => {
   const healPower = calcCombatHealPercentage(user);
+  const basicAttackCooldown = user?.rank === "STUDENT" ? 0 : 1;
   const jutsuStatTypes = ["Ninjutsu", "Genjutsu", "Taijutsu", "Bukijutsu"] as const;
   const lastUsed = (id: string, def = -10) =>
     user?.basicActions?.find((ba) => ba.id === id)?.lastUsedRound ?? def;
@@ -402,8 +403,8 @@ export const getDefaultBasicActions = (
       actionCostPerc: 20,
       range: 1,
       updatedAt: Date.now(),
-      cooldown: 1,
-      originalCooldown: 1,
+      cooldown: basicAttackCooldown,
+      originalCooldown: basicAttackCooldown,
       lastUsedRound: lastUsed("basicAttack"),
       level: user?.level,
       effects: [

--- a/app/src/libs/combat/ai_v2.ts
+++ b/app/src/libs/combat/ai_v2.ts
@@ -137,7 +137,16 @@ export const performAIaction = (
 
     // If we only have the last three actions (end turn, wait, and move),
     // available, but more actions in total, then add wait rule
-    const nonEffectActions = ["basicHeal", "flee", "wait", "move", "cleanse", "clear"];
+    const nonEffectActions = [
+      "basicHeal",
+      "meditate",
+      "flee",
+      "wait",
+      "move",
+      "replacementTechnique",
+      "cleanse",
+      "clear",
+    ];
     if (allActions?.find((a) => !nonEffectActions.includes(a.id)) && aiProfile) {
       aiProfile.rules.push({
         conditions: [],

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -1150,26 +1150,26 @@ export const updateUser = async (
     // Check if user has active PvP quests with pvp_kills or defeat_opponents objectives
     // Get user quests from extraState (static data that doesn't change during battle)
     const activeQuests = getUserQuestsFromBattle(curBattle, user.controllerId).filter(
-      (q) => q.quest?.content !== null,
+      (q) => Array.isArray(q.quest?.content?.objectives),
     );
+    const questHasObjective = (
+      uq: (typeof activeQuests)[number],
+      task: "pvp_kills" | "defeat_opponents",
+    ) => uq.quest?.content?.objectives.some((obj) => obj.task === task) ?? false;
     const activePvpQuests = activeQuests.filter((q) => q.questType === "pvp");
     const hasPvpKillsInPvpQuest = activePvpQuests.some((uq) =>
-      uq.quest.content.objectives.some((obj) => obj.task === "pvp_kills"),
+      questHasObjective(uq, "pvp_kills"),
     );
     const hasDefeatOpponentsInPvpQuest = activePvpQuests.some((uq) =>
-      uq.quest.content.objectives.some((obj) => obj.task === "defeat_opponents"),
+      questHasObjective(uq, "defeat_opponents"),
     );
     // Check if user has non-PvP quests with these objectives (should increment normally)
     const hasPvpKillsInNonPvpQuest = activeQuests
       .filter((q) => q.questType !== "pvp")
-      .some((uq) =>
-        uq.quest.content.objectives.some((obj) => obj.task === "pvp_kills"),
-      );
+      .some((uq) => questHasObjective(uq, "pvp_kills"));
     const hasDefeatOpponentsInNonPvpQuest = activeQuests
       .filter((q) => q.questType !== "pvp")
-      .some((uq) =>
-        uq.quest.content.objectives.some((obj) => obj.task === "defeat_opponents"),
-      );
+      .some((uq) => questHasObjective(uq, "defeat_opponents"));
     const isInWarTornSector = user.sector === MAP_WAR_TORN_BATTLEGROUND_SECTOR;
     // Only increment pvp_kills if:
     // - User has non-PvP quest with that objective (increment normally), OR

--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -262,7 +262,7 @@ export type BattleUserItem = {
  * Only stores per-user dynamic state.
  */
 export type BattleBasicAction = {
-  id: string; // basicAttack, basicHeal, move, cleanse, clear, flee
+  id: string; // basicAttack, offensiveStance, defensiveStance, basicHeal, meditate, move, replacementTechnique, cleanse, clear, flee
   lastUsedRound: number;
   cooldown?: number; // Optional GCD override (only set when GCD is applied)
 };
@@ -291,8 +291,12 @@ export type BattleUserState = Omit<UserData, "questData"> &
  */
 export type BasicActions = {
   basicAttack: CombatAction;
+  basicOffensiveStance: CombatAction;
+  basicDefensiveStance: CombatAction;
   basicHeal: CombatAction;
+  basicMeditate: CombatAction;
   basicMove: CombatAction;
+  basicReplacementTechnique: CombatAction;
   basicClear: CombatAction;
   basicCleanse: CombatAction;
   basicFlee: CombatAction;

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -328,7 +328,9 @@ export const getQuestDataFromBattle = (
  */
 export const hydrateUserForQuests = (battle: CompleteBattle, user: BattleUserState) => {
   // Hydrate relations from extraState
-  const userQuests = getUserQuestsFromBattle(battle, user.controllerId);
+  const userQuests = getUserQuestsFromBattle(battle, user.controllerId).filter((q) =>
+    Array.isArray(q.quest?.content?.objectives),
+  );
   const completedQuests = getCompletedQuestsFromBattle(battle, user.controllerId);
   const questData = getQuestDataFromBattle(battle, user.controllerId);
   const village = user.villageId ? getVillage(battle, user.villageId) : undefined;

--- a/app/src/libs/threejs/combat.ts
+++ b/app/src/libs/threejs/combat.ts
@@ -1349,8 +1349,9 @@ export const drawCombatUsers = (info: {
 const HIGHLIGHT_EDGE_Z_OFFSET = 0.5;
 const HIGHLIGHT_EDGE_Z_OFFSET_SELECTED = 0.6;
 
-// Cache for highlight edge geometries (keyed by tile name)
-const highlightEdgeGeometryCache = new Map<string, BufferGeometry>();
+// Cache highlight edges by the tile geometry object. Tile coordinates are reused across
+// battles, but generated terrain offsets can make the geometry differ per render.
+const highlightEdgeGeometryCache = new WeakMap<BufferGeometry, BufferGeometry>();
 
 // Reusable materials for highlight edges (created once, reused across frames)
 const highlightEdgeMaterials = {
@@ -1378,14 +1379,11 @@ type HighlightEdgePool = {
 /**
  * Get or create a cached edge geometry for a tile
  */
-const getOrCreateEdgeGeometry = (
-  mesh: HexagonalFaceMesh,
-  tileName: string,
-): BufferGeometry => {
-  let geometry = highlightEdgeGeometryCache.get(tileName);
+const getOrCreateEdgeGeometry = (mesh: HexagonalFaceMesh): BufferGeometry => {
+  let geometry = highlightEdgeGeometryCache.get(mesh.geometry);
   if (!geometry) {
     geometry = new EdgesGeometry(mesh.geometry);
-    highlightEdgeGeometryCache.set(tileName, geometry);
+    highlightEdgeGeometryCache.set(mesh.geometry, geometry);
   }
   return geometry;
 };
@@ -1497,7 +1495,7 @@ export const highlightTiles = (info: {
           newHighlights.add(mesh.name);
 
           // Get cached geometry and pooled mesh for highlight edge
-          const geometry = getOrCreateEdgeGeometry(mesh, tileName);
+          const geometry = getOrCreateEdgeGeometry(mesh);
           const edgeMesh = getPooledEdgeMesh(
             pool,
             geometry,
@@ -1557,7 +1555,7 @@ export const highlightTiles = (info: {
             mesh.material.color.copy(tintedColor);
           }
           // Get cached geometry and pooled mesh for selected edge
-          const geometry = getOrCreateEdgeGeometry(mesh, name);
+          const geometry = getOrCreateEdgeGeometry(mesh);
           const material =
             hasMove && tile === targetTile
               ? highlightEdgeMaterials.blue
@@ -1586,7 +1584,7 @@ export const highlightTiles = (info: {
             mesh.material.color.copy(tintedColor);
           }
           // Get cached geometry and pooled mesh for red edge
-          const geometry = getOrCreateEdgeGeometry(mesh, name);
+          const geometry = getOrCreateEdgeGeometry(mesh);
           const edgeMesh = getPooledEdgeMesh(
             pool,
             geometry,

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -366,7 +366,11 @@ export const combatRouter = createTRPCRouter({
       const basicActionIds = [
         "basicAttack",
         "basicHeal",
+        "meditate",
+        "offensiveStance",
+        "defensiveStance",
         "move",
+        "replacementTechnique",
         "cleanse",
         "clear",
         "flee",

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -30,6 +30,7 @@ import {
 import * as mapData from "@/data/hexasphere.json";
 import type { BattleType } from "@/drizzle/constants";
 import {
+  AdjustableBasicActions,
   AutoBattleTypes,
   BATTLE_ARENA_DAILY_LIMIT,
   BattleTypes,
@@ -363,19 +364,7 @@ export const combatRouter = createTRPCRouter({
       const showBasicActions = input.showBasicActions ?? true;
 
       // Basic action IDs to filter out when showBasicActions is false
-      const basicActionIds = [
-        "basicAttack",
-        "basicHeal",
-        "meditate",
-        "offensiveStance",
-        "defensiveStance",
-        "move",
-        "replacementTechnique",
-        "cleanse",
-        "clear",
-        "flee",
-        "wait",
-      ];
+      const basicActionIds = [...AdjustableBasicActions, "flee", "wait"];
 
       // Build where conditions
       const conditions = [eq(battleAction.battleId, input.battleId)];


### PR DESCRIPTION
# Pull Request

Changes:

- Move AP: 30 -> 10
- Basic Attack AP: 40 -> 20. 1 Turn cooldown

Additions:

- Meditate: 20 AP, Heals cp/sp with same values as heal.  Scales with Mednin. 4 round cooldown
- Offensive Stance: 20 AP, increase damage given by 5% for 1 turn.  1 turn cooldown
- Defensive Stance: 20 AP, decrease damage taken by 5% for 1 turn.  1 turn cooldown
- Replacement Technique: Turned from jutsu to basic action

Other Changes:

- Increase Bloodline swap delay from 48 hours (2 days) to 120 hours (5 days)

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes
* **New Features**
  * Added basic combat actions: **Meditate**, **Offensive Stance**, **Defensive Stance**, and **Replacement Technique** (replacement can reposition up to 5 hexes), with updated action icons.
* **Balance Changes**
  * **Move** AP cost reduced to **10 AP per hex**.
  * **Basic Attack** now costs **20 AP / 10 SP**, scales with **highest offense**, with a **1-round cooldown**.
  * **Stances** grant **damage up / damage taken down** for **1 round**; **Meditate** restores **chakra/stamina** on cooldown.
  * **Bloodline swap** cooldown increased from **48** to **120 hours**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->