### PR TITLE
Allow attacking one bracket under

### DIFF
--- a/app/src/layout/MenuBoxProfile.tsx
+++ b/app/src/layout/MenuBoxProfile.tsx
@@ -368,9 +368,9 @@ const MenuBoxProfile: React.FC = () => {
                 </TooltipTrigger>
                 <TooltipContent>
                   PvP bracket based on experience (Academy & Genin are bracket 0). You
-                  can freely attack players in your bracket or higher. Players below
-                  your bracket are protected unless their immunity is lifted or both
-                  sides are active war participants.
+                  can freely attack players in your bracket, one bracket below, or
+                  higher. Players more than one bracket below are protected unless their
+                  immunity is lifted or both sides are active war participants.
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>

--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -101,7 +101,7 @@ import StatusBar from "@/layout/StatusBar";
 import { publicUserText } from "@/layout/seoTexts";
 import Table from "@/layout/Table";
 import UserSearchSelect from "@/layout/UserSearchSelect";
-import { getExpBracket, showUserRank } from "@/libs/profile";
+import { canAttackBracket, getExpBracket, showUserRank } from "@/libs/profile";
 import { getEffectiveThemeTextColor } from "@/libs/themePreference";
 import { showMutationToast } from "@/libs/toast";
 import { groupBy } from "@/utils/grouping";
@@ -2298,11 +2298,11 @@ const BracketEligibilityBadge: React.FC<BracketEligibilityBadgeProps> = ({
     );
   }
 
-  if (attackerBracket <= targetBracket) {
+  if (canAttackBracket(attackerBracket, targetBracket)) {
     return (
       <p className="font-medium text-green-600 text-sm">
-        ✓ Bracket-eligible (they are in your bracket or higher — server-side checks
-        still apply)
+        ✓ Bracket-eligible (they are in your bracket, one below, or higher — server-side
+        checks still apply)
       </p>
     );
   }

--- a/app/src/libs/profile.ts
+++ b/app/src/libs/profile.ts
@@ -70,6 +70,16 @@ export const getExpBracket = (experience: number, rank?: UserRank): number => {
 };
 
 /**
+ * Whether an attacker may initiate PvP against a target based on XP brackets alone.
+ * Allowed: same bracket, higher brackets, or exactly one bracket below.
+ * Academy/Genin rank locks are enforced separately via RANKS_RESTRICTED_FROM_PVP.
+ */
+export const canAttackBracket = (
+  attackerBracket: number,
+  targetBracket: number,
+): boolean => targetBracket >= attackerBracket - 1;
+
+/**
  * Whether a user passes a scout/map bracket filter.
  * Matches the exact selected bracket when filterBracket >= 0;
  * use filterBracket < 0 to disable filtering entirely.

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -153,6 +153,7 @@ import {
   calcLevel,
   calcLevelRequirements,
   calcSP,
+  canAttackBracket,
   capUserStats,
   getExpBracket,
   manuallyAssignUserStats,
@@ -1833,7 +1834,7 @@ export const initiateBattle = async (
       }
     }
 
-    // XP Bracket restrictions — same-bracket-only PvP with immunity lift and war-participant exemptions
+    // XP Bracket restrictions — same bracket, higher, or one below; immunity lift and war exemptions
     if (battleType === "COMBAT" && userIds.includes(user.userId)) {
       // War-Torn sector is a free-for-all — skip all village and bracket restrictions
       const isInWarTornSector = user.sector === MAP_WAR_TORN_BATTLEGROUND_SECTOR;
@@ -1864,11 +1865,13 @@ export const initiateBattle = async (
         // Guard 3: Bracket restrictions
         const attackerBracket = getExpBracket(user.experience, user.rank);
 
-        // Collect every lower-bracket target — protection is one-directional:
-        // higher-bracket attackers cannot target lower-bracket players (without exemption),
-        // but lower-bracket players may freely attack higher-bracket players.
+        // Collect targets more than one bracket below — protection is one-directional:
+        // attackers may hit same bracket, higher, or one below (without exemption).
+        // Lower-bracket players may freely attack higher-bracket players.
+        // Academy/Genin remain blocked by the rank restrictions above.
         const crossBracketTargets = nonAiTargets.filter(
-          (t) => getExpBracket(t.experience, t.rank) < attackerBracket,
+          (t) =>
+            !canAttackBracket(attackerBracket, getExpBracket(t.experience, t.rank)),
         );
 
         if (crossBracketTargets.length > 0) {

--- a/app/tests/libs/profile.test.ts
+++ b/app/tests/libs/profile.test.ts
@@ -1,6 +1,6 @@
 // sum.test.js
 import { expect, test } from "vitest";
-import { calcLevelRequirements, calcLevel, getExpBracket, passesBracketFilter } from "@/libs/profile";
+import { calcLevelRequirements, calcLevel, getExpBracket, canAttackBracket, passesBracketFilter } from "@/libs/profile";
 
 test("Confirm that level<->experience calculations are consistent", () => {
   for (const level of [
@@ -40,6 +40,17 @@ test("getExpBracket returns 0 for Academy students and Genin", () => {
   expect(getExpBracket(99_999_999, "GENIN")).toBe(0);
   expect(getExpBracket(500_001, "CHUNIN")).toBe(2);
   expect(getExpBracket(3_000_001, "JONIN")).toBe(7);
+});
+
+test("canAttackBracket allows same, higher, or one below", () => {
+  expect(canAttackBracket(3, 3)).toBe(true);
+  expect(canAttackBracket(3, 4)).toBe(true);
+  expect(canAttackBracket(3, 7)).toBe(true);
+  expect(canAttackBracket(3, 2)).toBe(true);
+  expect(canAttackBracket(3, 1)).toBe(false);
+  expect(canAttackBracket(3, 0)).toBe(false);
+  expect(canAttackBracket(1, 0)).toBe(true);
+  expect(canAttackBracket(2, 1)).toBe(true);
 });
 
 test("passesBracketFilter matches exact bracket only", () => {


### PR DESCRIPTION
# Pull Request

Allow players to attack one bracket below them

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated PvP bracket rules: players can attack targets in their own bracket, higher brackets, or one bracket below.
  * Clarified bracket eligibility and protection messaging throughout the interface.
  * Preserved immunity and active-war exceptions where applicable.

* **Bug Fixes**
  * Aligned combat targeting with the updated bracket eligibility rules.
  * Added coverage for bracket boundary cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->