### PR TITLE
Remove bloodline from pool and adjust Seichi Silver

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -1264,6 +1264,12 @@ export const FED_NORMAL_ITEM_LOADOUTS = 1;
 export const FED_SILVER_ITEM_LOADOUTS = 2;
 export const FED_GOLD_ITEM_LOADOUTS = 3;
 export const LOADOUT_NAME_MAX_LENGTH = 24;
+// Matches the `actionLog.relatedText` varchar column width; audit text must be
+// clamped to this before insert or a long reason fails the write.
+export const ACTION_LOG_RELATED_MSG_MAX_LENGTH = 191;
+// Max magnitude of a single staff Seichi Silver adjustment (shared by the zod
+// schema and the client-side form validation so the bounds stay in sync).
+export const SEICHI_SILVER_ADJUST_LIMIT = 1_000_000;
 export const FED_EVENT_ITEMS_NORMAL = 15;
 export const FED_EVENT_ITEMS_SILVER = 20;
 export const FED_EVENT_ITEMS_GOLD = 25;

--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -10,7 +10,9 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Chart as ChartJS } from "chart.js/auto";
 import {
   Award,
+  Coins,
   CopyCheck,
+  Droplets,
   Flag,
   IdCard,
   Medal,
@@ -117,10 +119,12 @@ import {
   canEditQuests,
   canEditRank,
   canEditRankedLp,
+  canEditSeichiSilver,
   canEditStaffAccountFlag,
   canEditUsername,
   canEditVillage,
   canModifyUserBadges,
+  canRemoveBloodlineFromPool,
   canSeeActivityEvents,
   canSeeIps,
   canSeeSecretData,
@@ -553,6 +557,22 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = (props) => {
                   </form>
                 </Form>
               </Confirm2>
+            )}
+
+            {userData && canEditSeichiSilver(userData.role) && !profile.isAi && (
+              <AdjustSeichiSilver
+                userId={profile.userId}
+                username={profile.username}
+                currentSilver={profile.seichiSilver}
+              />
+            )}
+
+            {userData && canRemoveBloodlineFromPool(userData.role) && !profile.isAi && (
+              <BloodlinePoolManager
+                userId={profile.userId}
+                username={profile.username}
+                equippedBloodlineId={profile.bloodlineId ?? null}
+              />
             )}
 
             {userData && canAwardExperience(userData) && (
@@ -2283,5 +2303,213 @@ const BracketEligibilityBadge: React.FC<BracketEligibilityBadgeProps> = ({
     <p className="font-medium text-red-500 text-sm">
       ✗ Protected (lower bracket — {targetBracket} vs your {attackerBracket})
     </p>
+  );
+};
+
+interface AdjustSeichiSilverProps {
+  userId: string;
+  username: string;
+  currentSilver: number;
+}
+
+const AdjustSeichiSilver: React.FC<AdjustSeichiSilverProps> = ({
+  userId,
+  username,
+  currentSilver,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [delta, setDelta] = useState("");
+  const [reason, setReason] = useState("");
+  const utils = api.useUtils();
+  const parsedDelta = Number.parseInt(delta, 10);
+  const isValid =
+    Number.isInteger(parsedDelta) && parsedDelta !== 0 && reason.trim().length >= 10;
+
+  const { mutate, isPending } = api.profile.adjustSeichiSilver.useMutation({
+    onSuccess: async (data) => {
+      showMutationToast(data);
+      if (data.success) {
+        setIsOpen(false);
+        setDelta("");
+        setReason("");
+        await utils.profile.getPublicUser.invalidate();
+      }
+    },
+  });
+
+  return (
+    <>
+      <TooltipProvider delayDuration={50}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Coins
+              className="h-6 w-6 cursor-pointer hover:text-orange-500"
+              onClick={() => setIsOpen(true)}
+            />
+          </TooltipTrigger>
+          <TooltipContent>Adjust Seichi Silver</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <Modal2
+        title="Adjust Seichi Silver"
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        proceed_label={isPending ? "Saving..." : "Apply"}
+        isValid={isValid}
+        proceedDisabled={!isValid || isPending}
+        onAccept={(e) => {
+          e.preventDefault();
+          if (!isValid) return;
+          mutate({ userId, delta: parsedDelta, reason: reason.trim() });
+        }}
+      >
+        <div className="space-y-4">
+          <p className="text-muted-foreground text-sm">
+            Adjust <strong>{username}</strong>&apos;s Seichi Silver (current:{" "}
+            {currentSilver}). Use a negative number to subtract. This action is logged.
+          </p>
+          <div className="space-y-2">
+            <Label htmlFor="silver-delta">Amount (+/-)</Label>
+            <Input
+              id="silver-delta"
+              type="number"
+              value={delta}
+              onChange={(e) => setDelta(e.target.value)}
+              placeholder="e.g. 500 or -250"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="silver-reason">Reason *</Label>
+            <Input
+              id="silver-reason"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Reason (minimum 10 characters)..."
+            />
+          </div>
+        </div>
+      </Modal2>
+    </>
+  );
+};
+
+interface BloodlinePoolManagerProps {
+  userId: string;
+  username: string;
+  equippedBloodlineId: string | null;
+}
+
+const BloodlinePoolManager: React.FC<BloodlinePoolManagerProps> = ({
+  userId,
+  username,
+  equippedBloodlineId,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [reason, setReason] = useState("");
+  const utils = api.useUtils();
+
+  const { data: pool, isPending: poolLoading } =
+    api.bloodline.getUserHistoricBloodlinesForStaff.useQuery(
+      { userId },
+      { enabled: isOpen },
+    );
+
+  const { mutate, isPending } = api.bloodline.removeBloodlineFromPool.useMutation({
+    onSuccess: async (data) => {
+      showMutationToast(data);
+      if (data.success) {
+        // getPublicUser + the staff pool query refresh the admin's view of the
+        // target. The two self-scoped queries below only matter when an admin
+        // manages their OWN pool (userId === ctx.userId); a *different* player's
+        // open tab is a separate client we cannot invalidate from here — that
+        // staleness is harmless (a stale swap is rejected server-side).
+        await Promise.all([
+          utils.profile.getPublicUser.invalidate(),
+          utils.bloodline.getUserHistoricBloodlinesForStaff.invalidate({ userId }),
+          utils.bloodline.getUserHistoricBloodlines.invalidate(),
+          utils.bloodline.getSwapInfo.invalidate(),
+        ]);
+      }
+    },
+  });
+
+  const reasonValid = reason.trim().length >= 10;
+
+  return (
+    <>
+      <TooltipProvider delayDuration={50}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Droplets
+              className="h-6 w-6 cursor-pointer hover:text-orange-500"
+              onClick={() => setIsOpen(true)}
+            />
+          </TooltipTrigger>
+          <TooltipContent>Manage Bloodline Pool</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <Modal2
+        title={`Manage Bloodline Pool — ${username}`}
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        proceed_label={null}
+      >
+        <div className="space-y-4">
+          <p className="text-muted-foreground text-sm">
+            Remove a bloodline from this player&apos;s swappable pool. The equipped
+            bloodline cannot be removed — change it first. All removals are logged.
+          </p>
+          <div className="space-y-2">
+            <Label htmlFor="pool-reason">Reason * (applies to the removal)</Label>
+            <Input
+              id="pool-reason"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Reason (minimum 10 characters)..."
+            />
+          </div>
+          {poolLoading && <p className="text-sm">Loading pool...</p>}
+          {!poolLoading && (pool?.length ?? 0) === 0 && (
+            <p className="text-sm">No bloodlines in this player&apos;s pool.</p>
+          )}
+          <div className="space-y-2">
+            {pool?.map((bloodline) => {
+              const isEquipped = bloodline.id === equippedBloodlineId;
+              return (
+                <div
+                  key={bloodline.id}
+                  className="flex items-center justify-between gap-2 rounded-md border p-2"
+                >
+                  <span className="text-sm">
+                    {bloodline.name}
+                    {isEquipped ? " (equipped)" : ""}
+                  </span>
+                  <Button
+                    variant="destructive"
+                    disabled={isEquipped || !reasonValid || isPending}
+                    title={
+                      isEquipped
+                        ? "Change the equipped bloodline first"
+                        : !reasonValid
+                          ? "Enter a reason (10+ characters)"
+                          : undefined
+                    }
+                    onClick={() =>
+                      mutate({
+                        userId,
+                        bloodlineId: bloodline.id,
+                        reason: reason.trim(),
+                      })
+                    }
+                  >
+                    Remove
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </Modal2>
+    </>
   );
 };

--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -71,6 +71,7 @@ import {
   type BattleType,
   BattleTypes,
   IMG_AVATAR_DEFAULT,
+  SEICHI_SILVER_ADJUST_LIMIT,
   TrainingSpeeds,
   XP_BRACKETS,
 } from "@/drizzle/constants";
@@ -560,11 +561,7 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = (props) => {
             )}
 
             {userData && canEditSeichiSilver(userData.role) && !profile.isAi && (
-              <AdjustSeichiSilver
-                userId={profile.userId}
-                username={profile.username}
-                currentSilver={profile.seichiSilver}
-              />
+              <AdjustSeichiSilver userId={profile.userId} username={profile.username} />
             )}
 
             {userData && canRemoveBloodlineFromPool(userData.role) && !profile.isAi && (
@@ -2309,21 +2306,28 @@ const BracketEligibilityBadge: React.FC<BracketEligibilityBadgeProps> = ({
 interface AdjustSeichiSilverProps {
   userId: string;
   username: string;
-  currentSilver: number;
 }
 
 const AdjustSeichiSilver: React.FC<AdjustSeichiSilverProps> = ({
   userId,
   username,
-  currentSilver,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [delta, setDelta] = useState("");
   const [reason, setReason] = useState("");
   const utils = api.useUtils();
-  const parsedDelta = Number.parseInt(delta, 10);
+  const { data: currentSilver, isPending: silverLoading } =
+    api.profile.getSeichiSilverForStaff.useQuery({ userId }, { enabled: isOpen });
+  const trimmedDelta = delta.trim();
+  const parsedDelta = Number(trimmedDelta);
   const isValid =
-    Number.isInteger(parsedDelta) && parsedDelta !== 0 && reason.trim().length >= 10;
+    // Plain signed integer only — rejects "1.5", "1e3", "", and whitespace so the
+    // submitted value always matches what staff typed.
+    /^-?\d+$/.test(trimmedDelta) &&
+    Number.isSafeInteger(parsedDelta) &&
+    parsedDelta !== 0 &&
+    Math.abs(parsedDelta) <= SEICHI_SILVER_ADJUST_LIMIT &&
+    reason.trim().length >= 10;
 
   const { mutate, isPending } = api.profile.adjustSeichiSilver.useMutation({
     onSuccess: async (data) => {
@@ -2332,7 +2336,7 @@ const AdjustSeichiSilver: React.FC<AdjustSeichiSilverProps> = ({
         setIsOpen(false);
         setDelta("");
         setReason("");
-        await utils.profile.getPublicUser.invalidate();
+        await utils.profile.getSeichiSilverForStaff.invalidate({ userId });
       }
     },
   });
@@ -2342,10 +2346,15 @@ const AdjustSeichiSilver: React.FC<AdjustSeichiSilverProps> = ({
       <TooltipProvider delayDuration={50}>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Coins
-              className="h-6 w-6 cursor-pointer hover:text-orange-500"
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Adjust Seichi Silver"
+              className="hover:text-orange-500"
               onClick={() => setIsOpen(true)}
-            />
+            >
+              <Coins className="h-6 w-6" />
+            </Button>
           </TooltipTrigger>
           <TooltipContent>Adjust Seichi Silver</TooltipContent>
         </Tooltip>
@@ -2355,7 +2364,11 @@ const AdjustSeichiSilver: React.FC<AdjustSeichiSilverProps> = ({
         isOpen={isOpen}
         setIsOpen={setIsOpen}
         proceed_label={isPending ? "Saving..." : "Apply"}
-        isValid={isValid}
+        // Modal2 auto-closes on Apply when isValid is true/undefined. Pass false so a
+        // failed mutation (AI rejection / insufficient balance) keeps the form open
+        // with the entered amount + reason; we close in onSuccess instead. The accept
+        // button stays gated via proceedDisabled below.
+        isValid={false}
         proceedDisabled={!isValid || isPending}
         onAccept={(e) => {
           e.preventDefault();
@@ -2366,7 +2379,8 @@ const AdjustSeichiSilver: React.FC<AdjustSeichiSilverProps> = ({
         <div className="space-y-4">
           <p className="text-muted-foreground text-sm">
             Adjust <strong>{username}</strong>&apos;s Seichi Silver (current:{" "}
-            {currentSilver}). Use a negative number to subtract. This action is logged.
+            {silverLoading ? "…" : (currentSilver ?? 0)}). Use a negative number to
+            subtract. This action is logged.
           </p>
           <div className="space-y-2">
             <Label htmlFor="silver-delta">Amount (+/-)</Label>
@@ -2440,10 +2454,15 @@ const BloodlinePoolManager: React.FC<BloodlinePoolManagerProps> = ({
       <TooltipProvider delayDuration={50}>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Droplets
-              className="h-6 w-6 cursor-pointer hover:text-orange-500"
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Manage Bloodline Pool"
+              className="hover:text-orange-500"
               onClick={() => setIsOpen(true)}
-            />
+            >
+              <Droplets className="h-6 w-6" />
+            </Button>
           </TooltipTrigger>
           <TooltipContent>Manage Bloodline Pool</TooltipContent>
         </Tooltip>

--- a/app/src/server/api/routers/bloodline.ts
+++ b/app/src/server/api/routers/bloodline.ts
@@ -52,13 +52,21 @@ import { validateUserUpdateReason } from "@/libs/moderator";
 import { callDiscordContent } from "@/libs/socials";
 import { fetchUpdatedUser, fetchUser } from "@/routers/profile";
 import type { DrizzleClient } from "@/server/db";
-import { claimUserSnapshot } from "@/server/utils/concurrency";
+import {
+  claimUserSnapshot,
+  removeBloodlineFromPoolAtomically,
+} from "@/server/utils/concurrency";
 import { isMysqlDuplicateKeyError } from "@/server/utils/mysqlErrors";
 import { getRandomElement } from "@/utils/array";
 import { calculateContentDiff } from "@/utils/diff";
 import { getUnique } from "@/utils/grouping";
 import { getUserFederalStatus } from "@/utils/paypal";
-import { canChangeContent, canSwapBloodline, isStaffMember } from "@/utils/permissions";
+import {
+  canChangeContent,
+  canRemoveBloodlineFromPool,
+  canSwapBloodline,
+  isStaffMember,
+} from "@/utils/permissions";
 import {
   DAY_S,
   getDaysHoursMinutesSeconds,
@@ -72,6 +80,7 @@ import {
   bloodlineFilteringSchema,
   bloodlineReskinCreateSchema,
   bloodlineReskinUpdateSchema,
+  removeBloodlineFromPoolSchema,
 } from "@/validators/bloodline";
 import type { ZodAllTags } from "@/validators/combat";
 import { BloodlineValidator } from "@/validators/combat";
@@ -151,6 +160,16 @@ export const bloodlineRouter = createTRPCRouter({
     .meta({ mcp: { enabled: true, description: "Get user's historic bloodlines" } })
     .query(async ({ ctx }) => {
       return await fetchUserHistoricBloodlines(ctx.drizzle, ctx.userId);
+    }),
+  getUserHistoricBloodlinesForStaff: protectedProcedure
+    .meta({
+      mcp: { enabled: true, description: "Get a user's historic bloodlines (staff)" },
+    })
+    .input(z.object({ userId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const actor = await fetchUser(ctx.drizzle, ctx.userId);
+      if (!actor || !canRemoveBloodlineFromPool(actor.role)) return [];
+      return await fetchUserHistoricBloodlines(ctx.drizzle, input.userId);
     }),
   // Get bloodline swap info
   getSwapInfo: protectedProcedure
@@ -440,6 +459,68 @@ export const bloodlineRouter = createTRPCRouter({
         }),
       ]);
       return { success: true, message: "Bloodline reskin deleted" };
+    }),
+  removeBloodlineFromPool: protectedProcedure
+    .input(removeBloodlineFromPoolSchema)
+    .output(baseServerResponse)
+    .mutation(async ({ ctx, input }) => {
+      // Query
+      const [actor, target, targetPool] = await Promise.all([
+        fetchUser(ctx.drizzle, ctx.userId),
+        fetchUser(ctx.drizzle, input.userId),
+        fetchUserHistoricBloodlines(ctx.drizzle, input.userId),
+      ]);
+      // Guards
+      if (!actor || !target) return errorResponse("User not found");
+      if (actor.isBanned)
+        return errorResponse("You are banned and cannot perform this action");
+      if (!canRemoveBloodlineFromPool(actor.role)) return errorResponse("Unauthorized");
+      const poolBloodline = targetPool.find((b) => b.id === input.bloodlineId);
+      if (!poolBloodline) return errorResponse("Bloodline is not in the player's pool");
+      if (target.bloodlineId === input.bloodlineId) {
+        return errorResponse(
+          "Cannot remove the player's equipped bloodline; change it first",
+        );
+      }
+      // AI moderation of reason
+      const change = `Removed bloodline ${poolBloodline.name} from pool`;
+      const aiCheck = await validateUserUpdateReason(change, input.reason);
+      if (!aiCheck.allowUpdate) {
+        await ctx.drizzle.insert(actionLog).values({
+          id: nanoid(),
+          userId: ctx.userId,
+          tableName: "bloodline",
+          changes: [],
+          relatedId: target.userId,
+          relatedMsg: `Bloodline pool removal rejected by AI: ${input.reason}`,
+          relatedImage: target.avatarLight,
+        });
+        return errorResponse(aiCheck.comment);
+      }
+      // Mutation (atomic, NOT EXISTS equipped guard) + audit
+      const now = new Date();
+      const success = await removeBloodlineFromPoolAtomically({
+        client: ctx.drizzle,
+        userId: target.userId,
+        bloodlineId: input.bloodlineId,
+        now,
+      });
+      if (!success) {
+        return errorResponse("Bloodline became equipped; please retry");
+      }
+      await ctx.drizzle.insert(actionLog).values({
+        id: nanoid(),
+        userId: ctx.userId,
+        tableName: "bloodline",
+        changes: [change],
+        relatedId: target.userId,
+        relatedMsg: input.reason,
+        relatedImage: target.avatarLight,
+      });
+      return {
+        success: true,
+        message: `Removed ${poolBloodline.name} from ${target.username}'s pool`,
+      };
     }),
   getReskin: protectedProcedure
     .meta({ mcp: { enabled: true, description: "Get a specific bloodline reskin" } })

--- a/app/src/server/api/routers/bloodline.ts
+++ b/app/src/server/api/routers/bloodline.ts
@@ -23,6 +23,7 @@ import {
   serverError,
 } from "@/api/trpc";
 import {
+  ACTION_LOG_RELATED_MSG_MAX_LENGTH,
   BLOODLINE_COST,
   BLOODLINE_SWAP_COOLDOWN_HOURS,
   BLOODLINE_SWAP_FREE_DAYS,
@@ -168,7 +169,9 @@ export const bloodlineRouter = createTRPCRouter({
     .input(z.object({ userId: z.string() }))
     .query(async ({ ctx, input }) => {
       const actor = await fetchUser(ctx.drizzle, ctx.userId);
-      if (!actor || !canRemoveBloodlineFromPool(actor.role)) return [];
+      if (!actor || actor.isBanned || !canRemoveBloodlineFromPool(actor.role)) {
+        return [];
+      }
       return await fetchUserHistoricBloodlines(ctx.drizzle, input.userId);
     }),
   // Get bloodline swap info
@@ -492,7 +495,10 @@ export const bloodlineRouter = createTRPCRouter({
           tableName: "bloodline",
           changes: [],
           relatedId: target.userId,
-          relatedMsg: `Bloodline pool removal rejected by AI: ${input.reason}`,
+          relatedMsg: `Bloodline pool removal rejected by AI: ${input.reason}`.slice(
+            0,
+            ACTION_LOG_RELATED_MSG_MAX_LENGTH,
+          ),
           relatedImage: target.avatarLight,
         });
         return errorResponse(aiCheck.comment);
@@ -514,7 +520,7 @@ export const bloodlineRouter = createTRPCRouter({
         tableName: "bloodline",
         changes: [change],
         relatedId: target.userId,
-        relatedMsg: input.reason,
+        relatedMsg: input.reason.slice(0, ACTION_LOG_RELATED_MSG_MAX_LENGTH),
         relatedImage: target.avatarLight,
       });
       return {

--- a/app/src/server/api/routers/bloodline.ts
+++ b/app/src/server/api/routers/bloodline.ts
@@ -168,11 +168,14 @@ export const bloodlineRouter = createTRPCRouter({
     })
     .input(z.object({ userId: z.string() }))
     .query(async ({ ctx, input }) => {
-      const actor = await fetchUser(ctx.drizzle, ctx.userId);
+      const [actor, historic] = await Promise.all([
+        fetchUser(ctx.drizzle, ctx.userId),
+        fetchUserHistoricBloodlines(ctx.drizzle, input.userId),
+      ]);
       if (!actor || actor.isBanned || !canRemoveBloodlineFromPool(actor.role)) {
         return [];
       }
-      return await fetchUserHistoricBloodlines(ctx.drizzle, input.userId);
+      return historic;
     }),
   // Get bloodline swap info
   getSwapInfo: protectedProcedure

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -17,6 +17,7 @@ import {
 import { customAlphabet, nanoid } from "nanoid";
 import { z } from "zod";
 import {
+  ACTION_LOG_RELATED_MSG_MAX_LENGTH,
   ACTIVE_VOTING_SITES,
   ALLIANCEHALL_LAT,
   ALLIANCEHALL_LONG,
@@ -1718,7 +1719,6 @@ export const profileRouter = createTRPCRouter({
             bloodlineReskinId: true,
             bracketImmunityLiftedUntil: true,
             warParticipantUntil: true,
-            seichiSilver: true,
           },
           with: {
             village: true,
@@ -1979,6 +1979,24 @@ export const profileRouter = createTRPCRouter({
         message: "Successfully claimed reputation points for voting",
       };
     }),
+  // Read a user's Seichi Silver balance (staff only) — kept off the public profile
+  // response so spendable-currency balances aren't exposed to every viewer.
+  getSeichiSilverForStaff: protectedProcedure
+    .meta({
+      mcp: { enabled: true, description: "Get a user's Seichi Silver balance (staff)" },
+    })
+    .input(z.object({ userId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const [actor, target] = await Promise.all([
+        fetchUser(ctx.drizzle, ctx.userId),
+        ctx.drizzle.query.userData.findFirst({
+          columns: { seichiSilver: true },
+          where: eq(userData.userId, input.userId),
+        }),
+      ]);
+      if (!actor || actor.isBanned || !canEditSeichiSilver(actor.role)) return 0;
+      return target?.seichiSilver ?? 0;
+    }),
   // Adjust Seichi Silver for a user (staff only)
   adjustSeichiSilver: protectedProcedure
     .input(adjustSeichiSilverSchema)
@@ -1996,8 +2014,16 @@ export const profileRouter = createTRPCRouter({
       if (!canEditSeichiSilver(actor.role)) {
         return errorResponse("You don't have permission to edit Seichi Silver");
       }
-      // AI moderation of reason
-      const change = `Adjusted Seichi Silver by ${input.delta} (${target.seichiSilver} -> ${target.seichiSilver + input.delta})`;
+      // Early sufficiency check: gives the admin the precise "Insufficient"
+      // message and keeps the AI moderator from seeing a negative projected
+      // balance. The atomic CAS in adjustSeichiSilverAtomically remains the
+      // authoritative floor against a concurrent earn/spend.
+      if (input.delta < 0 && target.seichiSilver + input.delta < 0) {
+        return errorResponse("Insufficient Seichi Silver");
+      }
+      // AI moderation of reason. Log the delta only — a concurrent adjustment
+      // makes any pre-mutation before/after snapshot stale.
+      const change = `Adjusted Seichi Silver by ${input.delta}`;
       const aiCheck = await validateUserUpdateReason(change, input.reason);
       if (!aiCheck.allowUpdate) {
         await ctx.drizzle.insert(actionLog).values({
@@ -2006,7 +2032,10 @@ export const profileRouter = createTRPCRouter({
           tableName: "user",
           changes: [],
           relatedId: target.userId,
-          relatedMsg: `Seichi Silver adjustment rejected by AI: ${input.reason}`,
+          relatedMsg: `Seichi Silver adjustment rejected by AI: ${input.reason}`.slice(
+            0,
+            ACTION_LOG_RELATED_MSG_MAX_LENGTH,
+          ),
           relatedImage: target.avatarLight,
         });
         return errorResponse(aiCheck.comment);
@@ -2024,7 +2053,7 @@ export const profileRouter = createTRPCRouter({
         tableName: "user",
         changes: [change],
         relatedId: target.userId,
-        relatedMsg: input.reason,
+        relatedMsg: input.reason.slice(0, ACTION_LOG_RELATED_MSG_MAX_LENGTH),
         relatedImage: target.avatarLight,
       });
       return { success: true, message: `Seichi Silver adjusted by ${input.delta}` };

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -122,6 +122,7 @@ import { handleQuestConsequences, insertNextQuest } from "@/routers/quests";
 import { fetchVillage } from "@/routers/village";
 import { deleteUser } from "@/server/api/routers/staff";
 import type { DrizzleClient } from "@/server/db";
+import { adjustSeichiSilverAtomically } from "@/server/utils/concurrency";
 import { buildDerivedUserRegenUpdate } from "@/server/utils/profileRegen";
 import { getRandomElement } from "@/utils/array";
 import { calculateContentDiff } from "@/utils/diff";
@@ -136,6 +137,7 @@ import {
   canEditJutsus,
   canEditRank,
   canEditRankedLp,
+  canEditSeichiSilver,
   canEditStaffAccountFlag,
   canEditUsername,
   canEditVillage,
@@ -160,6 +162,7 @@ import { mutateContentSchema } from "@/validators/comments";
 import { attributes, colors, skin_colors, usernameSchema } from "@/validators/register";
 import type { GetPublicUsersSchema } from "@/validators/user";
 import {
+  adjustSeichiSilverSchema,
   getPublicUsersSchema,
   updateUserPreferencesSchema,
   updateUserSchema,
@@ -1715,6 +1718,7 @@ export const profileRouter = createTRPCRouter({
             bloodlineReskinId: true,
             bracketImmunityLiftedUntil: true,
             warParticipantUntil: true,
+            seichiSilver: true,
           },
           with: {
             village: true,
@@ -1974,6 +1978,56 @@ export const profileRouter = createTRPCRouter({
         success: true,
         message: "Successfully claimed reputation points for voting",
       };
+    }),
+  // Adjust Seichi Silver for a user (staff only)
+  adjustSeichiSilver: protectedProcedure
+    .input(adjustSeichiSilverSchema)
+    .output(baseServerResponse)
+    .mutation(async ({ ctx, input }) => {
+      // Query
+      const [actor, target] = await Promise.all([
+        fetchUser(ctx.drizzle, ctx.userId),
+        fetchUser(ctx.drizzle, input.userId),
+      ]);
+      // Guards
+      if (!actor || !target) return errorResponse("User not found");
+      if (actor.isBanned)
+        return errorResponse("You are banned and cannot perform this action");
+      if (!canEditSeichiSilver(actor.role)) {
+        return errorResponse("You don't have permission to edit Seichi Silver");
+      }
+      // AI moderation of reason
+      const change = `Adjusted Seichi Silver by ${input.delta} (${target.seichiSilver} -> ${target.seichiSilver + input.delta})`;
+      const aiCheck = await validateUserUpdateReason(change, input.reason);
+      if (!aiCheck.allowUpdate) {
+        await ctx.drizzle.insert(actionLog).values({
+          id: nanoid(),
+          userId: ctx.userId,
+          tableName: "user",
+          changes: [],
+          relatedId: target.userId,
+          relatedMsg: `Seichi Silver adjustment rejected by AI: ${input.reason}`,
+          relatedImage: target.avatarLight,
+        });
+        return errorResponse(aiCheck.comment);
+      }
+      // Mutation (atomic CAS) + audit
+      const success = await adjustSeichiSilverAtomically({
+        client: ctx.drizzle,
+        userId: target.userId,
+        delta: input.delta,
+      });
+      if (!success) return errorResponse("Insufficient Seichi Silver");
+      await ctx.drizzle.insert(actionLog).values({
+        id: nanoid(),
+        userId: ctx.userId,
+        tableName: "user",
+        changes: [change],
+        relatedId: target.userId,
+        relatedMsg: input.reason,
+        relatedImage: target.avatarLight,
+      });
+      return { success: true, message: `Seichi Silver adjusted by ${input.delta}` };
     }),
   // Award experience to a user (staff only)
   awardExperience: protectedProcedure

--- a/app/src/server/utils/concurrency.ts
+++ b/app/src/server/utils/concurrency.ts
@@ -9,8 +9,8 @@
  * Failed CAS (`success: false` / `false`) means another request mutated the row first — return a
  * safe client error and retry-friendly message.
  */
-import { and, eq } from "drizzle-orm";
-import { userData, userItem } from "@/drizzle/schema";
+import { and, eq, gte, ne, sql } from "drizzle-orm";
+import { bloodlineRolls, userData, userItem } from "@/drizzle/schema";
 import type { DrizzleClient } from "@/server/db";
 import type { QueryCondition } from "@/utils/typeutils";
 
@@ -109,4 +109,80 @@ export const consumeUserItemAtomically = async ({
     expectedQuantity,
     nextQuantity: expectedQuantity - 1,
   });
+};
+
+type AdjustSeichiSilverParams = {
+  client: DrizzleClient;
+  userId: string;
+  delta: number;
+};
+
+/**
+ * Atomically adds `delta` to a user's Seichi Silver. For a negative delta a CAS floor
+ * (`seichiSilver >= -delta`) prevents the balance going negative and guards against clobbering a
+ * concurrent earn/spend. Returns false when the floor blocks the change (no row updated).
+ */
+export const adjustSeichiSilverAtomically = async ({
+  client,
+  userId,
+  delta,
+}: AdjustSeichiSilverParams) => {
+  const result = await client
+    .update(userData)
+    .set({ seichiSilver: sql`${userData.seichiSilver} + ${delta}` })
+    .where(
+      and(
+        eq(userData.userId, userId),
+        delta < 0 ? gte(userData.seichiSilver, -delta) : undefined,
+      ),
+    );
+  return result.rowsAffected === 1;
+};
+
+type RemoveBloodlineFromPoolParams = {
+  client: DrizzleClient;
+  userId: string;
+  bloodlineId: string;
+  now: Date;
+};
+
+/**
+ * Removes a bloodline from a user's swappable pool. NATURAL rows are nulled (preserving the
+ * one-natural-roll unique constraint, so the player gets no free re-roll); every other roll type
+ * is deleted, because nulling an ITEM success row would match the failed-roll/pity bucket keyed on
+ * `goal && !bloodlineId` and corrupt pity accounting. Both statements carry a `NOT EXISTS` guard so
+ * the bloodline cannot be removed while it is the user's equipped bloodline (closes the read->write
+ * race). Returns false when nothing changed (e.g. it became equipped concurrently).
+ */
+export const removeBloodlineFromPoolAtomically = async ({
+  client,
+  userId,
+  bloodlineId,
+  now,
+}: RemoveBloodlineFromPoolParams) => {
+  const notEquipped = sql`NOT EXISTS (SELECT 1 FROM ${userData} WHERE ${userData.userId} = ${userId} AND ${userData.bloodlineId} = ${bloodlineId})`;
+  const [deleteResult, updateResult] = await Promise.all([
+    client
+      .delete(bloodlineRolls)
+      .where(
+        and(
+          eq(bloodlineRolls.userId, userId),
+          eq(bloodlineRolls.bloodlineId, bloodlineId),
+          ne(bloodlineRolls.type, "NATURAL"),
+          notEquipped,
+        ),
+      ),
+    client
+      .update(bloodlineRolls)
+      .set({ bloodlineId: null, updatedAt: now })
+      .where(
+        and(
+          eq(bloodlineRolls.userId, userId),
+          eq(bloodlineRolls.bloodlineId, bloodlineId),
+          eq(bloodlineRolls.type, "NATURAL"),
+          notEquipped,
+        ),
+      ),
+  ]);
+  return deleteResult.rowsAffected + updateResult.rowsAffected > 0;
 };

--- a/app/src/server/utils/concurrency.ts
+++ b/app/src/server/utils/concurrency.ts
@@ -153,6 +153,16 @@ type RemoveBloodlineFromPoolParams = {
  * `goal && !bloodlineId` and corrupt pity accounting. Both statements carry a `NOT EXISTS` guard so
  * the bloodline cannot be removed while it is the user's equipped bloodline (closes the read->write
  * race). Returns false when nothing changed (e.g. it became equipped concurrently).
+ *
+ * Known residual (the swap-vs-removal race the PR documents, viewed from this side): the DELETE and
+ * UPDATE are two separate statements, not atomic relative to each other. If a concurrent `swapBloodline`
+ * equips this bloodline in the gap between them, one statement's guard can pass while the other's blocks,
+ * leaving a partial removal (one roll type gone, the other retained) while this helper still returns
+ * true. We run them in PARALLEL on purpose: that gap is a sub-millisecond skew, whereas sequencing them
+ * would widen it to a full round-trip. PlanetScale/Vitess has no cheap serialization primitive across
+ * the two writes (interactive transactions are disallowed; advisory locks aren't viable on pooled
+ * serverless), so fully closing this would require guarding the equip side in `swapBloodline` — out of
+ * scope for this QoL change.
  */
 export const removeBloodlineFromPoolAtomically = async ({
   client,

--- a/app/src/utils/permissions.ts
+++ b/app/src/utils/permissions.ts
@@ -851,6 +851,10 @@ export const canEditRankedLp = (role: UserRole) => {
   ].includes(role);
 };
 
+export const canEditSeichiSilver = (role: UserRole) => canEditRankedLp(role);
+
+export const canRemoveBloodlineFromPool = (role: UserRole) => canEditRankedLp(role);
+
 export const canSeeHiddenBountyInfo = (role: UserRole) => {
   return role !== "USER";
 };

--- a/app/src/utils/permissions.ts
+++ b/app/src/utils/permissions.ts
@@ -851,9 +851,25 @@ export const canEditRankedLp = (role: UserRole) => {
   ].includes(role);
 };
 
-export const canEditSeichiSilver = (role: UserRole) => canEditRankedLp(role);
+export const canEditSeichiSilver = (role: UserRole) => {
+  return [
+    "CONTENT-ADMIN",
+    "OWNER",
+    "CODING-ADMIN",
+    "EVENT-ADMIN",
+    "MODERATOR-ADMIN",
+  ].includes(role);
+};
 
-export const canRemoveBloodlineFromPool = (role: UserRole) => canEditRankedLp(role);
+export const canRemoveBloodlineFromPool = (role: UserRole) => {
+  return [
+    "CONTENT-ADMIN",
+    "OWNER",
+    "CODING-ADMIN",
+    "EVENT-ADMIN",
+    "MODERATOR-ADMIN",
+  ].includes(role);
+};
 
 export const canSeeHiddenBountyInfo = (role: UserRole) => {
   return role !== "USER";

--- a/app/src/validators/bloodline.ts
+++ b/app/src/validators/bloodline.ts
@@ -37,7 +37,7 @@ export type BloodlineReskinUpdateSchema = z.infer<typeof bloodlineReskinUpdateSc
 export const removeBloodlineFromPoolSchema = z.object({
   userId: z.string(),
   bloodlineId: z.string(),
-  reason: z.string().min(10).max(500),
+  reason: z.string().trim().min(10).max(500),
 });
 export type RemoveBloodlineFromPoolSchema = z.infer<
   typeof removeBloodlineFromPoolSchema

--- a/app/src/validators/bloodline.ts
+++ b/app/src/validators/bloodline.ts
@@ -33,3 +33,12 @@ export const bloodlineReskinUpdateSchema = baseReskinSchema.extend({
   reason: z.string().min(5).max(500),
 });
 export type BloodlineReskinUpdateSchema = z.infer<typeof bloodlineReskinUpdateSchema>;
+
+export const removeBloodlineFromPoolSchema = z.object({
+  userId: z.string(),
+  bloodlineId: z.string(),
+  reason: z.string().min(10).max(500),
+});
+export type RemoveBloodlineFromPoolSchema = z.infer<
+  typeof removeBloodlineFromPoolSchema
+>;

--- a/app/src/validators/user.ts
+++ b/app/src/validators/user.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
 import type { ElementName, LetterRank, QuestType } from "@/drizzle/constants";
-import { GeneralTypes, StatTypes, UserRanks, UserRoles } from "@/drizzle/constants";
+import {
+  GeneralTypes,
+  SEICHI_SILVER_ADJUST_LIMIT,
+  StatTypes,
+  UserRanks,
+  UserRoles,
+} from "@/drizzle/constants";
 import type { UserWithRelations } from "@/routers/profile";
 import type { ZodAllTags } from "@/validators/combat";
 import { genders, usernameSchema } from "@/validators/register";
@@ -181,9 +187,9 @@ export const adjustSeichiSilverSchema = z.object({
   delta: z.coerce
     .number()
     .int()
-    .min(-1_000_000)
-    .max(1_000_000)
+    .min(-SEICHI_SILVER_ADJUST_LIMIT)
+    .max(SEICHI_SILVER_ADJUST_LIMIT)
     .refine((d) => d !== 0, { message: "Delta cannot be zero" }),
-  reason: z.string().min(10).max(500),
+  reason: z.string().trim().min(10).max(500),
 });
 export type AdjustSeichiSilverSchema = z.infer<typeof adjustSeichiSilverSchema>;

--- a/app/src/validators/user.ts
+++ b/app/src/validators/user.ts
@@ -175,3 +175,15 @@ export type TitleChangeSchema = z.infer<typeof titleChangeSchema>;
 
 export const genderChangeSchema = z.object({ gender: z.enum(genders) });
 export type GenderChangeSchema = z.infer<typeof genderChangeSchema>;
+
+export const adjustSeichiSilverSchema = z.object({
+  userId: z.string(),
+  delta: z.coerce
+    .number()
+    .int()
+    .min(-1_000_000)
+    .max(1_000_000)
+    .refine((d) => d !== 0, { message: "Delta cannot be zero" }),
+  reason: z.string().min(10).max(500),
+});
+export type AdjustSeichiSilverSchema = z.infer<typeof adjustSeichiSilverSchema>;

--- a/app/tests/server/utils/adminConcurrency.test.ts
+++ b/app/tests/server/utils/adminConcurrency.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  adjustSeichiSilverAtomically,
+  removeBloodlineFromPoolAtomically,
+} from "@/server/utils/concurrency";
+
+const silverClient = (rowsAffected: number) => {
+  const where = vi.fn().mockResolvedValue({ rowsAffected });
+  const set = vi.fn().mockReturnValue({ where });
+  const update = vi.fn().mockReturnValue({ set });
+  return { client: { update } as never, update, set, where };
+};
+
+describe("adjustSeichiSilverAtomically", () => {
+  it("succeeds on a positive delta (no floor predicate)", async () => {
+    const { client, update } = silverClient(1);
+    const ok = await adjustSeichiSilverAtomically({
+      client,
+      userId: "u1",
+      delta: 100,
+    });
+    expect(update).toHaveBeenCalledOnce();
+    expect(ok).toBe(true);
+  });
+
+  it("fails when a subtraction is blocked by the balance floor (0 rows)", async () => {
+    const { client } = silverClient(0);
+    const ok = await adjustSeichiSilverAtomically({
+      client,
+      userId: "u1",
+      delta: -100,
+    });
+    expect(ok).toBe(false);
+  });
+});
+
+const poolClient = (deleteRows: number, updateRows: number) => {
+  const deleteWhere = vi.fn().mockResolvedValue({ rowsAffected: deleteRows });
+  const del = vi.fn().mockReturnValue({ where: deleteWhere });
+  const updateWhere = vi.fn().mockResolvedValue({ rowsAffected: updateRows });
+  const set = vi.fn().mockReturnValue({ where: updateWhere });
+  const update = vi.fn().mockReturnValue({ set });
+  return { client: { delete: del, update } as never, del, update };
+};
+
+describe("removeBloodlineFromPoolAtomically", () => {
+  it("deletes non-NATURAL rows and nulls NATURAL rows; succeeds when rows change", async () => {
+    const { client, del, update } = poolClient(2, 1);
+    const ok = await removeBloodlineFromPoolAtomically({
+      client,
+      userId: "u1",
+      bloodlineId: "bl1",
+      now: new Date(0),
+    });
+    expect(del).toHaveBeenCalledOnce();
+    expect(update).toHaveBeenCalledOnce();
+    expect(ok).toBe(true);
+  });
+
+  it("fails when nothing changed (became equipped / not in pool)", async () => {
+    const { client } = poolClient(0, 0);
+    const ok = await removeBloodlineFromPoolAtomically({
+      client,
+      userId: "u1",
+      bloodlineId: "bl1",
+      now: new Date(0),
+    });
+    expect(ok).toBe(false);
+  });
+});

--- a/app/tests/utils/permissions.test.ts
+++ b/app/tests/utils/permissions.test.ts
@@ -4,8 +4,10 @@ import { UserRoles } from "@/drizzle/constants";
 import {
   canApproveApplications,
   canDeleteConceptArt,
+  canEditSeichiSilver,
   canModifyCombatSettings,
   canModifyEventGains,
+  canRemoveBloodlineFromPool,
   canViewAllApplications,
   getApprovalGroup,
 } from "@/utils/permissions";
@@ -109,4 +111,32 @@ test("combat settings use balance/content permissions instead of event gain perm
   expect(canModifyCombatSettings("CODER")).toBe(true);
   expect(canModifyCombatSettings("EVENT")).toBe(true);
   expect(canModifyCombatSettings("HEAD_EVENT")).toBe(true);
+});
+
+test("seichi silver + bloodline-pool admin actions mirror the ranked LP role set", () => {
+  const allowed = [
+    "CONTENT-ADMIN",
+    "OWNER",
+    "CODING-ADMIN",
+    "EVENT-ADMIN",
+    "MODERATOR-ADMIN",
+  ] as const satisfies readonly UserRole[];
+  const denied = [
+    "USER",
+    "CONTENT",
+    "BALANCE",
+    "EVENT",
+    "CODER",
+    "HEAD_CONTENT",
+    "HEAD_BALANCE",
+    "HEAD_EVENT",
+  ] as const satisfies readonly UserRole[];
+  for (const role of allowed) {
+    expect(canEditSeichiSilver(role)).toBe(true);
+    expect(canRemoveBloodlineFromPool(role)).toBe(true);
+  }
+  for (const role of denied) {
+    expect(canEditSeichiSilver(role)).toBe(false);
+    expect(canRemoveBloodlineFromPool(role)).toBe(false);
+  }
 });

--- a/app/tests/utils/permissions.test.ts
+++ b/app/tests/utils/permissions.test.ts
@@ -113,7 +113,7 @@ test("combat settings use balance/content permissions instead of event gain perm
   expect(canModifyCombatSettings("HEAD_EVENT")).toBe(true);
 });
 
-test("seichi silver + bloodline-pool admin actions mirror the ranked LP role set", () => {
+test("seichi silver + bloodline-pool admin actions gate to their own admin role set", () => {
   const allowed = [
     "CONTENT-ADMIN",
     "OWNER",


### PR DESCRIPTION
# Pull Request

Resolves #1329 (QoL). Adds two staff/admin actions on a player's profile: **remove a bloodline from a player's swappable pool**, and **adjust a player's Seichi Silver balance**.

## What was implemented

**1. Remove a bloodline from a player's pool**
- New staff mutation `bloodline.removeBloodlineFromPool` and staff-gated query `bloodline.getUserHistoricBloodlinesForStaff`.
- Removes a bloodline from the player's swappable history (`bloodlineRolls`) so they can no longer swap to it. Per roll type: `NATURAL` rows are nulled (preserving the one-natural-roll unique constraint, so no free re-roll), all other types are deleted (nulling an `ITEM` success row would corrupt the failed-roll/pity bucket).
- Removing the player's **currently-equipped** bloodline is blocked (read-time guard + an atomic `NOT EXISTS` write guard); the admin changes the equipped bloodline first.
- New `BloodlinePoolManager` control on the profile (Droplets icon): lists the player's pool, one Remove button per bloodline (equipped row disabled), gated behind a required reason.

**2. Adjust Seichi Silver**
- New staff mutation `profile.adjustSeichiSilver` applying a signed delta via an atomic SQL increment with a compare-and-swap floor (balance can't go negative or clobber a concurrent earn/spend).
- New `AdjustSeichiSilver` control on the profile (Coins icon): signed amount + required reason.

**Shared:** both actions are gated by the `canEditRankedLp` role set (CONTENT-ADMIN, OWNER, CODING-ADMIN, EVENT-ADMIN, MODERATOR-ADMIN), require a 10+ character reason run through the existing AI moderation (`validateUserUpdateReason`), and write an `actionLog` audit entry (actor + target + reason).

## Why

Issue #1329 asked for admins to be able to remove bloodlines a player can swap to, and to edit a player's Seichi Silver — both common moderation/support tasks with no existing UI. Cooldowns, the monthly free-swap counter, and reputation are intentionally left untouched (no rep refund on removal).

## Screenshots
User profile new icons
<img width="718" height="471" alt="image" src="https://github.com/user-attachments/assets/b40b7b76-2028-4eb7-95ff-221dfc9cc3c1" />

Adjust Seichi Silver UI (Delta +/-)
<img width="691" height="264" alt="image" src="https://github.com/user-attachments/assets/608251b8-e8a8-429e-b5b4-f11fd3c7ba9b" />

Manage Bloodline Pool UI
<img width="676" height="404" alt="image" src="https://github.com/user-attachments/assets/0ad340d5-84e5-4137-a555-b3dc345e268e" />


## Breaking changes

**None.** All changes are additive:
- New tRPC procedures, permission helpers, validators, and UI controls.
- One additive field (`seichiSilver`) added to the `getPublicUser` selection — consistent with the already-exposed `reputationPoints`. No schema migration; no changes to existing endpoints' behavior.

## Implementation notes

- **PlanetScale-safe:** no transactions — atomic `sql` increments + CAS predicates + `rowsAffected` checks throughout (atomic helpers live in `@/server/utils/concurrency.ts` alongside the existing CAS helpers).
- **Known residual (documented):** `swapBloodline` reads the pool then writes without re-validating, so a swap whose read precedes a removal but whose write follows it can still leave a dangling equip; combat resolves a missing bloodline gracefully, so this is scoped out of this QoL change.

## Testing

- New unit tests: `tests/server/utils/adminConcurrency.test.ts` (atomic helpers) and additions to `tests/utils/permissions.test.ts` — **11/11 passing**.
- `tsc --noEmit` clean (the only error is a pre-existing, unrelated `tests/libs/combat/damage_modifiers.test.ts` failure on `main`).
- `biome lint` clean on changed files.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added staff-only controls in the user profile toolbar to adjust Seichi Silver and manage bloodline swappable pools (with modals, validations, and success feedback).
  * Staff can now view a target user’s Seichi Silver balance.
* **Bug Fixes**
  * Added permission gating, ban/state checks, AI-moderated reason handling, and guarded/atomic updates to prevent race-condition inconsistencies.
  * Added staff audit logging for these actions.
* **Tests**
  * Added coverage for the new permission helpers and the atomic adjustment/removal flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->