### PR TITLE
feat(tag): vamp and lifesteal interaction, leech combination, and shield

### DIFF
--- a/app/src/libs/combat/constants.ts
+++ b/app/src/libs/combat/constants.ts
@@ -18,6 +18,13 @@ export const COMBAT_LOBBY_SECONDS = 15;
 
 export const SPAR_EXPIRY_SECONDS = 120;
 
+/**
+ * Max fraction of a hit's pre-shield damage that vamp + lifesteal can together
+ * return to the attacker as HP. Shared budget: vamp fills first, lifesteal takes
+ * the remainder.
+ */
+export const DAMAGE_LEECH_CAP_RATIO = 0.6;
+
 export const BARRIER_DAMAGE_TAG_TYPES = new Set<string>(["damage", "pierce"]);
 
 /**

--- a/app/src/libs/combat/process.ts
+++ b/app/src/libs/combat/process.ts
@@ -15,6 +15,7 @@ import type { ShieldTagType } from "@/validators/combat";
 import { VisualTag } from "@/validators/combat";
 import {
   BARRIER_DAMAGE_TAG_TYPES,
+  DAMAGE_LEECH_CAP_RATIO,
   damageBoostTypes,
   damageModifierTypes,
   damageReductionTypes,
@@ -647,7 +648,13 @@ export const applyEffects = (
 
       // Apply all the consequences
       if (target && user) {
-        let appliedVampHeal = 0;
+        // Vamp + lifesteal share one 60%-of-damage budget per consequence. Declared
+        // before the damage block because lifesteal is applied later, outside it, and
+        // still needs the budget when a shield-reduced damage===0 was dropped in merge.
+        const leechBudget = Math.floor(
+          (c.preShieldDamage ?? c.damage ?? 0) * DAMAGE_LEECH_CAP_RATIO,
+        );
+        let leechConsumed = 0;
         // damage_dealt tracker credit goes to the controller when the attacker is a
         // summon/clone, matching creatures_hunted attribution (kills a summon secures
         // already count for the summoner). Summons copy the summoner's direction at
@@ -666,15 +673,15 @@ export const applyEffects = (
             color: "red",
             types: c.types,
           });
-          // Vamp: heal the attacker based on the final damage dealt (post-boost, post-shield).
+          // Vamp: heal the attacker based on the full pre-shield damage dealt (post-boost,
+          // pre-shield; matches lifesteal, so a shield doesn't shrink the vamp heal).
           // Intentional: this can trigger on killing blows (no target.curHealth > 0 guard).
+          // Fills the shared leech budget first; lifesteal later takes whatever remains.
           const rawVampHeal = c.vampHeal ?? 0;
           if (rawVampHeal > 0 && user.curHealth > 0) {
-            const preShieldDamage = c.preShieldDamage ?? c.damage ?? 0;
-            const maxVamp = preShieldDamage * 0.6;
-            const vampHeal = Math.min(Math.floor(rawVampHeal), Math.floor(maxVamp));
-            appliedVampHeal = vampHeal;
+            const vampHeal = Math.min(Math.floor(rawVampHeal), leechBudget);
             if (vampHeal > 0) {
+              leechConsumed += vampHeal;
               user.curHealth = Math.min(user.maxHealth, user.curHealth + vampHeal);
               actionEffects.push({
                 txt: `${user.username} vamps ${vampHeal} damage as health`,
@@ -798,24 +805,26 @@ export const applyEffects = (
             color: "red",
           });
         }
-        // Vamp and lifesteal are mutually exclusive: if vamp drained this packet, suppress lifesteal.
+        // Lifesteal shares the leech budget with vamp: it takes whatever vamp left unused
+        // (both cap the combined heal at DAMAGE_LEECH_CAP_RATIO of the pre-shield damage).
+        // Still requires the target to have survived the whole tick and the attacker alive.
         if (
-          appliedVampHeal <= 0 &&
           c.lifesteal_hp !== undefined &&
           c.lifesteal_hp >= 0 &&
           target.curHealth > 0 &&
           user.curHealth > 0
         ) {
-          // Use pre-shield damage for the 60% cap calculation to avoid shield interference
-          const preShieldDamage = c.preShieldDamage ?? 0;
-          const maxLifesteal = preShieldDamage * 0.6;
-          const finalLifesteal = Math.min(c.lifesteal_hp, maxLifesteal);
-          user.curHealth += finalLifesteal;
-          user.curHealth = Math.min(user.maxHealth, user.curHealth);
-          actionEffects.push({
-            txt: `${user.username} steals ${finalLifesteal.toFixed(2)} damage as health`,
-            color: "green",
-          });
+          const remaining = Math.max(0, leechBudget - leechConsumed);
+          const finalLifesteal = Math.min(c.lifesteal_hp, remaining);
+          if (finalLifesteal > 0) {
+            leechConsumed += finalLifesteal;
+            user.curHealth += finalLifesteal;
+            user.curHealth = Math.min(user.maxHealth, user.curHealth);
+            actionEffects.push({
+              txt: `${user.username} steals ${finalLifesteal.toFixed(2)} damage as health`,
+              color: "green",
+            });
+          }
         }
         if (c.absorb_hp !== undefined && c.absorb_hp >= 0 && target.curHealth > 0) {
           // Use pre-shield damage for the 60% cap calculation to avoid shield interference

--- a/app/src/libs/combat/process.ts
+++ b/app/src/libs/combat/process.ts
@@ -679,7 +679,10 @@ export const applyEffects = (
           // Fills the shared leech budget first; lifesteal later takes whatever remains.
           const rawVampHeal = c.vampHeal ?? 0;
           if (rawVampHeal > 0 && user.curHealth > 0) {
-            const vampHeal = Math.min(Math.floor(rawVampHeal), leechBudget);
+            const vampHeal = Math.min(
+              Math.floor(rawVampHeal),
+              leechBudget - leechConsumed,
+            );
             if (vampHeal > 0) {
               leechConsumed += vampHeal;
               user.curHealth = Math.min(user.maxHealth, user.curHealth + vampHeal);

--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -1904,7 +1904,7 @@ export const lifesteal = (
   return getInfo(target, effect, `will steal ${qualifier} damage as health`);
 };
 
-/** Instantly heal the caster based on damage dealt by this jutsu. Applies independently of lifesteal. */
+/** Instantly heal the caster based on damage dealt by this jutsu. Shares a combined 60% cap with lifesteal. */
 export const vamp = (
   effect: UserEffect,
   usersEffects: UserEffect[],
@@ -1922,7 +1922,8 @@ export const vamp = (
   if (casterHealPrevented) return preventResponse(effect, target, "cannot vamp");
   const { power, qualifier } = getPower(effect);
   // Store vampRatio on each outgoing damage consequence so the application phase
-  // can compute the heal from the truly final damage total (post-boost, post-shield).
+  // can compute the heal from the full pre-shield damage total (post-boost, pre-shield;
+  // matches lifesteal, which also heals off the full hit a shield would otherwise reduce).
   if (effect.isNew && effect.castThisRound) {
     consequences.forEach((c) => {
       if (

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -1284,7 +1284,11 @@ export const collapseConsequences = (acc: Consequence[], val: Consequence) => {
         : val.lifesteal_hp;
     }
     if (val.vampRatio) {
-      current.vampHeal = (current.vampHeal ?? 0) + val.vampRatio * (val.damage ?? 0);
+      // Vamp heals off the FULL pre-shield hit (matches lifesteal + the 60% cap, which
+      // both use preShieldDamage). Fallback to damage when preShieldDamage is unset.
+      current.vampHeal =
+        (current.vampHeal ?? 0) +
+        val.vampRatio * (val.preShieldDamage ?? val.damage ?? 0);
     }
     if (val.preShieldDamage) {
       current.preShieldDamage = current.preShieldDamage
@@ -1332,7 +1336,8 @@ export const collapseConsequences = (acc: Consequence[], val: Consequence) => {
     }
   } else {
     if (val.vampRatio) {
-      val.vampHeal = (val.vampHeal ?? 0) + val.vampRatio * (val.damage ?? 0);
+      val.vampHeal =
+        (val.vampHeal ?? 0) + val.vampRatio * (val.preShieldDamage ?? val.damage ?? 0);
     }
     acc.push(val);
   }

--- a/app/tests/libs/combat/vamp_lifesteal_cap.test.ts
+++ b/app/tests/libs/combat/vamp_lifesteal_cap.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it } from "vitest";
+import { applyEffects } from "@/libs/combat/process";
+import { DAMAGE_LEECH_CAP_RATIO } from "@/libs/combat/constants";
+import type { CombatAction, CompleteBattle, UserEffect } from "@/libs/combat/types";
+import { makeBattleUser, makeDamageEffect, makeEffect } from "./helpers/battleScenario";
+
+const ROUND = 3;
+
+/** Minimal action fixture — effects drive the packet, not the action. */
+const makeAction = (): CombatAction =>
+  ({ chakraCost: 0, staminaCost: 0 }) as CombatAction;
+
+const makeBattle = (
+  usersState: ReturnType<typeof makeBattleUser>[],
+  usersEffects: UserEffect[],
+): CompleteBattle =>
+  ({
+    battleType: "COMBAT",
+    round: ROUND,
+    usersState,
+    usersEffects,
+    groundEffects: [],
+    extraState: {},
+  }) as unknown as CompleteBattle;
+
+/**
+ * Attacker with almost no current HP but a huge max, so any heal is fully
+ * observable (never clamped). Defender is a huge sponge so it always survives
+ * (lets lifesteal proc) unless a test overrides its HP.
+ */
+const makeAttacker = (overrides: Record<string, unknown> = {}) =>
+  makeBattleUser("attacker", { curHealth: 1, maxHealth: 100_000_000, ...overrides });
+const makeDefender = (overrides: Record<string, unknown> = {}) =>
+  makeBattleUser("defender", { curHealth: 100_000_000, maxHealth: 100_000_000, ...overrides });
+
+/**
+ * Same-round damage jutsu attacker -> defender. Distinct ids collapse onto one consequence.
+ *
+ * `rounds: 0` and `targetType: "user"` are added on top of the brief's fixture: neither
+ * `effectRuntimeSchema` nor `DamageTag`'s `BaseAttributes.rounds` supplies a default, so
+ * without them `damageUser`'s `instant`/`residual` check is false and no consequence (and
+ * thus no damage) is ever recorded — `applySingleEffect` also gates every effect type on
+ * `effect.targetType === "user"` before dispatching, and that field has no schema default
+ * either. See `summon_damage_credit.test.ts` for the same two fields on its instant-damage
+ * fixture.
+ */
+const makeAttack = (id = "damage-1"): UserEffect =>
+  makeDamageEffect({
+    id,
+    creatorId: "attacker",
+    targetId: "defender",
+    isNew: true,
+    castThisRound: true,
+    createdRound: ROUND,
+    rounds: 0,
+    targetType: "user",
+  } as Partial<UserEffect>);
+
+/**
+ * Same-round vamp self-buff cast by the attacker (matches consequences by creatorId).
+ *
+ * `rounds: 0` is added on top of the brief's fixture: `calcEffectRoundInfo` recomputes
+ * `effect.castThisRound` from `effect.rounds`/`effect.createdRound` at the top of
+ * `applySingleEffect`, overwriting whatever the fixture set. `VampTag` (like `DamageTag`)
+ * has no schema default for `rounds`, so without it `calcEffectRoundInfo` takes the
+ * `rounds === undefined` branch (`startRound: -1`) and `castThisRound` always resolves to
+ * `false` — silently defeating `vamp()`'s `effect.isNew && effect.castThisRound` gate.
+ */
+const makeVamp = (power: number): UserEffect =>
+  makeEffect(
+    "vamp",
+    { power, calculation: "percentage" },
+    {
+      id: "vamp-1",
+      creatorId: "attacker",
+      targetId: "attacker",
+      isNew: true,
+      castThisRound: true,
+      createdRound: ROUND,
+      actionId: "vamp-action",
+      targetType: "user",
+      rounds: 0,
+    },
+  );
+
+/** Lingering lifesteal buff on the attacker (matches consequences by targetId; must be non-new). */
+const makeLifesteal = (power: number): UserEffect =>
+  makeEffect(
+    "lifesteal",
+    { power, calculation: "percentage" },
+    {
+      id: "lifesteal-1",
+      creatorId: "attacker",
+      targetId: "attacker",
+      isNew: false,
+      castThisRound: false,
+      createdRound: 1,
+      actionId: "lifesteal-action",
+      targetType: "user",
+    },
+  );
+
+/**
+ * Active shield on the target that guarantees activation and absorbs a large
+ * chunk of a hit's damage.
+ *
+ * `shield()` (process.ts) only rolls/activates on `isNew` when `effect.rounds`
+ * is truthy; `ShieldTag.rounds` has a schema prefault of 3, so the default
+ * (unset) rounds already satisfies that gate. On activation it rolls
+ * `Math.random() < power/100` and, on success, sets `effect.power =
+ * shieldEffect.health` — the absorption pass later reads that `power` as
+ * remaining shield capacity (process.ts:549, 566-568). `power: 100` makes the
+ * roll always succeed (`Math.random()` is always `< 1`); `health` sets the
+ * post-activation capacity.
+ */
+const makeShield = (targetId: string): UserEffect =>
+  makeEffect(
+    "shield",
+    { power: 100, health: 100_000 },
+    {
+      id: `shield-${targetId}`,
+      creatorId: targetId,
+      targetId,
+      isNew: true,
+      castThisRound: true,
+      createdRound: ROUND,
+      actionId: "shield-action",
+      targetType: "user",
+    },
+  );
+
+/** A reflect buff on the defender: reflects a % of received damage back at the attacker. */
+const makeReflect = (power: number): UserEffect =>
+  makeEffect(
+    "reflect",
+    { power, calculation: "percentage" },
+    {
+      id: "reflect-1",
+      creatorId: "defender",
+      targetId: "defender",
+      isNew: false,
+      castThisRound: false,
+      createdRound: 1,
+      actionId: "reflect-action",
+      targetType: "user",
+    },
+  );
+
+/** A healprevent debuff targeting a user, created on a given round. */
+const makeHealPrevent = (targetId: string, createdRound: number): UserEffect =>
+  makeEffect(
+    "healprevent",
+    { power: 100, calculation: "static", rounds: 5 },
+    {
+      id: `healprevent-${targetId}`,
+      creatorId: "defender",
+      targetId,
+      targetType: "user",
+      isNew: false,
+      castThisRound: false,
+      createdRound,
+      actionId: "healprevent-action",
+    },
+  );
+
+/** Runs one packet and returns the observed HP deltas. */
+const runLeech = (effects: UserEffect[], attacker = makeAttacker(), defender = makeDefender()) => {
+  const battle = makeBattle([attacker, defender], effects);
+  const { newBattle } = applyEffects(battle, "attacker", makeAction());
+  const a = newBattle.usersState.find((u) => u.userId === "attacker");
+  const d = newBattle.usersState.find((u) => u.userId === "defender");
+  return {
+    healGained: (a?.curHealth ?? 0) - attacker.curHealth,
+    healthLost: defender.curHealth - (d?.curHealth ?? 0),
+  };
+};
+
+describe("applyEffects — vamp + lifesteal shared 60% cap", () => {
+  it("caps the COMBINED heal at 60% of damage when both proc (40% + 40% -> 60%)", () => {
+    // Both raw contributions are 40% of damage; summed 80% must clamp to the 60% budget.
+    const { healGained, healthLost } = runLeech([makeAttack(), makeVamp(40), makeLifesteal(40)]);
+
+    expect(healthLost).toBeGreaterThan(0);
+    // Combined heal clamps to the shared budget. (Before the fix this ratio was ~0.4 — vamp
+    // only — because lifesteal was fully suppressed by the mutual-exclusion guard.)
+    // Ratio assertion is robust to the damage formula's magnitude and to sub-HP flooring.
+    expect(healGained / healthLost).toBeCloseTo(DAMAGE_LEECH_CAP_RATIO, 2);
+  });
+
+  it("vamp alone still caps at 60% of damage", () => {
+    const { healGained, healthLost } = runLeech([makeAttack(), makeVamp(80)]);
+    expect(healthLost).toBeGreaterThan(0);
+    expect(healGained / healthLost).toBeCloseTo(DAMAGE_LEECH_CAP_RATIO, 2);
+  });
+
+  it("lifesteal alone still caps at ~60% of damage", () => {
+    const { healGained, healthLost } = runLeech([makeAttack(), makeLifesteal(80)]);
+    expect(healthLost).toBeGreaterThan(0);
+    expect(healGained / healthLost).toBeCloseTo(DAMAGE_LEECH_CAP_RATIO, 2);
+  });
+
+  it("adds vamp and lifesteal when the combined heal is under the cap", () => {
+    // Deterministic damage per run, so the combined heal equals the exact sum of the two
+    // individual heals (robust to the exact power->ratio math), and stays below the cap.
+    const vampOnly = runLeech([makeAttack(), makeVamp(20)]);
+    const lifestealOnly = runLeech([makeAttack(), makeLifesteal(20)]);
+    const both = runLeech([makeAttack(), makeVamp(20), makeLifesteal(20)]);
+    expect(both.healthLost).toBeGreaterThan(0);
+    expect(both.healGained).toBeCloseTo(vampOnly.healGained + lifestealOnly.healGained, 5);
+    expect(both.healGained).toBeLessThan(both.healthLost * DAMAGE_LEECH_CAP_RATIO);
+  });
+
+  it("shares one budget across merged multi-hit damage on the same target", () => {
+    // Two hits collapse (targetId-keyed) into one consequence; preShieldDamage sums, so the
+    // single budget is derived from the TOTAL damage. 40% + 40% still clamps to 60% of the sum.
+    const { healGained, healthLost } = runLeech([
+      makeAttack("damage-1"),
+      makeAttack("damage-2"),
+      makeVamp(40),
+      makeLifesteal(40),
+    ]);
+    expect(healthLost).toBeGreaterThan(0);
+    expect(healGained / healthLost).toBeCloseTo(DAMAGE_LEECH_CAP_RATIO, 2);
+  });
+
+  it("on a killing blow only vamp heals (lifesteal needs a live target)", () => {
+    const defender = makeDefender({ curHealth: 1 });
+    const kill = runLeech([makeAttack(), makeVamp(40), makeLifesteal(40)], makeAttacker(), defender);
+    // Damage is stat-based (not HP-based), so vamp against a LIVE defender deals identical
+    // damage and thus identical vamp healing. On a killing blow lifesteal is suppressed, so the
+    // heal must equal the vamp-only reference exactly — this would fail if lifesteal wrongly procced.
+    const ref = runLeech([makeAttack(), makeVamp(40)]);
+    expect(kill.healGained).toBeGreaterThan(0);
+    expect(kill.healGained).toBeCloseTo(ref.healGained, 5);
+  });
+
+  it("clamps the combined heal to maxHealth and never exceeds the budget", () => {
+    // Attacker near full: heal is clamped by maxHealth; state stays valid.
+    const attacker = makeAttacker({ curHealth: 99_999_990, maxHealth: 100_000_000 });
+    const { healGained, healthLost } = runLeech(
+      [makeAttack(), makeVamp(40), makeLifesteal(40)],
+      attacker,
+    );
+    expect(healthLost).toBeGreaterThan(0);
+    // curHealth clamped to max: gain is exactly the headroom (10).
+    expect(healGained).toBeCloseTo(10, 5);
+  });
+
+  it("vamps off the full pre-shield damage when the target has a shield", () => {
+    // No-shield reference: vamp (40%) heals 0.4 * full damage D; healthLost == D.
+    const ref = runLeech([makeAttack(), makeVamp(40)]);
+    // Same hit, but the defender has a shield that absorbs a large chunk of it.
+    const shielded = runLeech([makeAttack(), makeVamp(40), makeShield("defender")]);
+    expect(ref.healthLost).toBeGreaterThan(0);
+    // The shield absorbed damage, so less HP was lost than the unshielded reference.
+    expect(shielded.healthLost).toBeLessThan(ref.healthLost);
+    // ...but vamp heals off the FULL pre-shield hit, so the vamp heal matches the
+    // no-shield reference. (Before this change it would be smaller: ~0.4 * post-shield.)
+    expect(shielded.healGained).toBeCloseTo(ref.healGained, 5);
+  });
+
+  it("reflect still kills a low-HP attacker before lifesteal can save them (ordering preserved)", () => {
+    // Attacker at 1 HP with a lingering lifesteal buff; defender reflects the hit.
+    // Reflect runs before lifesteal and re-checks user.curHealth > 0, so the attacker dies
+    // and lifesteal never heals — exactly today's behavior.
+    const attacker = makeAttacker({ curHealth: 1, maxHealth: 100_000_000 });
+    const defender = makeDefender();
+    const battle = makeBattle([attacker, defender], [makeAttack(), makeLifesteal(60), makeReflect(60)]);
+    const { newBattle } = applyEffects(battle, "attacker", makeAction());
+    const a = newBattle.usersState.find((u) => u.userId === "attacker");
+    expect(a?.curHealth).toBe(0);
+  });
+
+  it("healprevent on the attacker blocks vamp (caster-direct check) while lifesteal is gated by its own preventCheck", () => {
+    // Positive control: the same effect stack WITHOUT the prevent heals a nonzero amount,
+    // so the blocked run's 0 is specifically the healprevent firing (not an unrelated no-op).
+    const control = runLeech([makeAttack(), makeVamp(40), makeLifesteal(40)]);
+    expect(control.healGained).toBeGreaterThan(0);
+    const prevent = makeHealPrevent("attacker", 0);
+    const { healGained } = runLeech([makeAttack(), makeVamp(40), makeLifesteal(40), prevent]);
+    expect(healGained).toBe(0);
+  });
+});


### PR DESCRIPTION
# Pull Request

## What was implemented

Two related changes to the combat leech mechanics — the `vamp` and `lifesteal` tags.

### 1. Vamp and lifesteal now stack, sharing a single 60% cap

Previously `vamp` and `lifesteal` were **mutually exclusive**: if a hit triggered vamp, lifesteal was fully suppressed, and each was independently capped at 60% of the hit. Now **both apply on the same hit**, but their **combined** heal is capped at 60% of the (pre-shield) damage:

- Vamp fills the shared 60% budget first; lifesteal takes whatever remains.
- Example: **40% vamp + 40% lifesteal → 60% total** (not 80%). Vamp alone or lifesteal alone still caps at 60%.

### 2. Vamp now leeches off the full pre-shield hit (including shield-absorbed damage)

Previously vamp healed off the **post-shield** damage, so an enemy shield shrank — or completely zeroed — the vamp heal. Vamp now heals off the **full pre-shield** damage. This is consistent with how `lifesteal` already behaves and with the 60% cap (which was already computed on pre-shield damage). A shield that fully absorbs a hit no longer prevents vamp from healing.

## Why

- Players wanted vamp and lifesteal to work together instead of one silently canceling the other, with a sane combined ceiling (60%).
- Vamp ignoring shield-absorbed damage was inconsistent with lifesteal and behaved like a bug in shielded matchups.

## Implementation notes

- **Application points are unchanged.** Vamp still applies early (inside the damage block, and still fires on killing blows); lifesteal still applies late (after reflect/recoil/afterburn, and still requires the target to survive). Only the mutual-exclusion guard was replaced with a shared per-hit budget (`leechBudget` / `leechConsumed`). This deliberately preserves all existing reflect/recoil/killing-blow/shield ordering semantics.
- Added constant `DAMAGE_LEECH_CAP_RATIO = 0.6` (combat constants), scoped to the vamp/lifesteal path.
- Removed the now-unused `appliedVampHeal` variable.
- Vamp-off-shield is a small change in `collapseConsequences`: vamp's heal is computed from `preShieldDamage` instead of the post-shield `damage`.
- **No database or schema changes.**

## Files changed

- `app/src/libs/combat/constants.ts` — add `DAMAGE_LEECH_CAP_RATIO`
- `app/src/libs/combat/process.ts` — shared leech budget; remove `appliedVampHeal`
- `app/src/libs/combat/util.ts` — vamp heals off `preShieldDamage`
- `app/src/libs/combat/tags.ts` — comment/docstring updates (no behavior change)
- `app/tests/libs/combat/vamp_lifesteal_cap.test.ts` — new unit-test suite (10 tests)

## Breaking changes

No API or schema breaks. This is a **gameplay / balance change**: heal outcomes change for any jutsu, item, or bloodline that uses vamp and/or lifesteal — they now stack (up to 60% combined) and vamp heals more in shielded matchups. No migration required.

## Testing

- New unit-test suite covering: combined cap (40%+40%→60%), vamp-only and lifesteal-only caps, additive-under-cap, merged multi-hit shared budget, killing blow (vamp only), maxHealth clamp, vamp-off-shield, reflect-ordering preserved, and heal-prevent independence.
- Full combat test suite: **127 / 127 passing**.
- `tsc --noEmit`: clean.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * **Vamp** and **lifesteal** healing now use a shared 60% per-hit “leech” cap; **vamp consumes first**, then lifesteal uses the remainder.
  * **Vamp** healing is calculated from **pre-shield damage** for more accurate recovery.
* **Bug Fixes**
  * Improved combined leech behavior for multi-hit packets, killing blows, shielded hits, clamping to attacker **max health**, and interaction ordering.
* **Documentation**
  * Updated **vamp** effect descriptions to match the shared cap behavior.
* **Tests**
  * Added coverage for shared-cap clamping and related combat interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->