### PR TITLE
ci: remove Completed label when PR checks fail

### DIFF
--- a/.github/workflows/pr-completed-guard.yml
+++ b/.github/workflows/pr-completed-guard.yml
@@ -7,13 +7,18 @@ on:
     types: [submitted]
   pull_request_review_comment:
     types: [created]
+  check_run:
+    types: [completed]
+  status: {}
 
 permissions:
   pull-requests: write
   issues: write
+  checks: read
+  statuses: read
 
 concurrency:
-  group: pr-completed-guard-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: pr-completed-guard-${{ github.event.pull_request.number || github.event.issue.number || github.event.check_run.head_sha || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -25,22 +30,26 @@ jobs:
         github.event.action == 'labeled' &&
         github.actor == 'github-actions[bot]')
     steps:
-      - name: Check for unresolved review threads
+      - name: Check for unresolved review threads and failing checks
         uses: actions/github-script@v8
         with:
           script: |
             const LABEL_NAME = "Completed";
+            const SELF_CHECK_NAME = "Guard Completed label";
+            // Conclusions/states that indicate a genuinely failing check.
+            // Excludes skipped/cancelled/neutral so concurrency cancellations
+            // and optional checks don't strip the label.
+            const FAILING_CHECK_CONCLUSIONS = [
+              "failure",
+              "timed_out",
+              "action_required",
+            ];
+            const FAILING_STATUS_STATES = ["failure", "error"];
 
-            const prNumber =
-              context.payload.pull_request?.number ??
-              context.payload.issue?.number;
+            // Determine which PRs to evaluate based on the triggering event
+            let prNumbers = [];
+            let headSha = null;
 
-            if (!prNumber) {
-              core.info("Could not determine PR number. Skipping.");
-              return;
-            }
-
-            // For "labeled" events, only proceed if the label is "Completed"
             if (
               context.eventName === "pull_request" &&
               context.payload.action === "labeled"
@@ -51,14 +60,62 @@ jobs:
                 );
                 return;
               }
-            }
-
-            // For review and review_comment events, check if the PR currently
-            // has the "Completed" label. If not, nothing to guard.
-            if (
+              prNumbers = [context.payload.pull_request.number];
+            } else if (
               context.eventName === "pull_request_review" ||
               context.eventName === "pull_request_review_comment"
             ) {
+              prNumbers = [context.payload.pull_request.number];
+            } else if (context.eventName === "check_run") {
+              const run = context.payload.check_run;
+              if (run.name === SELF_CHECK_NAME) {
+                core.info("Ignoring this workflow's own check run.");
+                return;
+              }
+              if (!FAILING_CHECK_CONCLUSIONS.includes(run.conclusion)) {
+                core.info(
+                  `Check "${run.name}" concluded "${run.conclusion}". Not a failure. Skipping.`,
+                );
+                return;
+              }
+              headSha = run.head_sha;
+            } else if (context.eventName === "status") {
+              if (!FAILING_STATUS_STATES.includes(context.payload.state)) {
+                core.info(
+                  `Status "${context.payload.context}" is "${context.payload.state}". Not a failure. Skipping.`,
+                );
+                return;
+              }
+              headSha = context.payload.sha;
+            }
+
+            // check_run/status events carry no PR context; resolve open PRs
+            // whose current head matches the commit the check ran against
+            if (headSha) {
+              const { data: prs } =
+                await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  commit_sha: headSha,
+                });
+              prNumbers = prs
+                .filter((pr) => pr.state === "open" && pr.head.sha === headSha)
+                .map((pr) => pr.number);
+              if (prNumbers.length === 0) {
+                core.info(
+                  `No open PRs with head ${headSha}. Skipping.`,
+                );
+                return;
+              }
+            }
+
+            if (prNumbers.length === 0) {
+              core.info("Could not determine PR number(s). Skipping.");
+              return;
+            }
+
+            for (const prNumber of prNumbers) {
+              // Only guard PRs that currently carry the "Completed" label
               const { data: labels } =
                 await github.rest.issues.listLabelsOnIssue({
                   owner: context.repo.owner,
@@ -74,24 +131,45 @@ jobs:
                 core.info(
                   `PR #${prNumber} does not have "${LABEL_NAME}" label. Skipping.`,
                 );
-                return;
+                continue;
               }
-            }
 
-            // Query unresolved review threads via GraphQL
-            const query = `
-              query($owner: String!, $repo: String!, $prNumber: Int!) {
-                repository(owner: $owner, name: $repo) {
-                  pullRequest(number: $prNumber) {
-                    reviewThreads(first: 100) {
-                      nodes {
-                        isResolved
-                        isOutdated
-                        comments(first: 1) {
-                          nodes {
-                            body
-                            author {
-                              login
+              // Query unresolved review threads and check rollup via GraphQL
+              const query = `
+                query($owner: String!, $repo: String!, $prNumber: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $prNumber) {
+                      reviewThreads(first: 100) {
+                        nodes {
+                          isResolved
+                          isOutdated
+                          comments(first: 1) {
+                            nodes {
+                              body
+                              author {
+                                login
+                              }
+                            }
+                          }
+                        }
+                      }
+                      commits(last: 1) {
+                        nodes {
+                          commit {
+                            statusCheckRollup {
+                              contexts(first: 100) {
+                                nodes {
+                                  __typename
+                                  ... on CheckRun {
+                                    name
+                                    conclusion
+                                  }
+                                  ... on StatusContext {
+                                    context
+                                    state
+                                  }
+                                }
+                              }
                             }
                           }
                         }
@@ -99,77 +177,129 @@ jobs:
                     }
                   }
                 }
-              }
-            `;
+              `;
 
-            const result = await github.graphql(query, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              prNumber: prNumber,
-            });
+              const result = await github.graphql(query, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                prNumber: prNumber,
+              });
 
-            const threads =
-              result.repository.pullRequest.reviewThreads.nodes;
-            const unresolvedThreads = threads.filter(
-              (t) => !t.isResolved && !t.isOutdated,
-            );
+              const pullRequest = result.repository.pullRequest;
 
-            if (unresolvedThreads.length === 0) {
-              core.info(
-                `PR #${prNumber} has no unresolved review threads. "${LABEL_NAME}" label is valid.`,
+              const threads = pullRequest.reviewThreads.nodes;
+              const unresolvedThreads = threads.filter(
+                (t) => !t.isResolved && !t.isOutdated,
               );
-              return;
-            }
 
-            // There are unresolved threads -- remove the label
-            core.info(
-              `PR #${prNumber} has ${unresolvedThreads.length} unresolved review thread(s). Removing "${LABEL_NAME}" label.`,
-            );
+              const rollupContexts =
+                pullRequest.commits.nodes[0]?.commit?.statusCheckRollup
+                  ?.contexts?.nodes ?? [];
+              const failingChecks = rollupContexts.filter((c) => {
+                if (c.__typename === "CheckRun") {
+                  return (
+                    c.name !== SELF_CHECK_NAME &&
+                    FAILING_CHECK_CONCLUSIONS.includes(
+                      (c.conclusion ?? "").toLowerCase(),
+                    )
+                  );
+                }
+                if (c.__typename === "StatusContext") {
+                  return FAILING_STATUS_STATES.includes(
+                    (c.state ?? "").toLowerCase(),
+                  );
+                }
+                return false;
+              });
 
-            try {
-              await github.rest.issues.removeLabel({
+              if (unresolvedThreads.length === 0 && failingChecks.length === 0) {
+                core.info(
+                  `PR #${prNumber} has no unresolved review threads or failing checks. "${LABEL_NAME}" label is valid.`,
+                );
+                continue;
+              }
+
+              core.info(
+                `PR #${prNumber} has ${unresolvedThreads.length} unresolved review thread(s) and ${failingChecks.length} failing check(s). Removing "${LABEL_NAME}" label.`,
+              );
+
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  name: LABEL_NAME,
+                });
+              } catch (removeError) {
+                if (removeError.status !== 404) throw removeError;
+                core.info(
+                  `"${LABEL_NAME}" label was already removed from PR #${prNumber}.`,
+                );
+              }
+
+              // Post a comment explaining the removal
+              const bodyParts = [
+                `## "${LABEL_NAME}" label removed`,
+                "",
+              ];
+
+              if (unresolvedThreads.length > 0) {
+                const threadSummary = unresolvedThreads
+                  .slice(0, 5)
+                  .map((t) => {
+                    const comment = t.comments.nodes[0];
+                    const author = comment?.author?.login ?? "unknown";
+                    const snippet =
+                      (comment?.body ?? "").substring(0, 80) +
+                      ((comment?.body ?? "").length > 80 ? "..." : "");
+                    return `- **@${author}**: ${snippet}`;
+                  })
+                  .join("\n");
+                const remaining =
+                  unresolvedThreads.length > 5
+                    ? `\n- ...and ${unresolvedThreads.length - 5} more`
+                    : "";
+                bodyParts.push(
+                  `This PR has **${unresolvedThreads.length} unresolved review thread(s)**.`,
+                  "",
+                  "**Unresolved threads:**",
+                  threadSummary + remaining,
+                  "",
+                );
+              }
+
+              if (failingChecks.length > 0) {
+                const checkSummary = failingChecks
+                  .slice(0, 10)
+                  .map((c) => {
+                    const name =
+                      c.__typename === "CheckRun" ? c.name : c.context;
+                    const outcome =
+                      c.__typename === "CheckRun" ? c.conclusion : c.state;
+                    return `- **${name}**: ${outcome}`;
+                  })
+                  .join("\n");
+                const remaining =
+                  failingChecks.length > 10
+                    ? `\n- ...and ${failingChecks.length - 10} more`
+                    : "";
+                bodyParts.push(
+                  `This PR has **${failingChecks.length} failing check(s)**.`,
+                  "",
+                  "**Failing checks:**",
+                  checkSummary + remaining,
+                  "",
+                );
+              }
+
+              bodyParts.push(
+                "Please resolve all review threads and fix failing checks before re-applying the label.",
+              );
+
+              await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: prNumber,
-                name: LABEL_NAME,
+                body: bodyParts.join("\n"),
               });
-            } catch (removeError) {
-              if (removeError.status !== 404) throw removeError;
-              core.info(
-                `"${LABEL_NAME}" label was already removed from PR #${prNumber}.`,
-              );
             }
-
-            // Post a comment explaining the removal
-            const threadSummary = unresolvedThreads
-              .slice(0, 5)
-              .map((t) => {
-                const comment = t.comments.nodes[0];
-                const author = comment?.author?.login ?? "unknown";
-                const snippet =
-                  (comment?.body ?? "").substring(0, 80) +
-                  ((comment?.body ?? "").length > 80 ? "..." : "");
-                return `- **@${author}**: ${snippet}`;
-              })
-              .join("\n");
-
-            const remaining =
-              unresolvedThreads.length > 5
-                ? `\n- ...and ${unresolvedThreads.length - 5} more`
-                : "";
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body: [
-                `## "${LABEL_NAME}" label removed`,
-                "",
-                `This PR has **${unresolvedThreads.length} unresolved review thread(s)**. The "${LABEL_NAME}" label has been automatically removed.`,
-                "",
-                "Please resolve all review threads before re-applying the label.",
-                "",
-                "**Unresolved threads:**",
-                threadSummary + remaining,
-              ].join("\n"),
-            });

--- a/.github/workflows/pr-completed-guard.yml
+++ b/.github/workflows/pr-completed-guard.yml
@@ -18,7 +18,7 @@ permissions:
   statuses: read
 
 concurrency:
-  group: pr-completed-guard-${{ github.event.pull_request.number || github.event.issue.number || github.event.check_run.head_sha || github.sha }}
+  group: pr-completed-guard-${{ github.event.pull_request.number || github.event.issue.number || github.event.check_run.head_sha || github.event.sha || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -134,12 +134,18 @@ jobs:
                 continue;
               }
 
-              // Query unresolved review threads and check rollup via GraphQL
+              // Query unresolved review threads and check rollup via GraphQL,
+              // following pagination cursors so PRs with more than 100 review
+              // threads or check contexts are fully evaluated
               const query = `
-                query($owner: String!, $repo: String!, $prNumber: Int!) {
+                query($owner: String!, $repo: String!, $prNumber: Int!, $threadCursor: String, $contextCursor: String) {
                   repository(owner: $owner, name: $repo) {
                     pullRequest(number: $prNumber) {
-                      reviewThreads(first: 100) {
+                      reviewThreads(first: 100, after: $threadCursor) {
+                        pageInfo {
+                          hasNextPage
+                          endCursor
+                        }
                         nodes {
                           isResolved
                           isOutdated
@@ -157,7 +163,11 @@ jobs:
                         nodes {
                           commit {
                             statusCheckRollup {
-                              contexts(first: 100) {
+                              contexts(first: 100, after: $contextCursor) {
+                                pageInfo {
+                                  hasNextPage
+                                  endCursor
+                                }
                                 nodes {
                                   __typename
                                   ... on CheckRun {
@@ -179,22 +189,45 @@ jobs:
                 }
               `;
 
-              const result = await github.graphql(query, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                prNumber: prNumber,
-              });
+              const threads = [];
+              const rollupContexts = [];
+              let threadCursor = null;
+              let contextCursor = null;
+              let hasMoreThreads = true;
+              let hasMoreContexts = true;
+              while (hasMoreThreads || hasMoreContexts) {
+                const result = await github.graphql(query, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  prNumber: prNumber,
+                  threadCursor,
+                  contextCursor,
+                });
+                const pullRequest = result.repository.pullRequest;
 
-              const pullRequest = result.repository.pullRequest;
+                if (hasMoreThreads) {
+                  const page = pullRequest.reviewThreads;
+                  threads.push(...page.nodes);
+                  hasMoreThreads = page.pageInfo.hasNextPage;
+                  threadCursor = page.pageInfo.endCursor;
+                }
+                if (hasMoreContexts) {
+                  const page =
+                    pullRequest.commits.nodes[0]?.commit?.statusCheckRollup
+                      ?.contexts;
+                  if (page) {
+                    rollupContexts.push(...page.nodes);
+                    hasMoreContexts = page.pageInfo.hasNextPage;
+                    contextCursor = page.pageInfo.endCursor;
+                  } else {
+                    hasMoreContexts = false;
+                  }
+                }
+              }
 
-              const threads = pullRequest.reviewThreads.nodes;
               const unresolvedThreads = threads.filter(
                 (t) => !t.isResolved && !t.isOutdated,
               );
-
-              const rollupContexts =
-                pullRequest.commits.nodes[0]?.commit?.statusCheckRollup
-                  ?.contexts?.nodes ?? [];
               const failingChecks = rollupContexts.filter((c) => {
                 if (c.__typename === "CheckRun") {
                   return (
@@ -232,9 +265,13 @@ jobs:
                 });
               } catch (removeError) {
                 if (removeError.status !== 404) throw removeError;
+                // A concurrent run (e.g. a check_run event racing a review
+                // event in a different concurrency group) already removed the
+                // label and posted the explanation; skip the duplicate comment
                 core.info(
                   `"${LABEL_NAME}" label was already removed from PR #${prNumber}.`,
                 );
+                continue;
               }
 
               // Post a comment explaining the removal

--- a/app/tests/libs/jutsu.test.ts
+++ b/app/tests/libs/jutsu.test.ts
@@ -7,26 +7,21 @@ import type { UserJutsuWithRelations } from "@/drizzle/schema";
 
 // Stub the dependency decisions so these tests target the validator's own logic
 // (ownership, hidden gate, equip caps, ordering) rather than canUseJutsu's
-// requirement rules or the federal-tier equip-limit maths.
+// requirement rules or the federal-tier equip-limit maths. The hidden-jutsu
+// gate uses the real canChangeContent, since module mocks leak across test
+// files under bun's test runner and would corrupt the permissions tests.
 vi.mock("@/libs/train", () => ({
   canUseJutsu: vi.fn((jutsu: { usable?: boolean }) => jutsu?.usable !== false),
   calcJutsuEquipLimit: vi.fn(() => 100),
 }));
-vi.mock("@/utils/permissions", () => ({
-  canChangeContent: vi.fn((role: string) => role === "CONTENT-ADMIN"),
-}));
 
 import { computeJutsuLoadoutAssignments } from "@/libs/jutsu";
 import type { UserWithRelations } from "@/routers/profile";
-import { canChangeContent } from "@/utils/permissions";
 import { calcJutsuEquipLimit } from "@/libs/train";
 
 const calcJutsuEquipLimitMock = calcJutsuEquipLimit as unknown as {
   mockReturnValue: (value: number) => void;
   mockReturnValueOnce: (value: number) => void;
-};
-const canChangeContentMock = canChangeContent as unknown as {
-  mockImplementation: (fn: (role: string) => boolean) => void;
 };
 
 // Minimal user-jutsu factory; only the fields the validator reads are set. The
@@ -59,7 +54,6 @@ const USER = { role: "USER" } as unknown as NonNullable<UserWithRelations>;
 describe("computeJutsuLoadoutAssignments", () => {
   beforeEach(() => {
     calcJutsuEquipLimitMock.mockReturnValue(100);
-    canChangeContentMock.mockImplementation((role) => role === "CONTENT-ADMIN");
   });
 
   it("equips all valid jutsu, preserving loadout order", () => {


### PR DESCRIPTION
## Summary

Extends the `PR Completed Label Guard` workflow so the `Completed` label is also removed when any review check fails — not just when unresolved review threads exist.

## Changes

- **New triggers**: `check_run` (completed) for GitHub Actions checks (test_build, test_typecheck, etc.) and `status` for commit statuses (Vercel, CodeRabbit).
- **PR resolution**: check_run/status events carry no PR context, so open PRs are resolved via the head SHA and only evaluated if their current head still matches the commit the check ran against (avoids acting on stale results after a new push).
- **Failure detection**: a PR's `statusCheckRollup` is queried via GraphQL; check runs with conclusion `failure`/`timed_out`/`action_required` and status contexts in `failure`/`error` count as failing. `skipped`/`cancelled`/`neutral` are ignored so concurrency cancellations and optional checks don't strip the label. The guard's own check run is excluded to prevent self-triggering.
- **Labeled event now validates checks too**: applying `Completed` while checks are already red removes the label immediately.
- **Concurrency fix**: group key falls back to head SHA for check/status events so runs for different PRs no longer collapse into one group.
- The removal comment now lists failing checks alongside unresolved threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for the **Completed** label, now gating on both unresolved review threads and failing status/check results.
  * The **Completed** label explanation and removal behavior now reflect the current mix of unresolved threads and failing checks.
  * Enhanced accuracy across pull request, review, check run, and status-related events.
* **Tests**
  * Updated hidden-jutsu tests to use real permission logic for the hidden-jutsu gate, improving coverage reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->