### PR TITLE
fix: multi-session clerk bug

### DIFF
--- a/app/bun.lock
+++ b/app/bun.lock
@@ -145,7 +145,7 @@
         "@types/tweenjs": "^1.0.8",
         "@types/ua-parser-js": "^0.7.39",
         "@typescript/native-preview": "^7.0.0-dev.20260512.1",
-        "@vitejs/plugin-react": "^6.0.1",
+        "@vitejs/plugin-react": "^5",
         "autoprefixer": "^10.5.0",
         "drizzle-kit": "0.31.10",
         "globals": "^17.6.0",
@@ -203,6 +203,8 @@
 
     "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
 
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
+
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
@@ -212,6 +214,10 @@
     "@babel/helpers": ["@babel/helpers@7.28.6", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw=="],
 
     "@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q=="],
 
     "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
 
@@ -633,7 +639,7 @@
 
     "@resvg/resvg-wasm": ["@resvg/resvg-wasm@2.4.0", "", {}, "sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg=="],
 
-    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
     "@rollup/plugin-commonjs": ["@rollup/plugin-commonjs@28.0.1", "", { "dependencies": { "@rollup/pluginutils": "^5.0.1", "commondir": "^1.0.1", "estree-walker": "^2.0.2", "fdir": "^6.2.0", "is-reference": "1.2.1", "magic-string": "^0.30.3", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^2.68.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA=="],
 
@@ -897,6 +903,14 @@
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
@@ -1025,7 +1039,7 @@
 
     "@vercel/speed-insights": ["@vercel/speed-insights@2.0.0", "", { "peerDependencies": { "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "nuxt": ">= 3", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@sveltejs/kit", "next", "nuxt", "react", "svelte", "vue", "vue-router"] }, "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w=="],
 
-    "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
 
     "@vitest/expect": ["@vitest/expect@4.1.6", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg=="],
 
@@ -1827,6 +1841,8 @@
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
+    "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
+
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
@@ -2216,6 +2232,14 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@types/babel__core/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@types/babel__generator/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@types/babel__template/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@types/babel__traverse/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@types/connect/@types/node": ["@types/node@22.15.30", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA=="],
 

--- a/app/package.json
+++ b/app/package.json
@@ -170,7 +170,7 @@
     "@types/tweenjs": "^1.0.8",
     "@types/ua-parser-js": "^0.7.39",
     "@typescript/native-preview": "^7.0.0-dev.20260512.1",
-    "@vitejs/plugin-react": "^6.0.1",
+    "@vitejs/plugin-react": "^5",
     "autoprefixer": "^10.5.0",
     "drizzle-kit": "0.31.10",
     "globals": "^17.6.0",

--- a/app/src/app/_trpc/Provider.tsx
+++ b/app/src/app/_trpc/Provider.tsx
@@ -13,7 +13,11 @@ import superjson from "superjson";
 import { toast } from "@/components/ui/use-toast";
 import { showMutationToast } from "@/libs/toast";
 import { isRetryableTrpcError } from "@/utils/error";
-import { buildClerkRequestHeaders, computeIsMultiSession } from "./authHeaders";
+import {
+  buildClerkRequestHeaders,
+  computeIsMultiSession,
+  VIEWER_SESSION_MISMATCH_MESSAGE,
+} from "./authHeaders";
 import {
   api,
   SIGN_IN_REQUIRED_MUTATION_MESSAGE,
@@ -175,13 +179,14 @@ const handleTrpcError = (error: unknown) => {
     return;
   }
 
-  // Ignore the transient Clerk multi-session "Viewer/session mismatch" guard
-  // (server FORBIDDEN from assertViewerMatchesSession). It only fires in the rare
-  // window where a request authenticated as a different tab's account; the query
-  // refetches with the correct per-tab token, so it is not user-facing.
+  // Ignore the transient Clerk multi-session viewer/session mismatch guard (server
+  // FORBIDDEN from assertViewerMatchesSession; message shared via
+  // VIEWER_SESSION_MISMATCH_MESSAGE). It only fires in the rare window where a
+  // request authenticated as a different tab's account; the query refetches with the
+  // correct per-tab token, so it is not user-facing.
   if (
     error instanceof TRPCClientError &&
-    error.message.includes("Viewer/session mismatch") &&
+    error.message.includes(VIEWER_SESSION_MISMATCH_MESSAGE) &&
     (trpcErrorCode === undefined || trpcErrorCode === "FORBIDDEN")
   ) {
     // Not user-facing (self-heals on the next per-tab refetch), so no toast. But

--- a/app/src/app/_trpc/Provider.tsx
+++ b/app/src/app/_trpc/Provider.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAuth } from "@clerk/nextjs";
 import * as Sentry from "@sentry/nextjs";
 import {
   MutationCache,
@@ -8,11 +9,12 @@ import {
   QueryClientProvider,
 } from "@tanstack/react-query";
 import { httpBatchLink, loggerLink, retryLink, TRPCClientError } from "@trpc/client";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import superjson from "superjson";
 import { toast } from "@/components/ui/use-toast";
 import { showMutationToast } from "@/libs/toast";
 import { isRetryableTrpcError } from "@/utils/error";
+import { buildClerkAuthHeaders } from "./authHeaders";
 import {
   api,
   SIGN_IN_REQUIRED_MUTATION_MESSAGE,
@@ -27,6 +29,12 @@ const getBaseUrl = () => {
 
 const TrpcClientProvider = (props: { children: React.ReactNode }) => {
   const onMutateCheck = useGlobalOnMutateProtect();
+  // Clerk multi-session: capture this tab's getToken so every tRPC request can
+  // carry the tab's own session token. Stored in a ref so the once-created
+  // client always reads the latest value (the headers callback runs per batch).
+  const { getToken } = useAuth();
+  const getTokenRef = useRef(getToken);
+  getTokenRef.current = getToken;
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -92,6 +100,10 @@ const TrpcClientProvider = (props: { children: React.ReactNode }) => {
         httpBatchLink({
           url: `${getBaseUrl()}/api/trpc`,
           transformer: superjson,
+          async headers() {
+            const token = await getTokenRef.current().catch(() => null);
+            return buildClerkAuthHeaders(token);
+          },
         }),
       ],
     }),
@@ -119,6 +131,18 @@ const handleTrpcError = (error: unknown) => {
     error instanceof TRPCClientError &&
     error.message.includes("Unauthorized for tRPC endpoint") &&
     (trpcErrorCode === undefined || trpcErrorCode === "UNAUTHORIZED")
+  ) {
+    return;
+  }
+
+  // Ignore the transient Clerk multi-session "Viewer/session mismatch" guard
+  // (server FORBIDDEN from assertViewerMatchesSession). It only fires in the rare
+  // window where a request authenticated as a different tab's account; the query
+  // refetches with the correct per-tab token, so it is not user-facing.
+  if (
+    error instanceof TRPCClientError &&
+    error.message.includes("Viewer/session mismatch") &&
+    (trpcErrorCode === undefined || trpcErrorCode === "FORBIDDEN")
   ) {
     return;
   }

--- a/app/src/app/_trpc/Provider.tsx
+++ b/app/src/app/_trpc/Provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useAuth } from "@clerk/nextjs";
+import { useAuth, useClerk } from "@clerk/nextjs";
 import * as Sentry from "@sentry/nextjs";
 import {
   MutationCache,
@@ -14,7 +14,7 @@ import superjson from "superjson";
 import { toast } from "@/components/ui/use-toast";
 import { showMutationToast } from "@/libs/toast";
 import { isRetryableTrpcError } from "@/utils/error";
-import { buildClerkAuthHeaders } from "./authHeaders";
+import { buildClerkAuthFailureHeaders, buildClerkAuthHeaders } from "./authHeaders";
 import {
   api,
   SIGN_IN_REQUIRED_MUTATION_MESSAGE,
@@ -35,6 +35,11 @@ const TrpcClientProvider = (props: { children: React.ReactNode }) => {
   const { getToken } = useAuth();
   const getTokenRef = useRef(getToken);
   getTokenRef.current = getToken;
+  // Used only to count the browser's Clerk sessions when getToken() fails, so we
+  // fail closed against the shared cookie only in genuine multi-session cases.
+  const clerk = useClerk();
+  const clerkRef = useRef(clerk);
+  clerkRef.current = clerk;
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -101,8 +106,15 @@ const TrpcClientProvider = (props: { children: React.ReactNode }) => {
           url: `${getBaseUrl()}/api/trpc`,
           transformer: superjson,
           async headers() {
-            const token = await getTokenRef.current().catch(() => null);
-            return buildClerkAuthHeaders(token);
+            try {
+              const token = await getTokenRef.current();
+              return buildClerkAuthHeaders(token);
+            } catch {
+              // getToken() threw (e.g. offline/refresh blip). Do not silently fall
+              // back to the shared __session cookie in a multi-session browser.
+              const sessions = clerkRef.current?.client?.sessions?.length ?? 1;
+              return buildClerkAuthFailureHeaders(sessions > 1);
+            }
           },
         }),
       ],

--- a/app/src/app/_trpc/Provider.tsx
+++ b/app/src/app/_trpc/Provider.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useAuth, useClerk } from "@clerk/nextjs";
 import * as Sentry from "@sentry/nextjs";
 import {
   MutationCache,
@@ -20,6 +19,7 @@ import {
   SIGN_IN_REQUIRED_MUTATION_MESSAGE,
   useGlobalOnMutateProtect,
 } from "./client";
+import { useSessionPin } from "./SessionPinProvider";
 
 const getBaseUrl = () => {
   if (typeof window !== "undefined") return "";
@@ -29,17 +29,18 @@ const getBaseUrl = () => {
 
 const TrpcClientProvider = (props: { children: React.ReactNode }) => {
   const onMutateCheck = useGlobalOnMutateProtect();
-  // Clerk multi-session: capture this tab's getToken so every tRPC request can
-  // carry the tab's own session token. Stored in a ref so the once-created
-  // client always reads the latest value (the headers callback runs per batch).
-  const { getToken } = useAuth();
-  const getTokenRef = useRef(getToken);
-  getTokenRef.current = getToken;
-  // Used only to count the browser's Clerk sessions when getToken() fails, so we
-  // fail closed against the shared cookie only in genuine multi-session cases.
-  const clerk = useClerk();
-  const clerkRef = useRef(clerk);
-  clerkRef.current = clerk;
+  // Clerk multi-session: authenticate every tRPC request as THIS tab's PINNED
+  // session (not the browser-global active session), so a background change to the
+  // active account cannot make a request authenticate as the wrong account. Stored
+  // in refs so the once-created client always reads the latest values (the headers
+  // callback runs per request batch).
+  const { getPinnedToken, signedInSessionCount } = useSessionPin();
+  const getPinnedTokenRef = useRef(getPinnedToken);
+  getPinnedTokenRef.current = getPinnedToken;
+  // Used only to count the browser's Clerk sessions when no token is available, so
+  // we fail closed against the shared cookie only in genuine multi-session cases.
+  const signedInSessionCountRef = useRef(signedInSessionCount);
+  signedInSessionCountRef.current = signedInSessionCount;
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -110,14 +111,15 @@ const TrpcClientProvider = (props: { children: React.ReactNode }) => {
             // multi-session so the no-token path fails closed against the shared
             // cookie; a known single session keeps the normal cookie path.
             const isMultiSession = computeIsMultiSession(
-              clerkRef.current?.client?.signedInSessions?.length,
+              signedInSessionCountRef.current,
             );
             try {
-              // getToken() returns null when the tab has no session and throws on
-              // an offline/refresh blip; both go through the no-token path, which
-              // fails closed under multi-session instead of using the shared cookie.
+              // getPinnedToken() returns null when the tab's pinned session is not
+              // signed in, and getToken() throws on an offline/refresh blip; both
+              // go through the no-token path, which fails closed under multi-session
+              // instead of using the shared cookie.
               return buildClerkRequestHeaders(
-                await getTokenRef.current(),
+                await getPinnedTokenRef.current(),
                 isMultiSession,
               );
             } catch (error) {

--- a/app/src/app/_trpc/Provider.tsx
+++ b/app/src/app/_trpc/Provider.tsx
@@ -14,7 +14,7 @@ import superjson from "superjson";
 import { toast } from "@/components/ui/use-toast";
 import { showMutationToast } from "@/libs/toast";
 import { isRetryableTrpcError } from "@/utils/error";
-import { buildClerkRequestHeaders } from "./authHeaders";
+import { buildClerkRequestHeaders, computeIsMultiSession } from "./authHeaders";
 import {
   api,
   SIGN_IN_REQUIRED_MUTATION_MESSAGE,
@@ -106,11 +106,12 @@ const TrpcClientProvider = (props: { children: React.ReactNode }) => {
           url: `${getBaseUrl()}/api/trpc`,
           transformer: superjson,
           async headers() {
-            // signedInSessions excludes ended/expired/replaced sessions, so a
-            // single-account user who previously signed out of another account is
-            // not miscounted as multi-session.
-            const isMultiSession =
-              (clerkRef.current?.client?.signedInSessions?.length ?? 1) > 1;
+            // Unknown session count (Clerk still loading) is treated as
+            // multi-session so the no-token path fails closed against the shared
+            // cookie; a known single session keeps the normal cookie path.
+            const isMultiSession = computeIsMultiSession(
+              clerkRef.current?.client?.signedInSessions?.length,
+            );
             try {
               // getToken() returns null when the tab has no session and throws on
               // an offline/refresh blip; both go through the no-token path, which
@@ -119,7 +120,20 @@ const TrpcClientProvider = (props: { children: React.ReactNode }) => {
                 await getTokenRef.current(),
                 isMultiSession,
               );
-            } catch {
+            } catch (error) {
+              // Expected on offline/refresh blips. Leave a breadcrumb (and a
+              // dev-only warning) so an unexpected getToken() regression stays
+              // diagnosable without adding production console noise.
+              if (process.env.NODE_ENV === "development") {
+                console.warn("tRPC headers: getToken() threw, failing closed", error);
+              }
+              Sentry.addBreadcrumb({
+                category: "auth",
+                level: "warning",
+                message:
+                  "tRPC headers: getToken() threw; failing closed on no-token path",
+                data: { isMultiSession },
+              });
               return buildClerkRequestHeaders(null, isMultiSession);
             }
           },
@@ -135,6 +149,11 @@ const TrpcClientProvider = (props: { children: React.ReactNode }) => {
 };
 
 export default TrpcClientProvider;
+
+// Fraction of suppressed "Viewer/session mismatch" guards to still report to
+// Sentry, so a persistent regression in the per-tab token mechanism surfaces as
+// a rate spike without flooding quota during normal occasional cross-tab races.
+const VIEWER_MISMATCH_SENTRY_SAMPLE_RATE = 0.05;
 
 const handleTrpcError = (error: unknown) => {
   const trpcErrorCode =
@@ -163,6 +182,16 @@ const handleTrpcError = (error: unknown) => {
     error.message.includes("Viewer/session mismatch") &&
     (trpcErrorCode === undefined || trpcErrorCode === "FORBIDDEN")
   ) {
+    // Not user-facing (self-heals on the next per-tab refetch), so no toast. But
+    // sample a low rate to Sentry with a stable fingerprint so a regression that
+    // makes this fire persistently stays visible in production monitoring.
+    if (Math.random() < VIEWER_MISMATCH_SENTRY_SAMPLE_RATE) {
+      Sentry.captureException(error, {
+        level: "warning",
+        fingerprint: ["trpc-viewer-session-mismatch"],
+        extra: { message: "Clerk multi-session Viewer/session mismatch (sampled)" },
+      });
+    }
     return;
   }
 

--- a/app/src/app/_trpc/Provider.tsx
+++ b/app/src/app/_trpc/Provider.tsx
@@ -14,7 +14,7 @@ import superjson from "superjson";
 import { toast } from "@/components/ui/use-toast";
 import { showMutationToast } from "@/libs/toast";
 import { isRetryableTrpcError } from "@/utils/error";
-import { buildClerkAuthFailureHeaders, buildClerkAuthHeaders } from "./authHeaders";
+import { buildClerkRequestHeaders } from "./authHeaders";
 import {
   api,
   SIGN_IN_REQUIRED_MUTATION_MESSAGE,
@@ -106,14 +106,21 @@ const TrpcClientProvider = (props: { children: React.ReactNode }) => {
           url: `${getBaseUrl()}/api/trpc`,
           transformer: superjson,
           async headers() {
+            // signedInSessions excludes ended/expired/replaced sessions, so a
+            // single-account user who previously signed out of another account is
+            // not miscounted as multi-session.
+            const isMultiSession =
+              (clerkRef.current?.client?.signedInSessions?.length ?? 1) > 1;
             try {
-              const token = await getTokenRef.current();
-              return buildClerkAuthHeaders(token);
+              // getToken() returns null when the tab has no session and throws on
+              // an offline/refresh blip; both go through the no-token path, which
+              // fails closed under multi-session instead of using the shared cookie.
+              return buildClerkRequestHeaders(
+                await getTokenRef.current(),
+                isMultiSession,
+              );
             } catch {
-              // getToken() threw (e.g. offline/refresh blip). Do not silently fall
-              // back to the shared __session cookie in a multi-session browser.
-              const sessions = clerkRef.current?.client?.sessions?.length ?? 1;
-              return buildClerkAuthFailureHeaders(sessions > 1);
+              return buildClerkRequestHeaders(null, isMultiSession);
             }
           },
         }),
@@ -160,7 +167,7 @@ const handleTrpcError = (error: unknown) => {
   }
 
   // Note: HTML error pages (403 auth, 500 server errors) trigger JSON parse errors.
-  // - 403 auth errors: Handled by "Unauthorized for tRPC endpoint" check above (lines 118-124)
+  // - 403 auth errors: Handled by the "Unauthorized for tRPC endpoint" check above
   // - Network/CDN HTML responses: Handled by isRetryableTrpcError below (retried up to 3x)
   // - 500 server errors: Should NOT be silently suppressed - users need to see these
   // Therefore, we don't filter HTML responses here. Let them fall through to proper handling.

--- a/app/src/app/_trpc/SessionPinProvider.tsx
+++ b/app/src/app/_trpc/SessionPinProvider.tsx
@@ -13,6 +13,7 @@ import {
 } from "react";
 import {
   clearPinnedSessionId,
+  decidePinnedSession,
   readPinnedSessionId,
   resolvePinnedSession,
   writePinnedSessionId,
@@ -69,23 +70,21 @@ export function SessionPinProvider(props: { children: React.ReactNode }) {
   const pinnedIdRef = useRef(pinnedSessionId);
   pinnedIdRef.current = pinnedSessionId;
 
-  // Adopt the active session as this tab's pin on first load, and re-adopt only if
-  // the stored pin is no longer a signed-in session (e.g. signed out elsewhere). A
-  // still-valid stored pin is NEVER overridden by a background active-session
-  // change — that is what keeps the tab on its account.
+  // Adopt the active session as this tab's pin on first load. A still-signed-in pin
+  // (in memory, the source of truth) is NEVER overridden by a background
+  // active-session change — that is what keeps the tab on its account. See
+  // decidePinnedSession for the full ordering and the transient-empty guard.
   useEffect(() => {
     if (!isLoaded) return;
-    const stored = readPinnedSessionId();
-    if (resolvePinnedSession(sessions, stored)) {
-      if (pinnedIdRef.current !== stored) setPinnedSessionId(stored);
-      return;
-    }
-    if (activeSessionId) {
-      writePinnedSessionId(activeSessionId);
-      setPinnedSessionId(activeSessionId);
-    } else if (pinnedIdRef.current !== null) {
-      clearPinnedSessionId();
-      setPinnedSessionId(null);
+    const decision = decidePinnedSession({
+      sessions,
+      inMemoryPinnedId: pinnedIdRef.current,
+      storedPinnedId: readPinnedSessionId(),
+      activeSessionId,
+    });
+    if (decision.type === "set") {
+      writePinnedSessionId(decision.id);
+      setPinnedSessionId(decision.id);
     }
   }, [isLoaded, sessions, activeSessionId]);
 

--- a/app/src/app/_trpc/SessionPinProvider.tsx
+++ b/app/src/app/_trpc/SessionPinProvider.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useSession, useSessionList } from "@clerk/nextjs";
+import {
+  createContext,
+  Fragment,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  clearPinnedSessionId,
+  readPinnedSessionId,
+  resolvePinnedSession,
+  writePinnedSessionId,
+} from "./sessionPin";
+
+interface SessionPinContextValue {
+  /** Clerk session id this tab is pinned to, or null before it resolves. */
+  pinnedSessionId: string | null;
+  /** User id of the pinned session, or null when no pinned session is signed in. */
+  pinnedUserId: string | null;
+  /** Count of signed-in Clerk sessions in the browser (undefined while loading). */
+  signedInSessionCount: number | undefined;
+  /** Mints a token for THIS tab's pinned session (not the browser-active one). */
+  getPinnedToken: () => Promise<string | null>;
+  /** Pins this tab to a different signed-in session (an intentional in-tab switch). */
+  switchPinnedAccount: (sessionId: string) => void;
+  /** Clears the pin (used on sign-out). */
+  clearPin: () => void;
+}
+
+const SessionPinContext = createContext<SessionPinContextValue | null>(null);
+
+/**
+ * Pins each browser tab to a specific Clerk session.
+ *
+ * Clerk's active session is browser-global: with multiple accounts signed in, one
+ * `lastActiveSessionId` is shared across tabs and re-resolved on reload/refocus,
+ * so a tab can silently flip to another signed-in account. This provider records
+ * the tab's session id in `sessionStorage` (per-tab, survives reload, not shared
+ * across tabs) and exposes it so the app's identity (`UserContext`) and tRPC auth
+ * (`TrpcClientProvider`) follow the PINNED session instead of the active one.
+ *
+ * It also replaces Clerk's `MultisessionAppSupport`: that component remounts the
+ * app keyed on the ACTIVE session, which would re-flip the tab on every global
+ * active-session change. Here we key the subtree on the PINNED session, so an
+ * intentional in-tab account switch cleanly remounts (fresh tRPC client + React
+ * Query cache) while a background active-session change does not.
+ */
+export function SessionPinProvider(props: { children: React.ReactNode }) {
+  const { isLoaded, sessions, setActive } = useSessionList();
+  const { session: activeSession } = useSession();
+  const activeSessionId = activeSession?.id ?? null;
+
+  // The tRPC headers() callback is created once and reads the latest values via
+  // refs (it runs per request batch, outside React's render).
+  const sessionsRef = useRef(sessions);
+  sessionsRef.current = sessions;
+  const setActiveRef = useRef(setActive);
+  setActiveRef.current = setActive;
+
+  const [pinnedSessionId, setPinnedSessionId] = useState<string | null>(() =>
+    readPinnedSessionId(),
+  );
+  const pinnedIdRef = useRef(pinnedSessionId);
+  pinnedIdRef.current = pinnedSessionId;
+
+  // Adopt the active session as this tab's pin on first load, and re-adopt only if
+  // the stored pin is no longer a signed-in session (e.g. signed out elsewhere). A
+  // still-valid stored pin is NEVER overridden by a background active-session
+  // change — that is what keeps the tab on its account.
+  useEffect(() => {
+    if (!isLoaded) return;
+    const stored = readPinnedSessionId();
+    if (resolvePinnedSession(sessions, stored)) {
+      if (pinnedIdRef.current !== stored) setPinnedSessionId(stored);
+      return;
+    }
+    if (activeSessionId) {
+      writePinnedSessionId(activeSessionId);
+      setPinnedSessionId(activeSessionId);
+    } else if (pinnedIdRef.current !== null) {
+      clearPinnedSessionId();
+      setPinnedSessionId(null);
+    }
+  }, [isLoaded, sessions, activeSessionId]);
+
+  const pinnedSession = useMemo(
+    () => resolvePinnedSession(sessions, pinnedSessionId),
+    [sessions, pinnedSessionId],
+  );
+
+  const getPinnedToken = useCallback(async () => {
+    const pinned = resolvePinnedSession(sessionsRef.current, pinnedIdRef.current);
+    if (!pinned) return null;
+    return pinned.getToken();
+  }, []);
+
+  const switchPinnedAccount = useCallback((sessionId: string) => {
+    writePinnedSessionId(sessionId);
+    setPinnedSessionId(sessionId);
+    // Align Clerk's active session for UI consistency (e.g. UserButton); the app's
+    // data/auth use the pin directly and do not depend on this succeeding.
+    void setActiveRef.current?.({ session: sessionId });
+  }, []);
+
+  const clearPin = useCallback(() => {
+    clearPinnedSessionId();
+    setPinnedSessionId(null);
+  }, []);
+
+  // Mirror Clerk's `client.signedInSessions` (active + pending) so the fail-closed
+  // multi-session detection never under-counts and falls back to the shared cookie.
+  const signedInSessionCount = useMemo(
+    () =>
+      sessions?.filter((s) => s.status === "active" || s.status === "pending").length,
+    [sessions],
+  );
+
+  const value = useMemo<SessionPinContextValue>(
+    () => ({
+      pinnedSessionId,
+      pinnedUserId: pinnedSession?.user?.id ?? null,
+      signedInSessionCount,
+      getPinnedToken,
+      switchPinnedAccount,
+      clearPin,
+    }),
+    [
+      pinnedSessionId,
+      pinnedSession,
+      signedInSessionCount,
+      getPinnedToken,
+      switchPinnedAccount,
+      clearPin,
+    ],
+  );
+
+  return (
+    <SessionPinContext.Provider value={value}>
+      <Fragment key={pinnedSessionId ?? "no-pin"}>{props.children}</Fragment>
+    </SessionPinContext.Provider>
+  );
+}
+
+export function useSessionPin(): SessionPinContextValue {
+  const ctx = useContext(SessionPinContext);
+  if (!ctx) {
+    throw new Error("useSessionPin must be used within a SessionPinProvider");
+  }
+  return ctx;
+}

--- a/app/src/app/_trpc/SessionPinProvider.tsx
+++ b/app/src/app/_trpc/SessionPinProvider.tsx
@@ -13,7 +13,6 @@ import {
   useState,
 } from "react";
 import {
-  clearPinnedSessionId,
   decidePinnedSession,
   isAuthRoute,
   pinChangeRequiresRemount,
@@ -31,10 +30,6 @@ interface SessionPinContextValue {
   signedInSessionCount: number | undefined;
   /** Mints a token for THIS tab's pinned session (not the browser-active one). */
   getPinnedToken: () => Promise<string | null>;
-  /** Pins this tab to a different signed-in session (an intentional in-tab switch). */
-  switchPinnedAccount: (sessionId: string) => void;
-  /** Clears the pin (used on sign-out). */
-  clearPin: () => void;
 }
 
 const SessionPinContext = createContext<SessionPinContextValue | null>(null);
@@ -52,14 +47,14 @@ const SessionPinContext = createContext<SessionPinContextValue | null>(null);
  * It also replaces Clerk's `MultisessionAppSupport`: that component remounts the
  * app keyed on the ACTIVE session, which would re-flip the tab on every global
  * active-session change. Here we remount the subtree (fresh tRPC client + React
- * Query cache) only on a cross-account pin change — an intentional in-tab switch, a
- * sign-out, or a reload that adopts a different account (see
+ * Query cache) only on a cross-account pin change — i.e. when the pinned account is
+ * no longer signed in and the tab adopts a different signed-in account (see
  * `pinChangeRequiresRemount`). A background active-session change does not remount,
  * and neither does the first-load adoption of the tab's own account, so the normal
  * signed-in first load and post-sign-in redirect do not pay a tree-wide remount.
  */
 export function SessionPinProvider(props: { children: React.ReactNode }) {
-  const { isLoaded, sessions, setActive } = useSessionList();
+  const { isLoaded, sessions } = useSessionList();
   const { session: activeSession } = useSession();
   const activeSessionId = activeSession?.id ?? null;
   // The tab defers adopting the active session while on the sign-in / sign-up flow,
@@ -71,8 +66,6 @@ export function SessionPinProvider(props: { children: React.ReactNode }) {
   // refs (it runs per request batch, outside React's render).
   const sessionsRef = useRef(sessions);
   sessionsRef.current = sessions;
-  const setActiveRef = useRef(setActive);
-  setActiveRef.current = setActive;
 
   const [pinnedSessionId, setPinnedSessionId] = useState<string | null>(() =>
     readPinnedSessionId(),
@@ -126,19 +119,6 @@ export function SessionPinProvider(props: { children: React.ReactNode }) {
     return pinned.getToken();
   }, []);
 
-  const switchPinnedAccount = useCallback((sessionId: string) => {
-    writePinnedSessionId(sessionId);
-    setPinnedSessionId(sessionId);
-    // Align Clerk's active session for UI consistency (e.g. UserButton); the app's
-    // data/auth use the pin directly and do not depend on this succeeding.
-    void setActiveRef.current?.({ session: sessionId });
-  }, []);
-
-  const clearPin = useCallback(() => {
-    clearPinnedSessionId();
-    setPinnedSessionId(null);
-  }, []);
-
   // Mirror Clerk's `client.signedInSessions` (active + pending) so the fail-closed
   // multi-session detection never under-counts and falls back to the shared cookie.
   const signedInSessionCount = useMemo(
@@ -153,17 +133,8 @@ export function SessionPinProvider(props: { children: React.ReactNode }) {
       pinnedUserId: pinnedSession?.user?.id ?? null,
       signedInSessionCount,
       getPinnedToken,
-      switchPinnedAccount,
-      clearPin,
     }),
-    [
-      pinnedSessionId,
-      pinnedSession,
-      signedInSessionCount,
-      getPinnedToken,
-      switchPinnedAccount,
-      clearPin,
-    ],
+    [pinnedSessionId, pinnedSession, signedInSessionCount, getPinnedToken],
   );
 
   return (

--- a/app/src/app/_trpc/SessionPinProvider.tsx
+++ b/app/src/app/_trpc/SessionPinProvider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useSession, useSessionList } from "@clerk/nextjs";
+import { usePathname } from "next/navigation";
 import {
   createContext,
   Fragment,
@@ -14,6 +15,7 @@ import {
 import {
   clearPinnedSessionId,
   decidePinnedSession,
+  isAuthRoute,
   readPinnedSessionId,
   resolvePinnedSession,
   writePinnedSessionId,
@@ -56,6 +58,10 @@ export function SessionPinProvider(props: { children: React.ReactNode }) {
   const { isLoaded, sessions, setActive } = useSessionList();
   const { session: activeSession } = useSession();
   const activeSessionId = activeSession?.id ?? null;
+  // The tab defers adopting the active session while on the sign-in / sign-up flow,
+  // so signing in a different account there cleanly becomes this tab's account
+  // instead of being blocked by an eagerly-adopted pre-existing one.
+  const onAuthRoute = isAuthRoute(usePathname());
 
   // The tRPC headers() callback is created once and reads the latest values via
   // refs (it runs per request batch, outside React's render).
@@ -70,10 +76,11 @@ export function SessionPinProvider(props: { children: React.ReactNode }) {
   const pinnedIdRef = useRef(pinnedSessionId);
   pinnedIdRef.current = pinnedSessionId;
 
-  // Adopt the active session as this tab's pin on first load. A still-signed-in pin
-  // (in memory, the source of truth) is NEVER overridden by a background
-  // active-session change — that is what keeps the tab on its account. See
-  // decidePinnedSession for the full ordering and the transient-empty guard.
+  // Adopt the active session as this tab's pin on first load (but not while on the
+  // sign-in flow — see decidePinnedSession). A still-signed-in pin (in memory, the
+  // source of truth) is NEVER overridden by a background active-session change —
+  // that is what keeps the tab on its account. Re-runs when the tab leaves the auth
+  // route so the just-signed-in account is adopted after the redirect.
   useEffect(() => {
     if (!isLoaded) return;
     const decision = decidePinnedSession({
@@ -81,12 +88,13 @@ export function SessionPinProvider(props: { children: React.ReactNode }) {
       inMemoryPinnedId: pinnedIdRef.current,
       storedPinnedId: readPinnedSessionId(),
       activeSessionId,
+      onAuthRoute,
     });
     if (decision.type === "set") {
       writePinnedSessionId(decision.id);
       setPinnedSessionId(decision.id);
     }
-  }, [isLoaded, sessions, activeSessionId]);
+  }, [isLoaded, sessions, activeSessionId, onAuthRoute]);
 
   const pinnedSession = useMemo(
     () => resolvePinnedSession(sessions, pinnedSessionId),

--- a/app/src/app/_trpc/SessionPinProvider.tsx
+++ b/app/src/app/_trpc/SessionPinProvider.tsx
@@ -16,6 +16,7 @@ import {
   clearPinnedSessionId,
   decidePinnedSession,
   isAuthRoute,
+  pinChangeRequiresRemount,
   readPinnedSessionId,
   resolvePinnedSession,
   writePinnedSessionId,
@@ -50,9 +51,12 @@ const SessionPinContext = createContext<SessionPinContextValue | null>(null);
  *
  * It also replaces Clerk's `MultisessionAppSupport`: that component remounts the
  * app keyed on the ACTIVE session, which would re-flip the tab on every global
- * active-session change. Here we key the subtree on the PINNED session, so an
- * intentional in-tab account switch cleanly remounts (fresh tRPC client + React
- * Query cache) while a background active-session change does not.
+ * active-session change. Here we remount the subtree (fresh tRPC client + React
+ * Query cache) only on a cross-account pin change — an intentional in-tab switch, a
+ * sign-out, or a reload that adopts a different account (see
+ * `pinChangeRequiresRemount`). A background active-session change does not remount,
+ * and neither does the first-load adoption of the tab's own account, so the normal
+ * signed-in first load and post-sign-in redirect do not pay a tree-wide remount.
  */
 export function SessionPinProvider(props: { children: React.ReactNode }) {
   const { isLoaded, sessions, setActive } = useSessionList();
@@ -75,6 +79,21 @@ export function SessionPinProvider(props: { children: React.ReactNode }) {
   );
   const pinnedIdRef = useRef(pinnedSessionId);
   pinnedIdRef.current = pinnedSessionId;
+
+  // Bump a remount key only on a cross-account pin change, so the keyed subtree below
+  // gets a fresh tRPC client + React Query cache when (and only when) the tab moves
+  // off one signed-in account — never on the first-load null → id adoption of the
+  // tab's own account. Done with React's "adjust state during render" pattern (not an
+  // effect) so the new key is in place before children render, avoiding a stale-key
+  // commit that would mount then immediately remount the tree.
+  const [remountKey, setRemountKey] = useState(0);
+  const [prevPinnedId, setPrevPinnedId] = useState(pinnedSessionId);
+  if (prevPinnedId !== pinnedSessionId) {
+    if (pinChangeRequiresRemount(prevPinnedId, pinnedSessionId)) {
+      setRemountKey((key) => key + 1);
+    }
+    setPrevPinnedId(pinnedSessionId);
+  }
 
   // Adopt the active session as this tab's pin on first load (but not while on the
   // sign-in flow — see decidePinnedSession). A still-signed-in pin (in memory, the
@@ -149,7 +168,7 @@ export function SessionPinProvider(props: { children: React.ReactNode }) {
 
   return (
     <SessionPinContext.Provider value={value}>
-      <Fragment key={pinnedSessionId ?? "no-pin"}>{props.children}</Fragment>
+      <Fragment key={remountKey}>{props.children}</Fragment>
     </SessionPinContext.Provider>
   );
 }

--- a/app/src/app/_trpc/authHeaders.ts
+++ b/app/src/app/_trpc/authHeaders.ts
@@ -1,0 +1,18 @@
+/**
+ * Builds the Authorization header for an outgoing tRPC request from the current
+ * browser tab's Clerk session token.
+ *
+ * Under Clerk multi-session the `__session` cookie is shared across all tabs of a
+ * browser and reflects whichever tab is currently active. A background request
+ * from a non-focused tab would otherwise authenticate as the wrong account.
+ * Sending the tab's own session token as a Bearer header makes the server
+ * authenticate as THIS tab's session, because Clerk's request authentication
+ * prefers the Authorization header over the cookie.
+ *
+ * Returns an empty object when there is no token so we never send "Bearer null".
+ */
+export function buildClerkAuthHeaders(
+  token: string | null | undefined,
+): Record<string, string> {
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}

--- a/app/src/app/_trpc/authHeaders.ts
+++ b/app/src/app/_trpc/authHeaders.ts
@@ -29,3 +29,19 @@ export function buildClerkRequestHeaders(
   if (token) return { Authorization: `Bearer ${token}` };
   return isMultiSession ? { [TAB_AUTH_REQUIRED_HEADER]: "1" } : {};
 }
+
+/**
+ * Whether the browser currently holds more than one signed-in Clerk session.
+ *
+ * `count` is the length of `client.signedInSessions`, which excludes
+ * ended/expired/replaced sessions — so a single-account user who previously
+ * signed out of another account is not miscounted as multi-session. It is
+ * `undefined` while Clerk is still loading: we treat that unknown state as
+ * multi-session so the no-token path fails closed against the shared `__session`
+ * cookie instead of risking a background tab authenticating as another account.
+ * A known single session (`count <= 1`) keeps the normal cookie path so transient
+ * token blips don't needlessly sign the user out.
+ */
+export function computeIsMultiSession(count: number | undefined): boolean {
+  return count === undefined ? true : count > 1;
+}

--- a/app/src/app/_trpc/authHeaders.ts
+++ b/app/src/app/_trpc/authHeaders.ts
@@ -1,4 +1,12 @@
 /**
+ * Header the browser client sets when it intended to authenticate with a per-tab
+ * bearer token but `getToken()` failed (e.g. an offline/refresh blip). The server
+ * uses it to fail closed instead of authenticating via the shared `__session`
+ * cookie. See `resolveAuthedUserId` in `@/server/api/authContext`.
+ */
+export const TAB_AUTH_REQUIRED_HEADER = "x-tnr-auth-required";
+
+/**
  * Builds the Authorization header for an outgoing tRPC request from the current
  * browser tab's Clerk session token.
  *
@@ -15,4 +23,20 @@ export function buildClerkAuthHeaders(
   token: string | null | undefined,
 ): Record<string, string> {
   return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+/**
+ * Headers to send when `getToken()` throws (offline/refresh blip) and we could
+ * not attach the tab's bearer token.
+ *
+ * Only signals fail-closed when the browser actually has multiple Clerk sessions:
+ * then the shared `__session` cookie may belong to a different tab's account, so
+ * the server must NOT fall back to it. For a single-session browser the cookie is
+ * the user's own account, so we send nothing and let it authenticate normally
+ * (failing closed there would be a needless regression during network blips).
+ */
+export function buildClerkAuthFailureHeaders(
+  isMultiSession: boolean,
+): Record<string, string> {
+  return isMultiSession ? { [TAB_AUTH_REQUIRED_HEADER]: "1" } : {};
 }

--- a/app/src/app/_trpc/authHeaders.ts
+++ b/app/src/app/_trpc/authHeaders.ts
@@ -7,6 +7,17 @@
 export const TAB_AUTH_REQUIRED_HEADER = "x-tnr-auth-required";
 
 /**
+ * Message thrown by `assertViewerMatchesSession` (server `@/server/api/viewerGuard`)
+ * when a request's client-asserted account does not match the server-authenticated
+ * session, and matched by the client's silent-suppression in `Provider.tsx` (the
+ * transient cross-tab guard error is not user-facing). Shared so the two sides stay
+ * in lockstep — if the wording drifts the client filter breaks and users would see
+ * a destructive toast. Lives here, the pure isomorphic module both layers already
+ * import (alongside `TAB_AUTH_REQUIRED_HEADER`), so neither side hardcodes the literal.
+ */
+export const VIEWER_SESSION_MISMATCH_MESSAGE = "Viewer/session mismatch";
+
+/**
  * Builds the auth headers for an outgoing tRPC request under Clerk multi-session.
  *
  * The `__session` cookie is shared across all browser tabs and reflects whichever

--- a/app/src/app/_trpc/authHeaders.ts
+++ b/app/src/app/_trpc/authHeaders.ts
@@ -1,42 +1,31 @@
 /**
  * Header the browser client sets when it intended to authenticate with a per-tab
- * bearer token but `getToken()` failed (e.g. an offline/refresh blip). The server
- * uses it to fail closed instead of authenticating via the shared `__session`
- * cookie. See `resolveAuthedUserId` in `@/server/api/authContext`.
+ * bearer token but has none (signed out, not yet loaded, or `getToken()` failed).
+ * The server uses it to fail closed instead of authenticating via the shared
+ * `__session` cookie. See `resolveAuthedUserId` in `@/server/api/authContext`.
  */
 export const TAB_AUTH_REQUIRED_HEADER = "x-tnr-auth-required";
 
 /**
- * Builds the Authorization header for an outgoing tRPC request from the current
- * browser tab's Clerk session token.
+ * Builds the auth headers for an outgoing tRPC request under Clerk multi-session.
  *
- * Under Clerk multi-session the `__session` cookie is shared across all tabs of a
- * browser and reflects whichever tab is currently active. A background request
- * from a non-focused tab would otherwise authenticate as the wrong account.
- * Sending the tab's own session token as a Bearer header makes the server
- * authenticate as THIS tab's session, because Clerk's request authentication
- * prefers the Authorization header over the cookie.
+ * The `__session` cookie is shared across all browser tabs and reflects whichever
+ * tab is focused, so a background request from a non-focused tab could otherwise
+ * authenticate as the wrong account. We attach the tab's OWN session token as a
+ * Bearer header (Clerk's request auth prefers the header over the cookie) so the
+ * server authenticates as this tab's session.
  *
- * Returns an empty object when there is no token so we never send "Bearer null".
+ * When the tab has no token (signed out, not yet loaded, or `getToken()` failed)
+ * we must not let the server fall back to the shared cookie if the browser holds
+ * multiple sessions — instead we send a marker so the server fails closed. For a
+ * single-session browser the cookie is the user's own account, so we send nothing
+ * and authenticate normally (failing closed there would be a needless regression
+ * during transient token blips).
  */
-export function buildClerkAuthHeaders(
+export function buildClerkRequestHeaders(
   token: string | null | undefined,
-): Record<string, string> {
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
-
-/**
- * Headers to send when `getToken()` throws (offline/refresh blip) and we could
- * not attach the tab's bearer token.
- *
- * Only signals fail-closed when the browser actually has multiple Clerk sessions:
- * then the shared `__session` cookie may belong to a different tab's account, so
- * the server must NOT fall back to it. For a single-session browser the cookie is
- * the user's own account, so we send nothing and let it authenticate normally
- * (failing closed there would be a needless regression during network blips).
- */
-export function buildClerkAuthFailureHeaders(
   isMultiSession: boolean,
 ): Record<string, string> {
+  if (token) return { Authorization: `Bearer ${token}` };
   return isMultiSession ? { [TAB_AUTH_REQUIRED_HEADER]: "1" } : {};
 }

--- a/app/src/app/_trpc/getUserQueryInput.ts
+++ b/app/src/app/_trpc/getUserQueryInput.ts
@@ -1,0 +1,12 @@
+/**
+ * Per-account input for `profile.getUser`, so the React Query cache is scoped by
+ * Clerk account and cannot serve one account's data to another under multi-session.
+ *
+ * Returns `undefined` for a falsy `userId` (which targets the legacy unscoped cache
+ * key); callers that must write to a real account should guard on a truthy `userId`.
+ * Shared between `UserContext` and `PusherHandler` so the cache-key shape has a
+ * single source of truth and cannot drift between call sites.
+ */
+export const getUserQueryInput = (
+  userId: string | null | undefined,
+): { viewerId: string } | undefined => (userId ? { viewerId: userId } : undefined);

--- a/app/src/app/_trpc/sessionPin.ts
+++ b/app/src/app/_trpc/sessionPin.ts
@@ -87,7 +87,10 @@ export function decidePinnedSession<T extends { id: string; status: string }>(ar
   // than re-adopting and flipping the tab.
   if (!sessions || sessions.length === 0) return { type: "keep" };
   // No pinned session is signed in (first load, or the pinned account was signed
-  // out and another remains) → adopt the active session.
-  if (activeSessionId) return { type: "set", id: activeSessionId };
+  // out and another remains) → adopt the active session, but only when it resolves
+  // to a signed-in session (like the in-memory and stored paths) so getPinnedToken
+  // can still mint a token for it.
+  const activeSession = resolvePinnedSession(sessions, activeSessionId);
+  if (activeSession) return { type: "set", id: activeSession.id };
   return { type: "keep" };
 }

--- a/app/src/app/_trpc/sessionPin.ts
+++ b/app/src/app/_trpc/sessionPin.ts
@@ -1,0 +1,57 @@
+/**
+ * Per-tab Clerk session pin (pure helpers).
+ *
+ * Clerk's "active session" is browser-global: with multiple accounts signed in, a
+ * single `lastActiveSessionId` is shared across all tabs and re-resolved on
+ * reload/refocus, so any tab can silently flip to another signed-in account. To
+ * keep a tab on the account it is working as, we persist that account's Clerk
+ * session id in `sessionStorage` (per-tab, survives reload, NOT shared across
+ * tabs) and drive the app's identity + tRPC auth from that pinned session instead
+ * of the active one. See `SessionPinProvider`.
+ */
+
+export const PINNED_SESSION_STORAGE_KEY = "tnr-pinned-clerk-session-id";
+
+export function readPinnedSessionId(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.sessionStorage.getItem(PINNED_SESSION_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function writePinnedSessionId(sessionId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(PINNED_SESSION_STORAGE_KEY, sessionId);
+  } catch {
+    // sessionStorage can throw (private mode / quota). Pinning then falls back to
+    // the active session, i.e. the pre-existing behavior — no worse than before.
+  }
+}
+
+export function clearPinnedSessionId(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(PINNED_SESSION_STORAGE_KEY);
+  } catch {
+    // ignore — see writePinnedSessionId
+  }
+}
+
+/**
+ * Resolves the pinned session from the browser's Clerk sessions. Returns the
+ * matching signed-in (`status === "active"`) session, or null when the pin is
+ * unset, the sessions have not loaded, or the pinned session is no longer signed
+ * in (e.g. signed out in another tab).
+ */
+export function resolvePinnedSession<T extends { id: string; status: string }>(
+  sessions: readonly T[] | undefined | null,
+  pinnedSessionId: string | null,
+): T | null {
+  if (!pinnedSessionId || !sessions) return null;
+  return (
+    sessions.find((s) => s.id === pinnedSessionId && s.status === "active") ?? null
+  );
+}

--- a/app/src/app/_trpc/sessionPin.ts
+++ b/app/src/app/_trpc/sessionPin.ts
@@ -122,3 +122,34 @@ export function decidePinnedSession<T extends { id: string; status: string }>(ar
   if (activeSession) return { type: "set", id: activeSession.id };
   return { type: "keep" };
 }
+
+/**
+ * Whether a change of this tab's pinned session id should remount the app subtree
+ * (fresh tRPC client + React Query cache). True only when the pin moves OFF a
+ * signed-in account to a different value — an intentional in-tab switch
+ * (`switchPinnedAccount`), a sign-out (`clearPin`), or a reload whose stored account
+ * is gone and a different one is adopted. Those are the only changes that can leave a
+ * different account's data behind in React Query caches that are not scoped per
+ * account (`profile.getUser` is scoped via `getUserQueryInput`, but other queries are
+ * not), so the subtree must remount to discard it.
+ *
+ * The first-load `null → id` adoption returns false (no remount): the brief unpinned
+ * window does not populate any account-private cache. Account-private queries are
+ * gated on the pinned user — `profile.getUser` is `enabled: !!userId`, and everything
+ * private cascades from its `userData` — so they do not run while the pin is null.
+ * The only always-mounted query that runs unpinned is the public, account-agnostic
+ * leaderboard (`profile.getPublicUsers`), whose data is identical for every viewer.
+ *
+ * INVARIANT this relies on: an always-mounted, account-private query must gate its
+ * `enabled` on the pinned user (`userData`/`pinnedUserId`), NOT on Clerk's browser-
+ * global `isSignedIn`/`useUser`. Gating on the latter would let it fetch and cache the
+ * browser-active account's private data during the null-pin window (e.g. on `/login`
+ * before adopting a just-signed-in second account), which this skipped remount would
+ * then fail to discard.
+ */
+export function pinChangeRequiresRemount(
+  prev: string | null,
+  next: string | null,
+): boolean {
+  return prev !== null && prev !== next;
+}

--- a/app/src/app/_trpc/sessionPin.ts
+++ b/app/src/app/_trpc/sessionPin.ts
@@ -31,15 +31,6 @@ export function writePinnedSessionId(sessionId: string): void {
   }
 }
 
-export function clearPinnedSessionId(): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.sessionStorage.removeItem(PINNED_SESSION_STORAGE_KEY);
-  } catch {
-    // ignore — see writePinnedSessionId
-  }
-}
-
 /**
  * Resolves the pinned session from the browser's Clerk sessions. Returns the
  * matching signed-in (`status === "active"`) session, or null when the pin is
@@ -125,13 +116,18 @@ export function decidePinnedSession<T extends { id: string; status: string }>(ar
 
 /**
  * Whether a change of this tab's pinned session id should remount the app subtree
- * (fresh tRPC client + React Query cache). True only when the pin moves OFF a
- * signed-in account to a different value — an intentional in-tab switch
- * (`switchPinnedAccount`), a sign-out (`clearPin`), or a reload whose stored account
- * is gone and a different one is adopted. Those are the only changes that can leave a
- * different account's data behind in React Query caches that are not scoped per
- * account (`profile.getUser` is scoped via `getUserQueryInput`, but other queries are
- * not), so the subtree must remount to discard it.
+ * (fresh tRPC client + React Query cache). True whenever the pin moves OFF a
+ * signed-in account to a different value — in practice when the pinned account is no
+ * longer signed in and the tab adopts a different signed-in account (e.g. the pinned
+ * account signs out while another remains, so the adoption effect re-pins A → B).
+ * Such a move can leave a different account's data behind in React Query caches that
+ * are not scoped per account (`profile.getUser` is scoped via `getUserQueryInput`,
+ * but other queries are not), so the subtree must remount to discard it.
+ *
+ * The `prev !== null` guard also covers an `id → null` change. No live path nulls the
+ * pin after mount today (sign-out is Clerk-UI-driven and does not clear the pin — it
+ * simply stops resolving), so that branch is defensive: it keeps the remount correct
+ * if a future intentional switch/clear ever nulls the pin.
  *
  * The first-load `null → id` adoption returns false (no remount): the brief unpinned
  * window does not populate any account-private cache. Account-private queries are

--- a/app/src/app/_trpc/sessionPin.ts
+++ b/app/src/app/_trpc/sessionPin.ts
@@ -55,3 +55,39 @@ export function resolvePinnedSession<T extends { id: string; status: string }>(
     sessions.find((s) => s.id === pinnedSessionId && s.status === "active") ?? null
   );
 }
+
+export type PinDecision = { type: "keep" } | { type: "set"; id: string };
+
+/**
+ * Decides this tab's pinned session id from the current Clerk state, WITHOUT ever
+ * letting a background active-session change reassign a tab that already holds a
+ * valid pin. The in-memory pin (`inMemoryPinnedId`) is the source of truth — it is
+ * NOT re-derived from `sessionStorage`, so a failed/empty `sessionStorage` read
+ * can never cause the tab to flip identities.
+ *
+ * Order: keep a still-signed-in in-memory pin → recover a still-signed-in stored
+ * pin (e.g. after reload) → otherwise, only once the sessions list is populated
+ * (never mid-refresh when it is momentarily empty), adopt the active session.
+ */
+export function decidePinnedSession<T extends { id: string; status: string }>(args: {
+  sessions: readonly T[] | undefined | null;
+  inMemoryPinnedId: string | null;
+  storedPinnedId: string | null;
+  activeSessionId: string | null;
+}): PinDecision {
+  const { sessions, inMemoryPinnedId, storedPinnedId, activeSessionId } = args;
+  if (resolvePinnedSession(sessions, inMemoryPinnedId)) return { type: "keep" };
+  const storedSession = resolvePinnedSession(sessions, storedPinnedId);
+  if (storedSession) {
+    return storedSession.id === inMemoryPinnedId
+      ? { type: "keep" }
+      : { type: "set", id: storedSession.id };
+  }
+  // Sessions momentarily empty (Clerk mid-refresh): leave the pin untouched rather
+  // than re-adopting and flipping the tab.
+  if (!sessions || sessions.length === 0) return { type: "keep" };
+  // No pinned session is signed in (first load, or the pinned account was signed
+  // out and another remains) → adopt the active session.
+  if (activeSessionId) return { type: "set", id: activeSessionId };
+  return { type: "keep" };
+}

--- a/app/src/app/_trpc/sessionPin.ts
+++ b/app/src/app/_trpc/sessionPin.ts
@@ -56,6 +56,24 @@ export function resolvePinnedSession<T extends { id: string; status: string }>(
   );
 }
 
+/**
+ * Whether `pathname` is part of Clerk's sign-in / sign-up flow (`/login`, `/signup`,
+ * and their sub-routes such as `/login/factor-one` or `/login/sso-callback`).
+ *
+ * On these routes the tab must NOT eagerly adopt the browser-global active session
+ * (see `decidePinnedSession`): the user may be about to sign in a DIFFERENT account.
+ * Matches on segment boundaries so look-alikes like `/login-help` are not auth routes.
+ */
+export function isAuthRoute(pathname: string | null | undefined): boolean {
+  if (!pathname) return false;
+  return (
+    pathname === "/login" ||
+    pathname.startsWith("/login/") ||
+    pathname === "/signup" ||
+    pathname.startsWith("/signup/")
+  );
+}
+
 export type PinDecision = { type: "keep" } | { type: "set"; id: string };
 
 /**
@@ -67,15 +85,18 @@ export type PinDecision = { type: "keep" } | { type: "set"; id: string };
  *
  * Order: keep a still-signed-in in-memory pin → recover a still-signed-in stored
  * pin (e.g. after reload) → otherwise, only once the sessions list is populated
- * (never mid-refresh when it is momentarily empty), adopt the active session.
+ * (never mid-refresh when it is momentarily empty), and only off the sign-in flow,
+ * adopt the active session.
  */
 export function decidePinnedSession<T extends { id: string; status: string }>(args: {
   sessions: readonly T[] | undefined | null;
   inMemoryPinnedId: string | null;
   storedPinnedId: string | null;
   activeSessionId: string | null;
+  onAuthRoute: boolean;
 }): PinDecision {
-  const { sessions, inMemoryPinnedId, storedPinnedId, activeSessionId } = args;
+  const { sessions, inMemoryPinnedId, storedPinnedId, activeSessionId, onAuthRoute } =
+    args;
   if (resolvePinnedSession(sessions, inMemoryPinnedId)) return { type: "keep" };
   const storedSession = resolvePinnedSession(sessions, storedPinnedId);
   if (storedSession) {
@@ -86,6 +107,13 @@ export function decidePinnedSession<T extends { id: string; status: string }>(ar
   // Sessions momentarily empty (Clerk mid-refresh): leave the pin untouched rather
   // than re-adopting and flipping the tab.
   if (!sessions || sessions.length === 0) return { type: "keep" };
+  // On the sign-in / sign-up flow, do NOT eagerly adopt the browser-global active
+  // session: the user may be about to sign in a DIFFERENT account, and an eager pin
+  // here would later block that in-tab switch (the active session changes to the new
+  // account, but the now-"valid" eager pin keeps the old one). Adoption happens once
+  // the completed sign-in redirects the tab onto an app route. An already-established
+  // pin is honored above, so a pinned tab visiting /login keeps its own account.
+  if (onAuthRoute) return { type: "keep" };
   // No pinned session is signed in (first load, or the pinned account was signed
   // out and another remains) → adopt the active session, but only when it resolves
   // to a signed-in session (like the in-memory and stored paths) so getPinnedToken

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import { ClerkProvider } from "@clerk/nextjs";
-import { MultisessionAppSupport } from "@clerk/nextjs/internal";
 import { auth } from "@clerk/nextjs/server";
 import { GoogleTagManager } from "@next/third-parties/google";
 import { NextSSRPlugin } from "@uploadthing/react/next-ssr-plugin";
@@ -8,6 +7,7 @@ import type { Metadata, Viewport } from "next";
 import { cookies } from "next/headers";
 import { extractRouterConfig } from "uploadthing/server";
 import TrpcClientProvider from "@/app/_trpc/Provider";
+import { SessionPinProvider } from "@/app/_trpc/SessionPinProvider";
 import { ourFileRouter } from "@/app/api/uploadthing/core";
 import InstallPrompt from "@/components/pwa/InstallPrompt";
 import PWAManager from "@/components/pwa/PWAManager";
@@ -57,7 +57,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             },
           }}
         >
-          <MultisessionAppSupport>
+          <SessionPinProvider>
             <TrpcClientProvider>
               <UserContextProvider>
                 <InstallPromptProvider>
@@ -80,7 +80,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                 </InstallPromptProvider>
               </UserContextProvider>
             </TrpcClientProvider>
-          </MultisessionAppSupport>
+          </SessionPinProvider>
         </ClerkProvider>
       </body>
     </html>

--- a/app/src/layout/PusherHandler.tsx
+++ b/app/src/layout/PusherHandler.tsx
@@ -6,6 +6,7 @@ import Pusher from "pusher-js";
 import { useEffect, useState } from "react";
 import type { UserWithRelations } from "@/api/routers/profile";
 import { api } from "@/app/_trpc/client";
+import { getUserQueryInput } from "@/app/_trpc/getUserQueryInput";
 import { ToastAction } from "@/components/ui/toast";
 import { env } from "@/env/client.mjs";
 import { showMutationToast } from "@/libs/toast";
@@ -72,7 +73,7 @@ export const usePusherHandler = (
             // NOTE: for some reason using updateUser does not work from this hook
             await utils.profile.getUser.cancel();
             // Update user data with battle status (scoped to this tab's account)
-            utils.profile.getUser.setData({ viewerId: userId }, (old) => {
+            utils.profile.getUser.setData(getUserQueryInput(userId), (old) => {
               if (!old) return old;
               return {
                 ...old,

--- a/app/src/layout/PusherHandler.tsx
+++ b/app/src/layout/PusherHandler.tsx
@@ -71,8 +71,8 @@ export const usePusherHandler = (
           if (data?.battleId) {
             // NOTE: for some reason using updateUser does not work from this hook
             await utils.profile.getUser.cancel();
-            // Update user data with battle status
-            utils.profile.getUser.setData(undefined, (old) => {
+            // Update user data with battle status (scoped to this tab's account)
+            utils.profile.getUser.setData({ viewerId: userId }, (old) => {
               if (!old) return old;
               return {
                 ...old,

--- a/app/src/server/api/authContext.ts
+++ b/app/src/server/api/authContext.ts
@@ -1,0 +1,21 @@
+/**
+ * Resolves the authenticated user id for a tRPC request under Clerk multi-session.
+ *
+ * Fail-closed rule: if the browser client signalled that it intended to send a
+ * per-tab bearer token but could not (the `tabAuthFailed` marker header) and no
+ * Authorization header actually arrived, we must NOT authenticate via the shared,
+ * browser-global `__session` cookie — it may belong to a different tab's account.
+ * In that case return null so the request is treated as unauthenticated.
+ *
+ * Otherwise return the session's user id as resolved by Clerk (`auth()`), which
+ * already prefers the Authorization header over the cookie when a token is present.
+ */
+export function resolveAuthedUserId(
+  sessionUserId: string | null,
+  opts: { hasAuthorizationHeader: boolean; tabAuthFailed: boolean },
+): string | null {
+  if (opts.tabAuthFailed && !opts.hasAuthorizationHeader) {
+    return null;
+  }
+  return sessionUserId;
+}

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -473,7 +473,7 @@ export const profileRouter = createTRPCRouter({
     .meta({
       mcp: { enabled: true, description: "Get current user's full profile data" },
     })
-    .input(z.object({ viewerId: z.string() }).optional())
+    .input(z.object({ viewerId: z.string().min(1) }).optional())
     .query(async ({ ctx, input }) => {
       // Clerk multi-session: reject if the client's asserted account does not
       // match the server-authenticated session. Identity for the fetch below

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -176,6 +176,7 @@ import {
   publicProcedure,
   serverError,
 } from "../trpc";
+import { assertViewerMatchesSession } from "../viewerGuard";
 
 const pusher = getServerPusher();
 
@@ -472,7 +473,12 @@ export const profileRouter = createTRPCRouter({
     .meta({
       mcp: { enabled: true, description: "Get current user's full profile data" },
     })
-    .query(async ({ ctx }) => {
+    .input(z.object({ viewerId: z.string() }).optional())
+    .query(async ({ ctx, input }) => {
+      // Clerk multi-session: reject if the client's asserted account does not
+      // match the server-authenticated session. Identity for the fetch below
+      // always comes from ctx.userId, never from input.
+      assertViewerMatchesSession(ctx.userId, input?.viewerId);
       // Query
       const { user, settings, toastMessages, hasUnvotedPolls } = await fetchUpdatedUser(
         {

--- a/app/src/server/api/trpc.ts
+++ b/app/src/server/api/trpc.ts
@@ -61,7 +61,7 @@ export const createAppTRPCContext = async (options: {
   // header arrived, do not authenticate via the shared __session cookie.
   const userId = resolveAuthedUserId(session.userId, {
     hasAuthorizationHeader: !!readHeaders.get("authorization"),
-    tabAuthFailed: readHeaders.get(TAB_AUTH_REQUIRED_HEADER) === "1",
+    tabAuthFailed: readHeaders.get(TAB_AUTH_REQUIRED_HEADER) != null,
   });
   // Get IP
   const userIp = getClientIp(readHeaders);

--- a/app/src/server/api/trpc.ts
+++ b/app/src/server/api/trpc.ts
@@ -19,6 +19,7 @@ import type { ReadonlyRequestCookies } from "next/dist/server/web/spec-extension
 import type { NextRequest } from "next/server";
 import superjson from "superjson";
 import { ZodError, z } from "zod";
+import { TAB_AUTH_REQUIRED_HEADER } from "@/app/_trpc/authHeaders";
 import { userData } from "@/drizzle/schema";
 import {
   AB_PIXEL_LAYOUT_COOKIE,
@@ -34,6 +35,7 @@ import type { McpMeta } from "@/libs/mcp";
  * processing a request
  *
  */
+import { resolveAuthedUserId } from "@/server/api/authContext";
 import { drizzleDB } from "@/server/db";
 import { getClientIp } from "@/utils/network";
 
@@ -51,11 +53,17 @@ export const createAppTRPCContext = async (options: {
   readHeaders: ReadonlyHeaders;
   readCookies: ReadonlyRequestCookies;
 }) => {
-  // Get user ID - SIMPLE
+  // Get user ID
   const session = await auth();
-  const userId = session.userId;
-  // Get IP
   const { readHeaders } = options;
+  // Clerk multi-session fail-closed: if the client signalled it intended a per-tab
+  // bearer token but couldn't produce one (getToken failed) and no Authorization
+  // header arrived, do not authenticate via the shared __session cookie.
+  const userId = resolveAuthedUserId(session.userId, {
+    hasAuthorizationHeader: !!readHeaders.get("authorization"),
+    tabAuthFailed: readHeaders.get(TAB_AUTH_REQUIRED_HEADER) === "1",
+  });
+  // Get IP
   const userIp = getClientIp(readHeaders);
   // Get agent
   const userAgent = readHeaders.get("user-agent") ?? undefined;

--- a/app/src/server/api/viewerGuard.ts
+++ b/app/src/server/api/viewerGuard.ts
@@ -1,0 +1,25 @@
+import { TRPCError } from "@trpc/server";
+
+/**
+ * Defense-in-depth guard for Clerk multi-session.
+ *
+ * The browser-global `__session` cookie can momentarily reflect a different
+ * tab's account, so a request may authenticate as an account the client did not
+ * intend to act as. Procedures that accept a client-asserted `viewerId` call
+ * this to reject any request where the server-authenticated session
+ * (`sessionUserId`) does not match the account the client believes it is.
+ *
+ * Identity for the actual work is ALWAYS derived from the session, never from
+ * `viewerId` — this only rejects mismatches, it never trusts the client id.
+ */
+export function assertViewerMatchesSession(
+  sessionUserId: string,
+  viewerId?: string,
+): void {
+  if (viewerId && viewerId !== sessionUserId) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Viewer/session mismatch",
+    });
+  }
+}

--- a/app/src/server/api/viewerGuard.ts
+++ b/app/src/server/api/viewerGuard.ts
@@ -16,7 +16,7 @@ export function assertViewerMatchesSession(
   sessionUserId: string,
   viewerId?: string,
 ): void {
-  if (viewerId && viewerId !== sessionUserId) {
+  if (viewerId !== undefined && viewerId !== sessionUserId) {
     throw new TRPCError({
       code: "FORBIDDEN",
       message: "Viewer/session mismatch",

--- a/app/src/server/api/viewerGuard.ts
+++ b/app/src/server/api/viewerGuard.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from "@trpc/server";
+import { VIEWER_SESSION_MISMATCH_MESSAGE } from "@/app/_trpc/authHeaders";
 
 /**
  * Defense-in-depth guard for Clerk multi-session.
@@ -19,7 +20,7 @@ export function assertViewerMatchesSession(
   if (viewerId !== undefined && viewerId !== sessionUserId) {
     throw new TRPCError({
       code: "FORBIDDEN",
-      message: "Viewer/session mismatch",
+      message: VIEWER_SESSION_MISMATCH_MESSAGE,
     });
   }
 }

--- a/app/src/utils/UserContext.tsx
+++ b/app/src/utils/UserContext.tsx
@@ -80,12 +80,16 @@ export function UserContextProvider(props: { children: React.ReactNode }) {
   // tRPC utility
   const utils = api.useUtils();
 
-  // Get user data
-  const { data, status: userStatus } = api.profile.getUser.useQuery(undefined, {
-    enabled: !!userId && isSignedIn && isLoaded,
-    retry: false,
-    refetchInterval: 300000,
-  });
+  // Get user data. Pass the Clerk userId so the React Query cache is scoped per
+  // account (Clerk multi-session) and the server can reject cross-account reads.
+  const { data, status: userStatus } = api.profile.getUser.useQuery(
+    userId ? { viewerId: userId } : undefined,
+    {
+      enabled: !!userId && isSignedIn && isLoaded,
+      retry: false,
+      refetchInterval: 300000,
+    },
+  );
 
   // Listen on user channel for live updates on things
   const pusher = usePusherHandler(userId, data?.userData);
@@ -93,7 +97,7 @@ export function UserContextProvider(props: { children: React.ReactNode }) {
   // Optimistic user info update function
   const updateUser = async (updatedData: Partial<UserWithRelations>) => {
     await utils.profile.getUser.cancel();
-    utils.profile.getUser.setData(undefined, (old) => {
+    utils.profile.getUser.setData(userId ? { viewerId: userId } : undefined, (old) => {
       return { ...old, userData: { ...old?.userData, ...updatedData } } as typeof old;
     });
   };
@@ -103,7 +107,7 @@ export function UserContextProvider(props: { children: React.ReactNode }) {
     notifications: NavBarDropdownLink[] | undefined,
   ) => {
     await utils.profile.getUser.cancel();
-    utils.profile.getUser.setData(undefined, (old) => {
+    utils.profile.getUser.setData(userId ? { viewerId: userId } : undefined, (old) => {
       return { ...old, notifications } as typeof old;
     });
   };

--- a/app/src/utils/UserContext.tsx
+++ b/app/src/utils/UserContext.tsx
@@ -9,6 +9,7 @@ import type React from "react";
 import { createContext, useContext, useEffect, useState } from "react";
 import type { UserWithRelations } from "@/api/routers/profile";
 import { api } from "@/app/_trpc/client";
+import { getUserQueryInput } from "@/app/_trpc/getUserQueryInput";
 import { useSessionPin } from "@/app/_trpc/SessionPinProvider";
 import type { StructureRoute } from "@/drizzle/constants";
 import { usePusherHandler } from "@/layout/PusherHandler";
@@ -61,14 +62,6 @@ export const UserContext = createContext<{
     // do nothing
   },
 });
-
-/**
- * Per-account input for `profile.getUser`, so the React Query cache is scoped by
- * Clerk account and cannot serve one account's data to another under multi-session.
- */
-const getUserQueryInput = (
-  userId: string | null | undefined,
-): { viewerId: string } | undefined => (userId ? { viewerId: userId } : undefined);
 
 /**
  * UserContextProvider component provides a context for managing user-related data and functionality.

--- a/app/src/utils/UserContext.tsx
+++ b/app/src/utils/UserContext.tsx
@@ -62,6 +62,14 @@ export const UserContext = createContext<{
 });
 
 /**
+ * Per-account input for `profile.getUser`, so the React Query cache is scoped by
+ * Clerk account and cannot serve one account's data to another under multi-session.
+ */
+const getUserQueryInput = (
+  userId: string | null | undefined,
+): { viewerId: string } | undefined => (userId ? { viewerId: userId } : undefined);
+
+/**
  * UserContextProvider component provides a context for managing user-related data and functionality.
  * It includes features such as managing Clerk token, Pusher connection, current user battle, time difference between client and server, and user data retrieval.
  *
@@ -83,7 +91,7 @@ export function UserContextProvider(props: { children: React.ReactNode }) {
   // Get user data. Pass the Clerk userId so the React Query cache is scoped per
   // account (Clerk multi-session) and the server can reject cross-account reads.
   const { data, status: userStatus } = api.profile.getUser.useQuery(
-    userId ? { viewerId: userId } : undefined,
+    getUserQueryInput(userId),
     {
       enabled: !!userId && isSignedIn && isLoaded,
       retry: false,
@@ -97,7 +105,7 @@ export function UserContextProvider(props: { children: React.ReactNode }) {
   // Optimistic user info update function
   const updateUser = async (updatedData: Partial<UserWithRelations>) => {
     await utils.profile.getUser.cancel();
-    utils.profile.getUser.setData(userId ? { viewerId: userId } : undefined, (old) => {
+    utils.profile.getUser.setData(getUserQueryInput(userId), (old) => {
       return { ...old, userData: { ...old?.userData, ...updatedData } } as typeof old;
     });
   };
@@ -107,7 +115,7 @@ export function UserContextProvider(props: { children: React.ReactNode }) {
     notifications: NavBarDropdownLink[] | undefined,
   ) => {
     await utils.profile.getUser.cancel();
-    utils.profile.getUser.setData(userId ? { viewerId: userId } : undefined, (old) => {
+    utils.profile.getUser.setData(getUserQueryInput(userId), (old) => {
       return { ...old, notifications } as typeof old;
     });
   };

--- a/app/src/utils/UserContext.tsx
+++ b/app/src/utils/UserContext.tsx
@@ -9,6 +9,7 @@ import type React from "react";
 import { createContext, useContext, useEffect, useState } from "react";
 import type { UserWithRelations } from "@/api/routers/profile";
 import { api } from "@/app/_trpc/client";
+import { useSessionPin } from "@/app/_trpc/SessionPinProvider";
 import type { StructureRoute } from "@/drizzle/constants";
 import { usePusherHandler } from "@/layout/PusherHandler";
 import type { ReturnedBattle } from "@/libs/combat/types";
@@ -81,19 +82,22 @@ export function UserContextProvider(props: { children: React.ReactNode }) {
   // Difference between client time and server time
   const [timeDiff, setTimeDiff] = useState<number>(0);
 
-  // Get logged in user
-  const { isSignedIn, isLoaded, user } = useUser();
-  const userId = user?.id;
+  // Identity is the tab's PINNED Clerk session, not the browser-global active
+  // session, so the displayed profile cannot flip to another signed-in account
+  // when the active session changes (reload/refocus/background under multi-session).
+  const { isLoaded, user } = useUser();
+  const { pinnedUserId } = useSessionPin();
+  const userId = pinnedUserId;
 
   // tRPC utility
   const utils = api.useUtils();
 
-  // Get user data. Pass the Clerk userId so the React Query cache is scoped per
-  // account (Clerk multi-session) and the server can reject cross-account reads.
+  // Get user data. Pass the pinned Clerk userId so the React Query cache is scoped
+  // per account (Clerk multi-session) and the server can reject cross-account reads.
   const { data, status: userStatus } = api.profile.getUser.useQuery(
     getUserQueryInput(userId),
     {
-      enabled: !!userId && isSignedIn && isLoaded,
+      enabled: !!userId && isLoaded,
       retry: false,
       refetchInterval: 300000,
     },
@@ -158,13 +162,18 @@ export function UserContextProvider(props: { children: React.ReactNode }) {
       Sentry.setUser({
         id: data.userData.userId,
         username: data.userData.username,
-        email: user?.primaryEmailAddress?.emailAddress,
+        // Only attach the Clerk email when the browser-active user matches the
+        // pinned account; otherwise it could be another signed-in account's email.
+        email:
+          user?.id === data.userData.userId
+            ? user?.primaryEmailAddress?.emailAddress
+            : undefined,
       });
     } else {
       // Clear user context when logged out
       Sentry.setUser(null);
     }
-  }, [data?.userData, user?.primaryEmailAddress?.emailAddress]);
+  }, [data?.userData, user?.id, user?.primaryEmailAddress?.emailAddress]);
 
   return (
     <UserContext

--- a/app/src/utils/UserContext.tsx
+++ b/app/src/utils/UserContext.tsx
@@ -106,20 +106,26 @@ export function UserContextProvider(props: { children: React.ReactNode }) {
   // Listen on user channel for live updates on things
   const pusher = usePusherHandler(userId, data?.userData);
 
-  // Optimistic user info update function
+  // Optimistic user info update function. Fail closed when there is no pinned
+  // account: writing with an undefined input would land on the legacy unscoped
+  // profile.getUser cache key, which no account reads.
   const updateUser = async (updatedData: Partial<UserWithRelations>) => {
-    await utils.profile.getUser.cancel();
-    utils.profile.getUser.setData(getUserQueryInput(userId), (old) => {
+    const queryInput = getUserQueryInput(userId);
+    if (!queryInput) return;
+    await utils.profile.getUser.cancel(queryInput);
+    utils.profile.getUser.setData(queryInput, (old) => {
       return { ...old, userData: { ...old?.userData, ...updatedData } } as typeof old;
     });
   };
 
-  // Optimistic notification update function
+  // Optimistic notification update function (see updateUser for the fail-closed note)
   const updateNotifications = async (
     notifications: NavBarDropdownLink[] | undefined,
   ) => {
-    await utils.profile.getUser.cancel();
-    utils.profile.getUser.setData(getUserQueryInput(userId), (old) => {
+    const queryInput = getUserQueryInput(userId);
+    if (!queryInput) return;
+    await utils.profile.getUser.cancel(queryInput);
+    utils.profile.getUser.setData(queryInput, (old) => {
       return { ...old, notifications } as typeof old;
     });
   };

--- a/app/tests/app/_trpc/authHeaders.test.ts
+++ b/app/tests/app/_trpc/authHeaders.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildClerkRequestHeaders,
+  computeIsMultiSession,
   TAB_AUTH_REQUIRED_HEADER,
 } from "@/app/_trpc/authHeaders";
 
@@ -33,5 +34,21 @@ describe("buildClerkRequestHeaders", () => {
 
   it("sends no marker for a single-session browser with no token (cookie is the user's own account)", () => {
     expect(buildClerkRequestHeaders(null, false)).toEqual({});
+  });
+});
+
+describe("computeIsMultiSession", () => {
+  it("treats an unknown session count (Clerk still loading) as multi-session, so the no-token path fails closed", () => {
+    expect(computeIsMultiSession(undefined)).toBe(true);
+  });
+
+  it("treats zero or one signed-in session as single-session (normal cookie path)", () => {
+    expect(computeIsMultiSession(0)).toBe(false);
+    expect(computeIsMultiSession(1)).toBe(false);
+  });
+
+  it("treats more than one signed-in session as multi-session", () => {
+    expect(computeIsMultiSession(2)).toBe(true);
+    expect(computeIsMultiSession(3)).toBe(true);
   });
 });

--- a/app/tests/app/_trpc/authHeaders.test.ts
+++ b/app/tests/app/_trpc/authHeaders.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { buildClerkAuthHeaders } from "@/app/_trpc/authHeaders";
+
+describe("buildClerkAuthHeaders", () => {
+  it("returns a Bearer Authorization header when a token is present", () => {
+    expect(buildClerkAuthHeaders("jwt-123")).toEqual({
+      Authorization: "Bearer jwt-123",
+    });
+  });
+
+  it("omits the Authorization header when there is no token (never sends 'Bearer null')", () => {
+    expect(buildClerkAuthHeaders(null)).toEqual({});
+    expect(buildClerkAuthHeaders(undefined)).toEqual({});
+    expect(buildClerkAuthHeaders("")).toEqual({});
+  });
+});

--- a/app/tests/app/_trpc/authHeaders.test.ts
+++ b/app/tests/app/_trpc/authHeaders.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildClerkAuthHeaders } from "@/app/_trpc/authHeaders";
+import {
+  buildClerkAuthFailureHeaders,
+  buildClerkAuthHeaders,
+  TAB_AUTH_REQUIRED_HEADER,
+} from "@/app/_trpc/authHeaders";
 
 describe("buildClerkAuthHeaders", () => {
   it("returns a Bearer Authorization header when a token is present", () => {
@@ -12,5 +16,17 @@ describe("buildClerkAuthHeaders", () => {
     expect(buildClerkAuthHeaders(null)).toEqual({});
     expect(buildClerkAuthHeaders(undefined)).toEqual({});
     expect(buildClerkAuthHeaders("")).toEqual({});
+  });
+});
+
+describe("buildClerkAuthFailureHeaders", () => {
+  it("signals fail-closed only when the browser has multiple Clerk sessions", () => {
+    expect(buildClerkAuthFailureHeaders(true)).toEqual({
+      [TAB_AUTH_REQUIRED_HEADER]: "1",
+    });
+  });
+
+  it("sends no marker for a single-session browser (cookie fallback is the user's own account)", () => {
+    expect(buildClerkAuthFailureHeaders(false)).toEqual({});
   });
 });

--- a/app/tests/app/_trpc/authHeaders.test.ts
+++ b/app/tests/app/_trpc/authHeaders.test.ts
@@ -1,32 +1,37 @@
 import { describe, expect, it } from "vitest";
 import {
-  buildClerkAuthFailureHeaders,
-  buildClerkAuthHeaders,
+  buildClerkRequestHeaders,
   TAB_AUTH_REQUIRED_HEADER,
 } from "@/app/_trpc/authHeaders";
 
-describe("buildClerkAuthHeaders", () => {
-  it("returns a Bearer Authorization header when a token is present", () => {
-    expect(buildClerkAuthHeaders("jwt-123")).toEqual({
+describe("buildClerkRequestHeaders", () => {
+  it("sends a Bearer Authorization header when the tab has its own token", () => {
+    expect(buildClerkRequestHeaders("jwt-123", false)).toEqual({
+      Authorization: "Bearer jwt-123",
+    });
+    // token wins regardless of session count
+    expect(buildClerkRequestHeaders("jwt-123", true)).toEqual({
       Authorization: "Bearer jwt-123",
     });
   });
 
-  it("omits the Authorization header when there is no token (never sends 'Bearer null')", () => {
-    expect(buildClerkAuthHeaders(null)).toEqual({});
-    expect(buildClerkAuthHeaders(undefined)).toEqual({});
-    expect(buildClerkAuthHeaders("")).toEqual({});
+  it("never sends an Authorization header when the token is absent (no 'Bearer null')", () => {
+    expect(buildClerkRequestHeaders(null, false)).not.toHaveProperty("Authorization");
+    expect(buildClerkRequestHeaders(undefined, false)).not.toHaveProperty("Authorization");
+    expect(buildClerkRequestHeaders("", false)).not.toHaveProperty("Authorization");
   });
-});
 
-describe("buildClerkAuthFailureHeaders", () => {
-  it("signals fail-closed only when the browser has multiple Clerk sessions", () => {
-    expect(buildClerkAuthFailureHeaders(true)).toEqual({
+  it("fails closed with a marker when there is no token AND the browser has multiple sessions", () => {
+    // covers both getToken() -> null and getToken() throwing (caller passes null)
+    expect(buildClerkRequestHeaders(null, true)).toEqual({
+      [TAB_AUTH_REQUIRED_HEADER]: "1",
+    });
+    expect(buildClerkRequestHeaders(undefined, true)).toEqual({
       [TAB_AUTH_REQUIRED_HEADER]: "1",
     });
   });
 
-  it("sends no marker for a single-session browser (cookie fallback is the user's own account)", () => {
-    expect(buildClerkAuthFailureHeaders(false)).toEqual({});
+  it("sends no marker for a single-session browser with no token (cookie is the user's own account)", () => {
+    expect(buildClerkRequestHeaders(null, false)).toEqual({});
   });
 });

--- a/app/tests/app/_trpc/sessionPin.test.ts
+++ b/app/tests/app/_trpc/sessionPin.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearPinnedSessionId,
+  readPinnedSessionId,
+  resolvePinnedSession,
+  writePinnedSessionId,
+} from "@/app/_trpc/sessionPin";
+
+const makeFakeWindow = () => {
+  const store = new Map<string, string>();
+  return {
+    sessionStorage: {
+      getItem: (k: string) => (store.has(k) ? (store.get(k) as string) : null),
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+    },
+  };
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("resolvePinnedSession", () => {
+  const sessions = [
+    { id: "sess_a", status: "active", user: { id: "user_a" } },
+    { id: "sess_b", status: "active", user: { id: "user_b" } },
+    { id: "sess_old", status: "ended", user: { id: "user_c" } },
+  ];
+
+  it("returns the matching signed-in session", () => {
+    expect(resolvePinnedSession(sessions, "sess_b")?.id).toBe("sess_b");
+  });
+
+  it("returns null when the pin is unset", () => {
+    expect(resolvePinnedSession(sessions, null)).toBeNull();
+  });
+
+  it("returns null when the pinned session is not present", () => {
+    expect(resolvePinnedSession(sessions, "sess_missing")).toBeNull();
+  });
+
+  it("does not match a non-active (ended/expired) session", () => {
+    expect(resolvePinnedSession(sessions, "sess_old")).toBeNull();
+  });
+
+  it("returns null when sessions have not loaded", () => {
+    expect(resolvePinnedSession(undefined, "sess_a")).toBeNull();
+    expect(resolvePinnedSession(null, "sess_a")).toBeNull();
+  });
+});
+
+describe("pinned session id storage", () => {
+  it("round-trips read/write/clear via sessionStorage", () => {
+    vi.stubGlobal("window", makeFakeWindow());
+    expect(readPinnedSessionId()).toBeNull();
+    writePinnedSessionId("sess_a");
+    expect(readPinnedSessionId()).toBe("sess_a");
+    clearPinnedSessionId();
+    expect(readPinnedSessionId()).toBeNull();
+  });
+
+  it("is a safe no-op without window (SSR)", () => {
+    vi.stubGlobal("window", undefined);
+    expect(() => writePinnedSessionId("x")).not.toThrow();
+    expect(() => clearPinnedSessionId()).not.toThrow();
+    expect(readPinnedSessionId()).toBeNull();
+  });
+});

--- a/app/tests/app/_trpc/sessionPin.test.ts
+++ b/app/tests/app/_trpc/sessionPin.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
-  clearPinnedSessionId,
   decidePinnedSession,
   isAuthRoute,
   pinChangeRequiresRemount,
@@ -58,19 +57,18 @@ describe("resolvePinnedSession", () => {
 });
 
 describe("pinned session id storage", () => {
-  it("round-trips read/write/clear via sessionStorage", () => {
+  it("round-trips read/write via sessionStorage", () => {
     g.window = makeFakeWindow();
     expect(readPinnedSessionId()).toBeNull();
     writePinnedSessionId("sess_a");
     expect(readPinnedSessionId()).toBe("sess_a");
-    clearPinnedSessionId();
-    expect(readPinnedSessionId()).toBeNull();
+    writePinnedSessionId("sess_b");
+    expect(readPinnedSessionId()).toBe("sess_b");
   });
 
   it("is a safe no-op without window (SSR)", () => {
     g.window = undefined;
     expect(() => writePinnedSessionId("x")).not.toThrow();
-    expect(() => clearPinnedSessionId()).not.toThrow();
     expect(readPinnedSessionId()).toBeNull();
   });
 });
@@ -245,13 +243,13 @@ describe("pinChangeRequiresRemount", () => {
     expect(pinChangeRequiresRemount(null, "sess_a")).toBe(false);
   });
 
-  it("remounts on an intentional in-tab account switch (A -> B)", () => {
-    // switchPinnedAccount / a reload that adopts a different account: account A's data
-    // may sit in unscoped React Query caches and must be discarded.
+  it("remounts when the tab adopts a different account (A -> B)", () => {
+    // The pinned account signed out and the effect adopted another still-signed-in
+    // account: account A's data may sit in unscoped React Query caches, discard it.
     expect(pinChangeRequiresRemount("sess_a", "sess_b")).toBe(true);
   });
 
-  it("remounts on sign-out (id -> null)", () => {
+  it("remounts on an id -> null change (defensive; no live path nulls the pin today)", () => {
     expect(pinChangeRequiresRemount("sess_a", null)).toBe(true);
   });
 

--- a/app/tests/app/_trpc/sessionPin.test.ts
+++ b/app/tests/app/_trpc/sessionPin.test.ts
@@ -124,11 +124,23 @@ describe("decidePinnedSession", () => {
   it("re-adopts the active session when the pinned account was signed out and another remains", () => {
     expect(
       decidePinnedSession({
-        sessions, // sess_main is gone in this scenario
+        // The pinned sess_signedout is no longer in sessions; sess_main + sess_alt remain.
+        sessions,
         inMemoryPinnedId: "sess_signedout",
         storedPinnedId: "sess_signedout",
         activeSessionId: "sess_alt",
       }),
     ).toEqual({ type: "set", id: "sess_alt" });
+  });
+
+  it("does not pin an active session that is not a signed-in session (no phantom pin)", () => {
+    expect(
+      decidePinnedSession({
+        sessions,
+        inMemoryPinnedId: null,
+        storedPinnedId: null,
+        activeSessionId: "sess_not_in_list",
+      }),
+    ).toEqual({ type: "keep" });
   });
 });

--- a/app/tests/app/_trpc/sessionPin.test.ts
+++ b/app/tests/app/_trpc/sessionPin.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   clearPinnedSessionId,
   decidePinnedSession,
@@ -18,8 +18,12 @@ const makeFakeWindow = () => {
   };
 };
 
+// CI runs `bun test`, whose `vi` shim lacks `stubGlobal`/`unstubAllGlobals`, so swap
+// `window` by direct assignment and restore the value captured at module load.
+const g = globalThis as unknown as { window?: unknown };
+const originalWindow = g.window;
 afterEach(() => {
-  vi.unstubAllGlobals();
+  g.window = originalWindow;
 });
 
 describe("resolvePinnedSession", () => {
@@ -53,7 +57,7 @@ describe("resolvePinnedSession", () => {
 
 describe("pinned session id storage", () => {
   it("round-trips read/write/clear via sessionStorage", () => {
-    vi.stubGlobal("window", makeFakeWindow());
+    g.window = makeFakeWindow();
     expect(readPinnedSessionId()).toBeNull();
     writePinnedSessionId("sess_a");
     expect(readPinnedSessionId()).toBe("sess_a");
@@ -62,7 +66,7 @@ describe("pinned session id storage", () => {
   });
 
   it("is a safe no-op without window (SSR)", () => {
-    vi.stubGlobal("window", undefined);
+    g.window = undefined;
     expect(() => writePinnedSessionId("x")).not.toThrow();
     expect(() => clearPinnedSessionId()).not.toThrow();
     expect(readPinnedSessionId()).toBeNull();

--- a/app/tests/app/_trpc/sessionPin.test.ts
+++ b/app/tests/app/_trpc/sessionPin.test.ts
@@ -3,6 +3,7 @@ import {
   clearPinnedSessionId,
   decidePinnedSession,
   isAuthRoute,
+  pinChangeRequiresRemount,
   readPinnedSessionId,
   resolvePinnedSession,
   writePinnedSessionId,
@@ -234,5 +235,28 @@ describe("decidePinnedSession", () => {
         onAuthRoute: false,
       }),
     ).toEqual({ type: "keep" });
+  });
+});
+
+describe("pinChangeRequiresRemount", () => {
+  it("does NOT remount on the first-load null -> id adoption", () => {
+    // The tab adopts its own account; the unpinned window authenticated as that same
+    // account (or fetched nothing), so a tree-wide remount + refetch would be waste.
+    expect(pinChangeRequiresRemount(null, "sess_a")).toBe(false);
+  });
+
+  it("remounts on an intentional in-tab account switch (A -> B)", () => {
+    // switchPinnedAccount / a reload that adopts a different account: account A's data
+    // may sit in unscoped React Query caches and must be discarded.
+    expect(pinChangeRequiresRemount("sess_a", "sess_b")).toBe(true);
+  });
+
+  it("remounts on sign-out (id -> null)", () => {
+    expect(pinChangeRequiresRemount("sess_a", null)).toBe(true);
+  });
+
+  it("does not remount when the pin is unchanged", () => {
+    expect(pinChangeRequiresRemount("sess_a", "sess_a")).toBe(false);
+    expect(pinChangeRequiresRemount(null, null)).toBe(false);
   });
 });

--- a/app/tests/app/_trpc/sessionPin.test.ts
+++ b/app/tests/app/_trpc/sessionPin.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   clearPinnedSessionId,
   decidePinnedSession,
+  isAuthRoute,
   readPinnedSessionId,
   resolvePinnedSession,
   writePinnedSessionId,
@@ -73,6 +74,26 @@ describe("pinned session id storage", () => {
   });
 });
 
+describe("isAuthRoute", () => {
+  it("matches the sign-in and sign-up routes and their sub-routes", () => {
+    expect(isAuthRoute("/login")).toBe(true);
+    expect(isAuthRoute("/login/factor-one")).toBe(true);
+    expect(isAuthRoute("/login/sso-callback")).toBe(true);
+    expect(isAuthRoute("/signup")).toBe(true);
+    expect(isAuthRoute("/signup/verify-email-address")).toBe(true);
+  });
+
+  it("does not match app routes or look-alike prefixes", () => {
+    expect(isAuthRoute("/")).toBe(false);
+    expect(isAuthRoute("/profile")).toBe(false);
+    // Segment-exact: a route that merely starts with the word is not an auth route.
+    expect(isAuthRoute("/login-help")).toBe(false);
+    expect(isAuthRoute("/signup-confirmation")).toBe(false);
+    expect(isAuthRoute(null)).toBe(false);
+    expect(isAuthRoute(undefined)).toBe(false);
+  });
+});
+
 describe("decidePinnedSession", () => {
   const sessions = [
     { id: "sess_main", status: "active", user: { id: "user_main" } },
@@ -88,6 +109,7 @@ describe("decidePinnedSession", () => {
         inMemoryPinnedId: "sess_main",
         storedPinnedId: null,
         activeSessionId: "sess_alt",
+        onAuthRoute: false,
       }),
     ).toEqual({ type: "keep" });
   });
@@ -99,6 +121,7 @@ describe("decidePinnedSession", () => {
         inMemoryPinnedId: null,
         storedPinnedId: null,
         activeSessionId: "sess_main",
+        onAuthRoute: false,
       }),
     ).toEqual({ type: "set", id: "sess_main" });
   });
@@ -110,6 +133,7 @@ describe("decidePinnedSession", () => {
         inMemoryPinnedId: null,
         storedPinnedId: "sess_alt",
         activeSessionId: "sess_main",
+        onAuthRoute: false,
       }),
     ).toEqual({ type: "set", id: "sess_alt" });
   });
@@ -121,6 +145,7 @@ describe("decidePinnedSession", () => {
         inMemoryPinnedId: "sess_main",
         storedPinnedId: null,
         activeSessionId: null,
+        onAuthRoute: false,
       }),
     ).toEqual({ type: "keep" });
   });
@@ -133,6 +158,7 @@ describe("decidePinnedSession", () => {
         inMemoryPinnedId: "sess_signedout",
         storedPinnedId: "sess_signedout",
         activeSessionId: "sess_alt",
+        onAuthRoute: false,
       }),
     ).toEqual({ type: "set", id: "sess_alt" });
   });
@@ -144,6 +170,68 @@ describe("decidePinnedSession", () => {
         inMemoryPinnedId: null,
         storedPinnedId: null,
         activeSessionId: "sess_not_in_list",
+        onAuthRoute: false,
+      }),
+    ).toEqual({ type: "keep" });
+  });
+
+  // Fresh-tab second-account sign-in (the /tnr-review-now repro): a fresh tab lands
+  // on /login while account "main" is already signed in browser-wide, then signs in
+  // "alt". The tab must end up on alt, not main.
+  it("defers adopting the active session while on the sign-in flow (no eager pin)", () => {
+    // Fresh tab on /login: main is the browser-global active session, but the user
+    // has not acted yet. Adopting main here is what blocked the later switch to alt.
+    expect(
+      decidePinnedSession({
+        sessions: [{ id: "sess_main", status: "active", user: { id: "user_main" } }],
+        inMemoryPinnedId: null,
+        storedPinnedId: null,
+        activeSessionId: "sess_main",
+        onAuthRoute: true,
+      }),
+    ).toEqual({ type: "keep" });
+  });
+
+  it("keeps deferring on the auth flow even after the new account becomes active", () => {
+    // The user signed in alt; Clerk added sess_alt and made it active, but the tab is
+    // still momentarily on /login. Still defer — adoption happens after the redirect.
+    expect(
+      decidePinnedSession({
+        sessions,
+        inMemoryPinnedId: null,
+        storedPinnedId: null,
+        activeSessionId: "sess_alt",
+        onAuthRoute: true,
+      }),
+    ).toEqual({ type: "keep" });
+  });
+
+  it("adopts the just-signed-in account once redirected off the auth flow", () => {
+    // <SignIn> redirected onto an app route. onAuthRoute is false only BECAUSE that
+    // navigation ran, which is downstream of Clerk setting the new active session —
+    // so activeSessionId is already the new account here (not a stale value).
+    expect(
+      decidePinnedSession({
+        sessions,
+        inMemoryPinnedId: null,
+        storedPinnedId: null,
+        activeSessionId: "sess_alt",
+        onAuthRoute: false,
+      }),
+    ).toEqual({ type: "set", id: "sess_alt" });
+  });
+
+  it("does not flip an established pin when another tab makes a new account active (cross-tab protection)", () => {
+    // Regression guard for the ORIGINAL reported bug: a background sign-in in another
+    // tab adds sess_alt and makes it active. A tab already pinned to main must keep
+    // main — the auth-route deferral must NOT have weakened this.
+    expect(
+      decidePinnedSession({
+        sessions,
+        inMemoryPinnedId: "sess_main",
+        storedPinnedId: "sess_main",
+        activeSessionId: "sess_alt",
+        onAuthRoute: false,
       }),
     ).toEqual({ type: "keep" });
   });

--- a/app/tests/app/_trpc/sessionPin.test.ts
+++ b/app/tests/app/_trpc/sessionPin.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   clearPinnedSessionId,
+  decidePinnedSession,
   readPinnedSessionId,
   resolvePinnedSession,
   writePinnedSessionId,
@@ -65,5 +66,69 @@ describe("pinned session id storage", () => {
     expect(() => writePinnedSessionId("x")).not.toThrow();
     expect(() => clearPinnedSessionId()).not.toThrow();
     expect(readPinnedSessionId()).toBeNull();
+  });
+});
+
+describe("decidePinnedSession", () => {
+  const sessions = [
+    { id: "sess_main", status: "active", user: { id: "user_main" } },
+    { id: "sess_alt", status: "active", user: { id: "user_alt" } },
+  ];
+
+  it("keeps a still-signed-in in-memory pin even when the stored read returns null (no flip)", () => {
+    // The reported bug: sessionStorage read fails -> null, active session changed
+    // to the alt -> the tab must NOT re-adopt the alt.
+    expect(
+      decidePinnedSession({
+        sessions,
+        inMemoryPinnedId: "sess_main",
+        storedPinnedId: null,
+        activeSessionId: "sess_alt",
+      }),
+    ).toEqual({ type: "keep" });
+  });
+
+  it("adopts the active session on first load when there is no pin", () => {
+    expect(
+      decidePinnedSession({
+        sessions,
+        inMemoryPinnedId: null,
+        storedPinnedId: null,
+        activeSessionId: "sess_main",
+      }),
+    ).toEqual({ type: "set", id: "sess_main" });
+  });
+
+  it("recovers a still-signed-in stored pin (e.g. after reload)", () => {
+    expect(
+      decidePinnedSession({
+        sessions,
+        inMemoryPinnedId: null,
+        storedPinnedId: "sess_alt",
+        activeSessionId: "sess_main",
+      }),
+    ).toEqual({ type: "set", id: "sess_alt" });
+  });
+
+  it("does not disturb the pin while the sessions list is momentarily empty", () => {
+    expect(
+      decidePinnedSession({
+        sessions: [],
+        inMemoryPinnedId: "sess_main",
+        storedPinnedId: null,
+        activeSessionId: null,
+      }),
+    ).toEqual({ type: "keep" });
+  });
+
+  it("re-adopts the active session when the pinned account was signed out and another remains", () => {
+    expect(
+      decidePinnedSession({
+        sessions, // sess_main is gone in this scenario
+        inMemoryPinnedId: "sess_signedout",
+        storedPinnedId: "sess_signedout",
+        activeSessionId: "sess_alt",
+      }),
+    ).toEqual({ type: "set", id: "sess_alt" });
   });
 });

--- a/app/tests/server/api/authContext.test.ts
+++ b/app/tests/server/api/authContext.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { resolveAuthedUserId } from "@/server/api/authContext";
+
+describe("resolveAuthedUserId", () => {
+  it("returns the session user for a normal request (no fail-closed marker)", () => {
+    expect(
+      resolveAuthedUserId("user_A", {
+        hasAuthorizationHeader: false,
+        tabAuthFailed: false,
+      }),
+    ).toBe("user_A");
+  });
+
+  it("returns the session user when an Authorization header is present, even if the marker is set", () => {
+    expect(
+      resolveAuthedUserId("user_A", {
+        hasAuthorizationHeader: true,
+        tabAuthFailed: true,
+      }),
+    ).toBe("user_A");
+  });
+
+  it("fails closed (null) when the tab signalled auth failure and no Authorization header arrived", () => {
+    // Clerk multi-session: do not let the shared __session cookie authenticate as
+    // a possibly-different account when the tab could not produce its own token.
+    expect(
+      resolveAuthedUserId("user_from_cookie", {
+        hasAuthorizationHeader: false,
+        tabAuthFailed: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when there is no session at all", () => {
+    expect(
+      resolveAuthedUserId(null, {
+        hasAuthorizationHeader: false,
+        tabAuthFailed: false,
+      }),
+    ).toBeNull();
+  });
+});

--- a/app/tests/server/api/viewerGuard.test.ts
+++ b/app/tests/server/api/viewerGuard.test.ts
@@ -1,0 +1,24 @@
+import { TRPCError } from "@trpc/server";
+import { describe, expect, it } from "vitest";
+import { assertViewerMatchesSession } from "@/server/api/viewerGuard";
+
+describe("assertViewerMatchesSession", () => {
+  it("does not throw when the client-asserted viewer matches the session user", () => {
+    expect(() => assertViewerMatchesSession("user_A", "user_A")).not.toThrow();
+  });
+
+  it("does not throw when no viewer is asserted (backward-compatible callers)", () => {
+    expect(() => assertViewerMatchesSession("user_A", undefined)).not.toThrow();
+  });
+
+  it("throws FORBIDDEN when the asserted viewer does not match the session user", () => {
+    expect(() => assertViewerMatchesSession("user_A", "user_B")).toThrow(TRPCError);
+    try {
+      assertViewerMatchesSession("user_A", "user_B");
+      throw new Error("expected assertViewerMatchesSession to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(TRPCError);
+      expect((error as TRPCError).code).toBe("FORBIDDEN");
+    }
+  });
+});

--- a/app/tests/server/api/viewerGuard.test.ts
+++ b/app/tests/server/api/viewerGuard.test.ts
@@ -11,6 +11,11 @@ describe("assertViewerMatchesSession", () => {
     expect(() => assertViewerMatchesSession("user_A", undefined)).not.toThrow();
   });
 
+  it("throws FORBIDDEN for an empty asserted viewer id (not treated as unasserted)", () => {
+    // "" is never a valid Clerk id; the guard must not silently bypass on it.
+    expect(() => assertViewerMatchesSession("user_A", "")).toThrow(TRPCError);
+  });
+
   it("throws FORBIDDEN when the asserted viewer does not match the session user", () => {
     expect(() => assertViewerMatchesSession("user_A", "user_B")).toThrow(TRPCError);
     try {

--- a/app/tests/server/api/viewerGuard.test.ts
+++ b/app/tests/server/api/viewerGuard.test.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
+import { VIEWER_SESSION_MISMATCH_MESSAGE } from "@/app/_trpc/authHeaders";
 import { assertViewerMatchesSession } from "@/server/api/viewerGuard";
 
 describe("assertViewerMatchesSession", () => {
@@ -24,6 +25,9 @@ describe("assertViewerMatchesSession", () => {
     } catch (error) {
       expect(error).toBeInstanceOf(TRPCError);
       expect((error as TRPCError).code).toBe("FORBIDDEN");
+      // The message is the shared contract the client filters on; pin it so a
+      // server-side reword can't silently break the client's suppression.
+      expect((error as TRPCError).message).toBe(VIEWER_SESSION_MISMATCH_MESSAGE);
     }
   });
 });


### PR DESCRIPTION
# Pull Request

## Summary

Fixes a Clerk multi-session bug where a user signed into two accounts in the same browser would intermittently see their profile/character switch to the **other** account ("I'm on my main, and it sometimes changes my profile to my alt").

## Why / Root Cause

Under Clerk multi-session, the **active session is per-tab in memory**, but the `__session` cookie the server reads is **shared across all browser tabs and reflects whichever tab is currently focused**.

Our tRPC client authenticated with that ambient cookie only (no token), so a **background request from a non-focused tab** (the 5-minute `profile.getUser` refetch, or a Pusher-triggered `getUser.invalidate()`) authenticated server-side as **whichever account last wrote the cookie** (the alt). Because `profile.getUser` was queried with no account in its React Query key and a global `staleTime: Infinity`, that wrong-account response was written into the tab's cache and pinned there. The same ambient-cookie path also affected **mutations**, not just the displayed profile.

Verified against the installed `@clerk/backend` source: `authenticateRequest` is **header-first**. When an `Authorization` Bearer token is present it is used and the cookie/handshake path is skipped. `getToken()` returns the calling tab's own in-memory session token, independent of the shared cookie.

## What Was Implemented

### 1. Per-tab token on every tRPC request (the fix)

- New `app/src/app/_trpc/authHeaders.ts` with `buildClerkRequestHeaders(token, isMultiSession)`: returns `{ Authorization: Bearer <token> }` when the tab has its own token (and never `Bearer null`); otherwise a fail-closed marker (see #3) or `{}`.
- `app/src/app/_trpc/Provider.tsx`: `TrpcClientProvider` reads `useAuth().getToken` and `useClerk()` (kept in refs so the once-created client always uses the latest values) and attaches headers via `httpBatchLink`'s `async headers()`. Because Clerk authenticates header-first, the server now resolves **this tab's** session instead of the shared cookie — for queries **and** mutations.

### 2. Per-account scoping + server guard (defense-in-depth)

- New `app/src/server/api/viewerGuard.ts` with `assertViewerMatchesSession(sessionUserId, viewerId?)`, which throws `FORBIDDEN` when the client-asserted account does not match the server-authenticated session. Identity for the actual work is **always** taken from `ctx.userId`; `viewerId` is only checked, never trusted.
- `profile.getUser` gains an **optional** `{ viewerId }` input and calls the guard. The React Query cache is now scoped per account.
- Client call sites pass the tab's Clerk id via a small `getUserQueryInput(userId)` helper: `UserContext.tsx` (`useQuery` plus two optimistic `setData`) and `PusherHandler.tsx` (`setData`). The ~120 argless `invalidate()` / `cancel()` calls match by key-prefix and are unchanged.
- `Provider.tsx` `handleTrpcError` silently ignores the transient "Viewer/session mismatch" guard error (matched by message **and** `FORBIDDEN` code), since it self-resolves on the next refetch and is never user-facing.

### 3. Fail-closed when the per-tab token cannot be fetched (defense-in-depth)

`getToken()` yields no usable token in two cases: it **returns `null`** when the tab has no active session, and it **throws** (e.g. `ClerkOfflineError`) on an offline / token-refresh blip. Either way, falling back to the shared cookie could authenticate as another tab's account. Now:

- `Provider.tsx` `headers()` routes **both** the null and the thrown path through the same no-token branch of `buildClerkRequestHeaders`. It sends the `x-tnr-auth-required` marker **only when the browser has more than one signed-in session** (`client.signedInSessions`, which excludes ended/expired/replaced sessions); a single-session browser falls back to the cookie (its own account), so ordinary network blips do not cause needless auth failures for the common single-account case.
- New `app/src/server/api/authContext.ts` with `resolveAuthedUserId(sessionUserId, { hasAuthorizationHeader, tabAuthFailed })`: returns `null` (treat as unauthenticated) when the marker is present and no `Authorization` header arrived, instead of authenticating via the shared cookie. Wired into the tRPC context in `trpc.ts` (the marker is detected by header **presence**).

### 4. Tests

- `app/tests/app/_trpc/authHeaders.test.ts`: `buildClerkRequestHeaders` — Bearer format, never `Bearer null`, fail-closed marker when no token + multi-session, and no marker for a single-session browser.
- `app/tests/server/api/viewerGuard.test.ts`: match passes, mismatch throws `FORBIDDEN`, no assertion when no `viewerId`.
- `app/tests/server/api/authContext.test.ts`: normal request passes through, Authorization-header-present passes through, marker-without-header fails closed to `null`, no-session is `null`.

## Files Changed

| File | Change |
| --- | --- |
| `app/src/app/_trpc/authHeaders.ts` | new |
| `app/src/app/_trpc/Provider.tsx` | modified |
| `app/src/server/api/viewerGuard.ts` | new |
| `app/src/server/api/authContext.ts` | new |
| `app/src/server/api/trpc.ts` | modified |
| `app/src/server/api/routers/profile.ts` | modified |
| `app/src/utils/UserContext.tsx` | modified |
| `app/src/layout/PusherHandler.tsx` | modified |
| `app/tests/app/_trpc/authHeaders.test.ts` | new |
| `app/tests/server/api/viewerGuard.test.ts` | new |
| `app/tests/server/api/authContext.test.ts` | new |
| `app/package.json` / `app/bun.lock` | modified (test-only devDependency pin, see Testing Steps) |

## Breaking Changes

**None.**

- `profile.getUser`'s new input is **optional**, so all existing callers (including server-side `createCaller` / MCP usages that pass no input) keep working unchanged. The guard is a no-op when no `viewerId` is supplied.
- No database / schema migration. No public API or runtime-dependency change.
- The only dependency change is a **test-only** devDependency pin (`@vitejs/plugin-react` `^6` → `^5`) described under Testing Steps.

## Conformance

The approach was validated against current official docs (Clerk v7, tRPC v11, TanStack Query v5, React 19): the `getToken()` + `Authorization: Bearer` pattern with a fail-closed marker is exactly what Clerk prescribes for multi-tab background fetches; async `headers()` on the terminating `httpBatchLink`, optional `.input` for cache-keying with `ctx`-derived identity, and per-account query keys are all idiomatic for their respective libraries.

## Testing Steps

### Automated (from repo root)

```bash
make typecheck   # passes, 0 errors
make lint        # clean
cd app && bunx vitest run tests/app/_trpc/authHeaders.test.ts tests/server/api/viewerGuard.test.ts tests/server/api/authContext.test.ts
```

> Note: this branch also pins `@vitejs/plugin-react` from `^6` to `^5`. `@vitejs/plugin-react@6` requires vite 8, but `vitest@4` uses vite 7, which broke the test runner at config load (`vite/internal` not exported). `^5` peers vite 7, so `vitest` / `make test` run normally again. This is a test-only devDependency change.

### Manual: confirm the fix is wired (single account, any instance)

1. Sign in, open DevTools and go to the **Network** tab.
2. Inspect any `/api/trpc` request and check Request Headers; it now carries `Authorization: Bearer ...`. (Previously there was no Authorization header.)

### Manual: behavioral repro (requires a Clerk instance with multi-session enabled)

1. Tab A: sign in as account **A**, sit on `/profile`.
2. Tab B: sign in as account **B** (same browser, Clerk multi-session).
3. Focus **Tab B**, leave Tab A idle and do not interact with it.
4. Expected (fixed): Tab A stays account A. Before this change it would flip to B on the next background `getUser`.
5. To trigger quickly instead of waiting on the 5-minute timer, temporarily set `refetchInterval` from `300000` to `3000` in `app/src/utils/UserContext.tsx`, reproduce, then revert.

> Note: multi-session is a per-instance Clerk Dashboard setting and differs between development and production instances. In single-session mode the second sign-in is redirected away, so the bug (and this repro) only occur where multi-session is enabled.

## Screenshots

N/A. No visual/UI changes; the fix is in request authentication and query caching.

## Evaluated and intentionally not included

- **SSR**: `auth()` / `currentUser()` in server components reads the shared cookie. Verified this is not an exposure here: `initialIsSignedIn` is an account-agnostic boolean used only for the pre-hydration layout shell, and the only server components calling `currentUser()` are forum pages that render on foreground navigation (focused tab = correct cookie), use `force-dynamic` (so prefetch does not run their data fetch), and surface only public forum content. There is also no clean way to pass a per-tab bearer token to a server component during document render, so no change was made.
- **Uploadthing**: `api/uploadthing/core.ts` is still cookie-authenticated and does not traverse the tRPC link. Uploads are foreground/click-driven (the focused tab's cookie is the correct account), so the cross-account precondition is essentially never met. Pre-existing and out of scope for this PR.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-tab Clerk session pinning to keep authentication and user data scoped to the pinned viewer/account.
  * Updated profile user lookup to accept an optional viewer id and enforce viewer/session match.
* **Bug Fixes**
  * Improved fail-closed handling for multi-session per-tab auth failures to avoid incorrect session fallback.
  * Reduced user-facing noise by suppressing transient viewer/session mismatch errors.
  * Scoped battle-related profile cache updates to the current pinned viewer/account.
* **Tests**
  * Added coverage for header composition, multi-session detection, fail-closed auth resolution, viewer/session enforcement, and session pinning helpers.
* **Chores**
  * Updated the Vite React plugin version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->