### PR TITLE
Fix Issue #1330: Add consume tag

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -161,6 +161,7 @@ export const SHARED_COOLDOWN_TAGS = [
   "cleanseprevent",
   "clear",
   "clearprevent",
+  "consume",
   "debuffprevent",
   "drain",
   "increasepoolcost",
@@ -168,7 +169,6 @@ export const SHARED_COOLDOWN_TAGS = [
   "pierce",
   "poison",
   "seal",
-  "shield",
   "stun",
   "summon",
   "vamp",
@@ -1243,6 +1243,7 @@ export const POST_DAMAGE_MODIFIER_TYPES: string[] = [
   "lifesteal",
   "absorb",
   "vamp",
+  "consume",
 ];
 
 // Black market config

--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -1232,6 +1232,13 @@ export const RANKS_RESTRICTED_FROM_PVP = ["STUDENT", "GENIN"];
 export const STREAK_LEVEL_DIFF = 10;
 
 /**
+ * Upper bound on the HP a single shield effect may hold. Enforced by ShieldTag.health
+ * and used to clamp shields generated in combat (e.g. by the consume tag) so they can
+ * never exceed what the schema accepts.
+ */
+export const SHIELD_MAX_HEALTH = 100000;
+
+/**
  * Effect types that depend on post-mitigated damage values.
  * These must be processed AFTER damage modifiers and pierce have been applied.
  */

--- a/app/src/layout/EditContent.tsx
+++ b/app/src/layout/EditContent.tsx
@@ -1616,6 +1616,10 @@ export const EffectFormWrapper: React.FC<EffectFormWrapperProps> = (props) => {
   if (props.type === "bloodline") {
     ignore.push(...["rounds", "friendlyFire"]);
   }
+  // Consume is instant; shield duration lives on shieldRounds (rounds is locked to 0).
+  if (tag.type === "consume") {
+    ignore.push("rounds");
+  }
   // Add direction to ignore list if not increasestat, decreasestat, or redirection
   if (!["increasestat", "decreasestat", "redirection"].includes(tag.type)) {
     ignore.push("direction");
@@ -1819,7 +1823,7 @@ export const EffectFormWrapper: React.FC<EffectFormWrapperProps> = (props) => {
           String(value) === "reward_reputation";
         return {
           id: value,
-          label: value,
+          label: FORM_LABEL_MAP[value] ?? value,
           type: "number",
           readonly: isReputationField && !hasReputationPermission,
         };
@@ -1843,6 +1847,19 @@ export const EffectFormWrapper: React.FC<EffectFormWrapperProps> = (props) => {
         return { id: value, label: value, type: "text" };
       }
     });
+
+  // Consume: hide locked rounds and surface shieldRounds where Rounds normally sits.
+  if (tag.type === "consume") {
+    const shieldIdx = formData.findIndex((e) => String(e.id) === "shieldRounds");
+    if (shieldIdx >= 0) {
+      const [shieldEntry] = formData.splice(shieldIdx, 1);
+      if (shieldEntry) {
+        const powerIdx = formData.findIndex((e) => String(e.id) === "power");
+        const insertAt = powerIdx >= 0 ? powerIdx : formData.length;
+        formData.splice(insertAt, 0, shieldEntry);
+      }
+    }
+  }
 
   // Add tag type as first entry
   if (!props.hideTagType) {
@@ -2533,6 +2550,7 @@ export const FORM_LABEL_MAP: Record<string, string> = {
   completeQuestIds: "Quests to Complete",
   tagType: "Combat Tag Type",
   singleBattle: "Track best single-battle only (else cumulative)",
+  shieldRounds: "Shield Rounds",
 };
 
 /**

--- a/app/src/layout/EditContent.tsx
+++ b/app/src/layout/EditContent.tsx
@@ -1553,9 +1553,14 @@ export const EffectFormWrapper: React.FC<EffectFormWrapperProps> = (props) => {
         const tagSchema = getTagSchema(watchType);
         const parsedTag = tagSchema.safeParse({ type: watchType });
         const shownTag = parsedTag.success ? parsedTag.data : tag;
+        // Consume locks rounds to 0 and hides the field (shield duration lives on
+        // shieldRounds), so carrying rounds across a switch either way would leave the
+        // new tag with a value its schema rejects on a field the admin cannot see.
+        const skipKeys = ["type", "calculation", "direction"];
+        if (tag.type === "consume" || watchType === "consume") skipKeys.push("rounds");
         // For all typed keys in shownTag, if the key exists in curTag, keep the value, except for type
         objectKeys(shownTag).forEach((key) => {
-          if (!["type", "calculation", "direction"].includes(key) && key in curTag) {
+          if (!skipKeys.includes(key) && key in curTag) {
             // @ts-expect-error - we know this is a key of the object
             shownTag[key] = curTag[key];
           }

--- a/app/src/layout/ItemWithEffects.tsx
+++ b/app/src/layout/ItemWithEffects.tsx
@@ -834,9 +834,16 @@ const ItemWithEffects: React.FC<ItemWithEffectsProps> = (props) => {
                       </div>
                       <div className="grid grid-cols-2">
                         {"rounds" in parsedEffect &&
-                          parsedEffect.rounds !== undefined && (
+                          parsedEffect.rounds !== undefined &&
+                          !("shieldRounds" in parsedEffect) && (
                             <span>
                               <b>Rounds: </b> {parsedEffect.rounds}
+                            </span>
+                          )}
+                        {"shieldRounds" in parsedEffect &&
+                          parsedEffect.shieldRounds !== undefined && (
+                            <span>
+                              <b>Shield Rounds: </b> {parsedEffect.shieldRounds}
                             </span>
                           )}
                         {"calculation" in parsedEffect && (

--- a/app/src/libs/combat/process.ts
+++ b/app/src/libs/combat/process.ts
@@ -12,7 +12,7 @@ import {
   POST_DAMAGE_MODIFIER_TYPES,
 } from "@/drizzle/constants";
 import type { ShieldTagType } from "@/validators/combat";
-import { VisualTag } from "@/validators/combat";
+import { ShieldTag, VisualTag } from "@/validators/combat";
 import {
   BARRIER_DAMAGE_TAG_TYPES,
   DAMAGE_LEECH_CAP_RATIO,
@@ -33,6 +33,7 @@ import {
   clear,
   clearPrevent,
   clone,
+  consume,
   copy,
   damageBarrier,
   damageUser,
@@ -197,6 +198,58 @@ const getVisualOrSound = (
     castThisRound: true,
     longitude,
     latitude,
+  };
+};
+
+/**
+ * Build the temporary shield effect granted by the consume tag.
+ *
+ * Parsing through ShieldTag keeps the shield contract in a single place: any field
+ * later added to ShieldTag (with a default) flows through here automatically instead
+ * of silently missing this call site. shieldHp is clamped to the schema's max health
+ * so a very large consumed hit can never throw during parsing mid-combat.
+ *
+ * isNew is intentionally false: shield()'s cast-round branch rolls a
+ * `Math.random() < power / 100` primary check to decide whether the shield lands, but
+ * here `power` is the raw shield HP (not a 0-100 probability). Marking the effect as
+ * not-new skips that roll so the consume shield is applied deterministically.
+ */
+const CONSUME_SHIELD_MAX_HP = 100000;
+const createConsumeShieldEffect = (
+  user: BattleUserState,
+  shieldHp: number,
+  rounds: number,
+  round: number,
+  targetId: string,
+): UserEffect => {
+  const cappedHp = Math.min(shieldHp, CONSUME_SHIELD_MAX_HP);
+  return {
+    ...ShieldTag.parse({
+      type: "shield",
+      description: "Temporary shield from consume",
+      rounds,
+      power: cappedHp,
+      powerPerLevel: 0,
+      direction: "offence",
+      calculation: "static",
+      health: cappedHp,
+      target: "SELF",
+    }),
+    id: nanoid(),
+    creatorId: user.userId,
+    targetId: user.userId,
+    level: 0,
+    // Regular shields are realized via realizeTag() as isNew, so shield() rolls its
+    // cast-round activation. Here power is already the raw HP, so keep isNew false to
+    // skip that roll and apply the shield deterministically.
+    isNew: false,
+    castThisRound: true,
+    createdRound: round,
+    longitude: user.longitude,
+    latitude: user.latitude,
+    barrierAbsorb: 0,
+    actionId: `consume-${user.userId}-${targetId}`,
+    targetType: "user",
   };
 };
 
@@ -693,6 +746,25 @@ export const applyEffects = (
               });
             }
           }
+          // Consume: convert a % of pre-shield damage into a temporary shield on the attacker.
+          // Not affected by heal modifiers and does not share the vamp/lifesteal leech budget.
+          const consumeShield = Math.floor(c.consumeShield ?? 0);
+          const consumeRounds = c.consumeRounds ?? 0;
+          if (consumeShield > 0 && consumeRounds > 0 && user.curHealth > 0) {
+            newUsersEffects.push(
+              createConsumeShieldEffect(
+                user,
+                consumeShield,
+                consumeRounds,
+                battle.round,
+                c.targetId,
+              ),
+            );
+            actionEffects.push({
+              txt: `${user.username} consumes ${consumeShield} damage as a shield for ${consumeRounds} rounds`,
+              color: "blue",
+            });
+          }
           // Reduce armor durability by 1 when hit (skip for battles that don't lose durability)
           if (!NO_DURABILITY_LOSS_COMBATS.includes(battle.battleType)) {
             const t = newUsersState.find((u) => u.userId === target.userId);
@@ -1128,6 +1200,8 @@ export const applySingleEffect = (
           info = lifesteal(effect, usersEffects, consequences, curTarget);
         } else if (effect.type === "vamp") {
           info = vamp(effect, usersEffects, consequences, curTarget);
+        } else if (effect.type === "consume") {
+          info = consume(effect, consequences);
         } else if (effect.type === "fleeprevent") {
           info = fleePrevent(effect, usersEffects, curTarget);
         } else if (effect.type === "healprevent") {

--- a/app/src/libs/combat/process.ts
+++ b/app/src/libs/combat/process.ts
@@ -10,6 +10,7 @@ import {
   OUT_OF_COMBAT_BASE_DAMAGE_INCREASE,
   OUT_OF_COMBAT_BASE_DAMAGE_REDUCTION,
   POST_DAMAGE_MODIFIER_TYPES,
+  SHIELD_MAX_HEALTH,
 } from "@/drizzle/constants";
 import type { ShieldTagType } from "@/validators/combat";
 import { ShieldTag, VisualTag } from "@/validators/combat";
@@ -202,53 +203,60 @@ const getVisualOrSound = (
 };
 
 /**
+ * Base shape of the temporary shield granted by the consume tag, parsed once at import.
+ *
+ * Going through ShieldTag keeps the shield contract in a single place: any field later
+ * added to ShieldTag (with a default) flows through here automatically instead of
+ * silently missing this call site. Everything the parse validates is static - rounds,
+ * power and health are overridden per cast below - so the parse never runs on the
+ * per-action combat path.
+ */
+const CONSUME_SHIELD_BASE = ShieldTag.parse({
+  type: "shield",
+  description: "Temporary shield from consume",
+  rounds: 1,
+  power: 1,
+  powerPerLevel: 0,
+  direction: "offence",
+  calculation: "static",
+  health: 1,
+  target: "SELF",
+});
+
+/**
  * Build the temporary shield effect granted by the consume tag.
  *
- * Parsing through ShieldTag keeps the shield contract in a single place: any field
- * later added to ShieldTag (with a default) flows through here automatically instead
- * of silently missing this call site. shieldHp is clamped to the schema's max health
- * so a very large consumed hit can never throw during parsing mid-combat.
+ * shieldHp and rounds are clamped to the bounds ShieldTag accepts, so a very large
+ * consumed hit can never produce a shield outside the schema's range.
  *
  * isNew is intentionally false: shield()'s cast-round branch rolls a
  * `Math.random() < power / 100` primary check to decide whether the shield lands, but
  * here `power` is the raw shield HP (not a 0-100 probability). Marking the effect as
  * not-new skips that roll so the consume shield is applied deterministically.
  */
-const CONSUME_SHIELD_MAX_HP = 100000;
 const createConsumeShieldEffect = (
   user: BattleUserState,
   shieldHp: number,
   rounds: number,
   round: number,
-  targetId: string,
 ): UserEffect => {
-  const cappedHp = Math.min(shieldHp, CONSUME_SHIELD_MAX_HP);
+  const cappedHp = Math.min(shieldHp, SHIELD_MAX_HEALTH);
   return {
-    ...ShieldTag.parse({
-      type: "shield",
-      description: "Temporary shield from consume",
-      rounds,
-      power: cappedHp,
-      powerPerLevel: 0,
-      direction: "offence",
-      calculation: "static",
-      health: cappedHp,
-      target: "SELF",
-    }),
+    ...CONSUME_SHIELD_BASE,
+    rounds: Math.min(rounds, 100),
+    power: cappedHp,
+    health: cappedHp,
     id: nanoid(),
     creatorId: user.userId,
     targetId: user.userId,
     level: 0,
-    // Regular shields are realized via realizeTag() as isNew, so shield() rolls its
-    // cast-round activation. Here power is already the raw HP, so keep isNew false to
-    // skip that roll and apply the shield deterministically.
     isNew: false,
     castThisRound: true,
     createdRound: round,
     longitude: user.longitude,
     latitude: user.latitude,
     barrierAbsorb: 0,
-    actionId: `consume-${user.userId}-${targetId}`,
+    actionId: `consume-${user.userId}-${round}`,
     targetType: "user",
   };
 };
@@ -592,6 +600,11 @@ export const applyEffects = (
     );
   });
 
+  // Consume shields are accumulated per attacker across all collapsed consequences and
+  // pushed once after the loop, so a multi-target action grants a single shield sized
+  // off the whole hit rather than one shield per damaged target.
+  const consumeShieldByUser = new Map<string, { hp: number; rounds: number }>();
+
   // Apply consequences to users
   Array.from(consequences.values())
     // Before collapsing consequences, we process each consequence indicidually
@@ -746,25 +759,6 @@ export const applyEffects = (
               });
             }
           }
-          // Consume: convert a % of pre-shield damage into a temporary shield on the attacker.
-          // Not affected by heal modifiers and does not share the vamp/lifesteal leech budget.
-          const consumeShield = Math.floor(c.consumeShield ?? 0);
-          const consumeRounds = c.consumeRounds ?? 0;
-          if (consumeShield > 0 && consumeRounds > 0 && user.curHealth > 0) {
-            newUsersEffects.push(
-              createConsumeShieldEffect(
-                user,
-                consumeShield,
-                consumeRounds,
-                battle.round,
-                c.targetId,
-              ),
-            );
-            actionEffects.push({
-              txt: `${user.username} consumes ${consumeShield} damage as a shield for ${consumeRounds} rounds`,
-              color: "blue",
-            });
-          }
           // Reduce armor durability by 1 when hit (skip for battles that don't lose durability)
           if (!NO_DURABILITY_LOSS_COMBATS.includes(battle.battleType)) {
             const t = newUsersState.find((u) => u.userId === target.userId);
@@ -779,6 +773,21 @@ export const applyEffects = (
               }
             });
           }
+        }
+        // Consume: convert a % of pre-shield damage into a temporary shield on the
+        // attacker. Not affected by heal modifiers and does not share the vamp/lifesteal
+        // leech budget. Accumulated here and granted once after the loop. Sits outside
+        // the damage block because consumeShield is only ever set from a pre-shield hit,
+        // which survives a merge that drops a shield-reduced damage===0 (same reason
+        // lifesteal is applied outside the block below).
+        const consumeShield = c.consumeShield ?? 0;
+        const consumeRounds = c.consumeRounds ?? 0;
+        if (consumeShield > 0 && consumeRounds > 0 && user.curHealth > 0) {
+          const prev = consumeShieldByUser.get(user.userId);
+          consumeShieldByUser.set(user.userId, {
+            hp: (prev?.hp ?? 0) + consumeShield,
+            rounds: Math.max(prev?.rounds ?? 0, consumeRounds),
+          });
         }
         if (c.residual !== undefined && c.residual >= 0) {
           target.curHealth -= c.residual;
@@ -989,6 +998,22 @@ export const applyEffects = (
         }
       }
     });
+
+  // Grant the accumulated consume shields: one effect and one log line per attacker,
+  // sized off the total pre-shield damage the action dealt across every target.
+  consumeShieldByUser.forEach(({ hp, rounds }, userId) => {
+    const user = newUsersState.find((u) => u.userId === userId);
+    if (!user || user.curHealth <= 0) return;
+    const shieldHp = Math.floor(hp);
+    if (shieldHp <= 0) return;
+    newUsersEffects.push(
+      createConsumeShieldEffect(user, shieldHp, rounds, battle.round),
+    );
+    actionEffects.push({
+      txt: `${user.username} consumes ${shieldHp} damage as a shield for ${rounds} rounds`,
+      color: "blue",
+    });
+  });
 
   // Apply pool adjustments to base values for all users with pool effects
   newUsersState.forEach((user) => {

--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -1924,19 +1924,28 @@ export const vamp = (
   // Store vampRatio on each outgoing damage consequence so the application phase
   // can compute the heal from the full pre-shield damage total (post-boost, pre-shield;
   // matches lifesteal, which also heals off the full hit a shield would otherwise reduce).
-  if (effect.isNew && effect.castThisRound) {
-    consequences.forEach((c) => {
-      if (
-        c.userId === effect.creatorId &&
-        c.targetId !== effect.creatorId &&
-        typeof c.damage === "number" &&
-        c.damage > 0
-      ) {
-        c.vampRatio = (c.vampRatio ?? 0) + power / 100;
-      }
-    });
-  }
+  forEachOutgoingDamage(effect, consequences, (c) => {
+    c.vampRatio = (c.vampRatio ?? 0) + power / 100;
+  });
   return getInfo(target, effect, `will vamp ${qualifier} damage as health`);
+};
+
+/**
+ * Convert a percentage of damage dealt into a temporary shield on the caster.
+ * Uses the same pre-shield damage basis as vamp, but is not affected by heal modifiers.
+ * Intentionally returns no cast-round announcement; process.ts logs when the shield is created.
+ */
+export const consume = (
+  effect: UserEffect,
+  consequences: Map<string, Consequence>,
+): ActionEffect | undefined => {
+  const { power } = getPower(effect);
+  const shieldRounds = "shieldRounds" in effect ? effect.shieldRounds : 3;
+  forEachOutgoingDamage(effect, consequences, (c) => {
+    c.consumeRatio = Math.min(1, (c.consumeRatio ?? 0) + power / 100);
+    c.consumeRounds = Math.max(c.consumeRounds ?? 0, shieldRounds);
+  });
+  return undefined;
 };
 
 /** Drain target's Chakra and Stamina over time */
@@ -3281,6 +3290,28 @@ export const getEfficiencyRatio = (dmgEffect: UserEffect, effect: UserEffect) =>
     }
   });
   return baseRatio ? 1 : 0;
+};
+
+/**
+ * Apply a callback to each outgoing damage consequence created this cast round.
+ * Shared by vamp, consume, and other damage-conversion tags.
+ */
+const forEachOutgoingDamage = (
+  effect: UserEffect,
+  consequences: Map<string, Consequence>,
+  fn: (c: Consequence) => void,
+) => {
+  if (!effect.isNew || !effect.castThisRound) return;
+  consequences.forEach((c) => {
+    if (
+      c.userId === effect.creatorId &&
+      c.targetId !== effect.creatorId &&
+      typeof c.damage === "number" &&
+      c.damage > 0
+    ) {
+      fn(c);
+    }
+  });
 };
 
 /**

--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -514,6 +514,12 @@ export type Consequence = {
   lifesteal_hp?: number;
   vampRatio?: number;
   vampHeal?: number;
+  /** Ratio of pre-shield damage converted into a temporary shield on the attacker */
+  consumeRatio?: number;
+  /** Resolved shield HP from consumeRatio * preShieldDamage */
+  consumeShield?: number;
+  /** How many rounds the consume-generated shield should last */
+  consumeRounds?: number;
   absorb_hp?: number;
   absorb_sp?: number;
   absorb_cp?: number;

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -1295,6 +1295,16 @@ export const collapseConsequences = (acc: Consequence[], val: Consequence) => {
         (current.vampHeal ?? 0) +
         val.vampRatio * (val.preShieldDamage ?? val.damage ?? 0);
     }
+    if (val.consumeRatio) {
+      // Consume shields off the FULL pre-shield hit (same basis as vamp), unaffected by heal mods.
+      current.consumeShield =
+        (current.consumeShield ?? 0) +
+        val.consumeRatio * (val.preShieldDamage ?? val.damage ?? 0);
+      current.consumeRounds = Math.max(
+        current.consumeRounds ?? 0,
+        val.consumeRounds ?? 0,
+      );
+    }
     if (val.preShieldDamage) {
       current.preShieldDamage = current.preShieldDamage
         ? current.preShieldDamage + val.preShieldDamage
@@ -1343,6 +1353,11 @@ export const collapseConsequences = (acc: Consequence[], val: Consequence) => {
     if (val.vampRatio) {
       val.vampHeal =
         (val.vampHeal ?? 0) + val.vampRatio * (val.preShieldDamage ?? val.damage ?? 0);
+    }
+    if (val.consumeRatio) {
+      val.consumeShield =
+        (val.consumeShield ?? 0) +
+        val.consumeRatio * (val.preShieldDamage ?? val.damage ?? 0);
     }
     acc.push(val);
   }

--- a/app/src/validators/combat.ts
+++ b/app/src/validators/combat.ts
@@ -16,6 +16,7 @@ import {
   MAX_GENS_CAP,
   MAX_STATS_CAP,
   PoolTypes,
+  SHIELD_MAX_HEALTH,
   SkillTreeEntryTypes,
   SkillTreeTargets,
   StatTypes,
@@ -510,9 +511,16 @@ export const ConsumeTag = z.object({
   ),
   calculation: z.enum(["percentage"]).prefault("percentage"),
   // The tag itself is instant (never lingers); shieldRounds is the duration of the
-  // shield it generates. Keeping rounds locked to 0 avoids a manual reset while the
-  // dedicated shieldRounds field carries the shield duration.
-  rounds: z.coerce.number().int().min(0).max(0).prefault(0),
+  // shield it generates. rounds is normalized to 0 rather than rejected above 0, so
+  // that switching tag types in the admin editor - which copies rounds across - cannot
+  // leave the form permanently invalid on a field that is hidden for this tag.
+  rounds: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .overwrite(() => 0)
+    .prefault(0),
   shieldRounds: z.coerce.number().int().min(1).max(100).prefault(3),
   target: z.enum(BaseTagTargets).optional().prefault("SELF"),
 });
@@ -556,7 +564,7 @@ export const ShieldTag = z.object({
   type: z.literal("shield").prefault("shield"),
   description: msg("Creates a temporary HP bar that lasts for a set amount of rounds"),
   rounds: z.coerce.number().int().min(1).max(100).prefault(3),
-  health: z.coerce.number().int().min(1).max(100000).prefault(100),
+  health: z.coerce.number().int().min(1).max(SHIELD_MAX_HEALTH).prefault(100),
 });
 export type ShieldTagType = z.infer<typeof ShieldTag>;
 
@@ -1186,24 +1194,14 @@ export const SuperRefineEffects = (effects: ZodAllTags[], ctx: z.RefinementCtx) 
           "WoundTag must be used together with a damage or pierce effect on the same action",
         );
       }
-    } else if (e.type === "vamp") {
+    } else if (e.type === "vamp" || e.type === "consume") {
       const hasDamageOrPierce = effects.some(
         (x) => x.type === "damage" || x.type === "pierce",
       );
       if (!hasDamageOrPierce) {
         addIssue(
           ctx,
-          "VampTag must be used together with a damage or pierce effect on the same action",
-        );
-      }
-    } else if (e.type === "consume") {
-      const hasDamageOrPierce = effects.some(
-        (x) => x.type === "damage" || x.type === "pierce",
-      );
-      if (!hasDamageOrPierce) {
-        addIssue(
-          ctx,
-          "ConsumeTag must be used together with a damage or pierce effect on the same action",
+          `${e.type === "vamp" ? "VampTag" : "ConsumeTag"} must be used together with a damage or pierce effect on the same action`,
         );
       }
     } else if (e.type === "rollbloodline" && e.powerPerLevel > 0) {

--- a/app/src/validators/combat.ts
+++ b/app/src/validators/combat.ts
@@ -501,6 +501,23 @@ export const VampTag = z.object({
 });
 export type VampTagType = z.infer<typeof VampTag>;
 
+export const ConsumeTag = z.object({
+  ...BaseAttributes,
+  ...PowerAttributes,
+  type: z.literal("consume").prefault("consume"),
+  description: msg(
+    "Convert a percentage of damage dealt by this jutsu into a temporary shield on yourself. Not affected by heal modifiers.",
+  ),
+  calculation: z.enum(["percentage"]).prefault("percentage"),
+  // The tag itself is instant (never lingers); shieldRounds is the duration of the
+  // shield it generates. Keeping rounds locked to 0 avoids a manual reset while the
+  // dedicated shieldRounds field carries the shield duration.
+  rounds: z.coerce.number().int().min(0).max(0).prefault(0),
+  shieldRounds: z.coerce.number().int().min(1).max(100).prefault(3),
+  target: z.enum(BaseTagTargets).optional().prefault("SELF"),
+});
+export type ConsumeTagType = z.infer<typeof ConsumeTag>;
+
 export const DisarmTag = z.object({
   ...BaseAttributes,
   ...PowerAttributes,
@@ -828,6 +845,7 @@ export const AllTags = z.union([
   ClearPreventTag.prefault({}),
   ClearTag.prefault({}),
   CloneTag.prefault({}),
+  ConsumeTag.prefault({}),
   CopyTag.prefault({}),
   DamageTag.prefault({}),
   DebuffPreventTag.prefault({}),
@@ -915,6 +933,7 @@ export const isPositiveUserEffect = (tag: ZodAllTags) => {
     [
       "absorb",
       // "clearprevent",
+      "consume",
       "debuffprevent",
       "decreasedamagetaken",
       "decreasepoolcost",
@@ -1175,6 +1194,16 @@ export const SuperRefineEffects = (effects: ZodAllTags[], ctx: z.RefinementCtx) 
         addIssue(
           ctx,
           "VampTag must be used together with a damage or pierce effect on the same action",
+        );
+      }
+    } else if (e.type === "consume") {
+      const hasDamageOrPierce = effects.some(
+        (x) => x.type === "damage" || x.type === "pierce",
+      );
+      if (!hasDamageOrPierce) {
+        addIssue(
+          ctx,
+          "ConsumeTag must be used together with a damage or pierce effect on the same action",
         );
       }
     } else if (e.type === "rollbloodline" && e.powerPerLevel > 0) {

--- a/app/src/validators/objectives.ts
+++ b/app/src/validators/objectives.ts
@@ -132,6 +132,7 @@ export const OBJECTIVE_TAG_TYPES = [
   "cleanseprevent",
   "clear",
   "clearprevent",
+  "consume",
   "copy",
   "damage",
   "debuffprevent",

--- a/app/tests/libs/combat/consume.test.ts
+++ b/app/tests/libs/combat/consume.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import { applyEffects } from "@/libs/combat/process";
+import type { CombatAction, CompleteBattle, UserEffect } from "@/libs/combat/types";
+import { makeBattleUser, makeDamageEffect, makeEffect } from "./helpers/battleScenario";
+
+const ROUND = 3;
+
+const makeAction = (): CombatAction =>
+  ({ chakraCost: 0, staminaCost: 0 }) as CombatAction;
+
+const makeBattle = (
+  usersState: ReturnType<typeof makeBattleUser>[],
+  usersEffects: UserEffect[],
+): CompleteBattle =>
+  ({
+    battleType: "COMBAT",
+    round: ROUND,
+    usersState,
+    usersEffects,
+    groundEffects: [],
+    extraState: {},
+  }) as unknown as CompleteBattle;
+
+const makeAttacker = (overrides: Record<string, unknown> = {}) =>
+  makeBattleUser("attacker", { curHealth: 1000, maxHealth: 1000, ...overrides });
+const makeDefender = (overrides: Record<string, unknown> = {}) =>
+  makeBattleUser("defender", {
+    curHealth: 100_000_000,
+    maxHealth: 100_000_000,
+    ...overrides,
+  });
+
+const makeAttack = (
+  id = "damage-1",
+  creatorId = "attacker",
+  targetId = "defender",
+): UserEffect =>
+  makeDamageEffect({
+    id,
+    creatorId,
+    targetId,
+    isNew: true,
+    castThisRound: true,
+    createdRound: ROUND,
+    rounds: 0,
+    targetType: "user",
+  } as Partial<UserEffect>);
+
+const makeConsume = (power: number, shieldRounds = 3): UserEffect =>
+  makeEffect(
+    "consume",
+    { power, calculation: "percentage", shieldRounds },
+    {
+      id: "consume-1",
+      creatorId: "attacker",
+      targetId: "attacker",
+      isNew: true,
+      castThisRound: true,
+      createdRound: ROUND,
+      actionId: "consume-action",
+      targetType: "user",
+    },
+  );
+
+/**
+ * Active shield on the target that guarantees activation and absorbs a large
+ * chunk of a hit's damage. See vamp_lifesteal_cap.test.ts for the same fixture.
+ */
+const makeShield = (targetId: string): UserEffect =>
+  makeEffect(
+    "shield",
+    { power: 100, health: 100_000 },
+    {
+      id: `shield-${targetId}`,
+      creatorId: targetId,
+      targetId,
+      isNew: true,
+      castThisRound: true,
+      createdRound: ROUND,
+      actionId: "shield-action",
+      targetType: "user",
+    },
+  );
+
+const findConsumeShield = (effects: UserEffect[]) =>
+  effects.find(
+    (e) => e.type === "shield" && e.targetId === "attacker" && (e.power ?? 0) > 0,
+  );
+
+describe("applyEffects — consume", () => {
+  it("converts a percentage of damage dealt into a shield on the attacker", () => {
+    const attacker = makeAttacker();
+    const defender = makeDefender();
+    const battle = makeBattle([attacker, defender], [makeAttack(), makeConsume(50)]);
+    const { newBattle, actionEffects } = applyEffects(battle, "attacker", makeAction());
+
+    const healthLost =
+      defender.curHealth -
+      (newBattle.usersState.find((u) => u.userId === "defender")?.curHealth ?? 0);
+    expect(healthLost).toBeGreaterThan(0);
+
+    const shields = newBattle.usersEffects.filter(
+      (e) => e.type === "shield" && e.targetId === "attacker" && (e.power ?? 0) > 0,
+    );
+    expect(shields).toHaveLength(1);
+    expect(shields[0]?.power).toBeCloseTo(Math.floor(healthLost * 0.5), 0);
+    expect(shields[0]?.rounds).toBe(3);
+    expect(
+      actionEffects.some((e) => e.txt.includes("consumes") && e.txt.includes("shield")),
+    ).toBe(true);
+  });
+
+  it("does not leave the consume tag itself as a lingering effect", () => {
+    const battle = makeBattle(
+      [makeAttacker(), makeDefender()],
+      [makeAttack(), makeConsume(25, 5)],
+    );
+    const { newBattle } = applyEffects(battle, "attacker", makeAction());
+
+    expect(newBattle.usersEffects.some((e) => e.type === "consume")).toBe(false);
+    const shield = newBattle.usersEffects.find(
+      (e) => e.type === "shield" && e.targetId === "attacker",
+    );
+    expect(shield).toBeDefined();
+    expect(shield?.rounds).toBe(5);
+  });
+
+  it("sizes the consume shield off pre-shield damage when the defender has a shield", () => {
+    // No-shield reference: consume (50%) of the full hit; healthLost == raw damage.
+    const refDefender = makeDefender();
+    const { newBattle: ref } = applyEffects(
+      makeBattle([makeAttacker(), refDefender], [makeAttack(), makeConsume(50)]),
+      "attacker",
+      makeAction(),
+    );
+    const refHealthLost =
+      refDefender.curHealth -
+      (ref.usersState.find((u) => u.userId === "defender")?.curHealth ?? 0);
+    const refShield = findConsumeShield(ref.usersEffects);
+    expect(refHealthLost).toBeGreaterThan(0);
+    expect(refShield?.power).toBeGreaterThan(0);
+
+    // Same hit, but the defender's shield absorbs the damage (post-shield HP loss ~0).
+    const shieldedDefender = makeDefender();
+    const { newBattle: shielded } = applyEffects(
+      makeBattle(
+        [makeAttacker(), shieldedDefender],
+        [makeAttack(), makeConsume(50), makeShield("defender")],
+      ),
+      "attacker",
+      makeAction(),
+    );
+    const shieldedHealthLost =
+      shieldedDefender.curHealth -
+      (shielded.usersState.find((u) => u.userId === "defender")?.curHealth ?? 0);
+    const consumeShield = findConsumeShield(shielded.usersEffects);
+
+    expect(shieldedHealthLost).toBeLessThan(refHealthLost);
+    // Consume is sized off the FULL pre-shield hit, so the granted shield matches the
+    // no-shield reference even when post-shield damage collapses toward 0.
+    expect(consumeShield?.power).toBeCloseTo(refShield!.power!, 0);
+  });
+
+  it("merges consume shields across multiple damage hits on the same target", () => {
+    // Two damage consequences share targetId and collapse; consumeShield must accumulate
+    // in the merge branch (current.consumeShield += ...), producing one shield sized off
+    // the total pre-shield damage — not two separate shields or only the first hit.
+    const defender = makeDefender();
+    const { newBattle } = applyEffects(
+      makeBattle(
+        [makeAttacker(), defender],
+        [makeAttack("damage-1"), makeAttack("damage-2"), makeConsume(50)],
+      ),
+      "attacker",
+      makeAction(),
+    );
+    const healthLost =
+      defender.curHealth -
+      (newBattle.usersState.find((u) => u.userId === "defender")?.curHealth ?? 0);
+    const shields = newBattle.usersEffects.filter(
+      (e) => e.type === "shield" && e.targetId === "attacker" && (e.power ?? 0) > 0,
+    );
+
+    expect(healthLost).toBeGreaterThan(0);
+    expect(shields).toHaveLength(1);
+    expect(shields[0]?.power).toBeCloseTo(Math.floor(healthLost * 0.5), 0);
+  });
+
+  it("grants a shield that absorbs incoming damage on a later action", () => {
+    // Drive createConsumeShieldEffect through applyEffects, then confirm the resulting
+    // effect actually soaks damage (catches a broken ShieldTag field that would leave a
+    // non-absorbing shield in usersEffects).
+    const { newBattle: afterConsume } = applyEffects(
+      makeBattle([makeAttacker(), makeDefender()], [makeAttack(), makeConsume(50)]),
+      "attacker",
+      makeAction(),
+    );
+    const consumeShield = findConsumeShield(afterConsume.usersEffects);
+    expect(consumeShield).toBeDefined();
+    expect(consumeShield!.power).toBeGreaterThan(0);
+    const shieldHpBefore = consumeShield!.power;
+
+    // Control: defender hits attacker with no shield.
+    const controlAttacker = makeAttacker({ curHealth: 100_000_000, maxHealth: 100_000_000 });
+    const { newBattle: control } = applyEffects(
+      makeBattle(
+        [controlAttacker, makeDefender()],
+        [makeAttack("retaliation", "defender", "attacker")],
+      ),
+      "defender",
+      makeAction(),
+    );
+    const controlLost =
+      controlAttacker.curHealth -
+      (control.usersState.find((u) => u.userId === "attacker")?.curHealth ?? 0);
+    expect(controlLost).toBeGreaterThan(0);
+
+    // Same retaliation with the consume-granted shield carried forward.
+    const shieldedAttacker = makeAttacker({
+      curHealth: 100_000_000,
+      maxHealth: 100_000_000,
+    });
+    const { newBattle: shielded, actionEffects } = applyEffects(
+      makeBattle(
+        [shieldedAttacker, makeDefender()],
+        [
+          { ...consumeShield!, power: shieldHpBefore },
+          makeAttack("retaliation", "defender", "attacker"),
+        ],
+      ),
+      "defender",
+      makeAction(),
+    );
+    const shieldedLost =
+      shieldedAttacker.curHealth -
+      (shielded.usersState.find((u) => u.userId === "attacker")?.curHealth ?? 0);
+    const remainingShield = findConsumeShield(shielded.usersEffects);
+
+    expect(shieldedLost).toBeLessThan(controlLost);
+    expect(
+      actionEffects.some((e) => e.txt.includes("shield absorbs")),
+    ).toBe(true);
+    // Shield HP decreased (or was destroyed) by the absorbed amount.
+    expect((remainingShield?.power ?? 0) < shieldHpBefore || remainingShield === undefined).toBe(
+      true,
+    );
+  });
+});

--- a/app/tests/libs/combat/consume.test.ts
+++ b/app/tests/libs/combat/consume.test.ts
@@ -23,8 +23,8 @@ const makeBattle = (
 
 const makeAttacker = (overrides: Record<string, unknown> = {}) =>
   makeBattleUser("attacker", { curHealth: 1000, maxHealth: 1000, ...overrides });
-const makeDefender = (overrides: Record<string, unknown> = {}) =>
-  makeBattleUser("defender", {
+const makeDefender = (id = "defender", overrides: Record<string, unknown> = {}) =>
+  makeBattleUser(id, {
     curHealth: 100_000_000,
     maxHealth: 100_000_000,
     ...overrides,
@@ -184,6 +184,41 @@ describe("applyEffects — consume", () => {
     expect(healthLost).toBeGreaterThan(0);
     expect(shields).toHaveLength(1);
     expect(shields[0]?.power).toBeCloseTo(Math.floor(healthLost * 0.5), 0);
+  });
+
+  it("grants one aggregated shield when the action hits multiple targets", () => {
+    // collapseConsequences merges by targetId, so a two-target action leaves two
+    // collapsed consequences. The attacker must still end up with a single shield sized
+    // off the combined hit rather than one shield per damaged target.
+    const first = makeDefender("defender-a");
+    const second = makeDefender("defender-b");
+    const { newBattle, actionEffects } = applyEffects(
+      makeBattle(
+        [makeAttacker(), first, second],
+        [
+          makeAttack("damage-a", "attacker", "defender-a"),
+          makeAttack("damage-b", "attacker", "defender-b"),
+          makeConsume(50),
+        ],
+      ),
+      "attacker",
+      makeAction(),
+    );
+    const perDefenderLost = [first, second].map(
+      (defender) =>
+        defender.curHealth -
+        (newBattle.usersState.find((u) => u.userId === defender.userId)?.curHealth ?? 0),
+    );
+    const healthLost = perDefenderLost.reduce((total, lost) => total + lost, 0);
+    const shields = newBattle.usersEffects.filter(
+      (e) => e.type === "shield" && e.targetId === "attacker" && (e.power ?? 0) > 0,
+    );
+
+    // Both targets must actually be hit, else the single-shield assertion is vacuous.
+    perDefenderLost.forEach((lost) => expect(lost).toBeGreaterThan(0));
+    expect(shields).toHaveLength(1);
+    expect(shields[0]?.power).toBeCloseTo(Math.floor(healthLost * 0.5), 0);
+    expect(actionEffects.filter((e) => e.txt.includes("consumes"))).toHaveLength(1);
   });
 
   it("grants a shield that absorbs incoming damage on a later action", () => {


### PR DESCRIPTION
# Pull Request

This is a new combat tag where a % of damage dealt is converted into a shield.  Also removes shield from gcd

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Consume** combat effect, converting a percentage of relevant outgoing **damage** (and **pierce**) into a temporary **self shield** for the attacker, with combat action-log messaging.
  * Updated effect handling to create the shield during resolution and to support configurable shield power and duration.
  * Expanded validation and objective/tag support so **Consume** is accepted as a valid battle/combat tag, including a rule that it requires the same action to also include **damage** or **pierce**.

* **Bug Fixes**
  * Ensure Consume shield values are merged correctly across combined outcomes and that the Consume effect does not persist after triggering.

* **Tests**
  * Added automated coverage for Consume behavior, shield creation, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->