### PR TITLE
Basic action changes

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -162,7 +162,7 @@ export const SHARED_COOLDOWN_TAGS = [
   "pierce",
   "poison",
   "seal",
-  "shield",
+  "stun",
   "summon",
   "vamp",
 ] as const;

--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -690,8 +690,10 @@ export type TrainingSpeed = (typeof TrainingSpeeds)[number];
 export const JUTSU_MAX_RESIDUAL_EQUIPPED = 4;
 export const JUTSU_MAX_PIERCE_EQUIPPED = 9999;
 export const JUTSU_MAX_EVENT_EQUIPPED = 2;
+export const JUTSU_MAX_FORBIDDEN_EQUIPPED = 1;
 export const JUTSU_MAX_BARRIER_EQUIPPED = 1;
-export const JUTSU_MAX_STUN_EQUIPPED = 3;
+export const JUTSU_MAX_SHIELD_EQUIPPED = 2;
+export const JUTSU_MAX_STUN_EQUIPPED = 2;
 
 // Content difficulty ratings
 export const BloodlineDifficultyRatings = ["Easy", "Medium", "Hard", "Expert"] as const;

--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -158,13 +158,11 @@ export const SHARED_COOLDOWN_TAGS = [
   "clearprevent",
   "debuffprevent",
   "drain",
-  "increasepoolcost",
   "moveprevent",
   "pierce",
   "poison",
   "seal",
   "shield",
-  "stun",
   "summon",
   "vamp",
 ] as const;
@@ -693,7 +691,7 @@ export const JUTSU_MAX_RESIDUAL_EQUIPPED = 4;
 export const JUTSU_MAX_PIERCE_EQUIPPED = 9999;
 export const JUTSU_MAX_EVENT_EQUIPPED = 2;
 export const JUTSU_MAX_BARRIER_EQUIPPED = 1;
-export const JUTSU_MAX_STUN_EQUIPPED = 1;
+export const JUTSU_MAX_STUN_EQUIPPED = 3;
 
 // Content difficulty ratings
 export const BloodlineDifficultyRatings = ["Easy", "Medium", "Hard", "Expert"] as const;

--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -690,7 +690,6 @@ export type TrainingSpeed = (typeof TrainingSpeeds)[number];
 export const JUTSU_MAX_RESIDUAL_EQUIPPED = 4;
 export const JUTSU_MAX_PIERCE_EQUIPPED = 9999;
 export const JUTSU_MAX_EVENT_EQUIPPED = 2;
-export const JUTSU_MAX_FORBIDDEN_EQUIPPED = 1;
 export const JUTSU_MAX_BARRIER_EQUIPPED = 1;
 export const JUTSU_MAX_SHIELD_EQUIPPED = 2;
 export const JUTSU_MAX_STUN_EQUIPPED = 2;

--- a/app/src/libs/combat/actions.ts
+++ b/app/src/libs/combat/actions.ts
@@ -541,7 +541,7 @@ export const getDefaultBasicActions = (
       level: user?.level,
       effects: [
         HealTag.parse({
-          power: healPower,
+          power: 30,
           powerPerLevel: 0.0,
           calculation: "static",
           rounds: 0,

--- a/app/src/libs/combat/actions.ts
+++ b/app/src/libs/combat/actions.ts
@@ -455,7 +455,7 @@ export const getDefaultBasicActions = (
       level: user?.level,
       effects: [
         IncreaseDamageGivenTag.parse({
-          power: 5,
+          power: 15,
           powerPerLevel: 0,
           calculation: "percentage",
           statTypes: [...jutsuStatTypes],
@@ -483,7 +483,7 @@ export const getDefaultBasicActions = (
       level: user?.level,
       effects: [
         DecreaseDamageTakenTag.parse({
-          power: 5,
+          power: 15,
           powerPerLevel: 0,
           calculation: "percentage",
           statTypes: [...jutsuStatTypes],

--- a/app/src/libs/jutsu.ts
+++ b/app/src/libs/jutsu.ts
@@ -2,8 +2,10 @@ import type { FederalStatus } from "@/drizzle/constants";
 import {
   JUTSU_MAX_BARRIER_EQUIPPED,
   JUTSU_MAX_EVENT_EQUIPPED,
+  JUTSU_MAX_FORBIDDEN_EQUIPPED,
   JUTSU_MAX_PIERCE_EQUIPPED,
   JUTSU_MAX_RESIDUAL_EQUIPPED,
+  JUTSU_MAX_SHIELD_EQUIPPED,
   JUTSU_MAX_STUN_EQUIPPED,
   JUTSU_TRANSFER_FREE_AMOUNT,
   JUTSU_TRANSFER_FREE_GOLD,
@@ -42,15 +44,17 @@ export interface JutsuCapFlags {
   isResidual: boolean;
   isPierce: boolean;
   isEvent: boolean;
+  isForbidden: boolean;
   isBarrier: boolean;
+  isShield: boolean;
   isStun: boolean;
 }
 
 /**
  * Which capped equip categories a jutsu counts against (residual / pierce /
- * event / barrier / stun). Centralised so the loadout, toggle-equip and
- * auto-equip paths share one definition and a new capped category only needs
- * editing in one place.
+ * event / forbidden / barrier / shield / stun). Centralised so the loadout,
+ * toggle-equip and auto-equip paths share one definition and a new capped
+ * category only needs editing in one place.
  */
 export const getJutsuCapFlags = (
   jutsu: Pick<Jutsu, "effects" | "jutsuType">,
@@ -58,7 +62,9 @@ export const getJutsuCapFlags = (
   isResidual: jutsu.effects.some((e) => "residualModifier" in e && e.residualModifier),
   isPierce: jutsu.effects.some((e) => e.type === "pierce"),
   isEvent: jutsu.jutsuType === "EVENT",
+  isForbidden: jutsu.jutsuType === "FORBIDDEN",
   isBarrier: jutsu.effects.some((e) => e.type === "barrier"),
+  isShield: jutsu.effects.some((e) => e.type === "shield"),
   isStun: jutsu.effects.some((e) => e.type === "stun"),
 });
 
@@ -85,7 +91,9 @@ export const computeJutsuLoadoutAssignments = (args: {
   let total = 0;
   let pierce = 0;
   let event = 0;
+  let forbidden = 0;
   let barrier = 0;
+  let shield = 0;
   let stun = 0;
   let residual = 0;
 
@@ -110,8 +118,15 @@ export const computeJutsuLoadoutAssignments = (args: {
       invalidJutsus.push(`${jutsu.name}: missing requirements`);
       continue;
     }
-    const { isResidual, isPierce, isEvent, isBarrier, isStun } =
-      getJutsuCapFlags(jutsu);
+    const {
+      isResidual,
+      isPierce,
+      isEvent,
+      isForbidden,
+      isBarrier,
+      isShield,
+      isStun,
+    } = getJutsuCapFlags(jutsu);
     if (total >= maxEquip) {
       invalidJutsus.push(`${jutsu.name}: equip limit reached`);
       continue;
@@ -128,8 +143,16 @@ export const computeJutsuLoadoutAssignments = (args: {
       invalidJutsus.push(`${jutsu.name}: event jutsu limit reached`);
       continue;
     }
+    if (isForbidden && forbidden >= JUTSU_MAX_FORBIDDEN_EQUIPPED) {
+      invalidJutsus.push(`${jutsu.name}: forbidden jutsu limit reached`);
+      continue;
+    }
     if (isBarrier && barrier >= JUTSU_MAX_BARRIER_EQUIPPED) {
       invalidJutsus.push(`${jutsu.name}: barrier jutsu limit reached`);
+      continue;
+    }
+    if (isShield && shield >= JUTSU_MAX_SHIELD_EQUIPPED) {
+      invalidJutsus.push(`${jutsu.name}: shield jutsu limit reached`);
       continue;
     }
     if (isStun && stun >= JUTSU_MAX_STUN_EQUIPPED) {
@@ -141,7 +164,9 @@ export const computeJutsuLoadoutAssignments = (args: {
     if (isResidual) residual += 1;
     if (isPierce) pierce += 1;
     if (isEvent) event += 1;
+    if (isForbidden) forbidden += 1;
     if (isBarrier) barrier += 1;
+    if (isShield) shield += 1;
     if (isStun) stun += 1;
   }
 

--- a/app/src/libs/jutsu.ts
+++ b/app/src/libs/jutsu.ts
@@ -2,7 +2,6 @@ import type { FederalStatus } from "@/drizzle/constants";
 import {
   JUTSU_MAX_BARRIER_EQUIPPED,
   JUTSU_MAX_EVENT_EQUIPPED,
-  JUTSU_MAX_FORBIDDEN_EQUIPPED,
   JUTSU_MAX_PIERCE_EQUIPPED,
   JUTSU_MAX_RESIDUAL_EQUIPPED,
   JUTSU_MAX_SHIELD_EQUIPPED,
@@ -44,7 +43,6 @@ export interface JutsuCapFlags {
   isResidual: boolean;
   isPierce: boolean;
   isEvent: boolean;
-  isForbidden: boolean;
   isBarrier: boolean;
   isShield: boolean;
   isStun: boolean;
@@ -52,9 +50,9 @@ export interface JutsuCapFlags {
 
 /**
  * Which capped equip categories a jutsu counts against (residual / pierce /
- * event / forbidden / barrier / shield / stun). Centralised so the loadout,
- * toggle-equip and auto-equip paths share one definition and a new capped
- * category only needs editing in one place.
+ * event / barrier / shield / stun). Centralised so the loadout, toggle-equip and
+ * auto-equip paths share one definition and a new capped category only needs
+ * editing in one place.
  */
 export const getJutsuCapFlags = (
   jutsu: Pick<Jutsu, "effects" | "jutsuType">,
@@ -62,7 +60,6 @@ export const getJutsuCapFlags = (
   isResidual: jutsu.effects.some((e) => "residualModifier" in e && e.residualModifier),
   isPierce: jutsu.effects.some((e) => e.type === "pierce"),
   isEvent: jutsu.jutsuType === "EVENT",
-  isForbidden: jutsu.jutsuType === "FORBIDDEN",
   isBarrier: jutsu.effects.some((e) => e.type === "barrier"),
   isShield: jutsu.effects.some((e) => e.type === "shield"),
   isStun: jutsu.effects.some((e) => e.type === "stun"),
@@ -91,7 +88,6 @@ export const computeJutsuLoadoutAssignments = (args: {
   let total = 0;
   let pierce = 0;
   let event = 0;
-  let forbidden = 0;
   let barrier = 0;
   let shield = 0;
   let stun = 0;
@@ -118,15 +114,8 @@ export const computeJutsuLoadoutAssignments = (args: {
       invalidJutsus.push(`${jutsu.name}: missing requirements`);
       continue;
     }
-    const {
-      isResidual,
-      isPierce,
-      isEvent,
-      isForbidden,
-      isBarrier,
-      isShield,
-      isStun,
-    } = getJutsuCapFlags(jutsu);
+    const { isResidual, isPierce, isEvent, isBarrier, isShield, isStun } =
+      getJutsuCapFlags(jutsu);
     if (total >= maxEquip) {
       invalidJutsus.push(`${jutsu.name}: equip limit reached`);
       continue;
@@ -141,10 +130,6 @@ export const computeJutsuLoadoutAssignments = (args: {
     }
     if (isEvent && event >= JUTSU_MAX_EVENT_EQUIPPED) {
       invalidJutsus.push(`${jutsu.name}: event jutsu limit reached`);
-      continue;
-    }
-    if (isForbidden && forbidden >= JUTSU_MAX_FORBIDDEN_EQUIPPED) {
-      invalidJutsus.push(`${jutsu.name}: forbidden jutsu limit reached`);
       continue;
     }
     if (isBarrier && barrier >= JUTSU_MAX_BARRIER_EQUIPPED) {
@@ -164,7 +149,6 @@ export const computeJutsuLoadoutAssignments = (args: {
     if (isResidual) residual += 1;
     if (isPierce) pierce += 1;
     if (isEvent) event += 1;
-    if (isForbidden) forbidden += 1;
     if (isBarrier) barrier += 1;
     if (isShield) shield += 1;
     if (isStun) stun += 1;

--- a/app/src/libs/ranked_pvp.ts
+++ b/app/src/libs/ranked_pvp.ts
@@ -1,7 +1,6 @@
 import type { RankedRank } from "@/drizzle/constants";
 import {
   JUTSU_MAX_EVENT_EQUIPPED,
-  JUTSU_MAX_FORBIDDEN_EQUIPPED,
   JUTSU_MAX_SHIELD_EQUIPPED,
   RANKED_DIVISIONS,
   RANKED_LEGEND_LP_REQUIREMENT,
@@ -218,13 +217,6 @@ export const validateJutsuLoadout = (jutsus: Jutsu[]) => {
   if (eventJutsus.length > JUTSU_MAX_EVENT_EQUIPPED) {
     check = false;
     message = `You can only equip up to ${JUTSU_MAX_EVENT_EQUIPPED} event jutsu in ranked PvP`;
-  }
-
-  // Check forbidden jutsu limit
-  const forbiddenJutsus = jutsus.filter((jutsu) => jutsu.jutsuType === "FORBIDDEN");
-  if (forbiddenJutsus.length > JUTSU_MAX_FORBIDDEN_EQUIPPED) {
-    check = false;
-    message = `You can only equip up to ${JUTSU_MAX_FORBIDDEN_EQUIPPED} forbidden jutsu in ranked PvP`;
   }
 
   if (jutsus.length > RANKED_LOADOUT_MAX_JUTSUS) {

--- a/app/src/libs/ranked_pvp.ts
+++ b/app/src/libs/ranked_pvp.ts
@@ -1,6 +1,8 @@
 import type { RankedRank } from "@/drizzle/constants";
 import {
   JUTSU_MAX_EVENT_EQUIPPED,
+  JUTSU_MAX_FORBIDDEN_EQUIPPED,
+  JUTSU_MAX_SHIELD_EQUIPPED,
   RANKED_DIVISIONS,
   RANKED_LEGEND_LP_REQUIREMENT,
   RANKED_LOADOUT_MAX_BARRIER_JUTSUS,
@@ -193,6 +195,15 @@ export const validateJutsuLoadout = (jutsus: Jutsu[]) => {
     message = `You can only equip up to ${RANKED_LOADOUT_MAX_BARRIER_JUTSUS} barrier jutsu in ranked PvP`;
   }
 
+  // Check shield jutsu limit
+  const shieldJutsus = jutsus.filter((jutsu) =>
+    jutsu.effects.some((e) => e.type === "shield"),
+  );
+  if (shieldJutsus.length > JUTSU_MAX_SHIELD_EQUIPPED) {
+    check = false;
+    message = `You can only equip up to ${JUTSU_MAX_SHIELD_EQUIPPED} shield jutsu in ranked PvP`;
+  }
+
   // Check stun jutsu limit
   const stunJutsus = jutsus.filter((jutsu) =>
     jutsu.effects.some((e) => e.type === "stun"),
@@ -207,6 +218,13 @@ export const validateJutsuLoadout = (jutsus: Jutsu[]) => {
   if (eventJutsus.length > JUTSU_MAX_EVENT_EQUIPPED) {
     check = false;
     message = `You can only equip up to ${JUTSU_MAX_EVENT_EQUIPPED} event jutsu in ranked PvP`;
+  }
+
+  // Check forbidden jutsu limit
+  const forbiddenJutsus = jutsus.filter((jutsu) => jutsu.jutsuType === "FORBIDDEN");
+  if (forbiddenJutsus.length > JUTSU_MAX_FORBIDDEN_EQUIPPED) {
+    check = false;
+    message = `You can only equip up to ${JUTSU_MAX_FORBIDDEN_EQUIPPED} forbidden jutsu in ranked PvP`;
   }
 
   if (jutsus.length > RANKED_LOADOUT_MAX_JUTSUS) {

--- a/app/src/server/api/routers/jutsu.ts
+++ b/app/src/server/api/routers/jutsu.ts
@@ -22,7 +22,6 @@ import {
   JUTSU_LEVEL_CAP,
   JUTSU_MAX_BARRIER_EQUIPPED,
   JUTSU_MAX_EVENT_EQUIPPED,
-  JUTSU_MAX_FORBIDDEN_EQUIPPED,
   JUTSU_MAX_PIERCE_EQUIPPED,
   JUTSU_MAX_RESIDUAL_EQUIPPED,
   JUTSU_MAX_SHIELD_EQUIPPED,
@@ -584,7 +583,6 @@ export const jutsuRouter = createTRPCRouter({
       const evolutionCapFlags = getJutsuCapFlags(evolutionJutsu);
       const isRestrictedEquipType =
         evolutionCapFlags.isEvent ||
-        evolutionCapFlags.isForbidden ||
         evolutionCapFlags.isPierce ||
         evolutionCapFlags.isBarrier ||
         evolutionCapFlags.isShield ||
@@ -1046,9 +1044,6 @@ export const jutsuRouter = createTRPCRouter({
       const eventJutsus = equippedJutsus.filter(
         (uj) => getJutsuCapFlags(uj.jutsu).isEvent,
       );
-      const forbiddenJutsus = equippedJutsus.filter(
-        (uj) => getJutsuCapFlags(uj.jutsu).isForbidden,
-      );
       const barrierJutsus = equippedJutsus.filter(
         (uj) => getJutsuCapFlags(uj.jutsu).isBarrier,
       );
@@ -1134,7 +1129,6 @@ export const jutsuRouter = createTRPCRouter({
           isResidual: jutsuHasResidual,
           isPierce: jutsuHasPierce,
           isEvent: jutsuIsEvent,
-          isForbidden: jutsuIsForbidden,
           isBarrier: jutsuHasBarrier,
           isShield: jutsuHasShield,
           isStun: jutsuHasStun,
@@ -1146,8 +1140,6 @@ export const jutsuRouter = createTRPCRouter({
           (!jutsuHasResidual || residualJutsus.length < JUTSU_MAX_RESIDUAL_EQUIPPED) &&
           (!jutsuHasPierce || pierceJutsus.length < JUTSU_MAX_PIERCE_EQUIPPED) &&
           (!jutsuIsEvent || eventJutsus.length < JUTSU_MAX_EVENT_EQUIPPED) &&
-          (!jutsuIsForbidden ||
-            forbiddenJutsus.length < JUTSU_MAX_FORBIDDEN_EQUIPPED) &&
           (!jutsuHasBarrier || barrierJutsus.length < JUTSU_MAX_BARRIER_EQUIPPED) &&
           (!jutsuHasShield || shieldJutsus.length < JUTSU_MAX_SHIELD_EQUIPPED) &&
           (!jutsuHasStun || stunJutsus.length < JUTSU_MAX_STUN_EQUIPPED);
@@ -1268,10 +1260,6 @@ export const jutsuRouter = createTRPCRouter({
         (j) => getJutsuCapFlags(j.jutsu).isEvent,
       ).length;
       const curJutsuIsEvent = curJutsuFlags?.isEvent ?? false;
-      const forbiddenEquipped = equippedJutsus.filter(
-        (j) => getJutsuCapFlags(j.jutsu).isForbidden,
-      ).length;
-      const curJutsuIsForbidden = curJutsuFlags?.isForbidden;
       const barrierEquipped = equippedJutsus.filter(
         (j) => getJutsuCapFlags(j.jutsu).isBarrier,
       ).length;
@@ -1327,15 +1315,6 @@ export const jutsuRouter = createTRPCRouter({
       if (!isEquipped && curJutsuIsEvent && eventEquipped >= JUTSU_MAX_EVENT_EQUIPPED) {
         return errorResponse(
           `You cannot equip more than ${JUTSU_MAX_EVENT_EQUIPPED} event jutsu`,
-        );
-      }
-      if (
-        !isEquipped &&
-        curJutsuIsForbidden &&
-        forbiddenEquipped >= JUTSU_MAX_FORBIDDEN_EQUIPPED
-      ) {
-        return errorResponse(
-          `You cannot equip more than ${JUTSU_MAX_FORBIDDEN_EQUIPPED} forbidden jutsu`,
         );
       }
       if (

--- a/app/src/server/api/routers/jutsu.ts
+++ b/app/src/server/api/routers/jutsu.ts
@@ -22,8 +22,10 @@ import {
   JUTSU_LEVEL_CAP,
   JUTSU_MAX_BARRIER_EQUIPPED,
   JUTSU_MAX_EVENT_EQUIPPED,
+  JUTSU_MAX_FORBIDDEN_EQUIPPED,
   JUTSU_MAX_PIERCE_EQUIPPED,
   JUTSU_MAX_RESIDUAL_EQUIPPED,
+  JUTSU_MAX_SHIELD_EQUIPPED,
   JUTSU_MAX_STUN_EQUIPPED,
   JUTSU_TRAIN_LEVEL_CAP,
   JUTSU_TRANSFER_COST,
@@ -582,8 +584,10 @@ export const jutsuRouter = createTRPCRouter({
       const evolutionCapFlags = getJutsuCapFlags(evolutionJutsu);
       const isRestrictedEquipType =
         evolutionCapFlags.isEvent ||
+        evolutionCapFlags.isForbidden ||
         evolutionCapFlags.isPierce ||
         evolutionCapFlags.isBarrier ||
+        evolutionCapFlags.isShield ||
         evolutionCapFlags.isStun ||
         evolutionCapFlags.isResidual;
       // Single compare-and-swap update that applies every userJutsu-row change at once:
@@ -1042,8 +1046,14 @@ export const jutsuRouter = createTRPCRouter({
       const eventJutsus = equippedJutsus.filter(
         (uj) => getJutsuCapFlags(uj.jutsu).isEvent,
       );
+      const forbiddenJutsus = equippedJutsus.filter(
+        (uj) => getJutsuCapFlags(uj.jutsu).isForbidden,
+      );
       const barrierJutsus = equippedJutsus.filter(
         (uj) => getJutsuCapFlags(uj.jutsu).isBarrier,
+      );
+      const shieldJutsus = equippedJutsus.filter(
+        (uj) => getJutsuCapFlags(uj.jutsu).isShield,
       );
       const stunJutsus = equippedJutsus.filter(
         (uj) => getJutsuCapFlags(uj.jutsu).isStun,
@@ -1124,7 +1134,9 @@ export const jutsuRouter = createTRPCRouter({
           isResidual: jutsuHasResidual,
           isPierce: jutsuHasPierce,
           isEvent: jutsuIsEvent,
+          isForbidden: jutsuIsForbidden,
           isBarrier: jutsuHasBarrier,
+          isShield: jutsuHasShield,
           isStun: jutsuHasStun,
         } = getJutsuCapFlags(info);
 
@@ -1134,7 +1146,10 @@ export const jutsuRouter = createTRPCRouter({
           (!jutsuHasResidual || residualJutsus.length < JUTSU_MAX_RESIDUAL_EQUIPPED) &&
           (!jutsuHasPierce || pierceJutsus.length < JUTSU_MAX_PIERCE_EQUIPPED) &&
           (!jutsuIsEvent || eventJutsus.length < JUTSU_MAX_EVENT_EQUIPPED) &&
+          (!jutsuIsForbidden ||
+            forbiddenJutsus.length < JUTSU_MAX_FORBIDDEN_EQUIPPED) &&
           (!jutsuHasBarrier || barrierJutsus.length < JUTSU_MAX_BARRIER_EQUIPPED) &&
+          (!jutsuHasShield || shieldJutsus.length < JUTSU_MAX_SHIELD_EQUIPPED) &&
           (!jutsuHasStun || stunJutsus.length < JUTSU_MAX_STUN_EQUIPPED);
 
         // Use onDuplicateKeyUpdate to handle race conditions
@@ -1253,10 +1268,18 @@ export const jutsuRouter = createTRPCRouter({
         (j) => getJutsuCapFlags(j.jutsu).isEvent,
       ).length;
       const curJutsuIsEvent = curJutsuFlags?.isEvent ?? false;
+      const forbiddenEquipped = equippedJutsus.filter(
+        (j) => getJutsuCapFlags(j.jutsu).isForbidden,
+      ).length;
+      const curJutsuIsForbidden = curJutsuFlags?.isForbidden;
       const barrierEquipped = equippedJutsus.filter(
         (j) => getJutsuCapFlags(j.jutsu).isBarrier,
       ).length;
       const curJutsuIsBarrier = curJutsuFlags?.isBarrier;
+      const shieldEquipped = equippedJutsus.filter(
+        (j) => getJutsuCapFlags(j.jutsu).isShield,
+      ).length;
+      const curJutsuIsShield = curJutsuFlags?.isShield;
       const stunEquipped = equippedJutsus.filter(
         (j) => getJutsuCapFlags(j.jutsu).isStun,
       ).length;
@@ -1308,11 +1331,29 @@ export const jutsuRouter = createTRPCRouter({
       }
       if (
         !isEquipped &&
+        curJutsuIsForbidden &&
+        forbiddenEquipped >= JUTSU_MAX_FORBIDDEN_EQUIPPED
+      ) {
+        return errorResponse(
+          `You cannot equip more than ${JUTSU_MAX_FORBIDDEN_EQUIPPED} forbidden jutsu`,
+        );
+      }
+      if (
+        !isEquipped &&
         curJutsuIsBarrier &&
         barrierEquipped >= JUTSU_MAX_BARRIER_EQUIPPED
       ) {
         return errorResponse(
           `You cannot equip more than ${JUTSU_MAX_BARRIER_EQUIPPED} barrier jutsu`,
+        );
+      }
+      if (
+        !isEquipped &&
+        curJutsuIsShield &&
+        shieldEquipped >= JUTSU_MAX_SHIELD_EQUIPPED
+      ) {
+        return errorResponse(
+          `You cannot equip more than ${JUTSU_MAX_SHIELD_EQUIPPED} shield jutsu`,
         );
       }
       if (!isEquipped && curJutsuIsStun && stunEquipped >= JUTSU_MAX_STUN_EQUIPPED) {

--- a/app/tests/libs/jutsu.test.ts
+++ b/app/tests/libs/jutsu.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   JUTSU_MAX_BARRIER_EQUIPPED,
   JUTSU_MAX_EVENT_EQUIPPED,
+  JUTSU_MAX_FORBIDDEN_EQUIPPED,
+  JUTSU_MAX_SHIELD_EQUIPPED,
+  JUTSU_MAX_STUN_EQUIPPED,
 } from "@/drizzle/constants";
 import type { UserJutsuWithRelations } from "@/drizzle/schema";
 
@@ -145,6 +148,22 @@ describe("computeJutsuLoadoutAssignments", () => {
     expect(out.invalidJutsus[0]).toMatch(/event/);
   });
 
+  it("allows one forbidden jutsu and rejects any beyond the cap", () => {
+    const count = JUTSU_MAX_FORBIDDEN_EQUIPPED + 1;
+    const userjutsus = Array.from({ length: count }, (_, i) =>
+      uj({ jutsuId: `forbidden${i}`, jutsuType: "FORBIDDEN" }),
+    );
+    const out = computeJutsuLoadoutAssignments({
+      jutsuIds: userjutsus.map((j) => j.jutsuId),
+      userjutsus,
+      user: USER,
+    });
+
+    expect(JUTSU_MAX_FORBIDDEN_EQUIPPED).toBe(1);
+    expect(out.equipIds).toHaveLength(1);
+    expect(out.invalidJutsus[0]).toMatch(/forbidden/);
+  });
+
   it("deduplicates repeated jutsuIds so they do not double-count toward caps", () => {
     calcJutsuEquipLimitMock.mockReturnValueOnce(2);
     const userjutsus = [uj({ jutsuId: "a" }), uj({ jutsuId: "b" })];
@@ -171,5 +190,37 @@ describe("computeJutsuLoadoutAssignments", () => {
     });
     expect(out.equipIds).toHaveLength(JUTSU_MAX_BARRIER_EQUIPPED);
     expect(out.invalidJutsus[0]).toMatch(/barrier/);
+  });
+
+  it("allows up to two shield jutsu and rejects any beyond the cap", () => {
+    const count = JUTSU_MAX_SHIELD_EQUIPPED + 1;
+    const userjutsus = Array.from({ length: count }, (_, i) =>
+      uj({ jutsuId: `shield${i}`, effectTypes: ["shield"] }),
+    );
+    const out = computeJutsuLoadoutAssignments({
+      jutsuIds: userjutsus.map((j) => j.jutsuId),
+      userjutsus,
+      user: USER,
+    });
+
+    expect(JUTSU_MAX_SHIELD_EQUIPPED).toBe(2);
+    expect(out.equipIds).toHaveLength(2);
+    expect(out.invalidJutsus[0]).toMatch(/shield/);
+  });
+
+  it("allows up to two stun jutsu and rejects any beyond the cap", () => {
+    const count = JUTSU_MAX_STUN_EQUIPPED + 1;
+    const userjutsus = Array.from({ length: count }, (_, i) =>
+      uj({ jutsuId: `stun${i}`, effectTypes: ["stun"] }),
+    );
+    const out = computeJutsuLoadoutAssignments({
+      jutsuIds: userjutsus.map((j) => j.jutsuId),
+      userjutsus,
+      user: USER,
+    });
+
+    expect(JUTSU_MAX_STUN_EQUIPPED).toBe(2);
+    expect(out.equipIds).toHaveLength(2);
+    expect(out.invalidJutsus[0]).toMatch(/stun/);
   });
 });

--- a/app/tests/libs/jutsu.test.ts
+++ b/app/tests/libs/jutsu.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   JUTSU_MAX_BARRIER_EQUIPPED,
   JUTSU_MAX_EVENT_EQUIPPED,
-  JUTSU_MAX_FORBIDDEN_EQUIPPED,
   JUTSU_MAX_SHIELD_EQUIPPED,
   JUTSU_MAX_STUN_EQUIPPED,
 } from "@/drizzle/constants";
@@ -146,22 +145,6 @@ describe("computeJutsuLoadoutAssignments", () => {
     });
     expect(out.equipIds).toHaveLength(JUTSU_MAX_EVENT_EQUIPPED);
     expect(out.invalidJutsus[0]).toMatch(/event/);
-  });
-
-  it("allows one forbidden jutsu and rejects any beyond the cap", () => {
-    const count = JUTSU_MAX_FORBIDDEN_EQUIPPED + 1;
-    const userjutsus = Array.from({ length: count }, (_, i) =>
-      uj({ jutsuId: `forbidden${i}`, jutsuType: "FORBIDDEN" }),
-    );
-    const out = computeJutsuLoadoutAssignments({
-      jutsuIds: userjutsus.map((j) => j.jutsuId),
-      userjutsus,
-      user: USER,
-    });
-
-    expect(JUTSU_MAX_FORBIDDEN_EQUIPPED).toBe(1);
-    expect(out.equipIds).toHaveLength(1);
-    expect(out.invalidJutsus[0]).toMatch(/forbidden/);
   });
 
   it("deduplicates repeated jutsuIds so they do not double-count toward caps", () => {

--- a/app/tests/libs/ranked_pvp.test.ts
+++ b/app/tests/libs/ranked_pvp.test.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect } from "vitest";
-import { calculateLpEloChange, getRankedRadius } from "@/libs/ranked_pvp";
-import { RANKED_MIN_LP_GAIN, RANKED_QUEUE_MAX_WAIT_SECS } from "@/drizzle/constants";
+import {
+  calculateLpEloChange,
+  getRankedRadius,
+  validateJutsuLoadout,
+} from "@/libs/ranked_pvp";
+import {
+  JUTSU_MAX_FORBIDDEN_EQUIPPED,
+  JUTSU_MAX_SHIELD_EQUIPPED,
+  RANKED_MIN_LP_GAIN,
+  RANKED_QUEUE_MAX_WAIT_SECS,
+} from "@/drizzle/constants";
+import type { Jutsu } from "@/drizzle/schema";
 
 describe("calculateLpEloChange", () => {
   it("floors a win to RANKED_MIN_LP_GAIN when the raw Elo gain is below it", () => {
@@ -51,5 +61,38 @@ describe("getRankedRadius", () => {
     expect(getRankedRadius(RANKED_QUEUE_MAX_WAIT_SECS)).toBe(Infinity);
     expect(getRankedRadius(600)).toBe(Infinity);
     expect(getRankedRadius(5000)).toBe(Infinity);
+  });
+});
+
+describe("validateJutsuLoadout", () => {
+  it("rejects ranked loadouts with more than two shield jutsu", () => {
+    const jutsus = Array.from({ length: JUTSU_MAX_SHIELD_EQUIPPED + 1 }, (_, i) =>
+      ({
+        id: `shield${i}`,
+        jutsuType: "NORMAL",
+        effects: [{ type: "shield" }],
+      }) as Jutsu,
+    );
+
+    const result = validateJutsuLoadout(jutsus);
+
+    expect(result.check).toBe(false);
+    expect(result.message).toMatch(/up to 2 shield jutsu/);
+  });
+
+  it("rejects ranked loadouts with more than one forbidden jutsu", () => {
+    const jutsus = Array.from({ length: JUTSU_MAX_FORBIDDEN_EQUIPPED + 1 }, (_, i) =>
+      ({
+        id: `forbidden${i}`,
+        jutsuType: "FORBIDDEN",
+        effects: [],
+      }) as Jutsu,
+    );
+
+    const result = validateJutsuLoadout(jutsus);
+
+    expect(JUTSU_MAX_FORBIDDEN_EQUIPPED).toBe(1);
+    expect(result.check).toBe(false);
+    expect(result.message).toMatch(/up to 1 forbidden jutsu/);
   });
 });

--- a/app/tests/libs/ranked_pvp.test.ts
+++ b/app/tests/libs/ranked_pvp.test.ts
@@ -5,7 +5,6 @@ import {
   validateJutsuLoadout,
 } from "@/libs/ranked_pvp";
 import {
-  JUTSU_MAX_FORBIDDEN_EQUIPPED,
   JUTSU_MAX_SHIELD_EQUIPPED,
   RANKED_MIN_LP_GAIN,
   RANKED_QUEUE_MAX_WAIT_SECS,
@@ -78,21 +77,5 @@ describe("validateJutsuLoadout", () => {
 
     expect(result.check).toBe(false);
     expect(result.message).toMatch(/up to 2 shield jutsu/);
-  });
-
-  it("rejects ranked loadouts with more than one forbidden jutsu", () => {
-    const jutsus = Array.from({ length: JUTSU_MAX_FORBIDDEN_EQUIPPED + 1 }, (_, i) =>
-      ({
-        id: `forbidden${i}`,
-        jutsuType: "FORBIDDEN",
-        effects: [],
-      }) as Jutsu,
-    );
-
-    const result = validateJutsuLoadout(jutsus);
-
-    expect(JUTSU_MAX_FORBIDDEN_EQUIPPED).toBe(1);
-    expect(result.check).toBe(false);
-    expect(result.message).toMatch(/up to 1 forbidden jutsu/);
   });
 });


### PR DESCRIPTION
# Pull Request

Updated Basic actions:
Offensive stance from 5% to 15%
Defensive stance from 5% to 15%
Updated Meditate basic action to use 30 power for Chakra and Stamina
Increase stun limit from 1 to 3. 



## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Balance Changes**
  * Increased offensive/defensive stance effectiveness for basic actions.
  * Made meditation healing a fixed value.
* **Gameplay Updates**
  * Updated shared cooldown/tag rules by removing specific entries.
  * Updated jutsu equip caps: stun limit increased to 2, and a new shield jutsu equip limit was added (max 2).
* **Validation Enhancements**
  * Enforced the shield jutsu equip cap during evolution, training auto-equip, manual equip toggling, and ranked PvP validation.
* **Tests**
  * Added coverage for both shield and stun equip-cap enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->