### PR TITLE
Show building names on the sector map via hover and a toggle

### DIFF
--- a/app/src/app/travel/page.tsx
+++ b/app/src/app/travel/page.tsx
@@ -2,6 +2,8 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
+  Captions,
+  CaptionsOff,
   Cookie,
   Eye,
   EyeOff,
@@ -110,6 +112,10 @@ export default function Travel() {
   );
   const [showOwnership, setShowOwnership] = useLocalStorage<boolean>(
     "showOwnership",
+    false,
+  );
+  const [showBuildingLabels, setShowBuildingLabels] = useLocalStorage<boolean>(
+    "showBuildingLabels",
     false,
   );
   const [autoAttackMode, setAutoAttackMode] = useLocalStorage<boolean>(
@@ -670,6 +676,7 @@ export default function Travel() {
           target={targetPosition}
           showSorrounding={showSorrounding}
           showActive={showActive}
+          showStructureLabels={showBuildingLabels}
           autoAttackMode={autoAttackMode}
           setShowSorrounding={setShowSorrounding}
           setTarget={setTargetPosition}
@@ -686,6 +693,7 @@ export default function Travel() {
     targetPosition,
     showSorrounding,
     showActive,
+    showBuildingLabels,
     autoAttackMode,
     villages,
   ]);
@@ -803,6 +811,25 @@ export default function Travel() {
                     onClick={() => setShowActive(true)}
                   />
                 )}
+                {/* Building labels toggle */}
+                <TooltipProvider delayDuration={50}>
+                  <Tooltip>
+                    <TooltipTrigger
+                      onClick={() => setShowBuildingLabels(!showBuildingLabels)}
+                    >
+                      {showBuildingLabels ? (
+                        <Captions className="mr-2 h-7 w-7 text-orange-500" />
+                      ) : (
+                        <CaptionsOff className="mr-2 h-7 w-7 hover:text-orange-500" />
+                      )}
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {showBuildingLabels
+                        ? "Hide building names"
+                        : "Show building names"}
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
                 <UserRoundSearch
                   className={`mr-2 h-7 w-7 hover:text-orange-500 ${showSorrounding ? "fill-orange-500" : ""}`}
                   onClick={() => setShowSorrounding((prev) => !prev)}

--- a/app/src/app/travel/page.tsx
+++ b/app/src/app/travel/page.tsx
@@ -815,6 +815,12 @@ export default function Travel() {
                 <TooltipProvider delayDuration={50}>
                   <Tooltip>
                     <TooltipTrigger
+                      aria-label={
+                        showBuildingLabels
+                          ? "Hide building names"
+                          : "Show building names"
+                      }
+                      aria-pressed={showBuildingLabels}
                       onClick={() => setShowBuildingLabels(!showBuildingLabels)}
                     >
                       {showBuildingLabels ? (

--- a/app/src/layout/Sector.tsx
+++ b/app/src/layout/Sector.tsx
@@ -64,6 +64,7 @@ import {
   drawSector,
   drawUsers,
   drawVillage,
+  intersectStructures,
   intersectUsers,
   intersectWindowTiles,
   type WindowNav,
@@ -137,6 +138,7 @@ interface SectorProps {
   target: SectorPoint | null;
   showSorrounding: boolean;
   showActive: boolean;
+  showStructureLabels: boolean;
   autoAttackMode: boolean;
   setShowSorrounding: React.Dispatch<React.SetStateAction<boolean>>;
   setTarget: React.Dispatch<React.SetStateAction<SectorPoint | null>>;
@@ -176,7 +178,14 @@ const findNearestWalkableEdgeTile = (
  */
 const Sector: React.FC<SectorProps> = (props) => {
   // Incoming props
-  const { sector, sectorWindow, target, showActive, autoAttackMode } = props;
+  const {
+    sector,
+    sectorWindow,
+    target,
+    showActive,
+    showStructureLabels,
+    autoAttackMode,
+  } = props;
   // The window always contains the current sector: crossings move into a
   // sector that was part of the previous window
   const centerEntry = sectorWindow.sectors.find((entry) => entry.sector === sector);
@@ -216,6 +225,7 @@ const Sector: React.FC<SectorProps> = (props) => {
   const gridRef = useRef<Grid<TerrainHex> | null>(null);
   const usersRef = useRef<SectorUser[]>([]);
   const showUsersRef = useRef<boolean>(showActive);
+  const showStructureLabelsRef = useRef<boolean>(showStructureLabels);
   const minBracketDrawRef = useRef<number>(storedBracket);
   const showAllyAttackRef = useRef<boolean>(allyAttack);
   const userRef = useRef<UserWithRelations>(undefined);
@@ -262,6 +272,9 @@ const Sector: React.FC<SectorProps> = (props) => {
   // without rebuilding the scene
   const interactionGroupsRef = useRef<Group[]>([]);
   const assetsGroupsRef = useRef<Group[]>([]);
+  // The window's building sprites, so the per-frame label hover raycast only
+  // tests a handful of structures instead of every decoration sprite
+  const structureSpritesRef = useRef<Sprite[]>([]);
   const animatedMaterialsRef = useRef<
     ReturnType<typeof drawSector>["animatedMaterials"]
   >([]);
@@ -1286,6 +1299,11 @@ const Sector: React.FC<SectorProps> = (props) => {
     const entries = [...registry.entries.values()];
     interactionGroupsRef.current = entries.map((render) => render.interaction);
     assetsGroupsRef.current = entries.map((render) => render.assets);
+    structureSpritesRef.current = entries.flatMap((render) =>
+      render.assets.children.filter(
+        (child): child is Sprite => child.userData.type === "structure",
+      ),
+    );
     animatedMaterialsRef.current = entries.flatMap(
       (render) => render.animatedMaterials,
     );
@@ -1584,6 +1602,10 @@ const Sector: React.FC<SectorProps> = (props) => {
   useEffect(() => {
     showUsersRef.current = showActive;
   }, [showActive]);
+
+  useEffect(() => {
+    showStructureLabelsRef.current = showStructureLabels;
+  }, [showStructureLabels]);
 
   useEffect(() => {
     isAttackingRef.current = isAttacking;
@@ -2193,6 +2215,18 @@ const Sector: React.FC<SectorProps> = (props) => {
           drawQuest({ group_quest, user: userRef.current, grid: gridRef.current });
           endQuest();
         }
+
+        // Building name labels: hovered building only, or every building
+        // while the travel page's label toggle is on
+        const endStructures = profiler.mark("animate_intersect_structures");
+        intersectStructures({
+          structureSprites: structureSpritesRef.current,
+          raycaster,
+          showAll: showStructureLabelsRef.current,
+          pointerOnMap: pointerOnMapRef.current,
+          cameraZoom: camera.zoom,
+        });
+        endStructures();
 
         // Highlight the hover path across the whole 3x3 window (offsetOfSector
         // is the component-scope helper defined above)

--- a/app/src/libs/threejs/sector.ts
+++ b/app/src/libs/threejs/sector.ts
@@ -1050,6 +1050,99 @@ export const createMultipleUserSprite = (
 };
 
 /**
+ * Floating name label for a village structure, rendered to a canvas so the
+ * whole label is a single sprite; starts hidden and is toggled by
+ * intersectStructures.
+ */
+export const createStructureLabel = (structure: VillageStructure, h: number) => {
+  const canvasWidth = 512;
+  const canvasHeight = 84;
+  const canvas = document.createElement("canvas");
+  canvas.width = canvasWidth;
+  canvas.height = canvasHeight;
+  const context = canvas.getContext("2d");
+  if (context) {
+    // Building name, shrunk to fit the canvas width
+    let fontSize = 64;
+    context.textAlign = "center";
+    context.textBaseline = "middle";
+    do {
+      context.font = `bold ${fontSize}px Serif`;
+      fontSize -= 2;
+    } while (
+      fontSize > 24 &&
+      context.measureText(structure.name).width > canvasWidth - 16
+    );
+    context.lineJoin = "round";
+    context.strokeStyle = "black";
+    context.lineWidth = 9;
+    context.strokeText(structure.name, canvasWidth / 2, canvasHeight / 2);
+    context.fillStyle = "white";
+    context.fillText(structure.name, canvasWidth / 2, canvasHeight / 2);
+  }
+  const texture = createTexture(canvas);
+  texture.generateMipmaps = false;
+  texture.minFilter = LinearFilter;
+  texture.needsUpdate = true;
+  const material = new SpriteMaterial({
+    map: texture,
+    depthWrite: false,
+    depthTest: false,
+  });
+  const sprite = new Sprite(material);
+  sprite.scale.set(h * 3.0, h * 3.0 * (canvasHeight / canvasWidth), 1);
+  // Anchor at the bottom edge so zoom compensation grows the label upwards,
+  // away from the building, instead of over it
+  sprite.center.set(0.5, 0);
+  sprite.renderOrder = 10;
+  sprite.name = `structure-label-${structure.id}`;
+  sprite.userData.type = "structureLabel";
+  sprite.userData.baseWidth = h * 3.0;
+  sprite.userData.baseHeight = h * 3.0 * (canvasHeight / canvasWidth);
+  sprite.visible = false;
+  return sprite;
+};
+
+/** Camera zoom at which structure labels render at their authored world size */
+const STRUCTURE_LABEL_REFERENCE_ZOOM = 2;
+
+/**
+ * Toggle building labels each frame: all visible when showAll is set,
+ * otherwise only the label of the structure sprite under the pointer.
+ * Visible labels are counter-scaled by the camera zoom so they keep a
+ * constant, readable on-screen size at every zoom level.
+ */
+export const intersectStructures = (info: {
+  structureSprites: Sprite[];
+  raycaster: Raycaster;
+  showAll: boolean;
+  pointerOnMap: boolean;
+  cameraZoom: number;
+}) => {
+  const { structureSprites, raycaster, showAll, pointerOnMap, cameraZoom } = info;
+  let hovered: Sprite | null = null;
+  if (!showAll && pointerOnMap && structureSprites.length > 0) {
+    const intersects = raycaster.intersectObjects(structureSprites, false);
+    hovered = (intersects[0]?.object as Sprite) ?? null;
+  }
+  const zoomComp = Math.min(
+    3,
+    Math.max(0.6, STRUCTURE_LABEL_REFERENCE_ZOOM / Math.max(0.1, cameraZoom)),
+  );
+  structureSprites.forEach((sprite) => {
+    const label = sprite.userData.labelSprite as Sprite | undefined;
+    if (!label) return;
+    label.visible = showAll || sprite === hovered;
+    if (label.visible) {
+      const width = (label.userData.baseWidth as number) * zoomComp;
+      if (Math.abs(label.scale.x - width) > 0.001) {
+        label.scale.set(width, (label.userData.baseHeight as number) * zoomComp, 1);
+      }
+    }
+  });
+};
+
+/**
  * Draw village on map
  */
 export const drawVillage = (
@@ -1126,6 +1219,13 @@ export const drawVillage = (
       sprite.userData.structureId = structure.id;
       sprite.userData.structureName = structure.name;
       group.add(sprite);
+      // Floating name label, revealed on hover or via the travel page's
+      // label toggle (see intersectStructures). Bottom-anchored just above
+      // the building sprite's top edge.
+      const label = createStructureLabel(structure, h);
+      label.position.set(x, y + h / 10 + h * 1.55, STATUS_LAYER);
+      sprite.userData.labelSprite = label;
+      group.add(label);
     }
   }
 };

--- a/app/src/libs/threejs/sector.ts
+++ b/app/src/libs/threejs/sector.ts
@@ -1066,13 +1066,14 @@ export const createStructureLabel = (structure: VillageStructure, h: number) => 
     let fontSize = 64;
     context.textAlign = "center";
     context.textBaseline = "middle";
-    do {
-      context.font = `bold ${fontSize}px Serif`;
-      fontSize -= 2;
-    } while (
+    context.font = `bold ${fontSize}px Serif`;
+    while (
       fontSize > 24 &&
       context.measureText(structure.name).width > canvasWidth - 16
-    );
+    ) {
+      fontSize -= 2;
+      context.font = `bold ${fontSize}px Serif`;
+    }
     context.lineJoin = "round";
     context.strokeStyle = "black";
     context.lineWidth = 9;
@@ -1089,6 +1090,9 @@ export const createStructureLabel = (structure: VillageStructure, h: number) => 
     depthWrite: false,
     depthTest: false,
   });
+  // Signal to disposeGroupPreservingShared that this texture is not shared
+  // and must be disposed together with the material to avoid leaking GPU memory
+  material.userData.ownsMap = true;
   const sprite = new Sprite(material);
   sprite.scale.set(h * 3.0, h * 3.0 * (canvasHeight / canvasWidth), 1);
   // Anchor at the bottom edge so zoom compensation grows the label upwards,

--- a/app/src/libs/threejs/util.ts
+++ b/app/src/libs/threejs/util.ts
@@ -599,7 +599,14 @@ export const disposeGroupPreservingShared = (root: Object3D) => {
         ? [mesh.material]
         : [];
     materials.forEach((material) => {
-      if (!material.userData?.shared) material.dispose();
+      if (material.userData?.shared) return;
+      // Textures owned by the sprite (e.g. per-instance canvas labels) must be
+      // disposed alongside the material; Material.dispose() does not cascade.
+      if (material.userData?.ownsMap) {
+        const map = (material as SpriteMaterial).map;
+        map?.dispose();
+      }
+      material.dispose();
     });
   });
 };


### PR DESCRIPTION
# Pull Request

**What was implemented:**

Buildings on the sector map were hard to tell apart — you had to walk adjacent to a structure to learn its name. This PR adds floating name labels to village structures:

- **Hover**: mousing over any building on the sector map shows its name as a floating label just above the building sprite.
- **Toggle**: a new captions icon in the travel page's icon bar (next to the show-players eye) keeps all building names visible permanently. The preference persists in localStorage (`showBuildingLabels`), like the other map toggles.
- **Zoom-independent readability**: labels are bottom-anchored and counter-scaled against the camera zoom every frame, so names keep a constant, readable on-screen size from max zoom-in down to full zoom-out.

**How it works:**

- `createStructureLabel` (sector.ts) renders each name to a canvas once at sector build time — one extra sprite per structure, created hidden.
- `intersectStructures` (sector.ts) runs in the render loop and raycasts only the window's structure sprites (collected in `refreshRenderCollections`, not the decoration sprites), toggling label visibility and applying the zoom compensation.
- The label sprites carry no `structureId` in userData, so the sector-map editor's drag-to-relocate raycast ignores them, and they stay hidden in `SectorPreview`.

**Why/how verified:** exercised live on a dev server — hover-only mode, the persistent toggle, and readability at min/default/max zoom, with a steady frame rate (labels add one raycast over ~a dozen sprites per frame).

**Breaking changes:** none.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a travel-map control to show or hide building names.
  * Building labels can now appear for all structures or only the building under the pointer.
  * The label setting is saved and restored automatically between visits.
  * Labels remain readable across different map zoom levels.
* **Bug Fixes**
  * Improved cleanup of cached/shared materials to prevent incorrect disposal and reduce rendering issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->