### PR TITLE
Display calc'd level

### DIFF
--- a/app/src/layout/Sector.tsx
+++ b/app/src/layout/Sector.tsx
@@ -43,7 +43,7 @@ import WebGlError from "@/layout/WebGLError";
 import type { TerrainHex } from "@/libs/hexgrid";
 import { findHex, PathCalculator } from "@/libs/hexgrid";
 import { isQuestObjectiveAvailable } from "@/libs/objectives";
-import { getExpBracket, passesBracketFilter } from "@/libs/profile";
+import { calcLevel, getExpBracket, passesBracketFilter } from "@/libs/profile";
 import { GATHERING_CANCEL_PREFIX, isLocationObjective } from "@/libs/quest";
 import { isUserCurrentlyStealthed } from "@/libs/stealth";
 import { getBackgroundColor } from "@/libs/threejs/biome";
@@ -1310,6 +1310,7 @@ const SorroundingUsers: React.FC<SorroundingUsersProps> = (props) => {
           const showRob = !isPvpRestrictedRank && sameHex && userData.isOutlaw;
           const userBracket =
             user.experience == null ? null : getExpBracket(user.experience, user.rank);
+          const userLevel = user.experience == null ? null : calcLevel(user.experience);
 
           // Show user
           return (
@@ -1394,7 +1395,7 @@ const SorroundingUsers: React.FC<SorroundingUsersProps> = (props) => {
               </div>
               <p>{user.username}</p>
               <p className="text-xs">
-                Bracket{" "}
+                Lvl. {userLevel ?? "?"} · Bracket{" "}
                 {userBracket == null ? "?" : `${userBracket}/${XP_BRACKETS.length}`} [
                 {user.longitude}, {user.latitude}]
               </p>


### PR DESCRIPTION
# Pull Request

Adds the calc'd level to the scouting page

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user level information to scouting results.
  * User levels are displayed alongside existing bracket details when experience data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->