### PR TITLE
Apply new restrictions

### DIFF
--- a/app/src/app/conceptart/page.tsx
+++ b/app/src/app/conceptart/page.tsx
@@ -58,7 +58,7 @@ import Confirm2 from "@/layout/Confirm2";
 import ContentBox from "@/layout/ContentBox";
 import { useInfinitePagination } from "@/libs/pagination";
 import { showMutationToast } from "@/libs/toast";
-import { getConceptArtCreateRestriction } from "@/utils/permissions";
+import { getBanOrSilenceRestriction } from "@/utils/permissions";
 import { useUserData } from "@/utils/UserContext";
 import { UploadDropzone } from "@/utils/uploadthing";
 import {
@@ -165,7 +165,7 @@ export default function ConceptArt() {
 
   const isPending = isImagePending || isVideoPending;
   const conceptArtCreateRestriction = userData
-    ? getConceptArtCreateRestriction(userData)
+    ? getBanOrSilenceRestriction(userData)
     : null;
 
   // Filters

--- a/app/src/app/manual/staff/page.tsx
+++ b/app/src/app/manual/staff/page.tsx
@@ -23,6 +23,7 @@ import Confirm2 from "@/layout/Confirm2";
 import ContentBox from "@/layout/ContentBox";
 import { cn } from "@/libs/shadui";
 import { showMutationToast } from "@/libs/toast";
+import { getBanOrSilenceRestriction } from "@/utils/permissions";
 import { useUserData } from "@/utils/UserContext";
 import type { CreateApplicationSchema } from "@/validators/applications";
 import { createApplicationSchema } from "@/validators/applications";
@@ -31,6 +32,7 @@ export default function Staff() {
   // User Data
   const { data: me } = useUserData();
   const isStaff = me?.role && me.role !== "USER";
+  const applicationRestriction = me ? getBanOrSilenceRestriction(me) : null;
 
   // Users Query
   const { data } = api.profile.getPublicUsers.useQuery(
@@ -79,7 +81,7 @@ export default function Staff() {
                 </Button>
               </Link>
             )}
-            {!pending && (
+            {!pending && !applicationRestriction && (
               <Confirm2
                 title="Apply for Staff"
                 proceed_label="Submit Application"

--- a/app/src/app/support/[ticketId]/page.tsx
+++ b/app/src/app/support/[ticketId]/page.tsx
@@ -447,6 +447,7 @@ export default function TicketDetail(props: { params: Promise<{ ticketId: string
         convo_id={ticket.conversationId}
         title="Conversation"
         subtitle="Talk with staff"
+        supportTicketCreatedByUserId={ticket.createdByUserId}
         onCommentPosted={() => {
           updateTicket.mutate({
             ticketId: params.ticketId,

--- a/app/src/layout/Conversation.tsx
+++ b/app/src/layout/Conversation.tsx
@@ -23,7 +23,13 @@ import { useInfinitePagination } from "@/libs/pagination";
 import { showMutationToast } from "@/libs/toast";
 import { getNewReactions, processMentions } from "@/utils/chat";
 import { parseHtml } from "@/utils/parse";
-import { canPostAsAi, getMessagingRestriction } from "@/utils/permissions";
+import {
+  canPostAsAi,
+  canReplyToStaffConversationWhileRestricted,
+  getMessagingRestriction,
+  RESTRICTED_STAFF_CONVERSATION_MESSAGE,
+  RESTRICTED_SUPPORT_TICKET_REPLY_MESSAGE,
+} from "@/utils/permissions";
 import { stripBlockquotes } from "@/utils/sanitize";
 import { secondsFromNow } from "@/utils/time";
 import type { ArrayElement } from "@/utils/typeutils";
@@ -44,6 +50,8 @@ interface ConversationProps {
   topRightContent?: React.ReactNode;
   onCommentPosted?: () => void;
   onBack?: () => void;
+  /** When set, banned/silenced users may only compose if they created this ticket */
+  supportTicketCreatedByUserId?: string;
 }
 
 export const ConversationSkeleton: React.FC<ConversationProps> = (props) => {
@@ -114,8 +122,25 @@ const Conversation: React.FC<ConversationProps> = (props) => {
   });
   const allComments = comments?.pages.flatMap((page) => page.data);
   const conversation = comments?.pages[0]?.convo;
+  const canComposeDespiteRestriction =
+    !!userData &&
+    !!conversation?.isStaffAvailable &&
+    canReplyToStaffConversationWhileRestricted(
+      userData,
+      props.supportTicketCreatedByUserId,
+    );
   const canComposeMessage =
-    !!userData && (conversation?.isStaffAvailable || !composeRestriction);
+    !!userData && (!composeRestriction || canComposeDespiteRestriction);
+  // Single source of truth for toast + inline copy when compose is blocked.
+  const composeRestrictionMessage = !composeRestriction
+    ? null
+    : conversation?.isStaffAvailable &&
+        (userData?.isBanned || userData?.isSilenced) &&
+        !canComposeDespiteRestriction
+      ? props.supportTicketCreatedByUserId
+        ? RESTRICTED_SUPPORT_TICKET_REPLY_MESSAGE
+        : RESTRICTED_STAFF_CONVERSATION_MESSAGE
+      : composeRestriction;
   type ReturnedComment = ArrayElement<typeof allComments>;
 
   // Search functionality
@@ -588,10 +613,10 @@ const Conversation: React.FC<ConversationProps> = (props) => {
    * Submit comment
    */
   const handleSubmitComment = handleSubmit((data) => {
-    if (composeRestriction && !conversation?.isStaffAvailable) {
+    if (composeRestriction && !canComposeDespiteRestriction) {
       showMutationToast({
         success: false,
-        message: composeRestriction,
+        message: composeRestrictionMessage,
       });
       return;
     }
@@ -656,7 +681,7 @@ const Conversation: React.FC<ConversationProps> = (props) => {
             !canComposeMessage &&
             composeRestriction && (
               <p className="mb-2 text-center text-muted-foreground text-sm">
-                {composeRestriction}
+                {composeRestrictionMessage}
               </p>
             )}
           {conversation && !conversation.isLocked && canComposeMessage && (

--- a/app/src/server/api/routers/applications.ts
+++ b/app/src/server/api/routers/applications.ts
@@ -18,6 +18,7 @@ import {
   canDeleteStaffApplication,
   canViewAllApplications,
   getApprovalGroup,
+  getBanOrSilenceRestriction,
 } from "@/utils/permissions";
 import {
   createApplicationSchema,
@@ -40,6 +41,8 @@ export const applicationsRouter = createTRPCRouter({
         }),
       ]);
       // Guards
+      const applicationRestriction = getBanOrSilenceRestriction(user);
+      if (applicationRestriction) return errorResponse(applicationRestriction);
       if (!StaffApplicationTargetRoles.includes(input.targetRole)) {
         return errorResponse("Invalid target role");
       }

--- a/app/src/server/api/routers/comments.ts
+++ b/app/src/server/api/routers/comments.ts
@@ -13,6 +13,7 @@ import {
   conversationComment,
   forumPost,
   forumThread,
+  supportTicket,
   user2conversation,
   userBlackList,
   userData,
@@ -42,10 +43,13 @@ import {
   canDeleteComment,
   canModerateRoles,
   canPostReportComment,
+  canReplyToStaffConversationWhileRestricted,
   canSeeReport,
   canSeeSecretData,
   canViewConversation,
   getMessagingRestriction,
+  RESTRICTED_STAFF_CONVERSATION_MESSAGE,
+  RESTRICTED_SUPPORT_TICKET_REPLY_MESSAGE,
 } from "@/utils/permissions";
 import { checkForBadWords } from "@/utils/profanity";
 import sanitize, { stripBlockquotes } from "@/utils/sanitize";
@@ -682,8 +686,29 @@ export const commentsRouter = createTRPCRouter({
       // Guard
       if (!convo) return errorResponse("Conversation not found");
       const messagingRestriction = getMessagingRestriction(user);
-      if (messagingRestriction && !convo.isStaffAvailable) {
-        return errorResponse(messagingRestriction);
+      if (messagingRestriction) {
+        // Only banned/silenced users may post in staff conversations (own help tickets).
+        // Other restrictions (e.g. level gate) are never bypassed.
+        const isBannedOrSilenced = user.isBanned || user.isSilenced;
+        if (!isBannedOrSilenced || !convo.isStaffAvailable) {
+          return errorResponse(messagingRestriction);
+        }
+        const linkedSupportTicket = await ctx.drizzle.query.supportTicket.findFirst({
+          where: eq(supportTicket.conversationId, convo.id),
+          columns: { createdByUserId: true },
+        });
+        if (
+          !canReplyToStaffConversationWhileRestricted(
+            user,
+            linkedSupportTicket?.createdByUserId,
+          )
+        ) {
+          return errorResponse(
+            linkedSupportTicket
+              ? RESTRICTED_SUPPORT_TICKET_REPLY_MESSAGE
+              : RESTRICTED_STAFF_CONVERSATION_MESSAGE,
+          );
+        }
       }
       if (!canViewConversation(convo, ctx.userId, user.role)) {
         return errorResponse("You are not allowed to view this conversation");

--- a/app/src/server/api/routers/conceptart.ts
+++ b/app/src/server/api/routers/conceptart.ts
@@ -16,10 +16,7 @@ import {
   uploadCompletedVideo,
 } from "@/libs/replicate";
 import { fetchUser } from "@/routers/profile";
-import {
-  canDeleteConceptArt,
-  getConceptArtCreateRestriction,
-} from "@/utils/permissions";
+import { canDeleteConceptArt, getBanOrSilenceRestriction } from "@/utils/permissions";
 import {
   conceptArtFilterSchema,
   conceptArtPromptSchema,
@@ -106,7 +103,7 @@ export const conceptartRouter = createTRPCRouter({
       // Query
       const user = await fetchUser(ctx.drizzle, ctx.userId);
       // Guard
-      const createRestriction = getConceptArtCreateRestriction(user);
+      const createRestriction = getBanOrSilenceRestriction(user);
       if (createRestriction) return errorResponse(createRestriction);
       if (user.reputationPoints < COST_CONCEPT_IMAGE) {
         return errorResponse("Not enough reputation points");
@@ -160,7 +157,7 @@ export const conceptartRouter = createTRPCRouter({
       // Query
       const user = await fetchUser(ctx.drizzle, ctx.userId);
       // Guard
-      const createRestriction = getConceptArtCreateRestriction(user);
+      const createRestriction = getBanOrSilenceRestriction(user);
       if (createRestriction) return errorResponse(createRestriction);
       if (user.reputationPoints < COST_CONCEPT_VIDEO) {
         return errorResponse(

--- a/app/src/utils/permissions.ts
+++ b/app/src/utils/permissions.ts
@@ -411,8 +411,8 @@ export const canDeleteConceptArt = (role: UserRole) => {
   ].includes(role);
 };
 
-/** Returns a restriction message if the user cannot create concept art, otherwise null. */
-export const getConceptArtCreateRestriction = (
+/** Returns a restriction message if the user is banned or silenced, otherwise null. */
+export const getBanOrSilenceRestriction = (
   user: Pick<UserData, "isBanned" | "isSilenced">,
 ): string | null => {
   if (user.isBanned) return "You are banned";
@@ -424,10 +424,31 @@ export const getConceptArtCreateRestriction = (
 export const getMessagingRestriction = (
   user: Pick<UserData, "isBanned" | "isSilenced" | "level">,
 ): string | null => {
-  if (user.isBanned) return "You are banned";
-  if (user.isSilenced) return "You are silenced";
+  const banOrSilence = getBanOrSilenceRestriction(user);
+  if (banOrSilence) return banOrSilence;
   if ((user.level ?? 0) < MESSAGING_MIN_LEVEL) return messagingLevelMessage;
   return null;
+};
+
+/**
+ * Banned/silenced users may only reply to support tickets they created.
+ * Staff applications and other people's tickets are not allowed.
+ * Returns false unless the user is banned or silenced — callers must not
+ * treat this as a general compose permission for unrestricted users.
+ */
+export const RESTRICTED_SUPPORT_TICKET_REPLY_MESSAGE =
+  "You can only reply to support tickets you created while banned or silenced";
+
+export const RESTRICTED_STAFF_CONVERSATION_MESSAGE =
+  "You cannot participate in this conversation while banned or silenced";
+
+export const canReplyToStaffConversationWhileRestricted = (
+  user: Pick<UserData, "userId" | "isBanned" | "isSilenced">,
+  supportTicketCreatedByUserId: string | null | undefined,
+): boolean => {
+  if (!user.isBanned && !user.isSilenced) return false;
+  if (!supportTicketCreatedByUserId) return false;
+  return supportTicketCreatedByUserId === user.userId;
 };
 
 export const canEscalateBan = (user: UserData, report: UserReport) => {


### PR DESCRIPTION
# Pull Request

Don't allow banned/silenced users to create staff applications.  Only allow banned/silenced users to reply to their own support tickets.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hid the “Apply for Staff” confirmation/form unless the user is eligible, now accounting for staff application restrictions (not just pending status).
  * Blocked staff application submission when staff application restrictions apply.
  * Improved support conversation restrictions: banned or silenced users can only reply/compose on support tickets they originally created.
  * Updated restriction messaging and toasts to correctly distinguish the restricted support-ticket scenario in guidance and blocked-action feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->