### PR TITLE
Limit to single accessory.  Don't let auto-equip equip multiple or duplicates

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -196,8 +196,12 @@
   "packageManager": "bun@1.3.13",
   "overrides": {
     "@modelcontextprotocol/sdk": "1.29.0",
-    "@types/cytoscape-edgehandles/cytoscape": "$cytoscape",
-    "@types/react-cytoscapejs/cytoscape": "$cytoscape"
+    "@types/cytoscape-edgehandles": {
+      "cytoscape": "$cytoscape"
+    },
+    "@types/react-cytoscapejs": {
+      "cytoscape": "$cytoscape"
+    }
   },
   "resolutions": {
     "import-in-the-middle": "1.14.2",

--- a/app/src/libs/item.ts
+++ b/app/src/libs/item.ts
@@ -237,13 +237,53 @@ export interface EquippedAssignment {
   info: EquipConstraintInfo;
 }
 
+/** Minimal equipped-item shape for category equip limits (bloodline / hand armor / accessory). */
+export interface EquippedConstraintState {
+  slot: string;
+  itemType: string;
+  bloodlineId: string | null;
+}
+
 /**
- * Equip-limit rules (per-item max, one-bloodline-item, one-hand-armor) for the
- * loadout application path. toggleEquipItem applies the equivalent rules inline
- * rather than calling this, because it counts maxEquips against the live
- * `equipped` state (which can include the candidate row when re-slotting),
- * whereas this counts only the assignments built so far. Returns an error
- * message if `candidate` cannot be equipped given `current`, otherwise null.
+ * Category equip limits shared by loadout application, buyItem auto-equip, and
+ * toggleEquipItem: at most one bloodline-gated item, one hand armor, and one
+ * accessory. maxEquips is intentionally excluded — callers count that against
+ * their own notion of already-equipped instances (assignments built so far vs
+ * live equipped rows that may include the candidate when re-slotting). Returns
+ * an error message if `candidate` cannot be equipped given `equippedItems`,
+ * otherwise null.
+ */
+export const canEquipAdditional = (
+  candidate: Pick<EquipConstraintInfo, "bloodlineId" | "itemType" | "slot">,
+  equippedItems: EquippedConstraintState[],
+): string | null => {
+  if (candidate.bloodlineId) {
+    if (equippedItems.some((a) => a.bloodlineId)) {
+      return "You can only equip one item with a bloodline requirement";
+    }
+  }
+  if (candidate.itemType === "ARMOR" && candidate.slot === "HAND") {
+    const handArmor = equippedItems.some(
+      (a) => (a.slot === "HAND_1" || a.slot === "HAND_2") && a.itemType === "ARMOR",
+    );
+    if (handArmor) {
+      return "You can only equip one armor item in your hand slots";
+    }
+  }
+  if (candidate.itemType === "ACCESSORY") {
+    if (equippedItems.some((a) => a.itemType === "ACCESSORY")) {
+      return "You can only equip one accessory";
+    }
+  }
+  return null;
+};
+
+/**
+ * Equip-limit rules (per-item max + category limits from canEquipAdditional)
+ * for the loadout application path. toggleEquipItem / buyItem call
+ * canEquipAdditional directly and apply maxEquips against live equipped state
+ * themselves. Returns an error message if `candidate` cannot be equipped given
+ * `current`, otherwise null.
  */
 export const checkEquipConstraints = (
   candidate: EquipConstraintInfo,
@@ -253,21 +293,14 @@ export const checkEquipConstraints = (
   if (sameItem >= candidate.maxEquips) {
     return `No more than ${candidate.maxEquips} instances. Already have ${sameItem} equipped.`;
   }
-  if (candidate.bloodlineId) {
-    if (current.some((a) => a.info.bloodlineId)) {
-      return "You can only equip one item with a bloodline requirement";
-    }
-  }
-  if (candidate.itemType === "ARMOR" && candidate.slot === "HAND") {
-    const handArmor = current.some(
-      (a) =>
-        (a.slot === "HAND_1" || a.slot === "HAND_2") && a.info.itemType === "ARMOR",
-    );
-    if (handArmor) {
-      return "You can only equip one armor item in your hand slots";
-    }
-  }
-  return null;
+  return canEquipAdditional(
+    candidate,
+    current.map((a) => ({
+      slot: a.slot,
+      itemType: a.info.itemType,
+      bloodlineId: a.info.bloodlineId,
+    })),
+  );
 };
 
 /**
@@ -385,7 +418,7 @@ export const computeLoadoutAssignments = (
       );
       continue;
     }
-    // Equip limits shared with toggleEquipItem.
+    // Equip limits via checkEquipConstraints (maxEquips + canEquipAdditional).
     const info: EquipConstraintInfo = {
       itemId: useritem.itemId,
       bloodlineId: item.bloodlineId,

--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -63,6 +63,7 @@ import {
   calcMaxEventItems,
   calcMaxItems,
   calcMaxMaterials,
+  canEquipAdditional,
   computeLoadoutAssignments,
   nonCombatConsume,
 } from "@/libs/item";
@@ -1975,31 +1976,25 @@ export const itemRouter = createTRPCRouter({
       const instancesEquipped = useritems.filter(
         (ui) => ui.itemId === info.id && ui.equipped !== "NONE",
       ).length;
-      const hasBloodlineItemEquipped = useritems.some(
-        (ui) => ui.equipped !== "NONE" && ui.item.bloodlineId,
-      );
       const canAutoEquip =
         !info.effects.find((e) => e.type.includes("bloodline")) &&
         instancesEquipped < info.maxEquips &&
         user.level >= info.requiredLevel &&
         (!info.bloodlineId || info.bloodlineId === user.bloodlineId) &&
-        (!info.bloodlineId || !hasBloodlineItemEquipped);
+        canEquipAdditional(
+          info,
+          useritems
+            .filter((ui) => ui.equipped !== "NONE")
+            .map((ui) => ({
+              slot: ui.equipped,
+              itemType: ui.item.itemType,
+              bloodlineId: ui.item.bloodlineId,
+            })),
+        ) === null;
 
       if (canAutoEquip) {
-        // Check if hand armor restriction applies
-        const isHandArmor = info.itemType === "ARMOR" && info.slot === "HAND";
-        const hasHandArmorEquipped = useritems.some(
-          (ui) =>
-            (ui.equipped === "HAND_1" || ui.equipped === "HAND_2") &&
-            ui.item.itemType === "ARMOR",
-        );
-
         ItemSlots.forEach((slot) => {
           if (slot.includes(info.slot) && !useritems.find((i) => i.equipped === slot)) {
-            // Skip auto-equip for hand armors if one is already equipped
-            if (isHandArmor && hasHandArmorEquipped) {
-              return;
-            }
             equipped = slot;
           }
         });
@@ -2092,10 +2087,13 @@ export const itemRouter = createTRPCRouter({
     .output(baseServerResponse)
     .mutation(async ({ ctx }) => {
       // Fetch user items
-      const [useritems, user] = await Promise.all([
+      const [fetchedItems, user] = await Promise.all([
         fetchUserItems(ctx.drizzle, ctx.userId),
         fetchUser(ctx.drizzle, ctx.userId),
       ]);
+      // Mutable inventory snapshot so each successful equip is visible to the next
+      // toggleEquipItem call (canEquipAdditional category limits).
+      let useritems = fetchedItems;
 
       // Get unequipped items that are not stored at home, sorted by cost (descending)
       const unequippedItems = useritems
@@ -2136,6 +2134,7 @@ export const itemRouter = createTRPCRouter({
             nEquipped++;
             updatePromises.push(...result.promises);
             availableSlots = availableSlots.filter((s) => s !== slot);
+            useritems = result.newUserItems;
           }
         }
       }
@@ -2631,26 +2630,20 @@ export const toggleEquipItem = async (
       `No more than ${info.maxEquips} instances. Already have ${instancesEquipped} equipped.`,
     );
   }
-  // Check bloodline item limit - only one item with a bloodline can be equipped
-  if (doEquip && info.bloodlineId) {
-    const equippedBloodlineItems = newUserItems.filter(
-      (ui) => ui.equipped !== "NONE" && ui.id !== useritem.id && ui.item.bloodlineId,
+  // Category limits (bloodline / hand armor / accessory) shared with loadout + buyItem
+  if (doEquip) {
+    const categoryError = canEquipAdditional(
+      info,
+      newUserItems
+        .filter((ui) => ui.equipped !== "NONE" && ui.id !== useritem.id)
+        .map((ui) => ({
+          slot: ui.equipped,
+          itemType: ui.item.itemType,
+          bloodlineId: ui.item.bloodlineId,
+        })),
     );
-    if (equippedBloodlineItems.length > 0) {
-      return errorResponse("You can only equip one item with a bloodline requirement");
-    }
-  }
-  // Check hand slot armor limit - only one armor item can be equipped in hand slots
-  if (doEquip && info.itemType === "ARMOR" && info.slot === "HAND") {
-    const equippedHandArmors = newUserItems.filter(
-      (ui) =>
-        ui.equipped !== "NONE" &&
-        ui.id !== useritem.id &&
-        (ui.equipped === "HAND_1" || ui.equipped === "HAND_2") &&
-        ui.item.itemType === "ARMOR",
-    );
-    if (equippedHandArmors.length > 0) {
-      return errorResponse("You can only equip one armor item in your hand slots");
+    if (categoryError) {
+      return errorResponse(categoryError);
     }
   }
   // Determine equipment slot (first empty slots, then any slot)

--- a/app/tests/libs/item.test.ts
+++ b/app/tests/libs/item.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from "vitest";
 import {
+  canEquipAdditional,
   checkEquipConstraints,
   computeLoadoutAssignments,
   type EquipConstraintInfo,
   type EquippedAssignment,
+  type EquippedConstraintState,
   isEquippableUserItem,
 } from "@/libs/item";
 import type { ItemSlot } from "@/drizzle/constants";
@@ -72,6 +74,56 @@ const info = (over: Partial<EquipConstraintInfo>): EquipConstraintInfo => ({
   ...over,
 });
 
+const equipped = (over: Partial<EquippedConstraintState>): EquippedConstraintState => ({
+  slot: "ITEM_1",
+  itemType: "WEAPON",
+  bloodlineId: null,
+  ...over,
+});
+
+describe("canEquipAdditional", () => {
+  it("allows an item when nothing is equipped", () => {
+    expect(canEquipAdditional(info({}), [])).toBeNull();
+  });
+  it("blocks a second bloodline item", () => {
+    expect(
+      canEquipAdditional(info({ bloodlineId: "bl1" }), [
+        equipped({ bloodlineId: "bl1" }),
+      ]),
+    ).toMatch(/one item with a bloodline/);
+  });
+  it("blocks a second ARMOR item in hand slots", () => {
+    expect(
+      canEquipAdditional(info({ itemType: "ARMOR", slot: "HAND" }), [
+        equipped({ slot: "HAND_1", itemType: "ARMOR" }),
+      ]),
+    ).toMatch(/one armor item in your hand/);
+  });
+  it("allows a non-armor hand item alongside an armor hand item", () => {
+    expect(
+      canEquipAdditional(info({ itemType: "WEAPON", slot: "HAND" }), [
+        equipped({ slot: "HAND_1", itemType: "ARMOR" }),
+      ]),
+    ).toBeNull();
+  });
+  it("blocks a second ACCESSORY", () => {
+    expect(
+      canEquipAdditional(info({ itemType: "ACCESSORY", slot: "ITEM" }), [
+        equipped({ itemType: "ACCESSORY" }),
+      ]),
+    ).toMatch(/one accessory/);
+  });
+  it("does not enforce maxEquips (callers own that check)", () => {
+    // Two already-equipped instances of the same item — still null here.
+    expect(
+      canEquipAdditional(info({ itemId: "i1", maxEquips: 1 }), [
+        equipped({ slot: "ITEM_1" }),
+        equipped({ slot: "ITEM_2" }),
+      ]),
+    ).toBeNull();
+  });
+});
+
 describe("checkEquipConstraints", () => {
   it("allows an item when nothing is equipped", () => {
     expect(checkEquipConstraints(info({}), [])).toBeNull();
@@ -90,29 +142,16 @@ describe("checkEquipConstraints", () => {
     ];
     expect(checkEquipConstraints(info({ itemId: "i1", maxEquips: 2 }), current)).toBeNull();
   });
-  it("blocks a second bloodline item", () => {
+  it("delegates category limits to canEquipAdditional", () => {
     const current: EquippedAssignment[] = [
-      { slot: "ITEM_1", info: info({ itemId: "b1", bloodlineId: "bl1" }) },
+      { slot: "ITEM_1", info: info({ itemId: "acc1", itemType: "ACCESSORY", slot: "ITEM" }) },
     ];
     expect(
-      checkEquipConstraints(info({ itemId: "b2", bloodlineId: "bl1" }), current),
-    ).toMatch(/one item with a bloodline/);
-  });
-  it("blocks a second ARMOR item in hand slots", () => {
-    const current: EquippedAssignment[] = [
-      { slot: "HAND_1", info: info({ itemId: "a1", itemType: "ARMOR", slot: "HAND" }) },
-    ];
-    expect(
-      checkEquipConstraints(info({ itemId: "a2", itemType: "ARMOR", slot: "HAND" }), current),
-    ).toMatch(/one armor item in your hand/);
-  });
-  it("allows a non-armor hand item alongside an armor hand item", () => {
-    const current: EquippedAssignment[] = [
-      { slot: "HAND_1", info: info({ itemId: "a1", itemType: "ARMOR", slot: "HAND" }) },
-    ];
-    expect(
-      checkEquipConstraints(info({ itemId: "w1", itemType: "WEAPON", slot: "HAND" }), current),
-    ).toBeNull();
+      checkEquipConstraints(
+        info({ itemId: "acc2", itemType: "ACCESSORY", slot: "ITEM" }),
+        current,
+      ),
+    ).toMatch(/one accessory/);
   });
 });
 
@@ -246,6 +285,35 @@ describe("computeLoadoutAssignments", () => {
     );
     expect(out.assignments.length).toBe(1);
     expect(out.invalidItems.length).toBe(1);
+  });
+
+  it("enforces a single accessory across the loadout", () => {
+    const items = [
+      ui({
+        id: "r1",
+        itemId: "acc1",
+        name: "Ring A",
+        slotType: "ITEM",
+        itemType: "ACCESSORY",
+      }),
+      ui({
+        id: "r2",
+        itemId: "acc2",
+        name: "Ring B",
+        slotType: "ITEM",
+        itemType: "ACCESSORY",
+      }),
+    ];
+    const out = computeLoadoutAssignments(
+      [
+        { itemId: "acc1", slot: "ITEM_1" },
+        { itemId: "acc2", slot: "ITEM_2" },
+      ],
+      items,
+      USER,
+    );
+    expect(out.assignments).toEqual([{ userItemId: "r1", slot: "ITEM_1" }]);
+    expect(out.invalidItems[0]).toMatch(/one accessory/);
   });
 
   it("skips home / level / bloodline / auction items", () => {


### PR DESCRIPTION
# Pull Request

**Changes:**
- Only a single accessory can be equipped
- Auto-equip no longer tries to equip multiple accessories or dupliacte items

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enforcement for equipping only one accessory.
  * Auto-equip now consistently respects bloodline, hand armor, and accessory limits.
  * Equip decisions now account for items equipped earlier in the same process.

* **Bug Fixes**
  * Improved consistency of equipment restriction checks across manual and automatic equipping.
  * Updated loadout assignment validation to reject multiple accessories.

* **Tests**
  * Expanded coverage for accessory, bloodline, armor, and hand-slot restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->