### PR TITLE
Keep VillageStructure coordinates signed for the -1 off-map sentinel

### DIFF
--- a/app/drizzle/migrations/0019_even_vision.sql
+++ b/app/drizzle/migrations/0019_even_vision.sql
@@ -57,10 +57,10 @@ CREATE TABLE `SectorMap` (
 
 ALTER TABLE `UserData` MODIFY COLUMN `longitude` smallint unsigned NOT NULL DEFAULT 10;
 ALTER TABLE `UserData` MODIFY COLUMN `latitude` smallint unsigned NOT NULL DEFAULT 7;
-ALTER TABLE `VillageStructure` MODIFY COLUMN `longitude` smallint unsigned NOT NULL DEFAULT 10;
-ALTER TABLE `VillageStructure` MODIFY COLUMN `latitude` smallint unsigned NOT NULL DEFAULT 10;
+ALTER TABLE `VillageStructure` MODIFY COLUMN `longitude` smallint NOT NULL DEFAULT 10;
+ALTER TABLE `VillageStructure` MODIFY COLUMN `latitude` smallint NOT NULL DEFAULT 10;
 CREATE INDEX `MapAsset_category_idx` ON `MapAsset` (`category`);
-CREATE INDEX `SectorMap_sector_status_idx` ON `SectorMap` (`sector`,`status`);
+CREATE INDEX `SectorMap_sector_status_idx` ON `SectorMap` (`sector`,`status`);--> statement-breakpoint
 -- Village biome relocation: move each village to a sector whose globe biome
 -- matches its theme (art/colors), on the 1944-sector cube-sphere world.
 --

--- a/app/drizzle/migrations/meta/0019_snapshot.json
+++ b/app/drizzle/migrations/meta/0019_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "dialect": "mysql",
-  "id": "52306179-5bc0-46ca-b6c4-58cfd4d0ef55",
+  "id": "cc622ad6-0935-44cc-a306-3cec3579258d",
   "prevId": "49218220-0571-4716-87f6-dcccd02592b8",
   "tables": {
     "AbEvent": {
@@ -14365,7 +14365,7 @@
         },
         "longitude": {
           "name": "longitude",
-          "type": "smallint unsigned",
+          "type": "smallint",
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false,
@@ -14373,7 +14373,7 @@
         },
         "latitude": {
           "name": "latitude",
-          "type": "smallint unsigned",
+          "type": "smallint",
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false,

--- a/app/drizzle/migrations/meta/_journal.json
+++ b/app/drizzle/migrations/meta/_journal.json
@@ -138,8 +138,8 @@
     {
       "idx": 19,
       "version": "5",
-      "when": 1784386583692,
-      "tag": "0019_premium_mysterio",
+      "when": 1784395621841,
+      "tag": "0019_even_vision",
       "breakpoints": false
     }
   ]

--- a/app/drizzle/schema.ts
+++ b/app/drizzle/schema.ts
@@ -3164,8 +3164,10 @@ export const villageStructure = mysqlTable(
     route: varchar("route", { length: 191 }).default("").notNull(),
     image: varchar("image", { length: 191 }).notNull(),
     villageId: varchar("villageId", { length: 191 }).notNull(),
-    longitude: smallint("longitude", { unsigned: true }).default(10).notNull(),
-    latitude: smallint("latitude", { unsigned: true }).default(10).notNull(),
+    // Signed: -1/-1 is the long-standing "not on the map" sentinel used by
+    // non-physical structures (Walls, Protectors) in every environment
+    longitude: smallint("longitude").default(10).notNull(),
+    latitude: smallint("latitude").default(10).notNull(),
     hasPage: tinyint("hasPage").default(0).notNull(),
     curSp: int("curSp").default(100).notNull(),
     maxSp: int("maxSp").default(100).notNull(),


### PR DESCRIPTION
The prod run of migration 0019 failed at query 6:

    Out of range value for column 'longitude' at row 9 (errno 1264)
    ALTER TABLE VillageStructure MODIFY COLUMN longitude smallint unsigned ...

**Root cause:** all 63 Walls/Protectors rows (one pair per settlement — prod and dev alike) store `longitude = latitude = -1`, the long-standing "not on the map" sentinel for non-physical structures. `smallint unsigned` cannot hold it. These rows are never rendered (`hasPage = 0`), so the sentinel is correct domain data; the schema was wrong to prescribe unsigned.

**Fix:** keep `VillageStructure.longitude/latitude` as **signed** `smallint` and regenerate the squashed migration (`0019_even_vision.sql`). DDL is identical apart from the two `MODIFY`s dropping `UNSIGNED`; the relocation data section (3 villages + 6 water-stranded settlements) is byte-identical. `UserData` stays unsigned — no sentinels there, and prod already applied those ALTERs cleanly.

Verified: `make makemigrations` reports no drift, snapshot/journal chain intact, typecheck clean, 445 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected map coordinate handling to support negative latitude and longitude values.
  * Improved representation of structures that are not physically placed on the map.

* **Data Updates**
  * Updated supporting map indexes to help maintain efficient map-related lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->