### PR TITLE
hide justsu with move tag while immobilized

### DIFF
--- a/app/src/libs/combat/actions.ts
+++ b/app/src/libs/combat/actions.ts
@@ -171,6 +171,13 @@ export const availableUserActions = (
               );
               if (hasSummonTag) return false;
             }
+            // Filter out movement jutsu when immobilized
+            if (isImmobilized) {
+              const hasMoveTag = jutsu.effects.some(
+                (e: { type: string }) => e.type === "move",
+              );
+              if (hasMoveTag) return false;
+            }
             // Filter out jutsus removed by elemental seal
             if (!elementalSeal?.elements?.length) return true;
             const jutsuElements = new Set<string>();

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -914,7 +914,13 @@ export const isUserImmobilized = (
   userEffects: UserEffect[] | undefined,
 ) => {
   return userEffects?.some(
-    (e) => e.type === "moveprevent" && e.targetId === userId && !e.castThisRound,
+    (e) =>
+      e.type === "moveprevent" &&
+      e.targetId === userId &&
+      !e.castThisRound &&
+      "rounds" in e &&
+      e.rounds &&
+      e.rounds > 0,
   );
 };
 


### PR DESCRIPTION
# Pull Request

**Please fill: what was implemented, why, possibly include screenshots, are any of the changes breaking, etc.**

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Characters affected by immobilization during combat can no longer execute movement-based abilities or actions
- Movement-restricting effects now properly expire once their active duration ends, restoring full character mobility
- Combat immobilization mechanics have been refined to prevent movement abilities from being used while effects remain active

<!-- end of auto-generated comment: release notes by coderabbit.ai -->