### PR TITLE
Fix quest mission kills to align with battle context

### DIFF
--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -41,7 +41,6 @@ import { stillInBattle } from "@/libs/combat/actions";
 import type { ActionEffect, CombatResult, CompleteBattle } from "@/libs/combat/types";
 import {
   getItem,
-  getUserQuestsFromBattle,
   getVillage,
   getWarsArray,
   hydrateUserForQuests,
@@ -1147,75 +1146,43 @@ export const updateUser = async (
   const updatedQuestIds: string[] = [];
   const user = curBattle.usersState.find((u) => u.userId === userId);
   if (result && user) {
-    // Check if user has active PvP quests with pvp_kills or defeat_opponents objectives
-    // Get user quests from extraState (static data that doesn't change during battle)
-    const activeQuests = getUserQuestsFromBattle(curBattle, user.controllerId).filter(
-      (q) => Array.isArray(q.quest?.content?.objectives),
-    );
-    const questHasObjective = (
-      uq: (typeof activeQuests)[number],
-      task: "pvp_kills" | "defeat_opponents",
-    ) => uq.quest?.content?.objectives.some((obj) => obj.task === task) ?? false;
-    const activePvpQuests = activeQuests.filter((q) => q.questType === "pvp");
-    const hasPvpKillsInPvpQuest = activePvpQuests.some((uq) =>
-      questHasObjective(uq, "pvp_kills"),
-    );
-    const hasDefeatOpponentsInPvpQuest = activePvpQuests.some((uq) =>
-      questHasObjective(uq, "defeat_opponents"),
-    );
-    // Check if user has non-PvP quests with these objectives (should increment normally)
-    const hasPvpKillsInNonPvpQuest = activeQuests
-      .filter((q) => q.questType !== "pvp")
-      .some((uq) => questHasObjective(uq, "pvp_kills"));
-    const hasDefeatOpponentsInNonPvpQuest = activeQuests
-      .filter((q) => q.questType !== "pvp")
-      .some((uq) => questHasObjective(uq, "defeat_opponents"));
     const isInWarTornSector = user.sector === MAP_WAR_TORN_BATTLEGROUND_SECTOR;
-    // Only increment pvp_kills if:
-    // - User has non-PvP quest with that objective (increment normally), OR
-    // - User has PvP quest with that objective AND is in war-torn sector
-    const shouldIncrementPvpKills =
-      hasPvpKillsInNonPvpQuest || (hasPvpKillsInPvpQuest && isInWarTornSector);
-    // Only increment defeat_opponents if:
-    // - User has non-PvP quest with that objective (increment normally), OR
-    // - User has PvP quest with that objective AND is in war-torn sector
-    const shouldIncrementDefeatOpponents =
-      hasDefeatOpponentsInNonPvpQuest ||
-      (hasDefeatOpponentsInPvpQuest && isInWarTornSector);
 
-    // War participant stamp: a winning killer who shares an active war with a non-summon foe on
-    // the opposing side of this battle earns ~2h of cross-bracket targetability. The
-    // `t.direction !== user.direction` guard restricts the match to actual opponents, so the rule
-    // is "won a fight that contained a war foe on the other side" rather than "...anywhere in the
-    // battle" — a war foe sitting on the killer's own side (e.g. a co-op raid) no longer counts.
-    // Computed from the pre-loaded battle state (no DB fetch) and folded into the main userData
-    // update below so it costs no extra roundtrip. War-torn sector kills are excluded (war state
-    // is not tracked there). Shrine AI kills are covered too: shrine AIs defend (right side) and
-    // carry the defending village's villageId, so findWarsWithUser matches them.
+    // War-kill detection: an opposing-side, non-summon foe who shares an active war with the
+    // user. The `t.direction !== user.direction` guard restricts the match to actual opponents,
+    // so it means "a fight that contained a war foe on the other side" rather than a war foe on
+    // the killer's own side (e.g. a co-op raid). War-torn sector kills are excluded (war state is
+    // not tracked there). Shrine AI kills are covered too: shrine AIs defend (right side) and
+    // carry the defending village's villageId, so findWarsWithUser matches them. Computed from
+    // pre-loaded battle state (no DB fetch).
     const userWars = getWarsArray(curBattle, user);
-    const isWinningWarParticipant =
-      result.didWin > 0 &&
-      !!user.villageId &&
+    const isOpposingWarFoe = (t: (typeof curBattle.usersState)[number]) =>
       !isInWarTornSector &&
-      curBattle.usersState.some(
-        (t) =>
-          t.userId !== userId &&
-          !t.isSummon &&
-          t.direction !== user.direction &&
-          findWarsWithUser(
-            getWarsArray(curBattle, t),
-            userWars,
-            t.villageId,
-            user.villageId,
-          ).length > 0,
-      );
+      !!user.villageId &&
+      t.userId !== userId &&
+      !t.isSummon &&
+      t.direction !== user.direction &&
+      findWarsWithUser(
+        getWarsArray(curBattle, t),
+        userWars,
+        t.villageId,
+        user.villageId,
+      ).length > 0;
+    // Battle-global war participation (outcome-independent): gates the per-battle pvp_kills
+    // counter for war quests. Per-opponent `warFoe` (below) gates defeat_opponents so a non-war
+    // target isn't credited just because a war foe shared the battle.
+    const isWarBattleParticipant = curBattle.usersState.some(isOpposingWarFoe);
+    // A winning war participant earns ~2h of cross-bracket targetability; folded into the main
+    // userData update below so it costs no extra roundtrip.
+    const isWinningWarParticipant = result.didWin > 0 && isWarBattleParticipant;
 
     // Accumulate all tracker tasks into a single array for one getNewTrackers call
     const trackerTasks: Parameters<typeof getNewTrackers>[1] = [];
 
-    // Update quest tracker with battle result
+    // Update quest tracker with battle result. pvp_kills is emitted on every COMBAT win; the
+    // war-torn (pvp quests) / active-war (war quests) gating is applied per quest in getNewTrackers.
     if (result.didWin > 0) {
-      if (curBattle.battleType === "COMBAT" && shouldIncrementPvpKills) {
+      if (curBattle.battleType === "COMBAT") {
         trackerTasks.push({ task: "pvp_kills", increment: 1 });
       }
       if (curBattle.battleType === "ARENA") {
@@ -1234,16 +1201,14 @@ export const updateUser = async (
       ...curBattle.usersState
         .filter((u) => u.userId !== userId)
         .flatMap((u) => [
-          // Defeat opponent with outcome - only if conditions are met
-          ...(shouldIncrementDefeatOpponents
-            ? [
-                {
-                  task: "defeat_opponents" as const,
-                  contentId: u.controllerId,
-                  text: result.outcome,
-                },
-              ]
-            : []),
+          // Defeat opponent with outcome; gated per quest type in getNewTrackers (pvp → war-torn
+          // sector, war → this opponent being an active-war foe).
+          {
+            task: "defeat_opponents" as const,
+            contentId: u.controllerId,
+            text: result.outcome,
+            warFoe: isOpposingWarFoe(u),
+          },
           // Start battle with outcome
           {
             task: "start_battle" as const,
@@ -1269,6 +1234,10 @@ export const updateUser = async (
     const { trackers, notifications, questIdsUpdated } = getNewTrackers(
       hydratedUser,
       trackerTasks,
+      {
+        inWarTornSector: isInWarTornSector,
+        isWarParticipant: isWarBattleParticipant,
+      },
     );
     updatedQuestIds.push(...questIdsUpdated);
     const updatedQuestData = filterQuestTrackersForDbPersist(

--- a/app/src/libs/quest.ts
+++ b/app/src/libs/quest.ts
@@ -873,13 +873,16 @@ export const getNewTrackers = (
             .forEach((taskUpdate) => {
               // War-context kill objectives only advance in their required context (pvp →
               // war-torn sector; war → active-war kill). All other tasks always count.
+              // `defeat_opponents` is per-opponent, so a missing `warFoe` must deny rather than
+              // fall back to the battle-global flag (which would credit a non-war target in a
+              // mixed war battle); `pvp_kills` keeps the battle-global fallback by design.
+              const taskWarFoe =
+                task === "defeat_opponents"
+                  ? (taskUpdate.warFoe ?? false)
+                  : taskUpdate.warFoe;
               const killCounts =
                 !isWarContextKillTask ||
-                killObjectiveCountsForQuest(
-                  quest.questType,
-                  combatContext,
-                  taskUpdate.warFoe,
-                );
+                killObjectiveCountsForQuest(quest.questType, combatContext, taskWarFoe);
               // If objective has a value, increment it
               if (status && "value" in objective) {
                 if (taskUpdate.increment && killCounts) {

--- a/app/src/libs/quest.ts
+++ b/app/src/libs/quest.ts
@@ -566,6 +566,37 @@ export type QuestConsequence = {
 };
 
 /**
+ * Battle context for gating "war-context" kill objectives. Supplied only from the combat path.
+ */
+export type CombatQuestContext = {
+  inWarTornSector: boolean;
+  isWarParticipant: boolean;
+};
+
+/**
+ * Decide whether a war-context kill objective (`pvp_kills` / `defeat_opponents`) should advance
+ * for a given quest type and battle context:
+ * - `pvp` quests count only inside the war-torn sector.
+ * - `war` quests count only active-war kills: a per-opponent `warFoe` flag when available (e.g.
+ *   `defeat_opponents`), otherwise the battle-global war-participant flag (e.g. the `pvp_kills`
+ *   counter, which is only emitted on a win).
+ * - every other quest type counts anywhere.
+ * Context is only passed from combat, so an absent context conservatively denies pvp/war
+ * counting; non-combat callers never emit kill progress for these tasks.
+ */
+export const killObjectiveCountsForQuest = (
+  questType: QuestType | undefined,
+  context: CombatQuestContext | undefined,
+  warFoe: boolean | undefined,
+): boolean => {
+  if (questType === "pvp") return context?.inWarTornSector === true;
+  if (questType === "war") {
+    return warFoe !== undefined ? warFoe : context?.isWarParticipant === true;
+  }
+  return true;
+};
+
+/**
  * Used to update the quest tracking data for a user. Takes in the user with his questData
  * information, as well as a task to update. The value is the value to update the task with,
  * e.g. if task is 'pvp_kills' and value is 1, then the user has killed 1 player. This function
@@ -585,7 +616,9 @@ export const getNewTrackers = (
     value?: number;
     text?: string;
     contentId?: string;
+    warFoe?: boolean;
   }[],
+  combatContext?: CombatQuestContext,
 ) => {
   const questData = user.questData ?? [];
   const activeQuests = getUserQuests(user);
@@ -738,6 +771,9 @@ export const getNewTrackers = (
 
           // Convenience
           const task = objective.task;
+          // Kill objectives whose counting is gated by battle context per quest type
+          const isWarContextKillTask =
+            task === "pvp_kills" || task === "defeat_opponents";
           const isKage = user.village?.kageId === user.userId;
 
           // General updates we want to apply every time
@@ -835,12 +871,21 @@ export const getNewTrackers = (
               (taskUpdate) => taskUpdate.task === task || taskUpdate.task === "any",
             )
             .forEach((taskUpdate) => {
+              // War-context kill objectives only advance in their required context (pvp →
+              // war-torn sector; war → active-war kill). All other tasks always count.
+              const killCounts =
+                !isWarContextKillTask ||
+                killObjectiveCountsForQuest(
+                  quest.questType,
+                  combatContext,
+                  taskUpdate.warFoe,
+                );
               // If objective has a value, increment it
               if (status && "value" in objective) {
-                if (taskUpdate.increment) {
+                if (taskUpdate.increment && killCounts) {
                   status.value += taskUpdate.increment;
                 }
-                if (taskUpdate.value) {
+                if (taskUpdate.value && killCounts) {
                   status.value = taskUpdate.value;
                 }
               }
@@ -962,6 +1007,7 @@ export const getNewTrackers = (
                 opponentIds.length > 0
               ) {
                 if (
+                  killCounts &&
                   taskUpdate.text &&
                   opponentIds.includes(taskUpdate.contentId || "1337")
                 ) {

--- a/app/tests/libs/quest_killcount.test.ts
+++ b/app/tests/libs/quest_killcount.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "vitest";
+import type { QuestType } from "@/drizzle/constants";
+import { getNewTrackers, killObjectiveCountsForQuest } from "@/libs/quest";
+
+// ---------------------------------------------------------------------------
+// Fixtures: minimal user + quest objects accepted by getNewTrackers/getUserQuests.
+// We cast through `unknown` since the full UserWithRelations type is large and
+// only the fields exercised below matter at runtime.
+// ---------------------------------------------------------------------------
+
+const pvpKillsObjective = (id: string, value = 3) => ({
+  id,
+  task: "pvp_kills" as const,
+  value,
+  description: "",
+  successDescription: "",
+});
+
+const defeatOpponentsObjective = (id: string, aiId: string) => ({
+  id,
+  task: "defeat_opponents" as const,
+  description: "",
+  successDescription: "",
+  completionOutcome: "Win" as const,
+  opponentAIs: [{ ids: aiId, number: 1 }],
+  sectorType: "specific" as const,
+  locationType: "specific" as const,
+  sector: 0,
+  longitude: 0,
+  latitude: 0,
+  sectorList: [],
+  hideLocation: false,
+});
+
+const makeQuest = (
+  id: string,
+  questType: QuestType,
+  objectives: ReturnType<typeof pvpKillsObjective | typeof defeatOpponentsObjective>[],
+) => ({
+  id,
+  name: `Quest ${id}`,
+  questType,
+  hidden: false,
+  consecutiveObjectives: false,
+  maxAttempts: 100,
+  maxCompletes: 100,
+  requiredVillage: null,
+  requiredBloodlineId: null,
+  prerequisiteQuestId: null,
+  requiredLevel: null,
+  maxLevel: null,
+  medicalRank: null,
+  huntingRank: null,
+  gatheringRank: null,
+  endsAt: null,
+  content: {
+    objectives,
+    reward: {},
+    sceneBackground: "",
+    sceneCharacters: [],
+  },
+});
+
+const makeUser = (quests: ReturnType<typeof makeQuest>[]) =>
+  ({
+    userId: "u1",
+    level: 50,
+    rank: "JONIN",
+    role: "USER",
+    villageId: "v1",
+    isOutlaw: false,
+    bloodlineId: null,
+    medicalExperience: 0,
+    huntingExperience: 0,
+    gatheringExperience: 0,
+    sector: 1,
+    village: { id: "v1", sector: 1 },
+    activeWars: [],
+    completedQuests: [],
+    questData: [],
+    userQuests: quests.map((q) => ({
+      id: `uq-${q.id}`,
+      questId: q.id,
+      completed: 0,
+      previousAttempts: 0,
+      previousCompletes: 0,
+      quest: q,
+    })),
+  }) as unknown as Parameters<typeof getNewTrackers>[0];
+
+const goalValue = (
+  result: ReturnType<typeof getNewTrackers>,
+  questId: string,
+  objectiveId: string,
+) =>
+  result.trackers
+    .find((t) => t.id === questId)
+    ?.goals.find((g) => g.id === objectiveId)?.value;
+
+const goalDone = (
+  result: ReturnType<typeof getNewTrackers>,
+  questId: string,
+  objectiveId: string,
+) =>
+  result.trackers
+    .find((t) => t.id === questId)
+    ?.goals.find((g) => g.id === objectiveId)?.done;
+
+// ---------------------------------------------------------------------------
+// killObjectiveCountsForQuest — the pure gating decision
+// ---------------------------------------------------------------------------
+
+describe("killObjectiveCountsForQuest", () => {
+  it("pvp quests count only inside the war-torn sector", () => {
+    expect(
+      killObjectiveCountsForQuest(
+        "pvp",
+        { inWarTornSector: true, isWarParticipant: false },
+        undefined,
+      ),
+    ).toBe(true);
+    expect(
+      killObjectiveCountsForQuest(
+        "pvp",
+        { inWarTornSector: false, isWarParticipant: true },
+        undefined,
+      ),
+    ).toBe(false);
+  });
+
+  it("pvp quests do not count without battle context", () => {
+    expect(killObjectiveCountsForQuest("pvp", undefined, undefined)).toBe(false);
+  });
+
+  it("war quests count a per-opponent war foe regardless of the battle-global flag", () => {
+    expect(
+      killObjectiveCountsForQuest(
+        "war",
+        { inWarTornSector: false, isWarParticipant: false },
+        true,
+      ),
+    ).toBe(true);
+    expect(
+      killObjectiveCountsForQuest(
+        "war",
+        { inWarTornSector: false, isWarParticipant: true },
+        false,
+      ),
+    ).toBe(false);
+  });
+
+  it("war quests fall back to the battle-global participant flag when warFoe is absent", () => {
+    expect(
+      killObjectiveCountsForQuest(
+        "war",
+        { inWarTornSector: false, isWarParticipant: true },
+        undefined,
+      ),
+    ).toBe(true);
+    expect(
+      killObjectiveCountsForQuest(
+        "war",
+        { inWarTornSector: false, isWarParticipant: false },
+        undefined,
+      ),
+    ).toBe(false);
+  });
+
+  it("non-pvp/war quest types count anywhere", () => {
+    for (const questType of ["daily", "mission", "achievement", "errand"] as const) {
+      expect(killObjectiveCountsForQuest(questType, undefined, undefined)).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getNewTrackers — wiring of the gate (reproduces the reported bug)
+// ---------------------------------------------------------------------------
+
+describe("getNewTrackers pvp_kills gating", () => {
+  it("a daily quest does not leak pvp_kills into a pvp quest outside the war-torn sector", () => {
+    const daily = makeQuest("daily-1", "daily", [pvpKillsObjective("d-obj")]);
+    const pvp = makeQuest("pvp-1", "pvp", [pvpKillsObjective("p-obj")]);
+    const user = makeUser([daily, pvp]);
+
+    const result = getNewTrackers(user, [{ task: "pvp_kills", increment: 1 }], {
+      inWarTornSector: false,
+      isWarParticipant: false,
+    });
+
+    expect(goalValue(result, "daily-1", "d-obj")).toBe(1);
+    expect(goalValue(result, "pvp-1", "p-obj")).toBe(0);
+  });
+
+  it("a pvp quest counts pvp_kills inside the war-torn sector", () => {
+    const pvp = makeQuest("pvp-1", "pvp", [pvpKillsObjective("p-obj")]);
+    const user = makeUser([pvp]);
+
+    const result = getNewTrackers(user, [{ task: "pvp_kills", increment: 1 }], {
+      inWarTornSector: true,
+      isWarParticipant: false,
+    });
+
+    expect(goalValue(result, "pvp-1", "p-obj")).toBe(1);
+  });
+
+  it("a war quest counts pvp_kills only when it is an active-war battle", () => {
+    const war = makeQuest("war-1", "war", [pvpKillsObjective("w-obj")]);
+
+    const counted = getNewTrackers(makeUser([war]), [{ task: "pvp_kills", increment: 1 }], {
+      inWarTornSector: false,
+      isWarParticipant: true,
+    });
+    expect(goalValue(counted, "war-1", "w-obj")).toBe(1);
+
+    const notCounted = getNewTrackers(
+      makeUser([war]),
+      [{ task: "pvp_kills", increment: 1 }],
+      { inWarTornSector: false, isWarParticipant: false },
+    );
+    expect(goalValue(notCounted, "war-1", "w-obj")).toBe(0);
+  });
+});
+
+describe("getNewTrackers defeat_opponents gating", () => {
+  it("a war quest completes defeat_opponents only against a per-opponent war foe", () => {
+    const war = makeQuest("war-1", "war", [defeatOpponentsObjective("w-obj", "ai-1")]);
+
+    const counted = getNewTrackers(
+      makeUser([war]),
+      [{ task: "defeat_opponents", contentId: "ai-1", text: "Won", warFoe: true }],
+      { inWarTornSector: false, isWarParticipant: true },
+    );
+    expect(goalDone(counted, "war-1", "w-obj")).toBe(true);
+
+    const notCounted = getNewTrackers(
+      makeUser([war]),
+      [{ task: "defeat_opponents", contentId: "ai-1", text: "Won", warFoe: false }],
+      { inWarTornSector: false, isWarParticipant: true },
+    );
+    expect(goalDone(notCounted, "war-1", "w-obj")).toBe(false);
+  });
+
+  it("a daily quest does not leak defeat_opponents into a pvp quest outside the war-torn sector", () => {
+    const daily = makeQuest("daily-1", "daily", [defeatOpponentsObjective("d-obj", "ai-1")]);
+    const pvp = makeQuest("pvp-1", "pvp", [defeatOpponentsObjective("p-obj", "ai-1")]);
+    const user = makeUser([daily, pvp]);
+
+    const result = getNewTrackers(
+      user,
+      [{ task: "defeat_opponents", contentId: "ai-1", text: "Won" }],
+      { inWarTornSector: false, isWarParticipant: false },
+    );
+
+    expect(goalDone(result, "daily-1", "d-obj")).toBe(true);
+    expect(goalDone(result, "pvp-1", "p-obj")).toBe(false);
+  });
+});

--- a/app/tests/libs/quest_killcount.test.ts
+++ b/app/tests/libs/quest_killcount.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { QuestType } from "@/drizzle/constants";
+import { QuestTypes, type QuestType } from "@/drizzle/constants";
 import { getNewTrackers, killObjectiveCountsForQuest } from "@/libs/quest";
 
 // ---------------------------------------------------------------------------
@@ -167,7 +167,8 @@ describe("killObjectiveCountsForQuest", () => {
   });
 
   it("non-pvp/war quest types count anywhere", () => {
-    for (const questType of ["daily", "mission", "achievement", "errand"] as const) {
+    // Derived from the canonical enum so new quest types are covered automatically.
+    for (const questType of QuestTypes.filter((t) => t !== "pvp" && t !== "war")) {
       expect(killObjectiveCountsForQuest(questType, undefined, undefined)).toBe(true);
     }
   });
@@ -239,6 +240,20 @@ describe("getNewTrackers defeat_opponents gating", () => {
       { inWarTornSector: false, isWarParticipant: true },
     );
     expect(goalDone(notCounted, "war-1", "w-obj")).toBe(false);
+  });
+
+  it("a war quest does not complete defeat_opponents from a missing warFoe in a mixed war battle", () => {
+    const war = makeQuest("war-1", "war", [defeatOpponentsObjective("w-obj", "ai-1")]);
+
+    // warFoe is omitted but the battle is a war battle (isWarParticipant: true). A per-opponent
+    // objective must deny rather than fall back to the battle-global flag.
+    const result = getNewTrackers(
+      makeUser([war]),
+      [{ task: "defeat_opponents", contentId: "ai-1", text: "Won" }],
+      { inWarTornSector: false, isWarParticipant: true },
+    );
+
+    expect(goalDone(result, "war-1", "w-obj")).toBe(false);
   });
 
   it("a daily quest does not leak defeat_opponents into a pvp quest outside the war-torn sector", () => {


### PR DESCRIPTION
# Pull Request

## What

Fixes quest **kill-objective counting** (`pvp_kills` / `defeat_opponents`) so it only advances in the battle context each quest type is meant for:

- **`pvp` quests** — count only inside the war-torn sector (sector 335).
- **`war` quests** — count only on an **active-war kill** (a win against an opponent from a village you're actively at war with; the war-torn sector is excluded because war state isn't tracked there).
- **all other quest types** (daily, mission, errand, crime, medical, achievement, …) — count anywhere, unchanged.

## Why

The war-torn gating in `combat/database.ts` computed the rule as **user-global booleans** (`shouldIncrementPvpKills` / `shouldIncrementDefeatOpponents`) and then pushed a single untyped tracker task. `getNewTrackers` applied that one task to **every** matching objective across **all** of a user's quests, with no per-quest filtering. Three confirmed bugs resulted:

- **A — cross-quest-type leak (reported):** holding a `daily`/`mission` quest with a `pvp_kills` objective flipped the global boolean to `true`, which then advanced a `pvp`-mission's `pvp_kills` **outside the war-torn sector**. ("The daily mission is causing PvP missions to count outside wartorn.")
- **B:** the exact same leak for `defeat_opponents`.
- **C:** `war`-type quests were bucketed as "non-pvp", so their kill objectives counted on **any** win, **anywhere**, with no war gating at all. ("War mission kills counting from non-war kills.") The `war` quest type was added ~6 weeks after the war-torn feature and was never threaded into this logic.

Root cause: an impedance mismatch — per-quest gating was collapsed into one boolean in `database.ts`, then re-broadcast to unrelated quests by `getNewTrackers`.

## How

Move the gating decision to where per-quest context still exists — the objective loop in `getNewTrackers` — and pass real battle context instead of a pre-collapsed boolean. **No new database round-trips** (all context comes from the pre-loaded battle state; the combat path keeps one read + one parallel write).

- **`app/src/libs/quest.ts`**
  - New exported helper `killObjectiveCountsForQuest(questType, context, warFoe)` encoding the per-quest-type rule.
  - `getNewTrackers` gains an optional `combatContext` param and an optional per-task `warFoe` flag; the gate is evaluated per quest at the `pvp_kills` increment and the `defeat_opponents` completion sites. Combat initiation (`putInCombat`) is intentionally left ungated.
- **`app/src/libs/combat/database.ts`**
  - Extracted a single `isOpposingWarFoe` predicate (reused for the battle-global participant flag, the existing cross-bracket targetability stamp, and the per-opponent `warFoe`).
  - Removed the four `has*` derivations and both `shouldIncrement*` booleans (and the now-unused import).
  - `pvp_kills` is emitted on every `COMBAT` win and `defeat_opponents` per opponent (carrying `warFoe`); gating now happens per quest in `getNewTrackers`.

Two refinements from peer review are included: the war flag is **win-independent** (so a `war` `defeat_opponents` with `completionOutcome` of Lose/Draw/Any still resolves), and `defeat_opponents` uses a **per-opponent** war-foe flag so a non-war target isn't credited just because a war foe shared the battle.

## Breaking changes

No schema/API/migration changes. This is a **behavior change** to quest progress:

- `pvp`-mission and `war`-quest kill objectives now stop counting kills made outside their intended context (this is the fix). Players will no longer see those objectives advance from unrelated battles.
- Daily / mission / errand / crime / medical / achievement kill objectives are unaffected.

## Testing

- New `app/tests/libs/quest_killcount.test.ts` (TDD — written failing first): unit tests for the decision matrix plus integration tests reproducing the cross-quest-type leak and the war-quest gating (10 tests, all passing).
- `tsc --noEmit` clean; `biome lint` clean on changed files.
- Full suite: 118/118 runnable tests pass. (Pre-existing `Invalid environment variables` suite-load failures in `tests/libs/combat/*` and one `tests/app/api/shrine-maintenance` suite are unrelated environment noise — confirmed identical on a clean checkout.)

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * War-related kill and defeat quest objectives now advance only with correct battle context (war-torn sector status and opponent war alignment).
* **Bug Fixes**
  * Fixed quest tracker progress to avoid increments/completions when required battle-context flags are missing or opponents don’t qualify as valid war foes.
* **Tests**
  * Added unit and integration-style coverage for gated kill-count behavior across PvP and war quest types, including opponent outcome transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->