### PR TITLE
Use dropdown for jutsu/item loadout swap

### DIFF
--- a/app/src/layout/Combat.tsx
+++ b/app/src/layout/Combat.tsx
@@ -1108,9 +1108,9 @@ const Combat: React.FC<CombatProps> = (props) => {
                     );
                   })}
               </div>
-              <div className="mt-3 flex flex-row items-center gap-4">
+              <div className="mt-3 flex flex-row items-end gap-3">
                 <ItemLoadoutSelector
-                  size="small"
+                  variant="dropdown"
                   label="Item Loadout"
                   onSelectOverride={(loadoutId) => {
                     if (battleRef?.current) {
@@ -1123,7 +1123,7 @@ const Combat: React.FC<CombatProps> = (props) => {
                   selectedOverrideId={battleSessionUser?.itemLoadout}
                 />
                 <JutsuLoadoutSelector
-                  size="small"
+                  variant="dropdown"
                   label="Jutsu Loadout"
                   onSelectOverride={(loadoutId) => {
                     if (battleRef?.current) {
@@ -1137,6 +1137,7 @@ const Combat: React.FC<CombatProps> = (props) => {
                 />
                 <Button
                   variant="secondary"
+                  className="shrink-0"
                   disabled={battleSessionUser?.iAmHere}
                   onClick={() => {
                     if (battleRef.current && suid) {

--- a/app/src/layout/ItemLoadoutSelector.tsx
+++ b/app/src/layout/ItemLoadoutSelector.tsx
@@ -10,6 +10,7 @@ import { useRequiredUserData } from "@/utils/UserContext";
 interface ItemLoadoutSelectorProps {
   size?: "small" | "large";
   label?: string;
+  variant?: "icons" | "dropdown";
   onSelectOverride?: (loadoutId: string) => void;
   selectedOverrideId?: string | null;
 }

--- a/app/src/layout/JutsuLoadoutSelector.tsx
+++ b/app/src/layout/JutsuLoadoutSelector.tsx
@@ -10,6 +10,7 @@ import { useRequiredUserData } from "@/utils/UserContext";
 interface JutsuLoadoutSelectorProps {
   size?: "small" | "large";
   label?: string;
+  variant?: "icons" | "dropdown";
   onSelectOverride?: (loadoutId: string) => void;
   selectedOverrideId?: string | null;
 }

--- a/app/src/layout/LoadoutSelector.tsx
+++ b/app/src/layout/LoadoutSelector.tsx
@@ -3,6 +3,13 @@
 import { Folder, Pencil } from "lucide-react";
 import type React from "react";
 import { useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { LOADOUT_NAME_MAX_LENGTH } from "@/drizzle/constants";
 import type { UserData } from "@/drizzle/schema";
 import Loader from "@/layout/Loader";
@@ -33,6 +40,8 @@ interface LoadoutSelectorConfig<T extends LoadoutData> {
 interface LoadoutSelectorProps<T extends LoadoutData> {
   size?: "small" | "large";
   label?: string;
+  /** "icons" shows folder buttons; "dropdown" uses a compact select */
+  variant?: "icons" | "dropdown";
   onSelectOverride?: (loadoutId: string) => void;
   selectedOverrideId?: string | null;
   config: LoadoutSelectorConfig<T>;
@@ -47,6 +56,7 @@ const LoadoutSelector = <T extends LoadoutData>(
   const { mutate: selectLoadout, isPending } = props.config.selectMutation();
   const [editingId, setEditingId] = useState<string | null>(null);
   const renameMutation = props.config.renameMutation?.();
+  const variant = props.variant ?? "icons";
 
   // Derived values (calculated after all hooks)
   const maxLoadouts = userData ? props.config.maxLoadoutsFn(userData) : 0;
@@ -74,6 +84,33 @@ const LoadoutSelector = <T extends LoadoutData>(
     }
   };
 
+  const getDisplayName = (loadout: LoadoutData, index: number) =>
+    loadout.name || `${props.label || "Loadout"} ${index + 1}`;
+
+  if (variant === "dropdown") {
+    return (
+      <div className="min-w-0 flex-1">
+        {props.label && <p className="mb-1 text-sm">{props.label}</p>}
+        <Select
+          value={selectedId ?? undefined}
+          onValueChange={handleSelect}
+          disabled={isPending}
+        >
+          <SelectTrigger className="h-8 w-full min-w-[8rem]">
+            <SelectValue placeholder="Select loadout" />
+          </SelectTrigger>
+          <SelectContent>
+            {data?.map((loadout, index) => (
+              <SelectItem key={loadout.id} value={loadout.id}>
+                {getDisplayName(loadout, index)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    );
+  }
+
   const submitRename = (id: string, value: string, currentName?: string) => {
     const trimmed = value.trim();
     setEditingId(null);
@@ -90,8 +127,7 @@ const LoadoutSelector = <T extends LoadoutData>(
       <div className="flex flex-row gap-1">
         {data?.map((loadout, index) => {
           const isSelected = selectedId === loadout.id;
-          const displayName =
-            loadout.name || `${props.label || "Loadout"} ${index + 1}`;
+          const displayName = getDisplayName(loadout, index);
           const isEditing = editingId === loadout.id;
           return (
             <div key={loadout.id} className="flex flex-col items-center">

--- a/app/src/libs/combat/constants.ts
+++ b/app/src/libs/combat/constants.ts
@@ -101,6 +101,8 @@ export const privateState = [
   "highestGenerals",
   "highestOffence",
   "intelligence",
+  "itemLoadout",
+  "jutsuLoadout",
   "ninjutsuDefence",
   "ninjutsuOffence",
   "speed",


### PR DESCRIPTION
# Pull Request

With a recent change to loadout swaps, part of the swaps flow off the screen on mobile.  This moves it do a dropdown to make loadout swaps easier on the initiative screen.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dropdown selection controls for item and jutsu loadouts in the battle lobby.
  * Loadout selectors now support both icon and dropdown display modes.
* **Style**
  * Improved loadout control alignment and spacing.
  * Kept the Ready button properly sized within the lobby layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->