### PR TITLE
fix: stop treating pinned-session tabs as signed out under Clerk multi-session

### DIFF
--- a/app/src/app/_trpc/SessionPinProvider.tsx
+++ b/app/src/app/_trpc/SessionPinProvider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useSession, useSessionList } from "@clerk/nextjs";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import {
   createContext,
   Fragment,
@@ -13,12 +13,15 @@ import {
   useState,
 } from "react";
 import {
+  clearPinnedSessionStorage,
   decidePinnedSession,
   isAuthRoute,
   pinChangeRequiresRemount,
   readPinnedSessionId,
+  readPinnedUserId,
   resolvePinnedSession,
   writePinnedSessionId,
+  writePinnedUserId,
 } from "./sessionPin";
 
 interface SessionPinContextValue {
@@ -47,10 +50,13 @@ const SessionPinContext = createContext<SessionPinContextValue | null>(null);
  * It also replaces Clerk's `MultisessionAppSupport`: that component remounts the
  * app keyed on the ACTIVE session, which would re-flip the tab on every global
  * active-session change. Here we remount the subtree (fresh tRPC client + React
- * Query cache) only on a cross-account pin change — i.e. when the pinned account is
- * no longer signed in and the tab adopts a different signed-in account (see
- * `pinChangeRequiresRemount`). A background active-session change does not remount,
- * and neither does the first-load adoption of the tab's own account, so the normal
+ * Query cache) only when the pin moves off a signed-in account (see
+ * `pinChangeRequiresRemount`) — re-pinning the same account's fresh session, or
+ * clearing a dead pin before the tab heads to the sign-in flow. The tab NEVER
+ * silently adopts a different signed-in account: when the pinned session dies while
+ * another account remains, the pin is released and the user picks an account on
+ * /login explicitly. A background active-session change does not remount, and
+ * neither does the first-load adoption of the tab's own account, so the normal
  * signed-in first load and post-sign-in redirect do not pay a tree-wide remount.
  */
 export function SessionPinProvider(props: { children: React.ReactNode }) {
@@ -93,20 +99,57 @@ export function SessionPinProvider(props: { children: React.ReactNode }) {
   // source of truth) is NEVER overridden by a background active-session change —
   // that is what keeps the tab on its account. Re-runs when the tab leaves the auth
   // route so the just-signed-in account is adopted after the redirect.
+  //
+  // When the pinned session is DEAD (no longer signed in) and the active session
+  // belongs to a DIFFERENT account, the decision is "release": clear the pin and
+  // send the tab to the sign-in flow so the user picks an account explicitly. The
+  // tab must never silently switch accounts. Nulling the pin remounts the app
+  // subtree (see pinChangeRequiresRemount), which drops the old account's caches.
+  const router = useRouter();
+  // True from a "release" until the tab reaches the sign-in flow. In that window
+  // the tab has no pin, so a Clerk sessions refresh re-running the effect before
+  // the /login navigation completes would otherwise read as a first-load and adopt
+  // the other account — the exact silent switch release exists to prevent.
+  const releasedRef = useRef(false);
   useEffect(() => {
     if (!isLoaded) return;
+    if (releasedRef.current) {
+      if (!onAuthRoute) {
+        // Still between release and the sign-in flow: adopt nothing, keep steering
+        // to /login (re-issued in case the original navigation was interrupted).
+        router.push("/login");
+        return;
+      }
+      releasedRef.current = false;
+    }
     const decision = decidePinnedSession({
       sessions,
       inMemoryPinnedId: pinnedIdRef.current,
       storedPinnedId: readPinnedSessionId(),
+      storedPinnedUserId: readPinnedUserId(),
       activeSessionId,
       onAuthRoute,
     });
     if (decision.type === "set") {
       writePinnedSessionId(decision.id);
+      const pinnedUser = resolvePinnedSession(sessions, decision.id)?.user?.id;
+      if (pinnedUser) writePinnedUserId(pinnedUser);
       setPinnedSessionId(decision.id);
+    } else if (decision.type === "clear" || decision.type === "release") {
+      clearPinnedSessionStorage();
+      setPinnedSessionId(null);
+      if (decision.type === "release") {
+        releasedRef.current = true;
+        router.push("/login");
+      }
+    } else {
+      // Backfill the stored user id for pins written before it existed, so a later
+      // dead-pin recovery can tell "same account again" from "different account".
+      const pinnedUser = resolvePinnedSession(sessions, pinnedIdRef.current)?.user?.id;
+      if (pinnedUser && readPinnedUserId() !== pinnedUser)
+        writePinnedUserId(pinnedUser);
     }
-  }, [isLoaded, sessions, activeSessionId, onAuthRoute]);
+  }, [isLoaded, sessions, activeSessionId, onAuthRoute, router]);
 
   const pinnedSession = useMemo(
     () => resolvePinnedSession(sessions, pinnedSessionId),

--- a/app/src/app/_trpc/authHeaders.ts
+++ b/app/src/app/_trpc/authHeaders.ts
@@ -18,6 +18,23 @@ export const TAB_AUTH_REQUIRED_HEADER = "x-tnr-auth-required";
 export const VIEWER_SESSION_MISMATCH_MESSAGE = "Viewer/session mismatch";
 
 /**
+ * Whether a failed request is one of the transient multi-session auth failures that
+ * self-heal once the per-tab token path recovers: the server's fail-closed
+ * UNAUTHORIZED (the tab intended a per-tab bearer token but none arrived — e.g. a
+ * `getToken()` blip) or the FORBIDDEN viewer/session mismatch guard (the request
+ * authenticated as another tab's account via the shared cookie). The client retries
+ * these instead of treating the tab as signed out — surfacing them immediately is
+ * what bounced signed-in users to the logged-out landing page.
+ */
+export function isTransientMultiSessionAuthError(
+  code: string | undefined,
+  message: string,
+): boolean {
+  if (code === "UNAUTHORIZED") return true;
+  return code === "FORBIDDEN" && message.includes(VIEWER_SESSION_MISMATCH_MESSAGE);
+}
+
+/**
  * Builds the auth headers for an outgoing tRPC request under Clerk multi-session.
  *
  * The `__session` cookie is shared across all browser tabs and reflects whichever

--- a/app/src/app/_trpc/client.ts
+++ b/app/src/app/_trpc/client.ts
@@ -7,6 +7,7 @@ import { TRPCClientError } from "@trpc/client";
 import { createTRPCReact } from "@trpc/react-query";
 import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
 import type { AppRouter } from "@/api/root";
+import { useSessionPin } from "@/app/_trpc/SessionPinProvider";
 import { toast } from "@/components/ui/use-toast";
 
 /** A set of type-safe react-query hooks for your tRPC API. */
@@ -55,13 +56,19 @@ export const onError = (err: unknown) => {
 export const PUBLIC_MUTATIONS: string[] = ["towerDefense.initiateGuestSession"];
 
 export const useGlobalOnMutateProtect = () => {
+  // Clerk multi-session: the tab's identity is its PINNED session, and the
+  // browser-global active session can flip or drop while the pinned session is
+  // still signed in (e.g. the other account signs out, or cross-tab active-context
+  // races). Either signal proves the tab can act — only block a mutation when
+  // NEITHER the pinned session nor the browser-global session is signed in.
   const { isSignedIn } = useUser();
+  const { pinnedUserId } = useSessionPin();
   return (mutationPath?: string) => {
     // Skip check for public mutations
     if (mutationPath && PUBLIC_MUTATIONS.includes(mutationPath)) {
       return;
     }
-    if (!isSignedIn) {
+    if (!isSignedIn && !pinnedUserId) {
       throw new Error(SIGN_IN_REQUIRED_MUTATION_MESSAGE);
     }
   };

--- a/app/src/app/_trpc/sessionPin.ts
+++ b/app/src/app/_trpc/sessionPin.ts
@@ -11,6 +11,7 @@
  */
 
 export const PINNED_SESSION_STORAGE_KEY = "tnr-pinned-clerk-session-id";
+export const PINNED_USER_STORAGE_KEY = "tnr-pinned-clerk-user-id";
 
 export function readPinnedSessionId(): string | null {
   if (typeof window === "undefined") return null;
@@ -28,6 +29,44 @@ export function writePinnedSessionId(sessionId: string): void {
   } catch {
     // sessionStorage can throw (private mode / quota). Pinning then falls back to
     // the active session, i.e. the pre-existing behavior — no worse than before.
+  }
+}
+
+/**
+ * The Clerk USER id of the pinned session, stored alongside the session id. A
+ * session id alone cannot tell whether a replacement session belongs to the same
+ * account once the original session is gone from the sessions list, so this is
+ * what lets a dead pin distinguish "same account signed in again" (silently
+ * re-adopt) from "a different account is active" (never silently switch — see
+ * `decidePinnedSession`).
+ */
+export function readPinnedUserId(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.sessionStorage.getItem(PINNED_USER_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function writePinnedUserId(userId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(PINNED_USER_STORAGE_KEY, userId);
+  } catch {
+    // Same failure mode as writePinnedSessionId: a missing stored user id only
+    // means a later dead-pin recovery routes through the explicit sign-in flow
+    // instead of silently re-adopting — safe, never account-swapping.
+  }
+}
+
+export function clearPinnedSessionStorage(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(PINNED_SESSION_STORAGE_KEY);
+    window.sessionStorage.removeItem(PINNED_USER_STORAGE_KEY);
+  } catch {
+    // Ignore: with storage unavailable there is nothing stale to clear.
   }
 }
 
@@ -65,7 +104,11 @@ export function isAuthRoute(pathname: string | null | undefined): boolean {
   );
 }
 
-export type PinDecision = { type: "keep" } | { type: "set"; id: string };
+export type PinDecision =
+  | { type: "keep" }
+  | { type: "set"; id: string }
+  | { type: "clear" }
+  | { type: "release" };
 
 /**
  * Decides this tab's pinned session id from the current Clerk state, WITHOUT ever
@@ -76,18 +119,41 @@ export type PinDecision = { type: "keep" } | { type: "set"; id: string };
  *
  * Order: keep a still-signed-in in-memory pin → recover a still-signed-in stored
  * pin (e.g. after reload) → otherwise, only once the sessions list is populated
- * (never mid-refresh when it is momentarily empty), and only off the sign-in flow,
- * adopt the active session.
+ * (never mid-refresh when it is momentarily empty), decide what a tab without a
+ * usable pin does:
+ *
+ * - A tab that never had a pin adopts the active session on first load (but not
+ *   while on the sign-in flow — adoption happens after the redirect).
+ * - A tab whose pin is DEAD (the pinned session is no longer signed in) only
+ *   silently re-adopts the active session when it belongs to the SAME account
+ *   (matched via the stored pinned user id — e.g. the user signed in again after
+ *   expiry). When the active session belongs to a different account — or the
+ *   pinned account is unknown — the decision is `release`: the tab must never
+ *   silently switch to another signed-in account; the caller clears the pin and
+ *   sends the tab through the sign-in flow so the user picks an account
+ *   explicitly.
+ * - On the sign-in flow a dead pin is `clear`ed (not kept): the user is about to
+ *   choose an account there, and a lingering dead pin would otherwise read as a
+ *   cross-account move and bounce the tab straight back to sign-in afterwards.
  */
-export function decidePinnedSession<T extends { id: string; status: string }>(args: {
+export function decidePinnedSession<
+  T extends { id: string; status: string; user?: { id: string } | null },
+>(args: {
   sessions: readonly T[] | undefined | null;
   inMemoryPinnedId: string | null;
   storedPinnedId: string | null;
+  storedPinnedUserId: string | null;
   activeSessionId: string | null;
   onAuthRoute: boolean;
 }): PinDecision {
-  const { sessions, inMemoryPinnedId, storedPinnedId, activeSessionId, onAuthRoute } =
-    args;
+  const {
+    sessions,
+    inMemoryPinnedId,
+    storedPinnedId,
+    storedPinnedUserId,
+    activeSessionId,
+    onAuthRoute,
+  } = args;
   if (resolvePinnedSession(sessions, inMemoryPinnedId)) return { type: "keep" };
   const storedSession = resolvePinnedSession(sessions, storedPinnedId);
   if (storedSession) {
@@ -98,36 +164,42 @@ export function decidePinnedSession<T extends { id: string; status: string }>(ar
   // Sessions momentarily empty (Clerk mid-refresh): leave the pin untouched rather
   // than re-adopting and flipping the tab.
   if (!sessions || sessions.length === 0) return { type: "keep" };
+  // From here on the tab either never had a pin, or its pin is dead (the pinned
+  // session is no longer signed in).
+  const hadPin = inMemoryPinnedId !== null || storedPinnedId !== null;
   // On the sign-in / sign-up flow, do NOT eagerly adopt the browser-global active
   // session: the user may be about to sign in a DIFFERENT account, and an eager pin
   // here would later block that in-tab switch (the active session changes to the new
   // account, but the now-"valid" eager pin keeps the old one). Adoption happens once
   // the completed sign-in redirects the tab onto an app route. An already-established
-  // pin is honored above, so a pinned tab visiting /login keeps its own account.
-  if (onAuthRoute) return { type: "keep" };
-  // No pinned session is signed in (first load, or the pinned account was signed
-  // out and another remains) → adopt the active session, but only when it resolves
-  // to a signed-in session (like the in-memory and stored paths) so getPinnedToken
-  // can still mint a token for it.
+  // pin is honored above, so a pinned tab visiting /login keeps its own account. A
+  // DEAD pin is cleared here so whatever account comes out of the sign-in flow is
+  // adopted cleanly instead of being mistaken for a cross-account move.
+  if (onAuthRoute) return hadPin ? { type: "clear" } : { type: "keep" };
+  // Only a signed-in active session can be adopted (like the in-memory and stored
+  // paths) so getPinnedToken can still mint a token for it.
   const activeSession = resolvePinnedSession(sessions, activeSessionId);
-  if (activeSession) return { type: "set", id: activeSession.id };
-  return { type: "keep" };
+  if (!activeSession) return { type: "keep" };
+  // First load with no pin: adopt the active session.
+  if (!hadPin) return { type: "set", id: activeSession.id };
+  // Dead pin: silently re-adopt only the SAME account (e.g. a fresh session after
+  // the old one expired). A different or unknown account must never be adopted
+  // silently — that is exactly the "randomly swapped to my other account" bug.
+  if (storedPinnedUserId && activeSession.user?.id === storedPinnedUserId) {
+    return { type: "set", id: activeSession.id };
+  }
+  return { type: "release" };
 }
 
 /**
  * Whether a change of this tab's pinned session id should remount the app subtree
  * (fresh tRPC client + React Query cache). True whenever the pin moves OFF a
- * signed-in account to a different value — in practice when the pinned account is no
- * longer signed in and the tab adopts a different signed-in account (e.g. the pinned
- * account signs out while another remains, so the adoption effect re-pins A → B).
- * Such a move can leave a different account's data behind in React Query caches that
- * are not scoped per account (`profile.getUser` is scoped via `getUserQueryInput`,
- * but other queries are not), so the subtree must remount to discard it.
- *
- * The `prev !== null` guard also covers an `id → null` change. No live path nulls the
- * pin after mount today (sign-out is Clerk-UI-driven and does not clear the pin — it
- * simply stops resolving), so that branch is defensive: it keeps the remount correct
- * if a future intentional switch/clear ever nulls the pin.
+ * signed-in account to a different value — re-pinning to the same account's fresh
+ * session (A → A'), or nulling the pin on a `clear`/`release` decision before the
+ * tab heads to the sign-in flow. Such a move can leave the previous account's data
+ * behind in React Query caches that are not scoped per account (`profile.getUser`
+ * is scoped via `getUserQueryInput`, but other queries are not), so the subtree
+ * must remount to discard it.
  *
  * The first-load `null → id` adoption returns false (no remount): the brief unpinned
  * window does not populate any account-private cache. Account-private queries are

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -15,13 +15,19 @@ export default function Index() {
   const { data: userData, status: userStatus, userId } = useUserData();
   const setReferral = api.register.setReferralSource.useMutation();
 
+  // Clerk multi-session: the tab is signed in when its pinned session resolves
+  // (`userId`), even when the browser-global active session momentarily is not —
+  // treating the global signal alone as truth showed the logged-out landing page
+  // to signed-in users.
+  const isSignedInTab = !!isSignedIn || !!userId;
+
   // Navigation
   const router = useRouter();
 
   // Redirect based on user status
   useEffect(() => {
     // When user is signed in (Clerk) but has not created a character yet, set referral immediately
-    if (isSignedIn && !userData && userStatus !== "pending") {
+    if (isSignedInTab && !userData && userStatus !== "pending") {
       // attempt to read utm_source from localStorage if present
       const utm = safeLocalStorageGetItem("utm_source");
       setReferral.mutate({ utmSource: utm ?? undefined });
@@ -36,10 +42,10 @@ export default function Index() {
     if (userData && userId) {
       void router.push("/profile");
     }
-  }, [isSignedIn, userData, userId, userStatus]);
+  }, [isSignedInTab, userData, userId, userStatus]);
 
   // Guard
-  if (!isSignedIn && !userData) {
+  if (!isSignedInTab && !userData) {
     return <Welcome />;
   } else {
     return <Loader explanation="Forwarding to profile" />;

--- a/app/src/layout/Welcome.tsx
+++ b/app/src/layout/Welcome.tsx
@@ -29,6 +29,7 @@ import { LEGAL_LINKS } from "@/libs/legalLinks";
 import { cn } from "@/libs/shadui";
 import { useActiveLayout, useIsPixelLanding } from "@/utils/LayoutContext";
 import { getFirstOfNextMonth } from "@/utils/time";
+import { useUserData } from "@/utils/UserContext";
 
 const Welcome: React.FC = () => {
   const activeLayout = useActiveLayout();
@@ -1036,6 +1037,9 @@ const usePixelHeroVideoPlayback = (
 const SetReferal = () => {
   const searchParams = useSearchParams();
   const { isSignedIn, isLoaded } = useUser();
+  // Clerk multi-session: a tab whose pinned session is signed in is not an
+  // anonymous visitor, even if the browser-global active session momentarily is.
+  const { userId } = useUserData();
   const { mutate: trackVisitor } = api.misc.trackVisitor.useMutation({
     onMutate: undefined,
   });
@@ -1048,13 +1052,13 @@ const SetReferal = () => {
     if (utm_source) safeLocalStorageSetItem("utm_source", utm_source);
     // Track anonymous visitor once
     const alreadyTracked = safeLocalStorageGetItem("visitor_tracked");
-    if (!alreadyTracked && isLoaded && !isSignedIn) {
+    if (!alreadyTracked && isLoaded && !isSignedIn && !userId) {
       const savedRef = safeLocalStorageGetItem("ref") ?? undefined;
       const savedUtm = safeLocalStorageGetItem("utm_source") ?? undefined;
       trackVisitor({ ref: savedRef, utmSource: savedUtm });
       safeLocalStorageSetItem("visitor_tracked", "1");
     }
-  }, [searchParams, isLoaded, isSignedIn, trackVisitor]);
+  }, [searchParams, isLoaded, isSignedIn, userId, trackVisitor]);
   return null;
 };
 

--- a/app/src/utils/UserContext.tsx
+++ b/app/src/utils/UserContext.tsx
@@ -8,6 +8,7 @@ import type Pusher from "pusher-js";
 import type React from "react";
 import { createContext, useContext, useEffect, useState } from "react";
 import type { UserWithRelations } from "@/api/routers/profile";
+import { isTransientMultiSessionAuthError } from "@/app/_trpc/authHeaders";
 import { api } from "@/app/_trpc/client";
 import { getUserQueryInput } from "@/app/_trpc/getUserQueryInput";
 import { useSessionPin } from "@/app/_trpc/SessionPinProvider";
@@ -87,11 +88,16 @@ export function UserContextProvider(props: { children: React.ReactNode }) {
 
   // Get user data. Pass the pinned Clerk userId so the React Query cache is scoped
   // per account (Clerk multi-session) and the server can reject cross-account reads.
+  // The transient multi-session auth failures (fail-closed UNAUTHORIZED, viewer
+  // mismatch FORBIDDEN) self-heal on the next per-tab-token request, so retry them
+  // instead of settling into a terminal error that reads as "signed out".
   const { data, status: userStatus } = api.profile.getUser.useQuery(
     getUserQueryInput(userId),
     {
       enabled: !!userId && isLoaded,
-      retry: false,
+      retry: (failureCount, error) =>
+        failureCount < 3 &&
+        isTransientMultiSessionAuthError(error.data?.code, error.message),
       refetchInterval: 300000,
     },
   );
@@ -205,15 +211,23 @@ export const useRequiredUserData = () => {
   const router = useRouter();
   // Get auth information
   const { isLoaded, isSignedIn } = useUser();
+  // Clerk multi-session: this TAB is signed in as long as its pinned session is —
+  // the browser-global active session can flip or drop (other account signed out,
+  // cross-tab active-context races) while the pinned session is perfectly valid.
+  // Redirecting on the browser-global signal alone booted signed-in users to the
+  // logged-out landing page; only treat the tab as signed out when NEITHER the
+  // pinned session nor the browser-global session is signed in.
+  const { pinnedUserId } = useSessionPin();
   // Get user information
   const info = useUserData();
   // Redirection if not logged in
   const { data, status } = info;
   useEffect(() => {
-    if (isLoaded && (!isSignedIn || (data === undefined && status !== "pending"))) {
+    const signedOutTab = !isSignedIn && !pinnedUserId;
+    if (isLoaded && (signedOutTab || (data === undefined && status !== "pending"))) {
       router.push("/");
     }
-  }, [status, data, isLoaded, isSignedIn]);
+  }, [status, data, isLoaded, isSignedIn, pinnedUserId]);
 
   // Return state
   return info;

--- a/app/tests/app/_trpc/authHeaders.test.ts
+++ b/app/tests/app/_trpc/authHeaders.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   buildClerkRequestHeaders,
   computeIsMultiSession,
+  isTransientMultiSessionAuthError,
   TAB_AUTH_REQUIRED_HEADER,
+  VIEWER_SESSION_MISMATCH_MESSAGE,
 } from "@/app/_trpc/authHeaders";
 
 describe("buildClerkRequestHeaders", () => {
@@ -34,6 +36,35 @@ describe("buildClerkRequestHeaders", () => {
 
   it("sends no marker for a single-session browser with no token (cookie is the user's own account)", () => {
     expect(buildClerkRequestHeaders(null, false)).toEqual({});
+  });
+});
+
+describe("isTransientMultiSessionAuthError", () => {
+  it("matches the server's fail-closed UNAUTHORIZED regardless of message", () => {
+    expect(
+      isTransientMultiSessionAuthError(
+        "UNAUTHORIZED",
+        "Unauthorized for tRPC endpoint. Path: profile.getUser",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches the FORBIDDEN viewer/session mismatch guard", () => {
+    expect(
+      isTransientMultiSessionAuthError("FORBIDDEN", VIEWER_SESSION_MISMATCH_MESSAGE),
+    ).toBe(true);
+  });
+
+  it("does not match other FORBIDDEN errors or other codes", () => {
+    expect(isTransientMultiSessionAuthError("FORBIDDEN", "No access to feature")).toBe(
+      false,
+    );
+    expect(isTransientMultiSessionAuthError("INTERNAL_SERVER_ERROR", "boom")).toBe(
+      false,
+    );
+    expect(
+      isTransientMultiSessionAuthError(undefined, VIEWER_SESSION_MISMATCH_MESSAGE),
+    ).toBe(false);
   });
 });
 

--- a/app/tests/app/_trpc/sessionPin.test.ts
+++ b/app/tests/app/_trpc/sessionPin.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  clearPinnedSessionStorage,
   decidePinnedSession,
   isAuthRoute,
   pinChangeRequiresRemount,
   readPinnedSessionId,
+  readPinnedUserId,
   resolvePinnedSession,
   writePinnedSessionId,
+  writePinnedUserId,
 } from "@/app/_trpc/sessionPin";
 
 const makeFakeWindow = () => {
@@ -66,10 +69,23 @@ describe("pinned session id storage", () => {
     expect(readPinnedSessionId()).toBe("sess_b");
   });
 
+  it("round-trips the pinned user id and clears both keys together", () => {
+    g.window = makeFakeWindow();
+    writePinnedSessionId("sess_a");
+    writePinnedUserId("user_a");
+    expect(readPinnedUserId()).toBe("user_a");
+    clearPinnedSessionStorage();
+    expect(readPinnedSessionId()).toBeNull();
+    expect(readPinnedUserId()).toBeNull();
+  });
+
   it("is a safe no-op without window (SSR)", () => {
     g.window = undefined;
     expect(() => writePinnedSessionId("x")).not.toThrow();
+    expect(() => writePinnedUserId("x")).not.toThrow();
+    expect(() => clearPinnedSessionStorage()).not.toThrow();
     expect(readPinnedSessionId()).toBeNull();
+    expect(readPinnedUserId()).toBeNull();
   });
 });
 
@@ -107,6 +123,7 @@ describe("decidePinnedSession", () => {
         sessions,
         inMemoryPinnedId: "sess_main",
         storedPinnedId: null,
+        storedPinnedUserId: null,
         activeSessionId: "sess_alt",
         onAuthRoute: false,
       }),
@@ -119,6 +136,7 @@ describe("decidePinnedSession", () => {
         sessions,
         inMemoryPinnedId: null,
         storedPinnedId: null,
+        storedPinnedUserId: null,
         activeSessionId: "sess_main",
         onAuthRoute: false,
       }),
@@ -131,6 +149,7 @@ describe("decidePinnedSession", () => {
         sessions,
         inMemoryPinnedId: null,
         storedPinnedId: "sess_alt",
+        storedPinnedUserId: "user_alt",
         activeSessionId: "sess_main",
         onAuthRoute: false,
       }),
@@ -143,23 +162,70 @@ describe("decidePinnedSession", () => {
         sessions: [],
         inMemoryPinnedId: "sess_main",
         storedPinnedId: null,
+        storedPinnedUserId: "user_main",
         activeSessionId: null,
         onAuthRoute: false,
       }),
     ).toEqual({ type: "keep" });
   });
 
-  it("re-adopts the active session when the pinned account was signed out and another remains", () => {
+  it("releases (never silently adopts) when the pinned account died and a DIFFERENT account is active", () => {
+    // The "randomly swapped to my other account" bug: the pinned session expired /
+    // was signed out while the alt remains. The tab must not silently become the
+    // alt — it releases the pin and routes through the sign-in flow instead.
     expect(
       decidePinnedSession({
-        // The pinned sess_signedout is no longer in sessions; sess_main + sess_alt remain.
         sessions,
-        inMemoryPinnedId: "sess_signedout",
-        storedPinnedId: "sess_signedout",
+        inMemoryPinnedId: "sess_dead",
+        storedPinnedId: "sess_dead",
+        storedPinnedUserId: "user_main",
         activeSessionId: "sess_alt",
         onAuthRoute: false,
       }),
-    ).toEqual({ type: "set", id: "sess_alt" });
+    ).toEqual({ type: "release" });
+  });
+
+  it("releases when the pinned account died and its account is unknown (no stored user id)", () => {
+    // Without a stored user id we cannot prove the active session is the same
+    // account, so the safe decision is the explicit sign-in flow, never adoption.
+    expect(
+      decidePinnedSession({
+        sessions,
+        inMemoryPinnedId: "sess_dead",
+        storedPinnedId: "sess_dead",
+        storedPinnedUserId: null,
+        activeSessionId: "sess_alt",
+        onAuthRoute: false,
+      }),
+    ).toEqual({ type: "release" });
+  });
+
+  it("silently re-adopts a fresh session of the SAME account after the pinned one died", () => {
+    // E.g. the session expired and the user signed in again: new session id, same
+    // account. This must not bounce the user through the sign-in flow.
+    expect(
+      decidePinnedSession({
+        sessions,
+        inMemoryPinnedId: "sess_dead",
+        storedPinnedId: "sess_dead",
+        storedPinnedUserId: "user_main",
+        activeSessionId: "sess_main",
+        onAuthRoute: false,
+      }),
+    ).toEqual({ type: "set", id: "sess_main" });
+  });
+
+  it("keeps a dead pin while no signed-in active session exists (nothing to adopt or release to)", () => {
+    expect(
+      decidePinnedSession({
+        sessions,
+        inMemoryPinnedId: "sess_dead",
+        storedPinnedId: "sess_dead",
+        storedPinnedUserId: "user_main",
+        activeSessionId: null,
+        onAuthRoute: false,
+      }),
+    ).toEqual({ type: "keep" });
   });
 
   it("does not pin an active session that is not a signed-in session (no phantom pin)", () => {
@@ -168,6 +234,7 @@ describe("decidePinnedSession", () => {
         sessions,
         inMemoryPinnedId: null,
         storedPinnedId: null,
+        storedPinnedUserId: null,
         activeSessionId: "sess_not_in_list",
         onAuthRoute: false,
       }),
@@ -185,6 +252,7 @@ describe("decidePinnedSession", () => {
         sessions: [{ id: "sess_main", status: "active", user: { id: "user_main" } }],
         inMemoryPinnedId: null,
         storedPinnedId: null,
+        storedPinnedUserId: null,
         activeSessionId: "sess_main",
         onAuthRoute: true,
       }),
@@ -199,21 +267,40 @@ describe("decidePinnedSession", () => {
         sessions,
         inMemoryPinnedId: null,
         storedPinnedId: null,
+        storedPinnedUserId: null,
         activeSessionId: "sess_alt",
         onAuthRoute: true,
       }),
     ).toEqual({ type: "keep" });
   });
 
+  it("clears a dead pin on the sign-in flow so the chosen account adopts cleanly afterwards", () => {
+    // A released tab lands on /login still carrying the dead pin. Clearing it here
+    // is what prevents the post-sign-in adoption from reading as a cross-account
+    // move and bouncing the tab straight back to /login.
+    expect(
+      decidePinnedSession({
+        sessions,
+        inMemoryPinnedId: "sess_dead",
+        storedPinnedId: "sess_dead",
+        storedPinnedUserId: "user_main",
+        activeSessionId: "sess_alt",
+        onAuthRoute: true,
+      }),
+    ).toEqual({ type: "clear" });
+  });
+
   it("adopts the just-signed-in account once redirected off the auth flow", () => {
     // <SignIn> redirected onto an app route. onAuthRoute is false only BECAUSE that
     // navigation ran, which is downstream of Clerk setting the new active session —
-    // so activeSessionId is already the new account here (not a stale value).
+    // so activeSessionId is already the new account here (not a stale value). The
+    // dead pin was cleared while on the auth route, so this is a no-pin adoption.
     expect(
       decidePinnedSession({
         sessions,
         inMemoryPinnedId: null,
         storedPinnedId: null,
+        storedPinnedUserId: null,
         activeSessionId: "sess_alt",
         onAuthRoute: false,
       }),
@@ -229,6 +316,7 @@ describe("decidePinnedSession", () => {
         sessions,
         inMemoryPinnedId: "sess_main",
         storedPinnedId: "sess_main",
+        storedPinnedUserId: "user_main",
         activeSessionId: "sess_alt",
         onAuthRoute: false,
       }),
@@ -243,13 +331,12 @@ describe("pinChangeRequiresRemount", () => {
     expect(pinChangeRequiresRemount(null, "sess_a")).toBe(false);
   });
 
-  it("remounts when the tab adopts a different account (A -> B)", () => {
-    // The pinned account signed out and the effect adopted another still-signed-in
-    // account: account A's data may sit in unscoped React Query caches, discard it.
+  it("remounts when the pin moves to a different session (e.g. same account, fresh session)", () => {
+    // The previous session's data may sit in unscoped React Query caches, discard it.
     expect(pinChangeRequiresRemount("sess_a", "sess_b")).toBe(true);
   });
 
-  it("remounts on an id -> null change (defensive; no live path nulls the pin today)", () => {
+  it("remounts on an id -> null change (clear/release of a dead pin)", () => {
     expect(pinChangeRequiresRemount("sess_a", null)).toBe(true);
   });
 


### PR DESCRIPTION
# Pull Request

## Summary

Fixes the regression reported after #1374 merged: **signed-in users being told they are not logged in** (bounced to the logged-out landing page, "You need to be signed in to perform this action." toasts) **until they log out and log in again**, with the underlying trigger being Clerk randomly flipping the browser-global active account when multiple accounts are signed in.

## Why / Root Cause

#1374 correctly made each tab's **identity** and **tRPC auth** follow its pinned Clerk session. But "am I signed in?" decisions still read Clerk's **browser-global** active-session state (`useUser().isSignedIn`), which multi-account usage flips or drops **without user action** — focused tabs overwrite the shared `__session` cookie and active-context claim on every token refresh (verified in `clerk-js`: `Session._getToken` dispatches `TokenUpdate` for non-active sessions too, and `AuthCookieService.updateSessionCookie` lets any focused tab write the cookie and claim the active context), and signing out of / expiring the *other* account can leave the global state signed-out entirely.

So a tab whose pinned session was perfectly valid could be treated as signed out:

1. **`useRequiredUserData`** redirected to `/` on global `!isSignedIn` alone. On `/`, the index page (also gating on global `isSignedIn`) rendered the logged-out `<Welcome>` landing page — or, when profile data was cached, entered a `/` ↔ `/profile` redirect loop.
2. **`useGlobalOnMutateProtect`** threw "You need to be signed in to perform this action." on global `!isSignedIn`, so every game action showed a sign-in toast in a working tab.
3. **`profile.getUser` had `retry: false`**, so the two *expected-transient* multi-session failures introduced by #1374 — the server's fail-closed `UNAUTHORIZED` (per-tab token blip) and the `FORBIDDEN` viewer/session mismatch guard — settled into a terminal error state with no data, which the hooks above read as "signed out" (`useRequiredUserData` boots to `/`; the index then pushes `/500`). Only re-login recovered.
4. **`decidePinnedSession` silently adopted the other signed-in account when the pinned session died** — the one remaining "randomly swapped me to my alt" path after #1374.

## What Was Implemented

### 1. Pinned session is the signed-in authority for the tab

`useRequiredUserData`, `useGlobalOnMutateProtect`, the index page's `<Welcome>` gate/referral effect, and the anonymous-visitor tracker now treat the tab as signed out only when **neither** the pinned session **nor** the browser-global session is signed in. A global-state flip or drop can no longer log a pinned tab "out"; a genuine sign-out (both signals gone) still redirects as before.

### 2. Transient multi-session auth failures retry instead of settling

New `isTransientMultiSessionAuthError(code, message)` in `authHeaders.ts` (the isomorphic module that already owns `VIEWER_SESSION_MISMATCH_MESSAGE`). `profile.getUser` retries these up to 3 times (they self-heal on the next per-tab-token request by design); all other errors keep failing fast as before.

### 3. A dead pin never silently switches accounts

The pinned **user id** is now stored alongside the pinned session id in `sessionStorage` (backfilled for existing pins). When the pinned session is no longer signed in and the sessions list is populated:

- **Same account active** (matched via stored user id, e.g. fresh session after expiry) → silently re-adopt, as before.
- **Different or unknown account active** → new `release` decision: clear the pin (remounts the subtree, dropping the old account's caches) and route to `/login` so the user picks an account **explicitly**. A `releasedRef` guard blocks adoption between the release and the `/login` navigation completing, so a mid-navigation Clerk sessions refresh cannot re-adopt the alt.
- **On the sign-in flow** a dead pin is `clear`ed (previously kept) so the account chosen there adopts cleanly instead of reading as a cross-account move and bouncing back to `/login`.

First-load adoption of a fresh tab is unchanged.

## What Was NOT Changed (known follow-ups)

- Clerk's `<UserButton>` (sidebar) still displays the browser-global active account, which can differ from the tab's pinned account; its "switch account" action changes only the global active session, which pinned tabs deliberately ignore. An explicit in-tab account switcher wired to the pin is a follow-up.
- Other protected queries do not get the transient-auth retry; `profile.getUser` is the identity-critical one that gates the whole app.

## Testing

- Updated `sessionPin.test.ts` for the new `decidePinnedSession` inputs/decisions: release on dead pin + different account, release on unknown account, silent same-account re-adopt, dead-pin clear on the auth route, dead pin with no adoptable active session, plus the pinned-user-id storage round-trip. All existing cross-tab/auth-route protections re-asserted.
- New `authHeaders.test.ts` cases for `isTransientMultiSessionAuthError`.
- `make test` (398 tests), `make typecheck`, and biome lint on changed files all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-session sign-in handling across tabs and sessions.
  * Prevented accidental account switching when a pinned session expires; affected users are routed through sign-in.
  * Reduced transient authentication errors during session refreshes.
  * Improved redirects and loading states when session information is still being restored.
  * Preserved authenticated access for valid pinned sessions even when global session status changes.
* **Tests**
  * Expanded coverage for pinned-session recovery, account switching, authentication errors, and storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->