### PR TITLE
Refresh village structure sprites, ground them in their biome, and fix CDN image optimization

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -805,11 +805,11 @@ export type SentimentType = (typeof Sentiment)[number];
 
 // Starter quest used for recruitment analytics
 export const IMG_URL_ASSISTANT =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJrCz0dVhuJPmdY8zI2ptZXAoEj1c6BMKvrQOx" as const;
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJrCz0dVhuJPmdY8zI2ptZXAoEj1c6BMKvrQOx.webp" as const;
 export const IMG_URL_ASSISTANT_2 =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJIG7HmDxfOewksxBoS1HQCihpL7c42Ky9uUFv" as const;
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJIG7HmDxfOewksxBoS1HQCihpL7c42Ky9uUFv.webp" as const;
 export const IMG_URL_HANDPOINTER =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJIvN7gkJxfOewksxBoS1HQCihpL7c42Ky9uUF" as const;
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJIvN7gkJxfOewksxBoS1HQCihpL7c42Ky9uUF.webp" as const;
 export const TUTORIAL_JUTSU_ID = "clh4d6pxd0006tb0h4y1yudi5";
 export const TUTORIAL_ITEM_ID = "VOditPJ3X2id0yC-F5Kz3";
 export const TUTORIAL_STARTER_QUEST_ID = "eYDVpL63vPhK3lywMexdv";
@@ -1378,7 +1378,7 @@ export const WAR_RECAPTURE_THRESHOLD = 0.25; // Threshold for recapture (25% of 
 export const SHRINE_STATUSES = ["ACTIVE", "CAPTURED"] as const; // Status tracking for shrine capture/recovery cycles
 export type ShrineStatus = (typeof SHRINE_STATUSES)[number];
 export const WAR_SHRINE_IMAGE =
-  "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJxtEfghWZsq9k0Von5rUfP6OgQ2TyptCKHS4u";
+  "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJxtEfghWZsq9k0Von5rUfP6OgQ2TyptCKHS4u.webp";
 /**
  * Sector-map shrine sprite per sector biome, so the shrine's baked ground
  * patch matches the terrain it stands on (water sectors use the desert
@@ -1386,12 +1386,12 @@ export const WAR_SHRINE_IMAGE =
  */
 export const WAR_SHRINE_IMAGE_BY_BIOME: Record<CombatBiome, string> = {
   ocean:
-    "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJe7TE7RyV3OvUJQExAi0bGoIZDF74LqSnHRdp",
+    "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJe7TE7RyV3OvUJQExAi0bGoIZDF74LqSnHRdp.webp",
   ground: WAR_SHRINE_IMAGE,
   dessert:
-    "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJe7TE7RyV3OvUJQExAi0bGoIZDF74LqSnHRdp",
-  ice: "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJco2C06SnxBpQqGNDcTHbLmYz8uXAl3oa54ti",
-  snow: "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJco2C06SnxBpQqGNDcTHbLmYz8uXAl3oa54ti",
+    "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJe7TE7RyV3OvUJQExAi0bGoIZDF74LqSnHRdp.webp",
+  ice: "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJco2C06SnxBpQqGNDcTHbLmYz8uXAl3oa54ti.webp",
+  snow: "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJco2C06SnxBpQqGNDcTHbLmYz8uXAl3oa54ti.webp",
   arena: WAR_SHRINE_IMAGE,
   default: WAR_SHRINE_IMAGE,
 };
@@ -1755,151 +1755,151 @@ export const DRACO_ENCODER_URL =
 
 // Biome backgrounds
 export const IMG_BG_OCEAN =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJIo4wHixfOewksxBoS1HQCihpL7c42Ky9uUFv";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJIo4wHixfOewksxBoS1HQCihpL7c42Ky9uUFv.webp";
 export const IMG_BG_GROUND =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJEJszlXPLfKL5D7TAFe29bymSaPCIQ846MdzG";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJEJszlXPLfKL5D7TAFe29bymSaPCIQ846MdzG.webp";
 export const IMG_BG_DESSERT =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJnQHU9dvmojJ0EqeDCvBrNmZaXVdY97gSpOWi";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJnQHU9dvmojJ0EqeDCvBrNmZaXVdY97gSpOWi.webp";
 export const IMG_BG_ICE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJRXmgug0udmODoNtpa0FMcwI4k2Eq7nJhyvjl";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJRXmgug0udmODoNtpa0FMcwI4k2Eq7nJhyvjl.webp";
 export const IMG_BG_SNOW =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJVWyAP1F2veAXohUuE59nTQHRJIYjtiG18aF4";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJVWyAP1F2veAXohUuE59nTQHRJIYjtiG18aF4.webp";
 export const IMG_BG_DIRT =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJob2ojkZ9MPZpHJ7VliuEWDfATdxhv62SXnm4";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJob2ojkZ9MPZpHJ7VliuEWDfATdxhv62SXnm4.webp";
 
 // Images
 export const IMG_PLAY_STORE_BANNER =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJyI5pULukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJyI5pULukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp.png";
 export const IMG_APP_STORE_BANNER =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJZOcwIVUaYQrBIUTu69nkMxWmS4ah0O7LVCp8";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJZOcwIVUaYQrBIUTu69nkMxWmS4ah0O7LVCp8.png";
 export const IMG_DEFAULT_PROFILE_PICTURE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ19UqON6bo95WClq4K0wxZUmJcvThgdVenO3P";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ19UqON6bo95WClq4K0wxZUmJcvThgdVenO3P.webp";
 export const IMG_OCCUPATION_GATHERING =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJePgzrqyV3OvUJQExAi0bGoIZDF74LqSnHRdp";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJePgzrqyV3OvUJQExAi0bGoIZDF74LqSnHRdp.webp";
 export const IMG_OCCUPATION_HUNTER =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ2xooNenMXlcRpYmJ5do0zKw4Qx6PVEtBa9b8";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ2xooNenMXlcRpYmJ5do0zKw4Qx6PVEtBa9b8.webp";
 export const IMG_OCCUPATION_CRAFTING =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ7YhkcAXKPBOUWGyFuM4DlL1v5HNTZhkte0z6";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ7YhkcAXKPBOUWGyFuM4DlL1v5HNTZhkte0z6.webp";
 
 // Marketing constants
 export const TOTAL_PLAYERS_MILESTONE = 1000000;
 
 export const IMG_FRONTPAGE_SCREENSHOT_COMBAT =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJliyD90rWYxAsuC7ofQn9pM45OD0ERqkdBXJU";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJliyD90rWYxAsuC7ofQn9pM45OD0ERqkdBXJU.webp";
 export const IMG_FRONTPAGE_SCREENSHOT_JUTSUS =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJyD4wioukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJyD4wioukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp.webp";
 export const IMG_FRONTPAGE_SCREENSHOT_GLOBAL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJeCMiuXvyV3OvUJQExAi0bGoIZDF74LqSnHRd";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJeCMiuXvyV3OvUJQExAi0bGoIZDF74LqSnHRd.webp";
 export const IMG_FRONTPAGE_SCREENSHOT_SECTOR =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJYfcD9oOMAlNnPZ41ev6fCGcFK3hmjX9I8W7d";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJYfcD9oOMAlNnPZ41ev6fCGcFK3hmjX9I8W7d.webp";
 export const IMG_FRONTPAGE_SCREENSHOT_VILLAGE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJzuU9cvZemvaQu94EYJs8HpxVzofny6iPtbgC";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJzuU9cvZemvaQu94EYJs8HpxVzofny6iPtbgC.webp";
 
 export const IMG_FRONTPAGE_SCREENSHOT_COMBAT_HR =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJhuLmX5MfUBdnwAX5LTajlNc4mrgzi0RJtqpM";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJhuLmX5MfUBdnwAX5LTajlNc4mrgzi0RJtqpM.webp";
 export const IMG_FRONTPAGE_SCREENSHOT_JUTSUS_HR =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJAaVOt2SoZUC4muiGcQNzjfEndY5y1w20B8hT";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJAaVOt2SoZUC4muiGcQNzjfEndY5y1w20B8hT.webp";
 export const IMG_FRONTPAGE_SCREENSHOT_GLOBAL_HR =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJvSzUp4EmSnXwslYEpV1yOeNL8gMtqhjPdf36";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJvSzUp4EmSnXwslYEpV1yOeNL8gMtqhjPdf36.webp";
 export const IMG_FRONTPAGE_SCREENSHOT_SECTOR_HR =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJXMBBarqIOpAoLKbZ4nW9Rsil2V67yuFwQhqv";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJXMBBarqIOpAoLKbZ4nW9Rsil2V67yuFwQhqv.webp";
 export const IMG_FRONTPAGE_SCREENSHOT_VILLAGE_HR =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJRmBtUg0udmODoNtpa0FMcwI4k2Eq7nJhyvjl";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJRmBtUg0udmODoNtpa0FMcwI4k2Eq7nJhyvjl.webp";
 
 export const IMG_REGISTRATIN_STEP1 =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJeKNAEEyV3OvUJQExAi0bGoIZDF74LqSnHRdp";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJeKNAEEyV3OvUJQExAi0bGoIZDF74LqSnHRdp.webp";
 export const IMG_REGISTRATIN_STEP2 =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJTOMd6Y5IU29dZYJPoOKSh5vmlqatMub3EigH";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJTOMd6Y5IU29dZYJPoOKSh5vmlqatMub3EigH.webp";
 export const IMG_REGISTRATIN_STEP3 =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJZlINOXaYQrBIUTu69nkMxWmS4ah0O7LVCp8b";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJZlINOXaYQrBIUTu69nkMxWmS4ah0O7LVCp8b.webp";
 export const IMG_REGISTRATIN_STEP4 =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJqppFvGcdkOZgJQ8mGRcdx3SsWvPelyYFTt5V";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJqppFvGcdkOZgJQ8mGRcdx3SsWvPelyYFTt5V.webp";
 export const IMG_REGISTRATIN_STEP5 =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ56sDpz797jl4ubX8xrRqTZasyMp2WA5eLGUP";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ56sDpz797jl4ubX8xrRqTZasyMp2WA5eLGUP.webp";
 export const IMG_REGISTRATIN_STEP6 =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJwm1XDCT2j854CWbaITZyegfXimvd7s16cO0h";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJwm1XDCT2j854CWbaITZyegfXimvd7s16cO0h.webp";
 export const IMG_REGISTRATIN_STEP7 =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJQU7pvzjhzBPya1rwfCIqOTU0cV5xgsMeo3u2";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJQU7pvzjhzBPya1rwfCIqOTU0cV5xgsMeo3u2.webp";
 export const IMG_REGISTRATIN_STEP8 =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ8B9jC0rkkp45TvAnoIBa0rtCf1lbyXYjVKQ2";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ8B9jC0rkkp45TvAnoIBa0rtCf1lbyXYjVKQ2.webp";
 export const IMG_REGISTRATIN_STEP9 =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJnjHXr3mojJ0EqeDCvBrNmZaXVdY97gSpOWiA";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJnjHXr3mojJ0EqeDCvBrNmZaXVdY97gSpOWiA.webp";
 
 export const IMG_SCENE_SCROLL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJRceTKeq0udmODoNtpa0FMcwI4k2Eq7nJhyvj";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJRceTKeq0udmODoNtpa0FMcwI4k2Eq7nJhyvj.webp";
 export const IMG_SCENE_BACKGROUND =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ1HAqWl6bo95WClq4K0wxZUmJcvThgdVenO3P";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ1HAqWl6bo95WClq4K0wxZUmJcvThgdVenO3P.webp";
 export const IMG_SCENE_CHARACTER =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJF08NAw3G2iOewJtjGzvNcmEX3TBnoSfMDZPH";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJF08NAw3G2iOewJtjGzvNcmEX3TBnoSfMDZPH.webp";
 
 export const IMG_BADGE_RESET_QUEST =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJeCQbfYiyV3OvUJQExAi0bGoIZDF74LqSnHRd";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJeCQbfYiyV3OvUJQExAi0bGoIZDF74LqSnHRd.webp";
 export const IMG_BADGE_FAIL_QUEST =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJuFEUH7CyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJuFEUH7CyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b.webp";
 export const IMG_BADGE_WIN_QUEST =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJnk99IbmojJ0EqeDCvBrNmZaXVdY97gSpOWiA";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJnk99IbmojJ0EqeDCvBrNmZaXVdY97gSpOWiA.webp";
 export const IMG_BADGE_NEW_QUEST =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJneJSZsmojJ0EqeDCvBrNmZaXVdY97gSpOWiA";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJneJSZsmojJ0EqeDCvBrNmZaXVdY97gSpOWiA.webp";
 export const IMG_BADGE_START_BATTLE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJqZXK1HdkOZgJQ8mGRcdx3SsWvPelyYFTt5Vn";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJqZXK1HdkOZgJQ8mGRcdx3SsWvPelyYFTt5Vn.webp";
 export const IMG_BADGE_DIALOG =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJpIn7vsbKBAOsGCHyl3Sk0mZFrgWPUdjMJ75D";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJpIn7vsbKBAOsGCHyl3Sk0mZFrgWPUdjMJ75D.webp";
 export const IMG_BADGE_RANDOM_ENCOUNTER_WINS =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJqyp2N4dkOZgJQ8mGRcdx3SsWvPelyYFTt5Vn";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJqyp2N4dkOZgJQ8mGRcdx3SsWvPelyYFTt5Vn.webp";
 export const IMG_BADGE_PVPKILLS =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJyPU0OdukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJyPU0OdukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp.webp";
 export const IMG_BADGE_ARENAKILLS =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJZXqeTaYQrBIUTu69nkMxWmS4ah0O7LVCp8bz";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJZXqeTaYQrBIUTu69nkMxWmS4ah0O7LVCp8bz.webp";
 export const IMG_BADGE_MINUTES_PASSED =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJCmrv4YU26OYrIJuNP1pvSyz29edFtKbngjRc";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJCmrv4YU26OYrIJuNP1pvSyz29edFtKbngjRc.webp";
 export const IMG_BADGE_ERRANDS_TOTAL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJFkFklPG2iOewJtjGzvNcmEX3TBnoSfMDZPH4";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJFkFklPG2iOewJtjGzvNcmEX3TBnoSfMDZPH4.webp";
 export const IMG_BADGE_D_MISSION_TOTAL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJuD6udtCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJuD6udtCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b.webp";
 export const IMG_BADGE_C_MISSION_TOTAL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJGudreBRfoVrha0LP4mAS5KM7wtiZbUNXJxdC";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJGudreBRfoVrha0LP4mAS5KM7wtiZbUNXJxdC.webp";
 export const IMG_BADGE_B_MISSION_TOTAL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJy2Uv1s5ukVH2MI5Lo4ehEfAXvZdcmtWqPg7r";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJy2Uv1s5ukVH2MI5Lo4ehEfAXvZdcmtWqPg7r.webp";
 export const IMG_BADGE_A_MISSION_TOTAL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJEJpK3acLfKL5D7TAFe29bymSaPCIQ846MdzG";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJEJpK3acLfKL5D7TAFe29bymSaPCIQ846MdzG.webp";
 export const IMG_BADGE_D_CRIME_TOTAL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJDyHMWFlzEwoh0WXMnscL279N8ayVQUCbRzS3";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJDyHMWFlzEwoh0WXMnscL279N8ayVQUCbRzS3.webp";
 export const IMG_BADGE_C_CRIME_TOTAL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJnJ43OQmojJ0EqeDCvBrNmZaXVdY97gSpOWiA";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJnJ43OQmojJ0EqeDCvBrNmZaXVdY97gSpOWiA.webp";
 export const IMG_BADGE_B_CRIME_TOTAL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJHS8H1zQvYURJhgs76VZtf9wxpMa13Cq0iOnr";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJHS8H1zQvYURJhgs76VZtf9wxpMa13Cq0iOnr.webp";
 export const IMG_BADGE_A_CRIME_TOTAL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJQ6PtAxjhzBPya1rwfCIqOTU0cV5xgsMeo3u2";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJQ6PtAxjhzBPya1rwfCIqOTU0cV5xgsMeo3u2.webp";
 export const IMG_BADGE_MINUTES_TRAINING =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJbZSRGyZAtYUndMi56GkX19q0A4PzyeIloBrE";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJbZSRGyZAtYUndMi56GkX19q0A4PzyeIloBrE.webp";
 export const IMG_BADGE_JUTSUS_MASTERED =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJDyHTMUuzEwoh0WXMnscL279N8ayVQUCbRzS3";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJDyHTMUuzEwoh0WXMnscL279N8ayVQUCbRzS3.webp";
 export const IMG_BADGE_STATS_TRAINED =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJVNQSNpF2veAXohUuE59nTQHRJIYjtiG18aF4";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJVNQSNpF2veAXohUuE59nTQHRJIYjtiG18aF4.webp";
 export const IMG_BADGE_DAYS_IN_VILLAGE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ2HU2el8nMXlcRpYmJ5do0zKw4Qx6PVEtBa9b";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ2HU2el8nMXlcRpYmJ5do0zKw4Qx6PVEtBa9b.webp";
 export const IMG_BADGE_REPUTATION_POINTS =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJxyYNkgWZsq9k0Von5rUfP6OgQ2TyptCKHS4u";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJxyYNkgWZsq9k0Von5rUfP6OgQ2TyptCKHS4u.webp";
 export const IMG_BADGE_USER_LEVEL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJo6lBgeZ9MPZpHJ7VliuEWDfATdxhv62SXnm4";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJo6lBgeZ9MPZpHJ7VliuEWDfATdxhv62SXnm4.webp";
 export const IMG_BADGE_MOVE_TO_LOCATION =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ5qXZuJi797jl4ubX8xrRqTZasyMp2WA5eLGU";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ5qXZuJi797jl4ubX8xrRqTZasyMp2WA5eLGU.webp";
 export const IMG_BADGE_COLLECT_ITEM =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJtxtluhUYJDfpFXWm3nrcPluEtIZqyLkaSV1j";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJtxtluhUYJDfpFXWm3nrcPluEtIZqyLkaSV1j.webp";
 export const IMG_BADGE_DEFEAT_OPPONENTS =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJYwI8YKOMAlNnPZ41ev6fCGcFK3hmjX9I8W7d";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJYwI8YKOMAlNnPZ41ev6fCGcFK3hmjX9I8W7d.webp";
 export const IMG_BADGE_EXCLUSIVE_RAID =
-  "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJw7O7n2PT2j854CWbaITZyegfXimvd7s16cO0";
+  "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJw7O7n2PT2j854CWbaITZyegfXimvd7s16cO0.webp";
 export const IMG_BADGE_OPEN_RAID =
-  "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJdEQfdeP62PI3ciLaYzgVX8FopBADxSrGmvQl";
+  "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJdEQfdeP62PI3ciLaYzgVX8FopBADxSrGmvQl.webp";
 export const IMG_BADGE_MEDICAL_EXPERIENCE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJzr5NPBemvaQu94EYJs8HpxVzofny6iPtbgCZ";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJzr5NPBemvaQu94EYJs8HpxVzofny6iPtbgCZ.webp";
 export const IMG_BADGE_GATHERING_EXPERIENCE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJMgUHxAtsO4cexqW2RDgkE3zZbNXSFGitmnar";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJMgUHxAtsO4cexqW2RDgkE3zZbNXSFGitmnar.webp";
 export const IMG_BADGE_HUNTING_EXPERIENCE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJg0V017cU9cpECTimBdjaqbNn7vQsxGR1wLk4";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJg0V017cU9cpECTimBdjaqbNn7vQsxGR1wLk4.webp";
 export const IMG_BADGE_CRAFTING_EXPERIENCE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJIY2lVjxfOewksxBoS1HQCihpL7c42Ky9uUFv";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJIY2lVjxfOewksxBoS1HQCihpL7c42Ky9uUFv.webp";
 export const IMG_BADGE_ITEMS_CRAFTED = IMG_BADGE_CRAFTING_EXPERIENCE;
 export const IMG_BADGE_CREATURES_HUNTED = IMG_BADGE_HUNTING_EXPERIENCE;
 export const IMG_BADGE_HERBS_GATHERED = IMG_BADGE_GATHERING_EXPERIENCE;
@@ -1913,120 +1913,120 @@ export const IMG_BADGE_TAG_USAGE_WIN = IMG_BADGE_START_BATTLE;
 export const IMG_BADGE_DAMAGE_DEALT = IMG_BADGE_DEFEAT_OPPONENTS;
 
 export const IMG_BG_COLISEUM =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJo5wb6hZ9MPZpHJ7VliuEWDfATdxhv62SXnm4";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJo5wb6hZ9MPZpHJ7VliuEWDfATdxhv62SXnm4.webp";
 export const IMG_BG_ARENA_CHRISMAS =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJQr5mXyjhzBPya1rwfCIqOTU0cV5xgsMeo3u2";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJQr5mXyjhzBPya1rwfCIqOTU0cV5xgsMeo3u2.webp";
 export const IMG_BG_ARENA_KONOKI =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJDyj0BtAzEwoh0WXMnscL279N8ayVQUCbRzS3";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJDyj0BtAzEwoh0WXMnscL279N8ayVQUCbRzS3.webp";
 export const IMG_BG_ARENA_SILENCE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJSZtKvF3jWrEB7TyZlmpoAxMK5Qi16kNPVJuH";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJSZtKvF3jWrEB7TyZlmpoAxMK5Qi16kNPVJuH.webp";
 
 export const IMG_VILLAGE_FACTION =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJyODt1NukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJyODt1NukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp.webp";
 
 export const IMG_RARITY_RARE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJvSyOMsEmSnXwslYEpV1yOeNL8gMtqhjPdf36";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJvSyOMsEmSnXwslYEpV1yOeNL8gMtqhjPdf36.webp";
 export const IMG_RARITY_LEGENDARY =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJoooBQZ9MPZpHJ7VliuEWDfATdxhv62SXnm4B";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJoooBQZ9MPZpHJ7VliuEWDfATdxhv62SXnm4B.webp";
 export const IMG_RARITY_EPIC =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJeCIgGvhyV3OvUJQExAi0bGoIZDF74LqSnHRd";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJeCIgGvhyV3OvUJQExAi0bGoIZDF74LqSnHRd.webp";
 export const IMG_RARITY_COMMON =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJQP8otBjhzBPya1rwfCIqOTU0cV5xgsMeo3u2";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJQP8otBjhzBPya1rwfCIqOTU0cV5xgsMeo3u2.webp";
 
 export const IMG_PROFILE_LEVELUPGUY =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJaeS5LnYYfKMcJ2B5EmWt6VsNgqxpG8OSXAQk";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJaeS5LnYYfKMcJ2B5EmWt6VsNgqxpG8OSXAQk.webp";
 export const IMG_RAMEN_WELCOME =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJmd2fWKHE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJmd2fWKHE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap.webp";
 export const IMG_RAMEN_SMALL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJj7ESnm4XzPI8f1v96qBot0Q3wsUp2nxu7SMb";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJj7ESnm4XzPI8f1v96qBot0Q3wsUp2nxu7SMb.webp";
 export const IMG_RAMEN_MEDIUM =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJyoMsmMukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJyoMsmMukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp.webp";
 export const IMG_RAMEN_LARGE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJHKlC2sQvYURJhgs76VZtf9wxpMa13Cq0iOnr";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJHKlC2sQvYURJhgs76VZtf9wxpMa13Cq0iOnr.webp";
 export const IMG_REPSHOP_BRONZE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJCg005h26OYrIJuNP1pvSyz29edFtKbngjRcA";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJCg005h26OYrIJuNP1pvSyz29edFtKbngjRcA.webp";
 export const IMG_REPSHOP_SILVER =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJSk2raeh3jWrEB7TyZlmpoAxMK5Qi16kNPVJu";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJSk2raeh3jWrEB7TyZlmpoAxMK5Qi16kNPVJu.webp";
 export const IMG_REPSHOP_GOLD =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJebK38NyV3OvUJQExAi0bGoIZDF74LqSnHRdp";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJebK38NyV3OvUJQExAi0bGoIZDF74LqSnHRdp.webp";
 export const IMG_EQUIP_SILHOUETTE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ6e2pEi7DfT5pyNCaUruzhPtAJqb8Kj9mc1nl";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ6e2pEi7DfT5pyNCaUruzhPtAJqb8Kj9mc1nl.webp";
 export const IMG_HOME_TRAIN =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ25o9TnMXlcRpYmJ5do0zKw4Qx6PVEtBa9b8C";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ25o9TnMXlcRpYmJ5do0zKw4Qx6PVEtBa9b8C.webp";
 export const IMG_HOME_EAT =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJbZ8Rz1xAtYUndMi56GkX19q0A4PzyeIloBrE";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJbZ8Rz1xAtYUndMi56GkX19q0A4PzyeIloBrE.webp";
 export const IMG_HOME_SLEEP =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJu8FpvZCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJu8FpvZCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b.webp";
 export const IMG_HOME_AWAKE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ1BKctL6bo95WClq4K0wxZUmJcvThgdVenO3P";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ1BKctL6bo95WClq4K0wxZUmJcvThgdVenO3P.webp";
 export const IMG_MANUAL_ACTIVITY_STREAK =
-  "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJTPVewE5IU29dZYJPoOKSh5vmlqatMub3EigH";
+  "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJTPVewE5IU29dZYJPoOKSh5vmlqatMub3EigH.webp";
 export const IMG_MANUAL_TOWER_UPGRADES =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ2HMAwecnMXlcRpYmJ5do0zKw4Qx6PVEtBa9b";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ2HMAwecnMXlcRpYmJ5do0zKw4Qx6PVEtBa9b.webp";
 export const IMG_MANUAL_TOWER_ENEMIES =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJwA3KPoT2j854CWbaITZyegfXimvd7s16cO0h";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJwA3KPoT2j854CWbaITZyegfXimvd7s16cO0h.webp";
 export const IMG_MANUAL_TOWER_LEADERBOARD =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJGdSeVPRfoVrha0LP4mAS5KM7wtiZbUNXJxdC";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJGdSeVPRfoVrha0LP4mAS5KM7wtiZbUNXJxdC.webp";
 export const IMG_MANUAL_RANKED =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJAa3ucxOoZUC4muiGcQNzjfEndY5y1w20B8hT";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJAa3ucxOoZUC4muiGcQNzjfEndY5y1w20B8hT.jpg";
 export const IMG_MANUAL_AWARDS =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJD2QXqVzEwoh0WXMnscL279N8ayVQUCbRzS3p";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJD2QXqVzEwoh0WXMnscL279N8ayVQUCbRzS3p.webp";
 export const IMG_MANUAL_COMBAT =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJUvE8xxILCIhwPniJ69VxpvAbTDWkOyGzS8rM";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJUvE8xxILCIhwPniJ69VxpvAbTDWkOyGzS8rM.webp";
 export const IMG_MANUAL_TRAVEL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJu1h1uHCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJu1h1uHCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b.webp";
 export const IMG_MANUAL_BLOODLINE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJaCMo8gYYfKMcJ2B5EmWt6VsNgqxpG8OSXAQk";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJaCMo8gYYfKMcJ2B5EmWt6VsNgqxpG8OSXAQk.webp";
 export const IMG_MANUAL_JUTSU =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJMI7fE4tsO4cexqW2RDgkE3zZbNXSFGitmnar";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJMI7fE4tsO4cexqW2RDgkE3zZbNXSFGitmnar.webp";
 export const IMG_MANUAL_JUTSU_RESKINS =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJEOTlPgLfKL5D7TAFe29bymSaPCIQ846MdzGg";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJEOTlPgLfKL5D7TAFe29bymSaPCIQ846MdzGg.webp";
 export const IMG_MANUAL_SKILLTREE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJQB2gVJjhzBPya1rwfCIqOTU0cV5xgsMeo3u2";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJQB2gVJjhzBPya1rwfCIqOTU0cV5xgsMeo3u2.webp";
 export const IMG_MANUAL_BALANCE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJunxMxUaCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJunxMxUaCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8.webp";
 export const IMG_MANUAL_BACKUP =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJctH7DQSnxBpQqGNDcTHbLmYz8uXAl3oa54ti";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJctH7DQSnxBpQqGNDcTHbLmYz8uXAl3oa54ti.webp";
 export const IMG_MANUAL_ITEM =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJb59vlYAtYUndMi56GkX19q0A4PzyeIloBrEa";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJb59vlYAtYUndMi56GkX19q0A4PzyeIloBrEa.webp";
 export const IMG_MANUAL_CRAFTING_RECIPES =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJrZmM8nhuJPmdY8zI2ptZXAoEj1c6BMKvrQOx";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJrZmM8nhuJPmdY8zI2ptZXAoEj1c6BMKvrQOx.webp";
 export const IMG_MANUAL_AI =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJuTQifZCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJuTQifZCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b.webp";
 export const IMG_MANUAL_STAFF =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ3CT6Io8pYHJX5rdkUTfOKtvu2eGIELmSWqBx";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ3CT6Io8pYHJX5rdkUTfOKtvu2eGIELmSWqBx.webp";
 export const IMG_MANUAL_QUEST =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJmWVaWXHE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJmWVaWXHE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap.webp";
 export const IMG_MANUAL_LOGS =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJwvy6QoT2j854CWbaITZyegfXimvd7s16cO0h";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJwvy6QoT2j854CWbaITZyegfXimvd7s16cO0h.webp";
 export const IMG_MANUAL_DAM_CALCS =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJQF6qYYjhzBPya1rwfCIqOTU0cV5xgsMeo3u2";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJQF6qYYjhzBPya1rwfCIqOTU0cV5xgsMeo3u2.webp";
 export const IMG_MANUAL_BADGE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJOUM5LPVHevxIThUauQkGJEBY3D2cPqy8f5sp";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJOUM5LPVHevxIThUauQkGJEBY3D2cPqy8f5sp.webp";
 export const IMG_MANUAL_ASSET =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJaGvHErYYfKMcJ2B5EmWt6VsNgqxpG8OSXAQk";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJaGvHErYYfKMcJ2B5EmWt6VsNgqxpG8OSXAQk.webp";
 export const IMG_MANUAL_OPINION =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ0dX0Z3grYldRWJcD6vE10SjNsXHeA9pVMfQi";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ0dX0Z3grYldRWJcD6vE10SjNsXHeA9pVMfQi.webp";
 export const IMG_MANUAL_RECRUITMENT =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJTB8H7n5IU29dZYJPoOKSh5vmlqatMub3EigH";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJTB8H7n5IU29dZYJPoOKSh5vmlqatMub3EigH.webp";
 export const IMG_MANUAL_POLLS =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJRc1v3JK0udmODoNtpa0FMcwI4k2Eq7nJhyvj";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJRc1v3JK0udmODoNtpa0FMcwI4k2Eq7nJhyvj.webp";
 export const IMG_LAYOUT_USERBANNER_MIDDLE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ6sgzOzDfT5pyNCaUruzhPtAJqb8Kj9mc1nlH";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ6sgzOzDfT5pyNCaUruzhPtAJqb8Kj9mc1nlH.webp";
 export const IMG_LAYOUT_SIDESCROLL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJAElfIGoZUC4muiGcQNzjfEndY5y1w20B8hTW";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJAElfIGoZUC4muiGcQNzjfEndY5y1w20B8hTW.webp";
 export const IMG_LAYOUT_MOBILE_TOP =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJHTt3S9QvYURJhgs76VZtf9wxpMa13Cq0iOnr";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJHTt3S9QvYURJhgs76VZtf9wxpMa13Cq0iOnr.webp";
 export const IMG_LAYOUT_SIDETOPBANNER_CONTENT =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJOG9gcTWVHevxIThUauQkGJEBY3D2cPqy8f5s";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJOG9gcTWVHevxIThUauQkGJEBY3D2cPqy8f5s.webp";
 export const IMG_LAYOUT_SIDETOPBANNER_BOTTOM =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ19AHU06bo95WClq4K0wxZUmJcvThgdVenO3P";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ19AHU06bo95WClq4K0wxZUmJcvThgdVenO3P.webp";
 export const IMG_LAYOUT_SCROLLBOTTOM_DECOR =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJCVjF0e26OYrIJuNP1pvSyz29edFtKbngjRcA";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJCVjF0e26OYrIJuNP1pvSyz29edFtKbngjRcA.webp";
 export const IMG_LAYOUT_USERSBANNER_TOP =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJDV31MCzEwoh0WXMnscL279N8ayVQUCbRzS3p";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJDV31MCzEwoh0WXMnscL279N8ayVQUCbRzS3p.webp";
 export const IMG_LAYOUT_USERSBANNER_BOTTOM =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJhWwvubMfUBdnwAX5LTajlNc4mrgzi0RJtqpM";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJhWwvubMfUBdnwAX5LTajlNc4mrgzi0RJtqpM.webp";
 export const IMG_AVATAR_DEFAULT =
   "https://uploadthing.b-cdn.net/f/630cf6e7-c152-4dea-a3ff-821de76d7f5a_default.webp";
 export const IMG_WALLPAPER_WINTER =
@@ -2040,28 +2040,28 @@ export const IMG_WALLPAPER_FALL =
 export const IMG_WALLPAPER_HALLOWEEN =
   "https://tnr-storage-cdn.b-cdn.net/wallpaper-halloween.webp";
 export const IMG_LAYOUT_BUTTONDECOR =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJYectQDOMAlNnPZ41ev6fCGcFK3hmjX9I8W7d";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJYectQDOMAlNnPZ41ev6fCGcFK3hmjX9I8W7d.webp";
 export const IMG_LAYOUT_NAVBAR =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ1znttRb6bo95WClq4K0wxZUmJcvThgdVenO3";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ1znttRb6bo95WClq4K0wxZUmJcvThgdVenO3.webp";
 export const IMG_LAYOUT_NAVBAR_HALLOWEEN =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJbYxvuGAtYUndMi56GkX19q0A4PzyeIloBrEa";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJbYxvuGAtYUndMi56GkX19q0A4PzyeIloBrEa.webp";
 export const IMG_LAYOUT_HANDSIGN =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ0hKI3IgrYldRWJcD6vE10SjNsXHeA9pVMfQi";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ0hKI3IgrYldRWJcD6vE10SjNsXHeA9pVMfQi.webp";
 export const IMG_LAYOUT_HANDSIGN_HALLOWEEN =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJcGYTUXSnxBpQqGNDcTHbLmYz8uXAl3oa54ti";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJcGYTUXSnxBpQqGNDcTHbLmYz8uXAl3oa54ti.webp";
 export const IMG_LAYOUT_WELCOME_IMG =
   "https://tnr-storage-cdn.b-cdn.net/welcomeimage_compressed.webp";
 export const IMG_PIXEL_HERO_POSTER =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJW2NIKTvszvj71yaSYC0MDOmbko5q9JAGuLHf";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJW2NIKTvszvj71yaSYC0MDOmbko5q9JAGuLHf.jpg";
 export const IMG_PIXEL_HERO_POSTER_OPTIMIZED =
   `${IMG_PIXEL_HERO_POSTER}?width=1280&height=720`;
-// "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJqbkFzRdkOZgJQ8mGRcdx3SsWvPelyYFTt5Vn";
+// "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJqbkFzRdkOZgJQ8mGRcdx3SsWvPelyYFTt5Vn.webp";
 // export const IMG_LOGO_FULL =
-//   "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ8b0eqBkkp45TvAnoIBa0rtCf1lbyXYjVKQ2q";
+//   "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ8b0eqBkkp45TvAnoIBa0rtCf1lbyXYjVKQ2q.webp";
 export const IMG_LOGO_FULL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJHeJzt0QvYURJhgs76VZtf9wxpMa13Cq0iOnr";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJHeJzt0QvYURJhgs76VZtf9wxpMa13Cq0iOnr.webp";
 export const IMG_LOGO_SHORT =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJCClYWI26OYrIJuNP1pvSyz29edFtKbngjRcA";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJCClYWI26OYrIJuNP1pvSyz29edFtKbngjRcA.webp";
 export const IMG_LOADER =
   "https://uploadthing.b-cdn.net/f/4a3100e5-97c6-4e5a-96e2-1c3520838179-gwm3dh.svg";
 export const IMG_SECTOR_INFO =
@@ -2069,7 +2069,7 @@ export const IMG_SECTOR_INFO =
 export const IMG_SECTOR_ATTACK =
   "https://uploadthing.b-cdn.net/f/d6587d1a-c11b-49e3-8e86-74bfb02a80a1-n9ug1k.png";
 export const IMG_SECTOR_ROB =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJvNL3jBEmSnXwslYEpV1yOeNL8gMtqhjPdf36";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJvNL3jBEmSnXwslYEpV1yOeNL8gMtqhjPdf36.webp";
 export const IMG_SECTOR_USER_MARKER =
   "https://uploadthing.b-cdn.net/f/cc347416-8bf6-40cf-9184-b4af64e6feae-n771t1.webp";
 export const IMG_SECTOR_USER_SPRITE_MASK =
@@ -2094,11 +2094,11 @@ export const IMG_MAP_HEXASPHERE =
 export const IMG_MAP_HEXASPHERE_SHA256 =
   "ec203f7c1fe33fa7fc3474dff500ade6850b6517ac8de552371d75e05465e4de";
 export const IMG_MAP_TILESET_ATLAS =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJMavndmtsO4cexqW2RDgkE3zZbNXSFGitmnar";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJMavndmtsO4cexqW2RDgkE3zZbNXSFGitmnar.png";
 export const IMG_MAP_WAR_ICON =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJgipq89cU9cpECTimBdjaqbNn7vQsxGR1wLk4";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJgipq89cU9cpECTimBdjaqbNn7vQsxGR1wLk4.webp";
 export const IMG_MAP_QUEST_ICON =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJRsb4NN0udmODoNtpa0FMcwI4k2Eq7nJhyvjl";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJRsb4NN0udmODoNtpa0FMcwI4k2Eq7nJhyvjl.webp";
 export const IMG_TRAIN_INTELLIGENCE =
   "https://uploadthing.b-cdn.net/f/815a53ea-23d2-4767-9219-a36ed3d4c619-d73vsv.png";
 export const IMG_TRAIN_WILLPOWER =
@@ -2125,156 +2125,156 @@ export const IMG_TRAIN_NIN_DEF =
   "https://uploadthing.b-cdn.net/f/308d9bee-5105-4534-b11c-59592db90181-yx7su0.png";
 
 export const IMG_ELEMENT_YINYANG =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJIlW2BrxfOewksxBoS1HQCihpL7c42Ky9uUFv";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJIlW2BrxfOewksxBoS1HQCihpL7c42Ky9uUFv.webp";
 export const IMG_ELEMENT_SHADOW =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJvSWrdXEmSnXwslYEpV1yOeNL8gMtqhjPdf36";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJvSWrdXEmSnXwslYEpV1yOeNL8gMtqhjPdf36.webp";
 export const IMG_ELEMENT_NONE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJeC2dFWVyV3OvUJQExAi0bGoIZDF74LqSnHRd";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJeC2dFWVyV3OvUJQExAi0bGoIZDF74LqSnHRd.webp";
 export const IMG_ELEMENT_EXPLOSION =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJCH1oeV26OYrIJuNP1pvSyz29edFtKbngjRcA";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJCH1oeV26OYrIJuNP1pvSyz29edFtKbngjRcA.webp";
 export const IMG_ELEMENT_WIND =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ2HrMNjAnMXlcRpYmJ5do0zKw4Qx6PVEtBa9b";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ2HrMNjAnMXlcRpYmJ5do0zKw4Qx6PVEtBa9b.webp";
 export const IMG_ELEMENT_WATER =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJoYFqRUhZ9MPZpHJ7VliuEWDfATdxhv62SXnm";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJoYFqRUhZ9MPZpHJ7VliuEWDfATdxhv62SXnm.webp";
 export const IMG_ELEMENT_LAVA =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJaK2IZBYYfKMcJ2B5EmWt6VsNgqxpG8OSXAQk";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJaK2IZBYYfKMcJ2B5EmWt6VsNgqxpG8OSXAQk.webp";
 export const IMG_ELEMENT_ICE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJCqHOvc26OYrIJuNP1pvSyz29edFtKbngjRcA";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJCqHOvc26OYrIJuNP1pvSyz29edFtKbngjRcA.webp";
 export const IMG_ELEMENT_WOOD =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJbZYZaSPAtYUndMi56GkX19q0A4PzyeIloBrE";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJbZYZaSPAtYUndMi56GkX19q0A4PzyeIloBrE.webp";
 export const IMG_ELEMENT_STORM =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJzu4spmSemvaQu94EYJs8HpxVzofny6iPtbgC";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJzu4spmSemvaQu94EYJs8HpxVzofny6iPtbgC.webp";
 export const IMG_ELEMENT_CRYSTAL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJaKoVVmYYfKMcJ2B5EmWt6VsNgqxpG8OSXAQk";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJaKoVVmYYfKMcJ2B5EmWt6VsNgqxpG8OSXAQk.webp";
 export const IMG_ELEMENT_MAGNET =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJuNr6tnCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJuNr6tnCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b.webp";
 export const IMG_ELEMENT_FIRE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJAX1vCjoZUC4muiGcQNzjfEndY5y1w20B8hTW";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJAX1vCjoZUC4muiGcQNzjfEndY5y1w20B8hTW.webp";
 export const IMG_ELEMENT_LIGHT =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJeVtMZpyV3OvUJQExAi0bGoIZDF74LqSnHRdp";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJeVtMZpyV3OvUJQExAi0bGoIZDF74LqSnHRdp.webp";
 export const IMG_ELEMENT_EARTH =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJgi7liFcU9cpECTimBdjaqbNn7vQsxGR1wLk4";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJgi7liFcU9cpECTimBdjaqbNn7vQsxGR1wLk4.webp";
 export const IMG_ELEMENT_SCORCH =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJCmW9wm326OYrIJuNP1pvSyz29edFtKbngjRc";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJCmW9wm326OYrIJuNP1pvSyz29edFtKbngjRc.webp";
 export const IMG_ELEMENT_DUST =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJchNmlmSnxBpQqGNDcTHbLmYz8uXAl3oa54ti";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJchNmlmSnxBpQqGNDcTHbLmYz8uXAl3oa54ti.webp";
 export const IMG_ELEMENT_SAND =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJzu4nv37emvaQu94EYJs8HpxVzofny6iPtbgC";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJzu4nv37emvaQu94EYJs8HpxVzofny6iPtbgC.webp";
 export const IMG_ELEMENT_LIGHTNING =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ4DIVIclYIif5CL8BKvMsOh2ZnmS7yHt0jTD3";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ4DIVIclYIif5CL8BKvMsOh2ZnmS7yHt0jTD3.webp";
 export const IMG_ELEMENT_BOIL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ5qAGAlo797jl4ubX8xrRqTZasyMp2WA5eLGU";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ5qAGAlo797jl4ubX8xrRqTZasyMp2WA5eLGU.png";
 export const IMG_ELEMENT_METAL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJu0t3mRCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJu0t3mRCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b.webp";
 
 export const IMG_BASIC_HEAL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJnlXNSKmojJ0EqeDCvBrNmZaXVdY97gSpOWiA";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJnlXNSKmojJ0EqeDCvBrNmZaXVdY97gSpOWiA.webp";
 export const IMG_BASIC_MEDITATE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJgt4hLTcU9cpECTimBdjaqbNn7vQsxGR1wLk4";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJgt4hLTcU9cpECTimBdjaqbNn7vQsxGR1wLk4.webp";
 export const IMG_BASIC_ATTACK =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJdMXlCrP62PI3ciLaYzgVX8FopBADxSrGmvQl";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJdMXlCrP62PI3ciLaYzgVX8FopBADxSrGmvQl.webp";
 export const IMG_BASIC_OFFENSIVE_STANCE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJnBZu0YmojJ0EqeDCvBrNmZaXVdY97gSpOWiA";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJnBZu0YmojJ0EqeDCvBrNmZaXVdY97gSpOWiA.webp";
 export const IMG_BASIC_DEFENSIVE_STANCE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJFr82ddG2iOewJtjGzvNcmEX3TBnoSfMDZPH4";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJFr82ddG2iOewJtjGzvNcmEX3TBnoSfMDZPH4.webp";
 export const IMG_BASIC_FLEE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJRohRDR0udmODoNtpa0FMcwI4k2Eq7nJhyvjl";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJRohRDR0udmODoNtpa0FMcwI4k2Eq7nJhyvjl.webp";
 export const IMG_BASIC_STEALTH =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJDtLSxhzEwoh0WXMnscL279N8ayVQUCbRzS3p";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJDtLSxhzEwoh0WXMnscL279N8ayVQUCbRzS3p.webp";
 export const IMG_BASIC_WAIT =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ8ByNJwOkkp45TvAnoIBa0rtCf1lbyXYjVKQ2";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ8ByNJwOkkp45TvAnoIBa0rtCf1lbyXYjVKQ2.webp";
 export const IMG_BASIC_MOVE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJnQxuGeXmojJ0EqeDCvBrNmZaXVdY97gSpOWi";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJnQxuGeXmojJ0EqeDCvBrNmZaXVdY97gSpOWi.webp";
 export const IMG_BASIC_REPLACEMENT_TECHNIQUE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJZtjLXMaYQrBIUTu69nkMxWmS4ah0O7LVCp8b";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJZtjLXMaYQrBIUTu69nkMxWmS4ah0O7LVCp8b.png";
 export const IMG_BASIC_CLEANSE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ5oYOji797jl4ubX8xrRqTZasyMp2WA5eLGUP";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ5oYOji797jl4ubX8xrRqTZasyMp2WA5eLGUP.webp";
 export const IMG_BASIC_CLEAR =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJTWnPJE5IU29dZYJPoOKSh5vmlqatMub3EigH";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJTWnPJE5IU29dZYJPoOKSh5vmlqatMub3EigH.webp";
 
 export const IMG_ICON_DISCORD =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJCZvaND26OYrIJuNP1pvSyz29edFtKbngjRcA";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJCZvaND26OYrIJuNP1pvSyz29edFtKbngjRcA.png";
 export const IMG_ICON_FACEBOOK =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ1zjiDxX6bo95WClq4K0wxZUmJcvThgdVenO3";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ1zjiDxX6bo95WClq4K0wxZUmJcvThgdVenO3.png";
 export const IMG_ICON_GITHUB =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJydaEQfukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJydaEQfukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp.png";
 export const IMG_ICON_GOOGLE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJCV0Mc426OYrIJuNP1pvSyz29edFtKbngjRcA";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJCV0Mc426OYrIJuNP1pvSyz29edFtKbngjRcA.png";
 export const IMG_ICON_INSTAGRAM =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJWLbTriPvszvj71yaSYC0MDOmbko5q9JAGuLH";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJWLbTriPvszvj71yaSYC0MDOmbko5q9JAGuLH.png";
 export const IMG_ICON_REDDIT =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJPYJEg8pKeUGyX2kj6u45AOQiSa1zYH0mqZoc";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJPYJEg8pKeUGyX2kj6u45AOQiSa1zYH0mqZoc.png";
 export const IMG_ICON_TIKTOK =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJoYcyUDSZ9MPZpHJ7VliuEWDfATdxhv62SXnm";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJoYcyUDSZ9MPZpHJ7VliuEWDfATdxhv62SXnm.png";
 export const IMG_ICON_TWITTER =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJMi2fCxtsO4cexqW2RDgkE3zZbNXSFGitmnar";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJMi2fCxtsO4cexqW2RDgkE3zZbNXSFGitmnar.png";
 export const IMG_ICON_YOUTUBE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJy7pL6jukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJy7pL6jukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp.png";
 export const IMG_ICON_FORUM =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJTwT9cY5IU29dZYJPoOKSh5vmlqatMub3EigH";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJTwT9cY5IU29dZYJPoOKSh5vmlqatMub3EigH.png";
 export const IMG_ICON_MOVE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJepKSYSyV3OvUJQExAi0bGoIZDF74LqSnHRdp";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJepKSYSyV3OvUJQExAi0bGoIZDF74LqSnHRdp.png";
 export const IMG_ICON_HEAL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJrtRSYfhuJPmdY8zI2ptZXAoEj1c6BMKvrQOx";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJrtRSYfhuJPmdY8zI2ptZXAoEj1c6BMKvrQOx.webp";
 
 export const IMG_MISSION_S =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJz3Ph17emvaQu94EYJs8HpxVzofny6iPtbgCZ";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJz3Ph17emvaQu94EYJs8HpxVzofny6iPtbgCZ.webp";
 export const IMG_MISSION_A =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ0ORGP9grYldRWJcD6vE10SjNsXHeA9pVMfQi";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ0ORGP9grYldRWJcD6vE10SjNsXHeA9pVMfQi.webp";
 export const IMG_MISSION_B =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJoVn7VTZ9MPZpHJ7VliuEWDfATdxhv62SXnm4";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJoVn7VTZ9MPZpHJ7VliuEWDfATdxhv62SXnm4.webp";
 export const IMG_MISSION_C =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJoe3eJHZ9MPZpHJ7VliuEWDfATdxhv62SXnm4";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJoe3eJHZ9MPZpHJ7VliuEWDfATdxhv62SXnm4.webp";
 export const IMG_MISSION_D =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ7r7fFcXKPBOUWGyFuM4DlL1v5HNTZhkte0z6";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ7r7fFcXKPBOUWGyFuM4DlL1v5HNTZhkte0z6.webp";
 export const IMG_MISSION_E =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJPAguocQpKeUGyX2kj6u45AOQiSa1zYH0mqZo";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJPAguocQpKeUGyX2kj6u45AOQiSa1zYH0mqZo.webp";
 export const IMG_MISSION_M =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJyweIVKukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJyweIVKukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp.webp";
 export const IMG_MISSION_PVP =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJzCBxBXemvaQu94EYJs8HpxVzofny6iPtbgCZ";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJzCBxBXemvaQu94EYJs8HpxVzofny6iPtbgCZ.webp";
 export const IMG_MISSION_WAR = "/War_mission.webp";
 
 export const IMG_BUILDING_MISSIONHALL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ2TCTWInMXlcRpYmJ5do0zKw4Qx6PVEtBa9b8";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ2TCTWInMXlcRpYmJ5do0zKw4Qx6PVEtBa9b8.webp";
 export const IMG_BUILDING_SCIENCEBUILDING =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJwQxr3PT2j854CWbaITZyegfXimvd7s16cO0h";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJwQxr3PT2j854CWbaITZyegfXimvd7s16cO0h.webp";
 export const IMG_BUILDING_NEWS =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJYKooj7OMAlNnPZ41ev6fCGcFK3hmjX9I8W7d";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJYKooj7OMAlNnPZ41ev6fCGcFK3hmjX9I8W7d.webp";
 export const IMG_BUILDING_SOUVENIER =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJHmrEYkQvYURJhgs76VZtf9wxpMa13Cq0iOnr";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJHmrEYkQvYURJhgs76VZtf9wxpMa13Cq0iOnr.webp";
 export const IMG_BUILDING_HOSPITAL =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ3n9SmD8pYHJX5rdkUTfOKtvu2eGIELmSWqBx";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ3n9SmD8pYHJX5rdkUTfOKtvu2eGIELmSWqBx.webp";
 export const IMG_BUILDING_GLOBALANBU =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJIfwMDCxfOewksxBoS1HQCihpL7c42Ky9uUFv";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJIfwMDCxfOewksxBoS1HQCihpL7c42Ky9uUFv.webp";
 export const IMG_BUILDING_ACADEMY =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ5kYqQv797jl4ubX8xrRqTZasyMp2WA5eLGUP";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ5kYqQv797jl4ubX8xrRqTZasyMp2WA5eLGUP.webp";
 export const IMG_BUILDING_BANK =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJEHFjuQLfKL5D7TAFe29bymSaPCIQ846MdzGg";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJEHFjuQLfKL5D7TAFe29bymSaPCIQ846MdzGg.webp";
 export const IMG_BUILDING_ARCHIVE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJXk8AUJqIOpAoLKbZ4nW9Rsil2V67yuFwQhqv";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJXk8AUJqIOpAoLKbZ4nW9Rsil2V67yuFwQhqv.webp";
 export const IMG_BUILDING_ADMINBUILDING =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJMyfWBKtsO4cexqW2RDgkE3zZbNXSFGitmnar";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJMyfWBKtsO4cexqW2RDgkE3zZbNXSFGitmnar.webp";
 
 export const IMG_ACTIONTIMER_BG =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJZNkUoDaYQrBIUTu69nkMxWmS4ah0O7LVCp8b";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJZNkUoDaYQrBIUTu69nkMxWmS4ah0O7LVCp8b.webp";
 export const IMG_ACTIONTIMER_YELLOW =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJXnRHYeqIOpAoLKbZ4nW9Rsil2V67yuFwQhqv";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJXnRHYeqIOpAoLKbZ4nW9Rsil2V67yuFwQhqv.webp";
 export const IMG_ACTIONTIMER_RED =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJyrbex4ukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJyrbex4ukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp.webp";
 export const IMG_ACTIONTIMER_BLUE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJqA6PRRdkOZgJQ8mGRcdx3SsWvPelyYFTt5Vn";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJqA6PRRdkOZgJQ8mGRcdx3SsWvPelyYFTt5Vn.webp";
 export const IMG_ACTIONTIMER_GREEN =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJwSFJxPT2j854CWbaITZyegfXimvd7s16cO0h";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJwSFJxPT2j854CWbaITZyegfXimvd7s16cO0h.webp";
 export const IMG_ACTIONTIMER_OVERLAY =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJHVKSE4QvYURJhgs76VZtf9wxpMa13Cq0iOnr";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJHVKSE4QvYURJhgs76VZtf9wxpMa13Cq0iOnr.webp";
 
 export const IMG_INITIATIVE_D20 =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJE7476GLfKL5D7TAFe29bymSaPCIQ846MdzGg";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJE7476GLfKL5D7TAFe29bymSaPCIQ846MdzGg.webp";
 export const IMG_BATTLEFIELD_TOMBSTONE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJVVIq2fF2veAXohUuE59nTQHRJIYjtiG18aF4";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJVVIq2fF2veAXohUuE59nTQHRJIYjtiG18aF4.webp";
 export const IMG_BATTLEFIELD_STAR =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJuGvcEjCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b";
+  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJuGvcEjCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b.webp";
 
 export const MUSIC_SHADOW_OF_THE_BLADE =
   "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJQCH0mJjhzBPya1rwfCIqOTU0cV5xgsMeo3u2";
@@ -2335,7 +2335,7 @@ export type HomeTypeDetails = (typeof HomeTypeDetails)[keyof typeof HomeTypeDeta
 
 // Auction system constants
 export const IMG_AUCTION_HOUSE =
-  "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJmcDNSqHE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap" as const;
+  "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJmcDNSqHE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap.webp" as const;
 
 export const AUCTION_LISTING_STATES = [
   "ACTIVE",

--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -1378,7 +1378,23 @@ export const WAR_RECAPTURE_THRESHOLD = 0.25; // Threshold for recapture (25% of 
 export const SHRINE_STATUSES = ["ACTIVE", "CAPTURED"] as const; // Status tracking for shrine capture/recovery cycles
 export type ShrineStatus = (typeof SHRINE_STATUSES)[number];
 export const WAR_SHRINE_IMAGE =
-  "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJgLihSncU9cpECTimBdjaqbNn7vQsxGR1wLk4";
+  "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJxtEfghWZsq9k0Von5rUfP6OgQ2TyptCKHS4u";
+/**
+ * Sector-map shrine sprite per sector biome, so the shrine's baked ground
+ * patch matches the terrain it stands on (water sectors use the desert
+ * variant - the tiles beneath become a sand island).
+ */
+export const WAR_SHRINE_IMAGE_BY_BIOME: Record<CombatBiome, string> = {
+  ocean:
+    "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJe7TE7RyV3OvUJQExAi0bGoIZDF74LqSnHRdp",
+  ground: WAR_SHRINE_IMAGE,
+  dessert:
+    "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJe7TE7RyV3OvUJQExAi0bGoIZDF74LqSnHRdp",
+  ice: "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJco2C06SnxBpQqGNDcTHbLmYz8uXAl3oa54ti",
+  snow: "https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJco2C06SnxBpQqGNDcTHbLmYz8uXAl3oa54ti",
+  arena: WAR_SHRINE_IMAGE,
+  default: WAR_SHRINE_IMAGE,
+};
 export const WAR_RAMEN_IMAGE =
   "https://uploadthing.b-cdn.net/f/6407eedd-9382-41e9-b27d-eb02afe87ce9-srb0e7.webp";
 export const WAR_STATES = [

--- a/app/drizzle/migrations/0020_broad_princess_powerful.sql
+++ b/app/drizzle/migrations/0020_broad_princess_powerful.sql
@@ -1,0 +1,227 @@
+-- Refresh village structure sprites: plinth-free, consistent 3/4 iso camera
+-- (corner-front, entrance lower-left, ~35deg), biome ground patches and
+-- baked lower-left cast shadows matching the decoration sprites.
+-- Akasumi: ANBU
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJIp5rjnxfOewksxBoS1HQCihpL7c42Ky9uUFv' WHERE `id` = 'DKHzc59I0oFpez4g-I1k8';--> statement-breakpoint
+-- Akasumi: Academy
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ8PljuOkkp45TvAnoIBa0rtCf1lbyXYjVKQ2q' WHERE `id` = 'Q48vtbsvTb2dsYZi2ji3T';--> statement-breakpoint
+-- Akasumi: Bank
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJOs3aTDVHevxIThUauQkGJEBY3D2cPqy8f5sp' WHERE `id` = 'QGM0FTDvOt12BIhcBp7GK';--> statement-breakpoint
+-- Akasumi: Battle Arena
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJGgc9awTRfoVrha0LP4mAS5KM7wtiZbUNXJxd' WHERE `id` = 'IWdNNRo3koJ-3tf0ZPhFI';--> statement-breakpoint
+-- Akasumi: Black Market
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJEJ5TCHOLfKL5D7TAFe29bymSaPCIQ846MdzG' WHERE `id` = '3OzTIuCmU8xOw8mv4v6XZ';--> statement-breakpoint
+-- Akasumi: Clan Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzulOCX5emvaQu94EYJs8HpxVzofny6iPtbgC' WHERE `id` = 'k2vd42PIBBQZoBbPqNcoF';--> statement-breakpoint
+-- Akasumi: Home
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ50TE8Q797jl4ubX8xrRqTZasyMp2WA5eLGUP' WHERE `id` = '6eRe-IbEI67jdyoUzW-HE';--> statement-breakpoint
+-- Akasumi: Hospital
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJnlqkc5mojJ0EqeDCvBrNmZaXVdY97gSpOWiA' WHERE `id` = 'vRudoSTv6EopF7uT81vig';--> statement-breakpoint
+-- Akasumi: Item shop
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJUjAlETILCIhwPniJ69VxpvAbTDWkOyGzS8rM' WHERE `id` = 'MU-tkKCe9-azuhaw4o1k-';--> statement-breakpoint
+-- Akasumi: Mission Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJv8tfdtEmSnXwslYEpV1yOeNL8gMtqhjPdf36' WHERE `id` = 'iAn2RSOQJ4y9EoMS3HMMM';--> statement-breakpoint
+-- Akasumi: Ramen Shop
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJQlxSx8HjhzBPya1rwfCIqOTU0cV5xgsMeo3u' WHERE `id` = 'x65Ff_Wx8vOUjjg7Xk5Vz';--> statement-breakpoint
+-- Akasumi: Town Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJYF1ta7NOMAlNnPZ41ev6fCGcFK3hmjX9I8W7' WHERE `id` = '2crHK1rrNuRQdzexcf5Ww';--> statement-breakpoint
+-- Akasumi: Training Grounds
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ6et4izJDfT5pyNCaUruzhPtAJqb8Kj9mc1nl' WHERE `id` = 'nynoIRr7hmvPymGIwunlV';--> statement-breakpoint
+-- Akikaze: ANBU
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJVSxMwDF2veAXohUuE59nTQHRJIYjtiG18aF4' WHERE `id` = 'Ahmb_K7AGmas4-l-as7Vj';--> statement-breakpoint
+-- Akikaze: Academy
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ8PljuOkkp45TvAnoIBa0rtCf1lbyXYjVKQ2q' WHERE `id` = 'ztVMQqHvSYcsfoGrDeFUW';--> statement-breakpoint
+-- Akikaze: Bank
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ7dVp0HfXKPBOUWGyFuM4DlL1v5HNTZhkte0z' WHERE `id` = 'UnHpI3Zb69G2s4SY8KbnE';--> statement-breakpoint
+-- Akikaze: Battle Arena
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ3Mrzu8pYHJX5rdkUTfOKtvu2eGIELmSWqBxy' WHERE `id` = 'fFR2_eU0Cq_f2_z9ojeCf';--> statement-breakpoint
+-- Akikaze: Black Market
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJF0RylVhG2iOewJtjGzvNcmEX3TBnoSfMDZPH' WHERE `id` = 'jyyHkcG9DBLjbPzjq1Cbi';--> statement-breakpoint
+-- Akikaze: Clan Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJuiJxHSCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b' WHERE `id` = 'TgvEEGae4IOA14Ygvpg3b';--> statement-breakpoint
+-- Akikaze: Home
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ4nEbyAlYIif5CL8BKvMsOh2ZnmS7yHt0jTD3' WHERE `id` = 'r6aN56ujaXS5W0H9OZg-6';--> statement-breakpoint
+-- Akikaze: Hospital
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJAaRO0qVoZUC4muiGcQNzjfEndY5y1w20B8hT' WHERE `id` = '7qcEI2RO2GF9dGUuUm6nl';--> statement-breakpoint
+-- Akikaze: Item shop
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJw7OuHuT2j854CWbaITZyegfXimvd7s16cO0h' WHERE `id` = 'jobdog7WW1s-vvtL4faaR';--> statement-breakpoint
+-- Akikaze: Mission Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJeIhOtHyV3OvUJQExAi0bGoIZDF74LqSnHRdp' WHERE `id` = '5doowY0fvUfwfNX_zemYF';--> statement-breakpoint
+-- Akikaze: Ramen Shop
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJm9kVX0HE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap' WHERE `id` = '9WAP0c4yPUeicVrPQig5I';--> statement-breakpoint
+-- Akikaze: Science Building
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJrtw9NyuhuJPmdY8zI2ptZXAoEj1c6BMKvrQO' WHERE `id` = 'ln37d9Vs2jZc-ctwjynbX';--> statement-breakpoint
+-- Akikaze: Town Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJTXO6gXG5IU29dZYJPoOKSh5vmlqatMub3Eig' WHERE `id` = 'MCPFbDlTJKdbXyjO2hWmF';--> statement-breakpoint
+-- Akikaze: Training Grounds
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJAe5GlKoZUC4muiGcQNzjfEndY5y1w20B8hTW' WHERE `id` = 'n4QSgFxG2rSQCf2heMngE';--> statement-breakpoint
+-- Freedom State: ANBU
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJxEfpuZqWZsq9k0Von5rUfP6OgQ2TyptCKHS4' WHERE `id` = 'ZOefoWWrwTtxbKUH2pn2';--> statement-breakpoint
+-- Freedom State: Academy
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ8PljuOkkp45TvAnoIBa0rtCf1lbyXYjVKQ2q' WHERE `id` = '0L8WK6VNC2VTcBUkqrWSG';--> statement-breakpoint
+-- Freedom State: Bank
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJY2PXyIOMAlNnPZ41ev6fCGcFK3hmjX9I8W7d' WHERE `id` = 'BeOH5XT_7V1KkX96l-XRH';--> statement-breakpoint
+-- Freedom State: Battle Arena
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJOqwNOBVHevxIThUauQkGJEBY3D2cPqy8f5sp' WHERE `id` = 'XTB5QAZcQl0mu7LQWolnO';--> statement-breakpoint
+-- Freedom State: Black Market
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJrxUju8huJPmdY8zI2ptZXAoEj1c6BMKvrQOx' WHERE `id` = 'crahRhfeqGA7r2r3pQmT9';--> statement-breakpoint
+-- Freedom State: Clan Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJPzirxMpKeUGyX2kj6u45AOQiSa1zYH0mqZoc' WHERE `id` = 'Lqdc81Zy5sMtWCTnGyC';--> statement-breakpoint
+-- Freedom State: Home
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJEwXYiNLfKL5D7TAFe29bymSaPCIQ846MdzGg' WHERE `id` = 'k0qganjlDyAMzP51j1VBr';--> statement-breakpoint
+-- Freedom State: Hospital
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJg3zja5scU9cpECTimBdjaqbNn7vQsxGR1wLk' WHERE `id` = 'h_qpvTyo_HdM1sRhcfHRA';--> statement-breakpoint
+-- Freedom State: Item shop
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ17ZAfc6bo95WClq4K0wxZUmJcvThgdVenO3P' WHERE `id` = 'Q8vykGiZlxo7bHbAt7wfd';--> statement-breakpoint
+-- Freedom State: Mission Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJCqkLCo26OYrIJuNP1pvSyz29edFtKbngjRcA' WHERE `id` = 'ZShTaZzX3LEvQv4OZk-tr';--> statement-breakpoint
+-- Freedom State: Ramen Shop
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJnyQbJsmojJ0EqeDCvBrNmZaXVdY97gSpOWiA' WHERE `id` = '_XJkJ7L-cHiQ65sqxrAwg';--> statement-breakpoint
+-- Freedom State: Town Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJu8TzdhCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b' WHERE `id` = 'Vg4Wqp3iy7OrIl-ys6OCx';--> statement-breakpoint
+-- Freedom State: Training Grounds
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJujzPHQCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b' WHERE `id` = 'N3U5uaHUuFN3pIekZo759';--> statement-breakpoint
+-- Horizon: Academy
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJDv4UVKzEwoh0WXMnscL279N8ayVQUCbRzS3p' WHERE `id` = 'dsakCY9pIQqPw4CbhH';--> statement-breakpoint
+-- Horizon: Bank
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJm6wawIHE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap' WHERE `id` = '7AbyMSMidwJEtMnW2G';--> statement-breakpoint
+-- Horizon: Battle Arena
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJA4NaNCoZUC4muiGcQNzjfEndY5y1w20B8hTW' WHERE `id` = '6pbRfZiKhOALs8pc2c';--> statement-breakpoint
+-- Horizon: Black Market
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJui976aCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b' WHERE `id` = 'xEJBOPUH3ExuBMkrYF';--> statement-breakpoint
+-- Horizon: Clan Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzXLAcXemvaQu94EYJs8HpxVzofny6iPtbgCZ' WHERE `id` = 'XzpL5fgtQPtCOgk-Um';--> statement-breakpoint
+-- Horizon: Home
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJQaou4sjhzBPya1rwfCIqOTU0cV5xgsMeo3u2' WHERE `id` = 'g1U-YLsa84K3B1THbE';--> statement-breakpoint
+-- Horizon: Hospital
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJEMUYBLfKL5D7TAFe29bymSaPCIQ846MdzGgV' WHERE `id` = '2Z6VKPg-q-b8N9-XGh';--> statement-breakpoint
+-- Horizon: Item shop
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJEM4sntLfKL5D7TAFe29bymSaPCIQ846MdzGg' WHERE `id` = 'uMSip0l1_cN7Mil0_v';--> statement-breakpoint
+-- Horizon: Mission Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ8j3AoBkkp45TvAnoIBa0rtCf1lbyXYjVKQ2q' WHERE `id` = '-eUkCY9pIQqPw4CbhH';--> statement-breakpoint
+-- Horizon: Ramen Shop
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJy2U9zsqukVH2MI5Lo4ehEfAXvZdcmtWqPg7r' WHERE `id` = 'VgmEjYU5V76-oacVbn';--> statement-breakpoint
+-- Horizon: Town Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJZgkeHLaYQrBIUTu69nkMxWmS4ah0O7LVCp8b' WHERE `id` = 'RGUJrSzSNol1nQcYYC';--> statement-breakpoint
+-- Horizon: Training Grounds
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ6991JEDfT5pyNCaUruzhPtAJqb8Kj9mc1nlH' WHERE `id` = 'R1r8P9DXxxV52OUQU0';--> statement-breakpoint
+-- Hyorin: ANBU
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJA1baIIoZUC4muiGcQNzjfEndY5y1w20B8hTW' WHERE `id` = 'REDQwkesCawbmiN1-gnkl';--> statement-breakpoint
+-- Hyorin: Academy
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJmjL8ym2HE4IMO5Goa7cgLxPJ0VC6lU8vbt1A' WHERE `id` = '1zN-m3tSlSCRdytS3URML';--> statement-breakpoint
+-- Hyorin: Bank
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJbZGZo4kAtYUndMi56GkX19q0A4PzyeIloBrE' WHERE `id` = '7cOYdBLQJXSF3RZA2Opnf';--> statement-breakpoint
+-- Hyorin: Battle Arena
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ0Sy1P1WgrYldRWJcD6vE10SjNsXHeA9pVMfQ' WHERE `id` = 'bfYvuGPmhIrmLzqAQ8k_T';--> statement-breakpoint
+-- Hyorin: Black Market
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJjrJ5NfC4XzPI8f1v96qBot0Q3wsUp2nxu7SM' WHERE `id` = 'ArPWrrdZTsAKJymUn4mPM';--> statement-breakpoint
+-- Hyorin: Clan Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJecIa42yV3OvUJQExAi0bGoIZDF74LqSnHRdp' WHERE `id` = 'p_b5dF-ttklDDHCTj4bPp';--> statement-breakpoint
+-- Hyorin: Home
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJSkyI6Aa3jWrEB7TyZlmpoAxMK5Qi16kNPVJu' WHERE `id` = 'a97Rh_Da15i8biQZOpkyO';--> statement-breakpoint
+-- Hyorin: Hospital
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJXUfKZbqIOpAoLKbZ4nW9Rsil2V67yuFwQhqv' WHERE `id` = 'G2CSNXMgWNTSrZvLBmGk3';--> statement-breakpoint
+-- Hyorin: Item shop
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJCdhaL626OYrIJuNP1pvSyz29edFtKbngjRcA' WHERE `id` = 'M1MpdzuiKd18gCT5na1b_';--> statement-breakpoint
+-- Hyorin: Mission Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJv6iSjTEmSnXwslYEpV1yOeNL8gMtqhjPdf36' WHERE `id` = 'TXaOVlOl7dtGXDltv8Y0Z';--> statement-breakpoint
+-- Hyorin: Ramen Shop
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJOXce2nVHevxIThUauQkGJEBY3D2cPqy8f5sp' WHERE `id` = '4syKSbOTZ_zr2tq4VctgJ';--> statement-breakpoint
+-- Hyorin: Town Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJt5IfImUYJDfpFXWm3nrcPluEtIZqyLkaSV1j' WHERE `id` = 'UlMRTKkynMfjDuqNlVFJi';--> statement-breakpoint
+-- Hyorin: Training Grounds
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJlMWZZ6KrWYxAsuC7ofQn9pM45OD0ERqkdBXJ' WHERE `id` = 'QyHMOwQvpmD91HdkLT5dt';--> statement-breakpoint
+-- Shirohana: ANBU
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJg0EDOOcU9cpECTimBdjaqbNn7vQsxGR1wLk4' WHERE `id` = 'ZOefoWWrwTtxbKUH2pnE8';--> statement-breakpoint
+-- Shirohana: Academy
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJDv4UVKzEwoh0WXMnscL279N8ayVQUCbRzS3p' WHERE `id` = 'C82Yxkt9by85-xQlwRBOw';--> statement-breakpoint
+-- Shirohana: Bank
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJuJZQvrCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b' WHERE `id` = 'wEm7K5A4PdKhy1bNTn9vS';--> statement-breakpoint
+-- Shirohana: Battle Arena
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJTedJ685IU29dZYJPoOKSh5vmlqatMub3EigH' WHERE `id` = 'IXOCEjm_HpVDpMxy9zeHs';--> statement-breakpoint
+-- Shirohana: Black Market
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzWF9MtemvaQu94EYJs8HpxVzofny6iPtbgCZ' WHERE `id` = 'D866KKvQtcOUCt_RcMvZa';--> statement-breakpoint
+-- Shirohana: Clan Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJCxlBp426OYrIJuNP1pvSyz29edFtKbngjRcA' WHERE `id` = 'Lqdc81Zy5sMtWCTnGyCby';--> statement-breakpoint
+-- Shirohana: Home
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzmjULremvaQu94EYJs8HpxVzofny6iPtbgCZ' WHERE `id` = 'NRXDQYudIyb8RIljwNkm7';--> statement-breakpoint
+-- Shirohana: Hospital
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJmSpq8dHE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap' WHERE `id` = 'OvwayKVzCk78B08uWRZvS';--> statement-breakpoint
+-- Shirohana: Item shop
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ6VpHsCDfT5pyNCaUruzhPtAJqb8Kj9mc1nlH' WHERE `id` = 'h3uFu6GfKLczp9pKivGco';--> statement-breakpoint
+-- Shirohana: Mission Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJc5lww5SnxBpQqGNDcTHbLmYz8uXAl3oa54ti' WHERE `id` = 'keqtU5WrMzufl1DFYJEt1';--> statement-breakpoint
+-- Shirohana: Ramen Shop
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJTgfBho5IU29dZYJPoOKSh5vmlqatMub3EigH' WHERE `id` = 'bI658UPyvJeGtu41dqvX7';--> statement-breakpoint
+-- Shirohana: Town Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJvstQicEmSnXwslYEpV1yOeNL8gMtqhjPdf36' WHERE `id` = 'Qnt0h_jvg5h2DYxZGk14Y';--> statement-breakpoint
+-- Shirohana: Training Grounds
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJuE7V4ZCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b' WHERE `id` = 'k2TAiE-Ytnd5xdfQrGfXG';--> statement-breakpoint
+-- Syndicate: Academy
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJDv4UVKzEwoh0WXMnscL279N8ayVQUCbRzS3p' WHERE `id` = 'nqeS3yy9snixhPRD9PsZ0';--> statement-breakpoint
+-- Syndicate: Auction House
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzWqr3LemvaQu94EYJs8HpxVzofny6iPtbgCZ' WHERE `id` = 'MeiAuctionHouse-Syndct26';--> statement-breakpoint
+-- Syndicate: Bank
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJu7nO4gCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b' WHERE `id` = 'AO5zgAvEir7LO_7Trj3ah';--> statement-breakpoint
+-- Syndicate: Battle Arena
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ5MTwNj797jl4ubX8xrRqTZasyMp2WA5eLGUP' WHERE `id` = 'UrVycqOhzBo0rLMQ2ie4L';--> statement-breakpoint
+-- Syndicate: Black Market
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJxKyrvKWZsq9k0Von5rUfP6OgQ2TyptCKHS4u' WHERE `id` = 'eLpEB0nStid710TDBwa25';--> statement-breakpoint
+-- Syndicate: Crimes Board
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJhl3qGAMfUBdnwAX5LTajlNc4mrgzi0RJtqpM' WHERE `id` = 'lc1Sbrok_2Fj75stxmQEs';--> statement-breakpoint
+-- Syndicate: Factions
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJCxlBp426OYrIJuNP1pvSyz29edFtKbngjRcA' WHERE `id` = 'qdc81Zy5sMtasdCTnGyCby';--> statement-breakpoint
+-- Syndicate: Home
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ2eB5kHnMXlcRpYmJ5do0zKw4Qx6PVEtBa9b8' WHERE `id` = 'Hr2vM5kLVj24fCYRSpHpy';--> statement-breakpoint
+-- Syndicate: Hospital
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJOdA5nJVHevxIThUauQkGJEBY3D2cPqy8f5sp' WHERE `id` = '7oKXGmGMphE3rh2sZX1yi';--> statement-breakpoint
+-- Syndicate: Item shop
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJAaGq3RFoZUC4muiGcQNzjfEndY5y1w20B8hT' WHERE `id` = '1h2B_fkmIKTOM-hoy2eYm';--> statement-breakpoint
+-- Syndicate: Ramen Shop
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJDs9QX7zEwoh0WXMnscL279N8ayVQUCbRzS3p' WHERE `id` = 'WFqxUlrNQT2BE_PNheL-y';--> statement-breakpoint
+-- Syndicate: Rumours
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJouGlVQZ9MPZpHJ7VliuEWDfATdxhv62SXnm4' WHERE `id` = '1q_wck3sA4NsWZi3vTjuR';--> statement-breakpoint
+-- Syndicate: Training Grounds
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzb7T2zemvaQu94EYJs8HpxVzofny6iPtbgCZ' WHERE `id` = 'Du3kNxteWFj5iC5kTeTiX';--> statement-breakpoint
+-- Tsukimori: ANBU
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJeebsANyV3OvUJQExAi0bGoIZDF74LqSnHRdp' WHERE `id` = 'TzngcYXAYsSDkd0CoImOM';--> statement-breakpoint
+-- Tsukimori: Academy
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ8PljuOkkp45TvAnoIBa0rtCf1lbyXYjVKQ2q' WHERE `id` = 't1otfv7FoyZfP9zoaw2Mh';--> statement-breakpoint
+-- Tsukimori: Bank
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJHWjc56QvYURJhgs76VZtf9wxpMa13Cq0iOnr' WHERE `id` = '7AbyMSMZpOidwJEtMnW2G';--> statement-breakpoint
+-- Tsukimori: Battle Arena
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ2MBv82nMXlcRpYmJ5do0zKw4Qx6PVEtBa9b8' WHERE `id` = '6pbR9RMfZiKhOALs8pc2c';--> statement-breakpoint
+-- Tsukimori: Black Market
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJeX9cMiyV3OvUJQExAi0bGoIZDF74LqSnHRdp' WHERE `id` = 'xEJ0grBOPUH3ExuBMkrYF';--> statement-breakpoint
+-- Tsukimori: Clan Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJg3zvwmscU9cpECTimBdjaqbNn7vQsxGR1wLk' WHERE `id` = 'XzpL5fteKgtQPtCOgk-Um';--> statement-breakpoint
+-- Tsukimori: Home
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJHUDNZLQvYURJhgs76VZtf9wxpMa13Cq0iOnr' WHERE `id` = 'g1U-YLsZV-a84K3B1THbE';--> statement-breakpoint
+-- Tsukimori: Hospital
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJtoT1voUYJDfpFXWm3nrcPluEtIZqyLkaSV1j' WHERE `id` = '2Z6VKPg-q-frdb8N9-XGh';--> statement-breakpoint
+-- Tsukimori: Item shop
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJmz1O9AHE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap' WHERE `id` = 'uMSip06bdl1_cN7Mil0_v';--> statement-breakpoint
+-- Tsukimori: Mission Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJy0fXJ1ukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp' WHERE `id` = '-eUkCY9pIQqPwbU34CbhH';--> statement-breakpoint
+-- Tsukimori: Ramen Shop
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJTw17M65IU29dZYJPoOKSh5vmlqatMub3EigH' WHERE `id` = 'Vgmvh6EjYU5V76-oacVbn';--> statement-breakpoint
+-- Tsukimori: Town Hall
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJtcYHhfUYJDfpFXWm3nrcPluEtIZqyLkaSV1j' WHERE `id` = 'RGUJrRejSzSNol1nQcYYC';--> statement-breakpoint
+-- Tsukimori: Training Grounds
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJOHJNYtVHevxIThUauQkGJEBY3D2cPqy8f5sp' WHERE `id` = 'R1r8P9sqLDXxxV52OUQU0';--> statement-breakpoint
+-- Wake Island: Administration Building
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzc2KxYemvaQu94EYJs8HpxVzofny6iPtbgCZ' WHERE `id` = 'YMV7Kbo1OduGfNDYfq5';--> statement-breakpoint
+-- Wake Island: Auction House
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJWt5x2Tvszvj71yaSYC0MDOmbko5q9JAGuLHf' WHERE `id` = 'AuctionHouse_WakeIsland';--> statement-breakpoint
+-- Wake Island: Colosseum
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJmoCFKnHE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap' WHERE `id` = 'YKbo1OduGfNDYfq5Iv';--> statement-breakpoint
+-- Wake Island: Global ANBU HQ
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJZo3FPhaYQrBIUTu69nkMxWmS4ah0O7LVCp8b' WHERE `id` = 'YMV7Kbo1OduGfNDYfq5I2';--> statement-breakpoint
+-- Wake Island: History Building
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJRcDsuGQ0udmODoNtpa0FMcwI4k2Eq7nJhyvj' WHERE `id` = 'YMV7Kbo1OduGfNDYfq5I1';--> statement-breakpoint
+-- Wake Island: Mini Games
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJmjtXF2mHE4IMO5Goa7cgLxPJ0VC6lU8vbt1A' WHERE `id` = 'fldisuagfeidg';--> statement-breakpoint
+-- Wake Island: Science Building
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJjc1yF34XzPI8f1v96qBot0Q3wsUp2nxu7SMb' WHERE `id` = 'YMV7Kbo1OduGfNDYfq5Iv';--> statement-breakpoint
+-- Wake Island: Souvenir Shop
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ0S62GrpgrYldRWJcD6vE10SjNsXHeA9pVMfQ' WHERE `id` = 'YMV7Kbo1OduGfNDYfq5I3';

--- a/app/drizzle/migrations/0020_broad_princess_powerful.sql
+++ b/app/drizzle/migrations/0020_broad_princess_powerful.sql
@@ -2,226 +2,226 @@
 -- (corner-front, entrance lower-left, ~35deg), biome ground patches and
 -- baked lower-left cast shadows matching the decoration sprites.
 -- Akasumi: ANBU
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJIp5rjnxfOewksxBoS1HQCihpL7c42Ky9uUFv' WHERE `id` = 'DKHzc59I0oFpez4g-I1k8';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJIp5rjnxfOewksxBoS1HQCihpL7c42Ky9uUFv.webp' WHERE `id` = 'DKHzc59I0oFpez4g-I1k8';--> statement-breakpoint
 -- Akasumi: Academy
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ8PljuOkkp45TvAnoIBa0rtCf1lbyXYjVKQ2q' WHERE `id` = 'Q48vtbsvTb2dsYZi2ji3T';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ8PljuOkkp45TvAnoIBa0rtCf1lbyXYjVKQ2q.webp' WHERE `id` = 'Q48vtbsvTb2dsYZi2ji3T';--> statement-breakpoint
 -- Akasumi: Bank
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJOs3aTDVHevxIThUauQkGJEBY3D2cPqy8f5sp' WHERE `id` = 'QGM0FTDvOt12BIhcBp7GK';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJOs3aTDVHevxIThUauQkGJEBY3D2cPqy8f5sp.webp' WHERE `id` = 'QGM0FTDvOt12BIhcBp7GK';--> statement-breakpoint
 -- Akasumi: Battle Arena
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJGgc9awTRfoVrha0LP4mAS5KM7wtiZbUNXJxd' WHERE `id` = 'IWdNNRo3koJ-3tf0ZPhFI';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJGgc9awTRfoVrha0LP4mAS5KM7wtiZbUNXJxd.webp' WHERE `id` = 'IWdNNRo3koJ-3tf0ZPhFI';--> statement-breakpoint
 -- Akasumi: Black Market
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJEJ5TCHOLfKL5D7TAFe29bymSaPCIQ846MdzG' WHERE `id` = '3OzTIuCmU8xOw8mv4v6XZ';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJEJ5TCHOLfKL5D7TAFe29bymSaPCIQ846MdzG.webp' WHERE `id` = '3OzTIuCmU8xOw8mv4v6XZ';--> statement-breakpoint
 -- Akasumi: Clan Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzulOCX5emvaQu94EYJs8HpxVzofny6iPtbgC' WHERE `id` = 'k2vd42PIBBQZoBbPqNcoF';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzulOCX5emvaQu94EYJs8HpxVzofny6iPtbgC.webp' WHERE `id` = 'k2vd42PIBBQZoBbPqNcoF';--> statement-breakpoint
 -- Akasumi: Home
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ50TE8Q797jl4ubX8xrRqTZasyMp2WA5eLGUP' WHERE `id` = '6eRe-IbEI67jdyoUzW-HE';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ50TE8Q797jl4ubX8xrRqTZasyMp2WA5eLGUP.webp' WHERE `id` = '6eRe-IbEI67jdyoUzW-HE';--> statement-breakpoint
 -- Akasumi: Hospital
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJnlqkc5mojJ0EqeDCvBrNmZaXVdY97gSpOWiA' WHERE `id` = 'vRudoSTv6EopF7uT81vig';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJnlqkc5mojJ0EqeDCvBrNmZaXVdY97gSpOWiA.webp' WHERE `id` = 'vRudoSTv6EopF7uT81vig';--> statement-breakpoint
 -- Akasumi: Item shop
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJUjAlETILCIhwPniJ69VxpvAbTDWkOyGzS8rM' WHERE `id` = 'MU-tkKCe9-azuhaw4o1k-';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJUjAlETILCIhwPniJ69VxpvAbTDWkOyGzS8rM.webp' WHERE `id` = 'MU-tkKCe9-azuhaw4o1k-';--> statement-breakpoint
 -- Akasumi: Mission Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJv8tfdtEmSnXwslYEpV1yOeNL8gMtqhjPdf36' WHERE `id` = 'iAn2RSOQJ4y9EoMS3HMMM';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJv8tfdtEmSnXwslYEpV1yOeNL8gMtqhjPdf36.webp' WHERE `id` = 'iAn2RSOQJ4y9EoMS3HMMM';--> statement-breakpoint
 -- Akasumi: Ramen Shop
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJQlxSx8HjhzBPya1rwfCIqOTU0cV5xgsMeo3u' WHERE `id` = 'x65Ff_Wx8vOUjjg7Xk5Vz';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJQlxSx8HjhzBPya1rwfCIqOTU0cV5xgsMeo3u.webp' WHERE `id` = 'x65Ff_Wx8vOUjjg7Xk5Vz';--> statement-breakpoint
 -- Akasumi: Town Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJYF1ta7NOMAlNnPZ41ev6fCGcFK3hmjX9I8W7' WHERE `id` = '2crHK1rrNuRQdzexcf5Ww';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJYF1ta7NOMAlNnPZ41ev6fCGcFK3hmjX9I8W7.webp' WHERE `id` = '2crHK1rrNuRQdzexcf5Ww';--> statement-breakpoint
 -- Akasumi: Training Grounds
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ6et4izJDfT5pyNCaUruzhPtAJqb8Kj9mc1nl' WHERE `id` = 'nynoIRr7hmvPymGIwunlV';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ6et4izJDfT5pyNCaUruzhPtAJqb8Kj9mc1nl.webp' WHERE `id` = 'nynoIRr7hmvPymGIwunlV';--> statement-breakpoint
 -- Akikaze: ANBU
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJVSxMwDF2veAXohUuE59nTQHRJIYjtiG18aF4' WHERE `id` = 'Ahmb_K7AGmas4-l-as7Vj';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJVSxMwDF2veAXohUuE59nTQHRJIYjtiG18aF4.webp' WHERE `id` = 'Ahmb_K7AGmas4-l-as7Vj';--> statement-breakpoint
 -- Akikaze: Academy
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ8PljuOkkp45TvAnoIBa0rtCf1lbyXYjVKQ2q' WHERE `id` = 'ztVMQqHvSYcsfoGrDeFUW';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ8PljuOkkp45TvAnoIBa0rtCf1lbyXYjVKQ2q.webp' WHERE `id` = 'ztVMQqHvSYcsfoGrDeFUW';--> statement-breakpoint
 -- Akikaze: Bank
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ7dVp0HfXKPBOUWGyFuM4DlL1v5HNTZhkte0z' WHERE `id` = 'UnHpI3Zb69G2s4SY8KbnE';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ7dVp0HfXKPBOUWGyFuM4DlL1v5HNTZhkte0z.webp' WHERE `id` = 'UnHpI3Zb69G2s4SY8KbnE';--> statement-breakpoint
 -- Akikaze: Battle Arena
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ3Mrzu8pYHJX5rdkUTfOKtvu2eGIELmSWqBxy' WHERE `id` = 'fFR2_eU0Cq_f2_z9ojeCf';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ3Mrzu8pYHJX5rdkUTfOKtvu2eGIELmSWqBxy.webp' WHERE `id` = 'fFR2_eU0Cq_f2_z9ojeCf';--> statement-breakpoint
 -- Akikaze: Black Market
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJF0RylVhG2iOewJtjGzvNcmEX3TBnoSfMDZPH' WHERE `id` = 'jyyHkcG9DBLjbPzjq1Cbi';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJF0RylVhG2iOewJtjGzvNcmEX3TBnoSfMDZPH.webp' WHERE `id` = 'jyyHkcG9DBLjbPzjq1Cbi';--> statement-breakpoint
 -- Akikaze: Clan Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJuiJxHSCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b' WHERE `id` = 'TgvEEGae4IOA14Ygvpg3b';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJuiJxHSCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b.webp' WHERE `id` = 'TgvEEGae4IOA14Ygvpg3b';--> statement-breakpoint
 -- Akikaze: Home
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ4nEbyAlYIif5CL8BKvMsOh2ZnmS7yHt0jTD3' WHERE `id` = 'r6aN56ujaXS5W0H9OZg-6';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ4nEbyAlYIif5CL8BKvMsOh2ZnmS7yHt0jTD3.webp' WHERE `id` = 'r6aN56ujaXS5W0H9OZg-6';--> statement-breakpoint
 -- Akikaze: Hospital
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJAaRO0qVoZUC4muiGcQNzjfEndY5y1w20B8hT' WHERE `id` = '7qcEI2RO2GF9dGUuUm6nl';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJAaRO0qVoZUC4muiGcQNzjfEndY5y1w20B8hT.webp' WHERE `id` = '7qcEI2RO2GF9dGUuUm6nl';--> statement-breakpoint
 -- Akikaze: Item shop
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJw7OuHuT2j854CWbaITZyegfXimvd7s16cO0h' WHERE `id` = 'jobdog7WW1s-vvtL4faaR';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJw7OuHuT2j854CWbaITZyegfXimvd7s16cO0h.webp' WHERE `id` = 'jobdog7WW1s-vvtL4faaR';--> statement-breakpoint
 -- Akikaze: Mission Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJeIhOtHyV3OvUJQExAi0bGoIZDF74LqSnHRdp' WHERE `id` = '5doowY0fvUfwfNX_zemYF';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJeIhOtHyV3OvUJQExAi0bGoIZDF74LqSnHRdp.webp' WHERE `id` = '5doowY0fvUfwfNX_zemYF';--> statement-breakpoint
 -- Akikaze: Ramen Shop
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJm9kVX0HE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap' WHERE `id` = '9WAP0c4yPUeicVrPQig5I';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJm9kVX0HE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap.webp' WHERE `id` = '9WAP0c4yPUeicVrPQig5I';--> statement-breakpoint
 -- Akikaze: Science Building
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJrtw9NyuhuJPmdY8zI2ptZXAoEj1c6BMKvrQO' WHERE `id` = 'ln37d9Vs2jZc-ctwjynbX';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJrtw9NyuhuJPmdY8zI2ptZXAoEj1c6BMKvrQO.webp' WHERE `id` = 'ln37d9Vs2jZc-ctwjynbX';--> statement-breakpoint
 -- Akikaze: Town Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJTXO6gXG5IU29dZYJPoOKSh5vmlqatMub3Eig' WHERE `id` = 'MCPFbDlTJKdbXyjO2hWmF';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJTXO6gXG5IU29dZYJPoOKSh5vmlqatMub3Eig.webp' WHERE `id` = 'MCPFbDlTJKdbXyjO2hWmF';--> statement-breakpoint
 -- Akikaze: Training Grounds
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJAe5GlKoZUC4muiGcQNzjfEndY5y1w20B8hTW' WHERE `id` = 'n4QSgFxG2rSQCf2heMngE';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJAe5GlKoZUC4muiGcQNzjfEndY5y1w20B8hTW.webp' WHERE `id` = 'n4QSgFxG2rSQCf2heMngE';--> statement-breakpoint
 -- Freedom State: ANBU
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJxEfpuZqWZsq9k0Von5rUfP6OgQ2TyptCKHS4' WHERE `id` = 'ZOefoWWrwTtxbKUH2pn2';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJxEfpuZqWZsq9k0Von5rUfP6OgQ2TyptCKHS4.webp' WHERE `id` = 'ZOefoWWrwTtxbKUH2pn2';--> statement-breakpoint
 -- Freedom State: Academy
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ8PljuOkkp45TvAnoIBa0rtCf1lbyXYjVKQ2q' WHERE `id` = '0L8WK6VNC2VTcBUkqrWSG';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ8PljuOkkp45TvAnoIBa0rtCf1lbyXYjVKQ2q.webp' WHERE `id` = '0L8WK6VNC2VTcBUkqrWSG';--> statement-breakpoint
 -- Freedom State: Bank
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJY2PXyIOMAlNnPZ41ev6fCGcFK3hmjX9I8W7d' WHERE `id` = 'BeOH5XT_7V1KkX96l-XRH';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJY2PXyIOMAlNnPZ41ev6fCGcFK3hmjX9I8W7d.webp' WHERE `id` = 'BeOH5XT_7V1KkX96l-XRH';--> statement-breakpoint
 -- Freedom State: Battle Arena
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJOqwNOBVHevxIThUauQkGJEBY3D2cPqy8f5sp' WHERE `id` = 'XTB5QAZcQl0mu7LQWolnO';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJOqwNOBVHevxIThUauQkGJEBY3D2cPqy8f5sp.webp' WHERE `id` = 'XTB5QAZcQl0mu7LQWolnO';--> statement-breakpoint
 -- Freedom State: Black Market
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJrxUju8huJPmdY8zI2ptZXAoEj1c6BMKvrQOx' WHERE `id` = 'crahRhfeqGA7r2r3pQmT9';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJrxUju8huJPmdY8zI2ptZXAoEj1c6BMKvrQOx.webp' WHERE `id` = 'crahRhfeqGA7r2r3pQmT9';--> statement-breakpoint
 -- Freedom State: Clan Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJPzirxMpKeUGyX2kj6u45AOQiSa1zYH0mqZoc' WHERE `id` = 'Lqdc81Zy5sMtWCTnGyC';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJPzirxMpKeUGyX2kj6u45AOQiSa1zYH0mqZoc.webp' WHERE `id` = 'Lqdc81Zy5sMtWCTnGyC';--> statement-breakpoint
 -- Freedom State: Home
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJEwXYiNLfKL5D7TAFe29bymSaPCIQ846MdzGg' WHERE `id` = 'k0qganjlDyAMzP51j1VBr';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJEwXYiNLfKL5D7TAFe29bymSaPCIQ846MdzGg.webp' WHERE `id` = 'k0qganjlDyAMzP51j1VBr';--> statement-breakpoint
 -- Freedom State: Hospital
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJg3zja5scU9cpECTimBdjaqbNn7vQsxGR1wLk' WHERE `id` = 'h_qpvTyo_HdM1sRhcfHRA';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJg3zja5scU9cpECTimBdjaqbNn7vQsxGR1wLk.webp' WHERE `id` = 'h_qpvTyo_HdM1sRhcfHRA';--> statement-breakpoint
 -- Freedom State: Item shop
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ17ZAfc6bo95WClq4K0wxZUmJcvThgdVenO3P' WHERE `id` = 'Q8vykGiZlxo7bHbAt7wfd';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ17ZAfc6bo95WClq4K0wxZUmJcvThgdVenO3P.webp' WHERE `id` = 'Q8vykGiZlxo7bHbAt7wfd';--> statement-breakpoint
 -- Freedom State: Mission Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJCqkLCo26OYrIJuNP1pvSyz29edFtKbngjRcA' WHERE `id` = 'ZShTaZzX3LEvQv4OZk-tr';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJCqkLCo26OYrIJuNP1pvSyz29edFtKbngjRcA.webp' WHERE `id` = 'ZShTaZzX3LEvQv4OZk-tr';--> statement-breakpoint
 -- Freedom State: Ramen Shop
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJnyQbJsmojJ0EqeDCvBrNmZaXVdY97gSpOWiA' WHERE `id` = '_XJkJ7L-cHiQ65sqxrAwg';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJnyQbJsmojJ0EqeDCvBrNmZaXVdY97gSpOWiA.webp' WHERE `id` = '_XJkJ7L-cHiQ65sqxrAwg';--> statement-breakpoint
 -- Freedom State: Town Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJu8TzdhCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b' WHERE `id` = 'Vg4Wqp3iy7OrIl-ys6OCx';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJu8TzdhCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b.webp' WHERE `id` = 'Vg4Wqp3iy7OrIl-ys6OCx';--> statement-breakpoint
 -- Freedom State: Training Grounds
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJujzPHQCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b' WHERE `id` = 'N3U5uaHUuFN3pIekZo759';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJujzPHQCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b.webp' WHERE `id` = 'N3U5uaHUuFN3pIekZo759';--> statement-breakpoint
 -- Horizon: Academy
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJDv4UVKzEwoh0WXMnscL279N8ayVQUCbRzS3p' WHERE `id` = 'dsakCY9pIQqPw4CbhH';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJDv4UVKzEwoh0WXMnscL279N8ayVQUCbRzS3p.webp' WHERE `id` = 'dsakCY9pIQqPw4CbhH';--> statement-breakpoint
 -- Horizon: Bank
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJm6wawIHE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap' WHERE `id` = '7AbyMSMidwJEtMnW2G';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJm6wawIHE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap.webp' WHERE `id` = '7AbyMSMidwJEtMnW2G';--> statement-breakpoint
 -- Horizon: Battle Arena
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJA4NaNCoZUC4muiGcQNzjfEndY5y1w20B8hTW' WHERE `id` = '6pbRfZiKhOALs8pc2c';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJA4NaNCoZUC4muiGcQNzjfEndY5y1w20B8hTW.webp' WHERE `id` = '6pbRfZiKhOALs8pc2c';--> statement-breakpoint
 -- Horizon: Black Market
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJui976aCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b' WHERE `id` = 'xEJBOPUH3ExuBMkrYF';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJui976aCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b.webp' WHERE `id` = 'xEJBOPUH3ExuBMkrYF';--> statement-breakpoint
 -- Horizon: Clan Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzXLAcXemvaQu94EYJs8HpxVzofny6iPtbgCZ' WHERE `id` = 'XzpL5fgtQPtCOgk-Um';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzXLAcXemvaQu94EYJs8HpxVzofny6iPtbgCZ.webp' WHERE `id` = 'XzpL5fgtQPtCOgk-Um';--> statement-breakpoint
 -- Horizon: Home
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJQaou4sjhzBPya1rwfCIqOTU0cV5xgsMeo3u2' WHERE `id` = 'g1U-YLsa84K3B1THbE';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJQaou4sjhzBPya1rwfCIqOTU0cV5xgsMeo3u2.webp' WHERE `id` = 'g1U-YLsa84K3B1THbE';--> statement-breakpoint
 -- Horizon: Hospital
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJEMUYBLfKL5D7TAFe29bymSaPCIQ846MdzGgV' WHERE `id` = '2Z6VKPg-q-b8N9-XGh';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJEMUYBLfKL5D7TAFe29bymSaPCIQ846MdzGgV.webp' WHERE `id` = '2Z6VKPg-q-b8N9-XGh';--> statement-breakpoint
 -- Horizon: Item shop
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJEM4sntLfKL5D7TAFe29bymSaPCIQ846MdzGg' WHERE `id` = 'uMSip0l1_cN7Mil0_v';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJEM4sntLfKL5D7TAFe29bymSaPCIQ846MdzGg.webp' WHERE `id` = 'uMSip0l1_cN7Mil0_v';--> statement-breakpoint
 -- Horizon: Mission Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ8j3AoBkkp45TvAnoIBa0rtCf1lbyXYjVKQ2q' WHERE `id` = '-eUkCY9pIQqPw4CbhH';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ8j3AoBkkp45TvAnoIBa0rtCf1lbyXYjVKQ2q.webp' WHERE `id` = '-eUkCY9pIQqPw4CbhH';--> statement-breakpoint
 -- Horizon: Ramen Shop
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJy2U9zsqukVH2MI5Lo4ehEfAXvZdcmtWqPg7r' WHERE `id` = 'VgmEjYU5V76-oacVbn';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJy2U9zsqukVH2MI5Lo4ehEfAXvZdcmtWqPg7r.webp' WHERE `id` = 'VgmEjYU5V76-oacVbn';--> statement-breakpoint
 -- Horizon: Town Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJZgkeHLaYQrBIUTu69nkMxWmS4ah0O7LVCp8b' WHERE `id` = 'RGUJrSzSNol1nQcYYC';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJZgkeHLaYQrBIUTu69nkMxWmS4ah0O7LVCp8b.webp' WHERE `id` = 'RGUJrSzSNol1nQcYYC';--> statement-breakpoint
 -- Horizon: Training Grounds
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ6991JEDfT5pyNCaUruzhPtAJqb8Kj9mc1nlH' WHERE `id` = 'R1r8P9DXxxV52OUQU0';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ6991JEDfT5pyNCaUruzhPtAJqb8Kj9mc1nlH.webp' WHERE `id` = 'R1r8P9DXxxV52OUQU0';--> statement-breakpoint
 -- Hyorin: ANBU
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJA1baIIoZUC4muiGcQNzjfEndY5y1w20B8hTW' WHERE `id` = 'REDQwkesCawbmiN1-gnkl';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJA1baIIoZUC4muiGcQNzjfEndY5y1w20B8hTW.webp' WHERE `id` = 'REDQwkesCawbmiN1-gnkl';--> statement-breakpoint
 -- Hyorin: Academy
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJmjL8ym2HE4IMO5Goa7cgLxPJ0VC6lU8vbt1A' WHERE `id` = '1zN-m3tSlSCRdytS3URML';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJmjL8ym2HE4IMO5Goa7cgLxPJ0VC6lU8vbt1A.webp' WHERE `id` = '1zN-m3tSlSCRdytS3URML';--> statement-breakpoint
 -- Hyorin: Bank
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJbZGZo4kAtYUndMi56GkX19q0A4PzyeIloBrE' WHERE `id` = '7cOYdBLQJXSF3RZA2Opnf';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJbZGZo4kAtYUndMi56GkX19q0A4PzyeIloBrE.webp' WHERE `id` = '7cOYdBLQJXSF3RZA2Opnf';--> statement-breakpoint
 -- Hyorin: Battle Arena
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ0Sy1P1WgrYldRWJcD6vE10SjNsXHeA9pVMfQ' WHERE `id` = 'bfYvuGPmhIrmLzqAQ8k_T';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ0Sy1P1WgrYldRWJcD6vE10SjNsXHeA9pVMfQ.webp' WHERE `id` = 'bfYvuGPmhIrmLzqAQ8k_T';--> statement-breakpoint
 -- Hyorin: Black Market
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJjrJ5NfC4XzPI8f1v96qBot0Q3wsUp2nxu7SM' WHERE `id` = 'ArPWrrdZTsAKJymUn4mPM';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJjrJ5NfC4XzPI8f1v96qBot0Q3wsUp2nxu7SM.webp' WHERE `id` = 'ArPWrrdZTsAKJymUn4mPM';--> statement-breakpoint
 -- Hyorin: Clan Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJecIa42yV3OvUJQExAi0bGoIZDF74LqSnHRdp' WHERE `id` = 'p_b5dF-ttklDDHCTj4bPp';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJecIa42yV3OvUJQExAi0bGoIZDF74LqSnHRdp.webp' WHERE `id` = 'p_b5dF-ttklDDHCTj4bPp';--> statement-breakpoint
 -- Hyorin: Home
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJSkyI6Aa3jWrEB7TyZlmpoAxMK5Qi16kNPVJu' WHERE `id` = 'a97Rh_Da15i8biQZOpkyO';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJSkyI6Aa3jWrEB7TyZlmpoAxMK5Qi16kNPVJu.webp' WHERE `id` = 'a97Rh_Da15i8biQZOpkyO';--> statement-breakpoint
 -- Hyorin: Hospital
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJXUfKZbqIOpAoLKbZ4nW9Rsil2V67yuFwQhqv' WHERE `id` = 'G2CSNXMgWNTSrZvLBmGk3';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJXUfKZbqIOpAoLKbZ4nW9Rsil2V67yuFwQhqv.webp' WHERE `id` = 'G2CSNXMgWNTSrZvLBmGk3';--> statement-breakpoint
 -- Hyorin: Item shop
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJCdhaL626OYrIJuNP1pvSyz29edFtKbngjRcA' WHERE `id` = 'M1MpdzuiKd18gCT5na1b_';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJCdhaL626OYrIJuNP1pvSyz29edFtKbngjRcA.webp' WHERE `id` = 'M1MpdzuiKd18gCT5na1b_';--> statement-breakpoint
 -- Hyorin: Mission Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJv6iSjTEmSnXwslYEpV1yOeNL8gMtqhjPdf36' WHERE `id` = 'TXaOVlOl7dtGXDltv8Y0Z';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJv6iSjTEmSnXwslYEpV1yOeNL8gMtqhjPdf36.webp' WHERE `id` = 'TXaOVlOl7dtGXDltv8Y0Z';--> statement-breakpoint
 -- Hyorin: Ramen Shop
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJOXce2nVHevxIThUauQkGJEBY3D2cPqy8f5sp' WHERE `id` = '4syKSbOTZ_zr2tq4VctgJ';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJOXce2nVHevxIThUauQkGJEBY3D2cPqy8f5sp.webp' WHERE `id` = '4syKSbOTZ_zr2tq4VctgJ';--> statement-breakpoint
 -- Hyorin: Town Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJt5IfImUYJDfpFXWm3nrcPluEtIZqyLkaSV1j' WHERE `id` = 'UlMRTKkynMfjDuqNlVFJi';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJt5IfImUYJDfpFXWm3nrcPluEtIZqyLkaSV1j.webp' WHERE `id` = 'UlMRTKkynMfjDuqNlVFJi';--> statement-breakpoint
 -- Hyorin: Training Grounds
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJlMWZZ6KrWYxAsuC7ofQn9pM45OD0ERqkdBXJ' WHERE `id` = 'QyHMOwQvpmD91HdkLT5dt';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJlMWZZ6KrWYxAsuC7ofQn9pM45OD0ERqkdBXJ.webp' WHERE `id` = 'QyHMOwQvpmD91HdkLT5dt';--> statement-breakpoint
 -- Shirohana: ANBU
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJg0EDOOcU9cpECTimBdjaqbNn7vQsxGR1wLk4' WHERE `id` = 'ZOefoWWrwTtxbKUH2pnE8';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJg0EDOOcU9cpECTimBdjaqbNn7vQsxGR1wLk4.webp' WHERE `id` = 'ZOefoWWrwTtxbKUH2pnE8';--> statement-breakpoint
 -- Shirohana: Academy
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJDv4UVKzEwoh0WXMnscL279N8ayVQUCbRzS3p' WHERE `id` = 'C82Yxkt9by85-xQlwRBOw';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJDv4UVKzEwoh0WXMnscL279N8ayVQUCbRzS3p.webp' WHERE `id` = 'C82Yxkt9by85-xQlwRBOw';--> statement-breakpoint
 -- Shirohana: Bank
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJuJZQvrCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b' WHERE `id` = 'wEm7K5A4PdKhy1bNTn9vS';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJuJZQvrCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b.webp' WHERE `id` = 'wEm7K5A4PdKhy1bNTn9vS';--> statement-breakpoint
 -- Shirohana: Battle Arena
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJTedJ685IU29dZYJPoOKSh5vmlqatMub3EigH' WHERE `id` = 'IXOCEjm_HpVDpMxy9zeHs';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJTedJ685IU29dZYJPoOKSh5vmlqatMub3EigH.webp' WHERE `id` = 'IXOCEjm_HpVDpMxy9zeHs';--> statement-breakpoint
 -- Shirohana: Black Market
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzWF9MtemvaQu94EYJs8HpxVzofny6iPtbgCZ' WHERE `id` = 'D866KKvQtcOUCt_RcMvZa';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzWF9MtemvaQu94EYJs8HpxVzofny6iPtbgCZ.webp' WHERE `id` = 'D866KKvQtcOUCt_RcMvZa';--> statement-breakpoint
 -- Shirohana: Clan Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJCxlBp426OYrIJuNP1pvSyz29edFtKbngjRcA' WHERE `id` = 'Lqdc81Zy5sMtWCTnGyCby';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJCxlBp426OYrIJuNP1pvSyz29edFtKbngjRcA.webp' WHERE `id` = 'Lqdc81Zy5sMtWCTnGyCby';--> statement-breakpoint
 -- Shirohana: Home
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzmjULremvaQu94EYJs8HpxVzofny6iPtbgCZ' WHERE `id` = 'NRXDQYudIyb8RIljwNkm7';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzmjULremvaQu94EYJs8HpxVzofny6iPtbgCZ.webp' WHERE `id` = 'NRXDQYudIyb8RIljwNkm7';--> statement-breakpoint
 -- Shirohana: Hospital
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJmSpq8dHE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap' WHERE `id` = 'OvwayKVzCk78B08uWRZvS';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJmSpq8dHE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap.webp' WHERE `id` = 'OvwayKVzCk78B08uWRZvS';--> statement-breakpoint
 -- Shirohana: Item shop
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ6VpHsCDfT5pyNCaUruzhPtAJqb8Kj9mc1nlH' WHERE `id` = 'h3uFu6GfKLczp9pKivGco';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ6VpHsCDfT5pyNCaUruzhPtAJqb8Kj9mc1nlH.webp' WHERE `id` = 'h3uFu6GfKLczp9pKivGco';--> statement-breakpoint
 -- Shirohana: Mission Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJc5lww5SnxBpQqGNDcTHbLmYz8uXAl3oa54ti' WHERE `id` = 'keqtU5WrMzufl1DFYJEt1';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJc5lww5SnxBpQqGNDcTHbLmYz8uXAl3oa54ti.webp' WHERE `id` = 'keqtU5WrMzufl1DFYJEt1';--> statement-breakpoint
 -- Shirohana: Ramen Shop
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJTgfBho5IU29dZYJPoOKSh5vmlqatMub3EigH' WHERE `id` = 'bI658UPyvJeGtu41dqvX7';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJTgfBho5IU29dZYJPoOKSh5vmlqatMub3EigH.webp' WHERE `id` = 'bI658UPyvJeGtu41dqvX7';--> statement-breakpoint
 -- Shirohana: Town Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJvstQicEmSnXwslYEpV1yOeNL8gMtqhjPdf36' WHERE `id` = 'Qnt0h_jvg5h2DYxZGk14Y';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJvstQicEmSnXwslYEpV1yOeNL8gMtqhjPdf36.webp' WHERE `id` = 'Qnt0h_jvg5h2DYxZGk14Y';--> statement-breakpoint
 -- Shirohana: Training Grounds
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJuE7V4ZCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b' WHERE `id` = 'k2TAiE-Ytnd5xdfQrGfXG';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJuE7V4ZCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b.webp' WHERE `id` = 'k2TAiE-Ytnd5xdfQrGfXG';--> statement-breakpoint
 -- Syndicate: Academy
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJDv4UVKzEwoh0WXMnscL279N8ayVQUCbRzS3p' WHERE `id` = 'nqeS3yy9snixhPRD9PsZ0';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJDv4UVKzEwoh0WXMnscL279N8ayVQUCbRzS3p.webp' WHERE `id` = 'nqeS3yy9snixhPRD9PsZ0';--> statement-breakpoint
 -- Syndicate: Auction House
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzWqr3LemvaQu94EYJs8HpxVzofny6iPtbgCZ' WHERE `id` = 'MeiAuctionHouse-Syndct26';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzWqr3LemvaQu94EYJs8HpxVzofny6iPtbgCZ.webp' WHERE `id` = 'MeiAuctionHouse-Syndct26';--> statement-breakpoint
 -- Syndicate: Bank
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJu7nO4gCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b' WHERE `id` = 'AO5zgAvEir7LO_7Trj3ah';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJu7nO4gCyJLoOFkrcn4gxSwCfEQ9eMNXZlG8b.webp' WHERE `id` = 'AO5zgAvEir7LO_7Trj3ah';--> statement-breakpoint
 -- Syndicate: Battle Arena
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ5MTwNj797jl4ubX8xrRqTZasyMp2WA5eLGUP' WHERE `id` = 'UrVycqOhzBo0rLMQ2ie4L';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ5MTwNj797jl4ubX8xrRqTZasyMp2WA5eLGUP.webp' WHERE `id` = 'UrVycqOhzBo0rLMQ2ie4L';--> statement-breakpoint
 -- Syndicate: Black Market
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJxKyrvKWZsq9k0Von5rUfP6OgQ2TyptCKHS4u' WHERE `id` = 'eLpEB0nStid710TDBwa25';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJxKyrvKWZsq9k0Von5rUfP6OgQ2TyptCKHS4u.webp' WHERE `id` = 'eLpEB0nStid710TDBwa25';--> statement-breakpoint
 -- Syndicate: Crimes Board
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJhl3qGAMfUBdnwAX5LTajlNc4mrgzi0RJtqpM' WHERE `id` = 'lc1Sbrok_2Fj75stxmQEs';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJhl3qGAMfUBdnwAX5LTajlNc4mrgzi0RJtqpM.webp' WHERE `id` = 'lc1Sbrok_2Fj75stxmQEs';--> statement-breakpoint
 -- Syndicate: Factions
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJCxlBp426OYrIJuNP1pvSyz29edFtKbngjRcA' WHERE `id` = 'qdc81Zy5sMtasdCTnGyCby';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJCxlBp426OYrIJuNP1pvSyz29edFtKbngjRcA.webp' WHERE `id` = 'qdc81Zy5sMtasdCTnGyCby';--> statement-breakpoint
 -- Syndicate: Home
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ2eB5kHnMXlcRpYmJ5do0zKw4Qx6PVEtBa9b8' WHERE `id` = 'Hr2vM5kLVj24fCYRSpHpy';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ2eB5kHnMXlcRpYmJ5do0zKw4Qx6PVEtBa9b8.webp' WHERE `id` = 'Hr2vM5kLVj24fCYRSpHpy';--> statement-breakpoint
 -- Syndicate: Hospital
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJOdA5nJVHevxIThUauQkGJEBY3D2cPqy8f5sp' WHERE `id` = '7oKXGmGMphE3rh2sZX1yi';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJOdA5nJVHevxIThUauQkGJEBY3D2cPqy8f5sp.webp' WHERE `id` = '7oKXGmGMphE3rh2sZX1yi';--> statement-breakpoint
 -- Syndicate: Item shop
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJAaGq3RFoZUC4muiGcQNzjfEndY5y1w20B8hT' WHERE `id` = '1h2B_fkmIKTOM-hoy2eYm';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJAaGq3RFoZUC4muiGcQNzjfEndY5y1w20B8hT.webp' WHERE `id` = '1h2B_fkmIKTOM-hoy2eYm';--> statement-breakpoint
 -- Syndicate: Ramen Shop
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJDs9QX7zEwoh0WXMnscL279N8ayVQUCbRzS3p' WHERE `id` = 'WFqxUlrNQT2BE_PNheL-y';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJDs9QX7zEwoh0WXMnscL279N8ayVQUCbRzS3p.webp' WHERE `id` = 'WFqxUlrNQT2BE_PNheL-y';--> statement-breakpoint
 -- Syndicate: Rumours
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJouGlVQZ9MPZpHJ7VliuEWDfATdxhv62SXnm4' WHERE `id` = '1q_wck3sA4NsWZi3vTjuR';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJouGlVQZ9MPZpHJ7VliuEWDfATdxhv62SXnm4.webp' WHERE `id` = '1q_wck3sA4NsWZi3vTjuR';--> statement-breakpoint
 -- Syndicate: Training Grounds
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzb7T2zemvaQu94EYJs8HpxVzofny6iPtbgCZ' WHERE `id` = 'Du3kNxteWFj5iC5kTeTiX';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzb7T2zemvaQu94EYJs8HpxVzofny6iPtbgCZ.webp' WHERE `id` = 'Du3kNxteWFj5iC5kTeTiX';--> statement-breakpoint
 -- Tsukimori: ANBU
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJeebsANyV3OvUJQExAi0bGoIZDF74LqSnHRdp' WHERE `id` = 'TzngcYXAYsSDkd0CoImOM';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJeebsANyV3OvUJQExAi0bGoIZDF74LqSnHRdp.webp' WHERE `id` = 'TzngcYXAYsSDkd0CoImOM';--> statement-breakpoint
 -- Tsukimori: Academy
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ8PljuOkkp45TvAnoIBa0rtCf1lbyXYjVKQ2q' WHERE `id` = 't1otfv7FoyZfP9zoaw2Mh';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ8PljuOkkp45TvAnoIBa0rtCf1lbyXYjVKQ2q.webp' WHERE `id` = 't1otfv7FoyZfP9zoaw2Mh';--> statement-breakpoint
 -- Tsukimori: Bank
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJHWjc56QvYURJhgs76VZtf9wxpMa13Cq0iOnr' WHERE `id` = '7AbyMSMZpOidwJEtMnW2G';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJHWjc56QvYURJhgs76VZtf9wxpMa13Cq0iOnr.webp' WHERE `id` = '7AbyMSMZpOidwJEtMnW2G';--> statement-breakpoint
 -- Tsukimori: Battle Arena
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ2MBv82nMXlcRpYmJ5do0zKw4Qx6PVEtBa9b8' WHERE `id` = '6pbR9RMfZiKhOALs8pc2c';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ2MBv82nMXlcRpYmJ5do0zKw4Qx6PVEtBa9b8.webp' WHERE `id` = '6pbR9RMfZiKhOALs8pc2c';--> statement-breakpoint
 -- Tsukimori: Black Market
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJeX9cMiyV3OvUJQExAi0bGoIZDF74LqSnHRdp' WHERE `id` = 'xEJ0grBOPUH3ExuBMkrYF';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJeX9cMiyV3OvUJQExAi0bGoIZDF74LqSnHRdp.webp' WHERE `id` = 'xEJ0grBOPUH3ExuBMkrYF';--> statement-breakpoint
 -- Tsukimori: Clan Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJg3zvwmscU9cpECTimBdjaqbNn7vQsxGR1wLk' WHERE `id` = 'XzpL5fteKgtQPtCOgk-Um';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJg3zvwmscU9cpECTimBdjaqbNn7vQsxGR1wLk.webp' WHERE `id` = 'XzpL5fteKgtQPtCOgk-Um';--> statement-breakpoint
 -- Tsukimori: Home
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJHUDNZLQvYURJhgs76VZtf9wxpMa13Cq0iOnr' WHERE `id` = 'g1U-YLsZV-a84K3B1THbE';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJHUDNZLQvYURJhgs76VZtf9wxpMa13Cq0iOnr.webp' WHERE `id` = 'g1U-YLsZV-a84K3B1THbE';--> statement-breakpoint
 -- Tsukimori: Hospital
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJtoT1voUYJDfpFXWm3nrcPluEtIZqyLkaSV1j' WHERE `id` = '2Z6VKPg-q-frdb8N9-XGh';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJtoT1voUYJDfpFXWm3nrcPluEtIZqyLkaSV1j.webp' WHERE `id` = '2Z6VKPg-q-frdb8N9-XGh';--> statement-breakpoint
 -- Tsukimori: Item shop
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJmz1O9AHE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap' WHERE `id` = 'uMSip06bdl1_cN7Mil0_v';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJmz1O9AHE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap.webp' WHERE `id` = 'uMSip06bdl1_cN7Mil0_v';--> statement-breakpoint
 -- Tsukimori: Mission Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJy0fXJ1ukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp' WHERE `id` = '-eUkCY9pIQqPwbU34CbhH';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJy0fXJ1ukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp.webp' WHERE `id` = '-eUkCY9pIQqPwbU34CbhH';--> statement-breakpoint
 -- Tsukimori: Ramen Shop
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJTw17M65IU29dZYJPoOKSh5vmlqatMub3EigH' WHERE `id` = 'Vgmvh6EjYU5V76-oacVbn';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJTw17M65IU29dZYJPoOKSh5vmlqatMub3EigH.webp' WHERE `id` = 'Vgmvh6EjYU5V76-oacVbn';--> statement-breakpoint
 -- Tsukimori: Town Hall
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJtcYHhfUYJDfpFXWm3nrcPluEtIZqyLkaSV1j' WHERE `id` = 'RGUJrRejSzSNol1nQcYYC';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJtcYHhfUYJDfpFXWm3nrcPluEtIZqyLkaSV1j.webp' WHERE `id` = 'RGUJrRejSzSNol1nQcYYC';--> statement-breakpoint
 -- Tsukimori: Training Grounds
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJOHJNYtVHevxIThUauQkGJEBY3D2cPqy8f5sp' WHERE `id` = 'R1r8P9sqLDXxxV52OUQU0';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJOHJNYtVHevxIThUauQkGJEBY3D2cPqy8f5sp.webp' WHERE `id` = 'R1r8P9sqLDXxxV52OUQU0';--> statement-breakpoint
 -- Wake Island: Administration Building
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzc2KxYemvaQu94EYJs8HpxVzofny6iPtbgCZ' WHERE `id` = 'YMV7Kbo1OduGfNDYfq5';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJzc2KxYemvaQu94EYJs8HpxVzofny6iPtbgCZ.webp' WHERE `id` = 'YMV7Kbo1OduGfNDYfq5';--> statement-breakpoint
 -- Wake Island: Auction House
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJWt5x2Tvszvj71yaSYC0MDOmbko5q9JAGuLHf' WHERE `id` = 'AuctionHouse_WakeIsland';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJWt5x2Tvszvj71yaSYC0MDOmbko5q9JAGuLHf.webp' WHERE `id` = 'AuctionHouse_WakeIsland';--> statement-breakpoint
 -- Wake Island: Colosseum
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJmoCFKnHE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap' WHERE `id` = 'YKbo1OduGfNDYfq5Iv';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJmoCFKnHE4IMO5Goa7cgLxPJ0VC6lU8vbt1Ap.webp' WHERE `id` = 'YKbo1OduGfNDYfq5Iv';--> statement-breakpoint
 -- Wake Island: Global ANBU HQ
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJZo3FPhaYQrBIUTu69nkMxWmS4ah0O7LVCp8b' WHERE `id` = 'YMV7Kbo1OduGfNDYfq5I2';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJZo3FPhaYQrBIUTu69nkMxWmS4ah0O7LVCp8b.webp' WHERE `id` = 'YMV7Kbo1OduGfNDYfq5I2';--> statement-breakpoint
 -- Wake Island: History Building
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJRcDsuGQ0udmODoNtpa0FMcwI4k2Eq7nJhyvj' WHERE `id` = 'YMV7Kbo1OduGfNDYfq5I1';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJRcDsuGQ0udmODoNtpa0FMcwI4k2Eq7nJhyvj.webp' WHERE `id` = 'YMV7Kbo1OduGfNDYfq5I1';--> statement-breakpoint
 -- Wake Island: Mini Games
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJmjtXF2mHE4IMO5Goa7cgLxPJ0VC6lU8vbt1A' WHERE `id` = 'fldisuagfeidg';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJmjtXF2mHE4IMO5Goa7cgLxPJ0VC6lU8vbt1A.webp' WHERE `id` = 'fldisuagfeidg';--> statement-breakpoint
 -- Wake Island: Science Building
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJjc1yF34XzPI8f1v96qBot0Q3wsUp2nxu7SMb' WHERE `id` = 'YMV7Kbo1OduGfNDYfq5Iv';--> statement-breakpoint
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJjc1yF34XzPI8f1v96qBot0Q3wsUp2nxu7SMb.webp' WHERE `id` = 'YMV7Kbo1OduGfNDYfq5Iv';--> statement-breakpoint
 -- Wake Island: Souvenir Shop
-UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ0S62GrpgrYldRWJcD6vE10SjNsXHeA9pVMfQ' WHERE `id` = 'YMV7Kbo1OduGfNDYfq5I3';
+UPDATE `VillageStructure` SET `image` = 'https://ui0arpl8sm.ufs.sh/f/Hzww9EQvYURJ0S62GrpgrYldRWJcD6vE10SjNsXHeA9pVMfQ.webp' WHERE `id` = 'YMV7Kbo1OduGfNDYfq5I3';

--- a/app/drizzle/migrations/meta/0020_snapshot.json
+++ b/app/drizzle/migrations/meta/0020_snapshot.json
@@ -1,0 +1,15120 @@
+{
+  "id": "035002c0-928c-469d-bf03-c6e58b694fdf",
+  "prevId": "cc622ad6-0935-44cc-a306-3cec3579258d",
+  "version": "5",
+  "dialect": "mysql",
+  "tables": {
+    "AbEvent": {
+      "name": "AbEvent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "experiment": {
+          "name": "experiment",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "AbEvent_userId_idx": {
+          "name": "AbEvent_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "AbEvent_experiment_idx": {
+          "name": "AbEvent_experiment_idx",
+          "columns": [
+            "experiment"
+          ],
+          "isUnique": false
+        },
+        "AbEvent_event_idx": {
+          "name": "AbEvent_event_idx",
+          "columns": [
+            "event"
+          ],
+          "isUnique": false
+        },
+        "AbEvent_source_idx": {
+          "name": "AbEvent_source_idx",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "AbEvent_experiment_event_ip_key": {
+          "name": "AbEvent_experiment_event_ip_key",
+          "columns": [
+            "experiment",
+            "event",
+            "ip"
+          ],
+          "isUnique": true
+        },
+        "AbEvent_createdAt_idx": {
+          "name": "AbEvent_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AbEvent_id": {
+          "name": "AbEvent_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ActionLog": {
+      "name": "ActionLog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "tableName": {
+          "name": "tableName",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relatedId": {
+          "name": "relatedId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "relatedText": {
+          "name": "relatedText",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "relatedImage": {
+          "name": "relatedImage",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "relatedValue": {
+          "name": "relatedValue",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ActionLog_userId_idx": {
+          "name": "ActionLog_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "ActionLog_relatedId_idx": {
+          "name": "ActionLog_relatedId_idx",
+          "columns": [
+            "relatedId"
+          ],
+          "isUnique": false
+        },
+        "ActionLog_tableName_idx": {
+          "name": "ActionLog_tableName_idx",
+          "columns": [
+            "tableName"
+          ],
+          "isUnique": false
+        },
+        "ActionLog_createdAt_idx": {
+          "name": "ActionLog_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ActionLog_id": {
+          "name": "ActionLog_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ActivityStreakConfig": {
+      "name": "ActivityStreakConfig",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "totalDays": {
+          "name": "totalDays",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 14
+        },
+        "streakType": {
+          "name": "streakType",
+          "type": "enum('RECURRING','EVENT_PASS')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'RECURRING'"
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "ryoCost": {
+          "name": "ryoCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "repsCost": {
+          "name": "repsCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "seichiSilverCost": {
+          "name": "seichiSilverCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ActivityStreakConfig_id": {
+          "name": "ActivityStreakConfig_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ActivityStreakReward": {
+      "name": "ActivityStreakReward",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "configId": {
+          "name": "configId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dayNumber": {
+          "name": "dayNumber",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewards": {
+          "name": "rewards",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "ActivityStreakReward_configId_idx": {
+          "name": "ActivityStreakReward_configId_idx",
+          "columns": [
+            "configId"
+          ],
+          "isUnique": false
+        },
+        "ActivityStreakReward_dayNumber_idx": {
+          "name": "ActivityStreakReward_dayNumber_idx",
+          "columns": [
+            "dayNumber"
+          ],
+          "isUnique": false
+        },
+        "ActivityStreakReward_configId_dayNumber_key": {
+          "name": "ActivityStreakReward_configId_dayNumber_key",
+          "columns": [
+            "configId",
+            "dayNumber"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ActivityStreakReward_id": {
+          "name": "ActivityStreakReward_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "AiProfile": {
+      "name": "AiProfile",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "includeDefaultRules": {
+          "name": "includeDefaultRules",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "AiProfile_userId_idx": {
+          "name": "AiProfile_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AiProfile_id": {
+          "name": "AiProfile_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "AnbuSquad": {
+      "name": "AnbuSquad",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "leaderId": {
+          "name": "leaderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pvpActivity": {
+          "name": "pvpActivity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "kageOrderId": {
+          "name": "kageOrderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "points": {
+          "name": "points",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "espionageLevel": {
+          "name": "espionageLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stealthLevel": {
+          "name": "stealthLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "leaderOrderId": {
+          "name": "leaderOrderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "AnbuSquad_name_key": {
+          "name": "AnbuSquad_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "AnbuSquad_leaderId_idx": {
+          "name": "AnbuSquad_leaderId_idx",
+          "columns": [
+            "leaderId"
+          ],
+          "isUnique": false
+        },
+        "AnbuSquad_villageId_idx": {
+          "name": "AnbuSquad_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AnbuSquad_id": {
+          "name": "AnbuSquad_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "AuctionBid": {
+      "name": "AuctionBid",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auctionId": {
+          "name": "auctionId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bidderId": {
+          "name": "bidderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('ACTIVE','REFUNDED','WON')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "AuctionBid_auctionId_idx": {
+          "name": "AuctionBid_auctionId_idx",
+          "columns": [
+            "auctionId"
+          ],
+          "isUnique": false
+        },
+        "AuctionBid_bidderId_idx": {
+          "name": "AuctionBid_bidderId_idx",
+          "columns": [
+            "bidderId"
+          ],
+          "isUnique": false
+        },
+        "AuctionBid_amount_idx": {
+          "name": "AuctionBid_amount_idx",
+          "columns": [
+            "amount"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AuctionBid_id": {
+          "name": "AuctionBid_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "AuctionListing": {
+      "name": "AuctionListing",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sellerId": {
+          "name": "sellerId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "buyerId": {
+          "name": "buyerId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userItemId": {
+          "name": "userItemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "listingType": {
+          "name": "listingType",
+          "type": "enum('AUCTION','DIRECT')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startingPrice": {
+          "name": "startingPrice",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "buyoutPrice": {
+          "name": "buyoutPrice",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currentPrice": {
+          "name": "currentPrice",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currencyType": {
+          "name": "currencyType",
+          "type": "enum('MONEY','REPUTATION')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'MONEY'"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('ACTIVE','SOLD','EXPIRED','CANCELLED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "bidderMinLevel": {
+          "name": "bidderMinLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "bidderMaxLevel": {
+          "name": "bidderMaxLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "AuctionListing_sellerId_idx": {
+          "name": "AuctionListing_sellerId_idx",
+          "columns": [
+            "sellerId"
+          ],
+          "isUnique": false
+        },
+        "AuctionListing_buyerId_idx": {
+          "name": "AuctionListing_buyerId_idx",
+          "columns": [
+            "buyerId"
+          ],
+          "isUnique": false
+        },
+        "AuctionListing_userItemId_idx": {
+          "name": "AuctionListing_userItemId_idx",
+          "columns": [
+            "userItemId"
+          ],
+          "isUnique": false
+        },
+        "AuctionListing_targetUserId_idx": {
+          "name": "AuctionListing_targetUserId_idx",
+          "columns": [
+            "targetUserId"
+          ],
+          "isUnique": false
+        },
+        "AuctionListing_status_idx": {
+          "name": "AuctionListing_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "AuctionListing_expiresAt_idx": {
+          "name": "AuctionListing_expiresAt_idx",
+          "columns": [
+            "expiresAt"
+          ],
+          "isUnique": false
+        },
+        "AuctionListing_status_listingType_bidderLevels_idx": {
+          "name": "AuctionListing_status_listingType_bidderLevels_idx",
+          "columns": [
+            "status",
+            "listingType",
+            "bidderMinLevel",
+            "bidderMaxLevel"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AuctionListing_id": {
+          "name": "AuctionListing_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "AutomatedModeration": {
+      "name": "AutomatedModeration",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relationType": {
+          "name": "relationType",
+          "type": "enum('comment','privateMessage','forumPost','userReport','userNindo','clanOrder','anbuOrder','kageOrder','userAvatar')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sexual": {
+          "name": "sexual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sexual_minors": {
+          "name": "sexual_minors",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "harassment": {
+          "name": "harassment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "harassment_threatening": {
+          "name": "harassment_threatening",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hate": {
+          "name": "hate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hate_threatening": {
+          "name": "hate_threatening",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "illicit": {
+          "name": "illicit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "illicit_violent": {
+          "name": "illicit_violent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "self_harm": {
+          "name": "self_harm",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "self_harm_intent": {
+          "name": "self_harm_intent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "self_harm_instructions": {
+          "name": "self_harm_instructions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "violence": {
+          "name": "violence",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "violence_graphic": {
+          "name": "violence_graphic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "AutoMod_userId_idx": {
+          "name": "AutoMod_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "AutoMod_relationType_idx": {
+          "name": "AutoMod_relationType_idx",
+          "columns": [
+            "relationType"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AutomatedModeration_id": {
+          "name": "AutomatedModeration_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Badge": {
+      "name": "Badge",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "Badge_name_key": {
+          "name": "Badge_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Badge_id": {
+          "name": "Badge_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BankTransfers": {
+      "name": "BankTransfers",
+      "columns": {
+        "senderId": {
+          "name": "senderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "receiverId": {
+          "name": "receiverId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('bank','sensei','recruiter')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'bank'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "BankTransfers_senderId_idx": {
+          "name": "BankTransfers_senderId_idx",
+          "columns": [
+            "senderId"
+          ],
+          "isUnique": false
+        },
+        "BankTransfers_receiverId_idx": {
+          "name": "BankTransfers_receiverId_idx",
+          "columns": [
+            "receiverId"
+          ],
+          "isUnique": false
+        },
+        "BankTransfers_senderId_receiverId_idx": {
+          "name": "BankTransfers_senderId_receiverId_idx",
+          "columns": [
+            "senderId",
+            "receiverId"
+          ],
+          "isUnique": false
+        },
+        "BankTransfers_createdAt_idx": {
+          "name": "BankTransfers_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Battle": {
+      "name": "Battle",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "roundStartAt": {
+          "name": "roundStartAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "background": {
+          "name": "background",
+          "type": "enum('ocean','ground','dessert','ice','snow','arena','default')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 13
+        },
+        "height": {
+          "name": "height",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 9
+        },
+        "battleType": {
+          "name": "battleType",
+          "type": "enum('ARENA','COMBAT','SPARRING','KAGE_AI','KAGE_PVP','CLAN_CHALLENGE','CLAN_BATTLE','SHRINE_WAR','TOURNAMENT','QUEST','RANDOM_ENCOUNTER','VILLAGE_PROTECTOR','TRAINING','RANKED_PVP','RANKED_SPARRING','RAID')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usersState": {
+          "name": "usersState",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usersEffects": {
+          "name": "usersEffects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "groundEffects": {
+          "name": "groundEffects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extraState": {
+          "name": "extraState",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewardScaling": {
+          "name": "rewardScaling",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "version": {
+          "name": "version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "round": {
+          "name": "round",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "forceKeepPools": {
+          "name": "forceKeepPools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "activeUserId": {
+          "name": "activeUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Battle_id_version_key": {
+          "name": "Battle_id_version_key",
+          "columns": [
+            "id",
+            "version"
+          ],
+          "isUnique": true
+        },
+        "Battle_battleType_createdAt_idx": {
+          "name": "Battle_battleType_createdAt_idx",
+          "columns": [
+            "battleType",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Battle_id": {
+          "name": "Battle_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BattleAction": {
+      "name": "BattleAction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "battleId": {
+          "name": "battleId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleVersion": {
+          "name": "battleVersion",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleRound": {
+          "name": "battleRound",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "actionId": {
+          "name": "actionId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appliedEffects": {
+          "name": "appliedEffects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "BattleAction_round_key": {
+          "name": "BattleAction_round_key",
+          "columns": [
+            "battleId",
+            "battleVersion",
+            "battleRound"
+          ],
+          "isUnique": true
+        },
+        "BattleAction_createdAt_idx": {
+          "name": "BattleAction_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "BattleAction_battleId_idx": {
+          "name": "BattleAction_battleId_idx",
+          "columns": [
+            "battleId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BattleAction_id": {
+          "name": "BattleAction_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BattleHistory": {
+      "name": "BattleHistory",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "battleId": {
+          "name": "battleId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleType": {
+          "name": "battleType",
+          "type": "enum('ARENA','COMBAT','SPARRING','KAGE_AI','KAGE_PVP','CLAN_CHALLENGE','CLAN_BATTLE','SHRINE_WAR','TOURNAMENT','QUEST','RANDOM_ENCOUNTER','VILLAGE_PROTECTOR','TRAINING','RANKED_PVP','RANKED_SPARRING','RAID')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attackedId": {
+          "name": "attackedId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "defenderId": {
+          "name": "defenderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "BattleHistory_createdAt_idx": {
+          "name": "BattleHistory_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "BattleHistory_battleId_idx": {
+          "name": "BattleHistory_battleId_idx",
+          "columns": [
+            "battleId"
+          ],
+          "isUnique": false
+        },
+        "BattleHistory_battleType_idx": {
+          "name": "BattleHistory_battleType_idx",
+          "columns": [
+            "battleType"
+          ],
+          "isUnique": false
+        },
+        "BattleHistory_attackedId_idx": {
+          "name": "BattleHistory_attackedId_idx",
+          "columns": [
+            "attackedId"
+          ],
+          "isUnique": false
+        },
+        "BattleHistory_defenderId_idx": {
+          "name": "BattleHistory_defenderId_idx",
+          "columns": [
+            "defenderId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BattleHistory_id": {
+          "name": "BattleHistory_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Bloodline": {
+      "name": "Bloodline",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "statClassification": {
+          "name": "statClassification",
+          "type": "enum('Highest','Ninjutsu','Genjutsu','Taijutsu','Bukijutsu')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "regenIncrease": {
+          "name": "regenIncrease",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "NULL"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "enum('D','C','B','A','S','H')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "enum('Easy','Medium','Hard','Expert')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "traits": {
+          "name": "traits",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Bloodline_name_key": {
+          "name": "Bloodline_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "Bloodline_image_key": {
+          "name": "Bloodline_image_key",
+          "columns": [
+            "image"
+          ],
+          "isUnique": false
+        },
+        "Bloodline_village_idx": {
+          "name": "Bloodline_village_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        },
+        "Bloodline_rank_idx": {
+          "name": "Bloodline_rank_idx",
+          "columns": [
+            "rank"
+          ],
+          "isUnique": false
+        },
+        "Bloodline_difficulty_idx": {
+          "name": "Bloodline_difficulty_idx",
+          "columns": [
+            "difficulty"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Bloodline_id": {
+          "name": "Bloodline_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BloodlineReskin": {
+      "name": "BloodlineReskin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bloodlineId": {
+          "name": "bloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "BloodlineReskin_bloodlineId_idx": {
+          "name": "BloodlineReskin_bloodlineId_idx",
+          "columns": [
+            "bloodlineId"
+          ],
+          "isUnique": false
+        },
+        "BloodlineReskin_createdBy_idx": {
+          "name": "BloodlineReskin_createdBy_idx",
+          "columns": [
+            "createdBy"
+          ],
+          "isUnique": false
+        },
+        "BloodlineReskin_bloodlineId_name_key": {
+          "name": "BloodlineReskin_bloodlineId_name_key",
+          "columns": [
+            "bloodlineId",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BloodlineReskin_id": {
+          "name": "BloodlineReskin_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BloodlineRolls": {
+      "name": "BloodlineRolls",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bloodlineId": {
+          "name": "bloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used": {
+          "name": "used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pityRolls": {
+          "name": "pityRolls",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('NATURAL','ITEM','PITY','DIRECT','QUEST','REGISTRATION')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NATURAL'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "enum('D','C','B','A','S','H')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "naturalRollDedupeKey": {
+          "name": "naturalRollDedupeKey",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "type": "stored",
+            "as": "CASE WHEN `type` = 'NATURAL' THEN `userId` ELSE NULL END"
+          }
+        }
+      },
+      "indexes": {
+        "BloodlineRolls_userId_idx": {
+          "name": "BloodlineRolls_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "BloodlineRolls_bloodlineId_idx": {
+          "name": "BloodlineRolls_bloodlineId_idx",
+          "columns": [
+            "bloodlineId"
+          ],
+          "isUnique": false
+        },
+        "BloodlineRolls_natural_roll_per_user_key": {
+          "name": "BloodlineRolls_natural_roll_per_user_key",
+          "columns": [
+            "naturalRollDedupeKey"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BloodlineRolls_id": {
+          "name": "BloodlineRolls_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Bounty": {
+      "name": "Bounty",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creatorUserId": {
+          "name": "creatorUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amountRyo": {
+          "name": "amountRyo",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "originalAmountRyo": {
+          "name": "originalAmountRyo",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('OPEN','CLAIMED','EXPIRED','CANCELLED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'OPEN'"
+        },
+        "claimedByUserId": {
+          "name": "claimedByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "collectedAt": {
+          "name": "collectedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimedAt": {
+          "name": "claimedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "Bounty_targetUserId_idx": {
+          "name": "Bounty_targetUserId_idx",
+          "columns": [
+            "targetUserId"
+          ],
+          "isUnique": false
+        },
+        "Bounty_creatorUserId_idx": {
+          "name": "Bounty_creatorUserId_idx",
+          "columns": [
+            "creatorUserId"
+          ],
+          "isUnique": false
+        },
+        "Bounty_status_idx": {
+          "name": "Bounty_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Bounty_id": {
+          "name": "Bounty_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BountyContribution": {
+      "name": "BountyContribution",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bountyId": {
+          "name": "bountyId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contributorUserId": {
+          "name": "contributorUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amountRyo": {
+          "name": "amountRyo",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "BountyContribution_bountyId_idx": {
+          "name": "BountyContribution_bountyId_idx",
+          "columns": [
+            "bountyId"
+          ],
+          "isUnique": false
+        },
+        "BountyContribution_contributorUserId_idx": {
+          "name": "BountyContribution_contributorUserId_idx",
+          "columns": [
+            "contributorUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BountyContribution_id": {
+          "name": "BountyContribution_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BountySignup": {
+      "name": "BountySignup",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bountyId": {
+          "name": "bountyId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hunterUserId": {
+          "name": "hunterUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "BountySignup_bounty_hunter_key": {
+          "name": "BountySignup_bounty_hunter_key",
+          "columns": [
+            "bountyId",
+            "hunterUserId"
+          ],
+          "isUnique": true
+        },
+        "BountySignup_bountyId_idx": {
+          "name": "BountySignup_bountyId_idx",
+          "columns": [
+            "bountyId"
+          ],
+          "isUnique": false
+        },
+        "BountySignup_hunterUserId_idx": {
+          "name": "BountySignup_hunterUserId_idx",
+          "columns": [
+            "hunterUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BountySignup_id": {
+          "name": "BountySignup_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "CannedResponse": {
+      "name": "CannedResponse",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "CannedResponse_createdByUserId_idx": {
+          "name": "CannedResponse_createdByUserId_idx",
+          "columns": [
+            "createdByUserId"
+          ],
+          "isUnique": false
+        },
+        "CannedResponse_title_idx": {
+          "name": "CannedResponse_title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "CannedResponse_id": {
+          "name": "CannedResponse_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Captcha": {
+      "name": "Captcha",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "captcha": {
+          "name": "captcha",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3) + INTERVAL 1 DAY )"
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "Captcha_userId_key": {
+          "name": "Captcha_userId_key",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "Captcha_used_idx": {
+          "name": "Captcha_used_idx",
+          "columns": [
+            "used"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Captcha_id": {
+          "name": "Captcha_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Clan": {
+      "name": "Clan",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "founderId": {
+          "name": "founderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "leaderId": {
+          "name": "leaderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "coLeader1": {
+          "name": "coLeader1",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coLeader2": {
+          "name": "coLeader2",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coLeader3": {
+          "name": "coLeader3",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin1": {
+          "name": "assassin1",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin2": {
+          "name": "assassin2",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin3": {
+          "name": "assassin3",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin4": {
+          "name": "assassin4",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin5": {
+          "name": "assassin5",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin6": {
+          "name": "assassin6",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin7": {
+          "name": "assassin7",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin8": {
+          "name": "assassin8",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin9": {
+          "name": "assassin9",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin10": {
+          "name": "assassin10",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "leaderOrderId": {
+          "name": "leaderOrderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trainingBoost": {
+          "name": "trainingBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "ryoBoost": {
+          "name": "ryoBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "regenBoost": {
+          "name": "regenBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionRewardBoost": {
+          "name": "missionRewardBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "craftingTimeBoost": {
+          "name": "craftingTimeBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "craftingExpBoost": {
+          "name": "craftingExpBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hunterExpBoost": {
+          "name": "hunterExpBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gathererExpBoost": {
+          "name": "gathererExpBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "elderNomineeId": {
+          "name": "elderNomineeId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "elderCutoffMonth": {
+          "name": "elderCutoffMonth",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "elderCutoffYear": {
+          "name": "elderCutoffYear",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "elderCutoffRank": {
+          "name": "elderCutoffRank",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "activityPoints": {
+          "name": "activityPoints",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "points": {
+          "name": "points",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bank": {
+          "name": "bank",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pvpActivity": {
+          "name": "pvpActivity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "repTreasury": {
+          "name": "repTreasury",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hasHideout": {
+          "name": "hasHideout",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "Clan_name_key": {
+          "name": "Clan_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "Clan_village_idx": {
+          "name": "Clan_village_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Clan_id": {
+          "name": "Clan_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ConceptImage": {
+      "name": "ConceptImage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video": {
+          "name": "video",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mediaType": {
+          "name": "mediaType",
+          "type": "enum('image','video')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'image'"
+        },
+        "replicateId": {
+          "name": "replicateId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'started'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "varchar(5000)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "negative_prompt": {
+          "name": "negative_prompt",
+          "type": "varchar(5000)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "seed": {
+          "name": "seed",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 42
+        },
+        "guidance_scale": {
+          "name": "guidance_scale",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 4
+        },
+        "n_likes": {
+          "name": "n_likes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "n_loves": {
+          "name": "n_loves",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "n_laugh": {
+          "name": "n_laugh",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "n_comments": {
+          "name": "n_comments",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "concept_image_key": {
+          "name": "concept_image_key",
+          "columns": [
+            "image"
+          ],
+          "isUnique": true
+        },
+        "image_done_idx": {
+          "name": "image_done_idx",
+          "columns": [
+            "done"
+          ],
+          "isUnique": false
+        },
+        "image_userId_idx": {
+          "name": "image_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ConceptImage_id": {
+          "name": "ConceptImage_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ContentBackup": {
+      "name": "ContentBackup",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('bloodline','jutsu','item','ai')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sqlText": {
+          "name": "sqlText",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "ContentBackup_type_idx": {
+          "name": "ContentBackup_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "ContentBackup_createdAt_idx": {
+          "name": "ContentBackup_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ContentBackup_id": {
+          "name": "ContentBackup_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ContentTag": {
+      "name": "ContentTag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ContentTag_name_key": {
+          "name": "ContentTag_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ContentTag_id": {
+          "name": "ContentTag_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Conversation": {
+      "name": "Conversation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "isLocked": {
+          "name": "isLocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "isStaffAvailable": {
+          "name": "isStaffAvailable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "Conversation_title_key": {
+          "name": "Conversation_title_key",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "Conversation_createdById_idx": {
+          "name": "Conversation_createdById_idx",
+          "columns": [
+            "createdById"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Conversation_id": {
+          "name": "Conversation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ConversationComment": {
+      "name": "ConversationComment",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reactions": {
+          "name": "reactions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('{}')"
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isReported": {
+          "name": "isReported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isStaffOnly": {
+          "name": "isStaffOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "ConversationComment_userId_idx": {
+          "name": "ConversationComment_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "ConversationComment_createdAt_idx": {
+          "name": "ConversationComment_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "ConversationComment_conversationId_idx": {
+          "name": "ConversationComment_conversationId_idx",
+          "columns": [
+            "conversationId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ConversationComment_id": {
+          "name": "ConversationComment_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "CraftingRequirement": {
+      "name": "CraftingRequirement",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "craftItemId": {
+          "name": "craftItemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requirementItemId": {
+          "name": "requirementItemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "CraftingRequirement_craftItemId_idx": {
+          "name": "CraftingRequirement_craftItemId_idx",
+          "columns": [
+            "craftItemId"
+          ],
+          "isUnique": false
+        },
+        "CraftingRequirement_requirementItemId_idx": {
+          "name": "CraftingRequirement_requirementItemId_idx",
+          "columns": [
+            "requirementItemId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "CraftingRequirement_id": {
+          "name": "CraftingRequirement_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "DailyBankInterest": {
+      "name": "DailyBankInterest",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed": {
+          "name": "claimed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "interestPercent": {
+          "name": "interestPercent",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "DailyBankInterest_userId_idx": {
+          "name": "DailyBankInterest_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "DailyBankInterest_id": {
+          "name": "DailyBankInterest_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "DailyBankInterest_userId_date_key": {
+          "name": "DailyBankInterest_userId_date_key",
+          "columns": [
+            "userId",
+            "date"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "DamageCalculation": {
+      "name": "DamageCalculation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "state": {
+          "name": "state",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "DamageCalculation_userId_idx": {
+          "name": "DamageCalculation_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "DamageCalculation_createdAt_idx": {
+          "name": "DamageCalculation_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "DamageCalculation_id": {
+          "name": "DamageCalculation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "DataBattleAction": {
+      "name": "DataBattleAction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('jutsu','item','bloodline','basic','ai')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contentId": {
+          "name": "contentId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relatedBloodlineId": {
+          "name": "relatedBloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "battleType": {
+          "name": "battleType",
+          "type": "enum('ARENA','COMBAT','SPARRING','KAGE_AI','KAGE_PVP','CLAN_CHALLENGE','CLAN_BATTLE','SHRINE_WAR','TOURNAMENT','QUEST','RANDOM_ENCOUNTER','VILLAGE_PROTECTOR','TRAINING','RANKED_PVP','RANKED_SPARRING','RAID')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "battleWon": {
+          "name": "battleWon",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "DataBattleActions_type_idx": {
+          "name": "DataBattleActions_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "DataBattleActions_battleWon_idx": {
+          "name": "DataBattleActions_battleWon_idx",
+          "columns": [
+            "battleWon"
+          ],
+          "isUnique": false
+        },
+        "DataBattleActions_battleType_idx": {
+          "name": "DataBattleActions_battleType_idx",
+          "columns": [
+            "battleType"
+          ],
+          "isUnique": false
+        },
+        "DataBattleActions_contentId_idx": {
+          "name": "DataBattleActions_contentId_idx",
+          "columns": [
+            "contentId"
+          ],
+          "isUnique": false
+        },
+        "DataBattleActions_count_idx": {
+          "name": "DataBattleActions_count_idx",
+          "columns": [
+            "count"
+          ],
+          "isUnique": false
+        },
+        "DataBattleActions_createdAt": {
+          "name": "DataBattleActions_createdAt",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "DataBattleAction_id": {
+          "name": "DataBattleAction_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "uniqueContentId": {
+          "name": "uniqueContentId",
+          "columns": [
+            "type",
+            "contentId",
+            "battleType",
+            "battleWon",
+            "relatedBloodlineId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "EmailReminder": {
+      "name": "EmailReminder",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callName": {
+          "name": "callName",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latestRejoinRequest": {
+          "name": "latestRejoinRequest",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastActivity": {
+          "name": "lastActivity",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "validated": {
+          "name": "validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "EmailReminder_userId_idx": {
+          "name": "EmailReminder_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "EmailReminder_id": {
+          "name": "EmailReminder_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ForumBoard": {
+      "name": "ForumBoard",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "nPosts": {
+          "name": "nPosts",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "nThreads": {
+          "name": "nThreads",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ForumBoard_name_key": {
+          "name": "ForumBoard_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ForumBoard_id": {
+          "name": "ForumBoard_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ForumPost": {
+      "name": "ForumPost",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isReported": {
+          "name": "isReported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "ForumPost_userId_idx": {
+          "name": "ForumPost_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "ForumPost_threadId_idx": {
+          "name": "ForumPost_threadId_idx",
+          "columns": [
+            "threadId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ForumPost_id": {
+          "name": "ForumPost_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ForumThread": {
+      "name": "ForumThread",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "boardId": {
+          "name": "boardId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nPosts": {
+          "name": "nPosts",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isLocked": {
+          "name": "isLocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "ForumThread_boardId_idx": {
+          "name": "ForumThread_boardId_idx",
+          "columns": [
+            "boardId"
+          ],
+          "isUnique": false
+        },
+        "ForumThread_userId_idx": {
+          "name": "ForumThread_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ForumThread_id": {
+          "name": "ForumThread_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "GameAsset": {
+      "name": "GameAsset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('STATIC','ANIMATION','SCENE_BACKGROUND','SCENE_CHARACTER','SFX','MUSIC')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "frames": {
+          "name": "frames",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "speed": {
+          "name": "speed",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "folder": {
+          "name": "folder",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "licenseDetails": {
+          "name": "licenseDetails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('TNR')"
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "onInitialBattleField": {
+          "name": "onInitialBattleField",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "GameAsset_type_idx": {
+          "name": "GameAsset_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "GameAsset_id": {
+          "name": "GameAsset_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "GameAssetTag": {
+      "name": "GameAssetTag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "GameAssetTag_assetId_tag_key": {
+          "name": "GameAssetTag_assetId_tag_key",
+          "columns": [
+            "assetId",
+            "tagId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "GameAssetTag_id": {
+          "name": "GameAssetTag_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "GameSetting": {
+      "name": "GameSetting",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "name": {
+          "name": "name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "GameSetting_id": {
+          "name": "GameSetting_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "HistoricalAvatar": {
+      "name": "HistoricalAvatar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatarLight": {
+          "name": "avatarLight",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replicateId": {
+          "name": "replicateId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'started'"
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "HistoricalAvatar_replicateId_key": {
+          "name": "HistoricalAvatar_replicateId_key",
+          "columns": [
+            "replicateId"
+          ],
+          "isUnique": true
+        },
+        "HistoricalAvatar_avatar_key": {
+          "name": "HistoricalAvatar_avatar_key",
+          "columns": [
+            "avatar"
+          ],
+          "isUnique": true
+        },
+        "HistoricalAvatar_done_idx": {
+          "name": "HistoricalAvatar_done_idx",
+          "columns": [
+            "done"
+          ],
+          "isUnique": false
+        },
+        "HistoricalAvatar_status_idx": {
+          "name": "HistoricalAvatar_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "HistoricalAvatar_userId_idx": {
+          "name": "HistoricalAvatar_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "HistoricalAvatar_id": {
+          "name": "HistoricalAvatar_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "HistoricalIp": {
+      "name": "HistoricalIp",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usedAt": {
+          "name": "usedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "HistoricalIp_userId_ip_key": {
+          "name": "HistoricalIp_userId_ip_key",
+          "columns": [
+            "userId",
+            "ip"
+          ],
+          "isUnique": true
+        },
+        "HistoricalIp_userId_idx": {
+          "name": "HistoricalIp_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "HistoricalIp_userIp_idx": {
+          "name": "HistoricalIp_userIp_idx",
+          "columns": [
+            "ip"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "HistoricalIp_id": {
+          "name": "HistoricalIp_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "HistoricalSoundEffect": {
+      "name": "HistoricalSoundEffect",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "relationId": {
+          "name": "relationId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replicateId": {
+          "name": "replicateId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "secondsTotal": {
+          "name": "secondsTotal",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "negativePrompt": {
+          "name": "negativePrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'started'"
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "HistoricalSoundEffect_replicateId_idx": {
+          "name": "HistoricalSoundEffect_replicateId_idx",
+          "columns": [
+            "replicateId"
+          ],
+          "isUnique": false
+        },
+        "HistoricalSoundEffect_relationId_idx": {
+          "name": "HistoricalSoundEffect_relationId_idx",
+          "columns": [
+            "relationId"
+          ],
+          "isUnique": false
+        },
+        "HistoricalSoundEffect_userId_idx": {
+          "name": "HistoricalSoundEffect_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "HistoricalSoundEffect_done_idx": {
+          "name": "HistoricalSoundEffect_done_idx",
+          "columns": [
+            "done"
+          ],
+          "isUnique": false
+        },
+        "HistoricalSoundEffect_status_idx": {
+          "name": "HistoricalSoundEffect_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "HistoricalSoundEffect_id": {
+          "name": "HistoricalSoundEffect_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Item": {
+      "name": "Item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "expireFromStoreAt": {
+          "name": "expireFromStoreAt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "itemType": {
+          "name": "itemType",
+          "type": "enum('WEAPON','CONSUMABLE','ARMOR','ACCESSORY','MATERIAL','KEYSTONE','CRYSTAL','OTHER')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "enum('COMMON','RARE','EPIC','LEGENDARY')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot": {
+          "name": "slot",
+          "type": "enum('HEAD','CHEST','LEGS','FEET','HAND','THROWN','ITEM','WAIST','KEYSTONE','NONE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cooldown": {
+          "name": "cooldown",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "weaponType": {
+          "name": "weaponType",
+          "type": "enum('STAFF','AXE','FIST_WEAPON','SHURIKEN','SICKLE','DAGGER','SWORD','POLEARM','FLAIL','CHAIN','FAN','BOW','HAMMER','NONE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "target": {
+          "name": "target",
+          "type": "enum('SELF','OTHER_USER','OPPONENT','ALLY','CHARACTER','GROUND','EMPTY_GROUND')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "enum('SINGLE','ALL','AOE_CIRCLE_SPAWN','AOE_LINE_SHOOT','AOE_WALL_SHOOT','AOE_LARGE_WALL_SHOOT','AOE_CIRCLE_SHOOT','AOE_SPIRAL_SHOOT')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'SINGLE'"
+        },
+        "cost": {
+          "name": "cost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "reputationCost": {
+          "name": "reputationCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "seichiSilverCost": {
+          "name": "seichiSilverCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stackSize": {
+          "name": "stackSize",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destroyOnUse": {
+          "name": "destroyOnUse",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "range": {
+          "name": "range",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "chakraCost": {
+          "name": "chakraCost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "staminaCost": {
+          "name": "staminaCost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "healthCost": {
+          "name": "healthCost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "staminaCostReducePerLvl": {
+          "name": "staminaCostReducePerLvl",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "chakraCostReducePerLvl": {
+          "name": "chakraCostReducePerLvl",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "healthCostReducePerLvl": {
+          "name": "healthCostReducePerLvl",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "actionCostPerc": {
+          "name": "actionCostPerc",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "battleDescription": {
+          "name": "battleDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('')"
+        },
+        "canStack": {
+          "name": "canStack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "maxImbueNumber": {
+          "name": "maxImbueNumber",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "maxDurability": {
+          "name": "maxDurability",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "inShop": {
+          "name": "inShop",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "isEventItem": {
+          "name": "isEventItem",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "maxEquips": {
+          "name": "maxEquips",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "preventBattleUsage": {
+          "name": "preventBattleUsage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "requiredLevel": {
+          "name": "requiredLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "canBeCrafted": {
+          "name": "canBeCrafted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "canBeImbued": {
+          "name": "canBeImbued",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "canBeHunted": {
+          "name": "canBeHunted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "canBeGathered": {
+          "name": "canBeGathered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "canBeTraded": {
+          "name": "canBeTraded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "craftingExperience": {
+          "name": "craftingExperience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crystalTargetTypes": {
+          "name": "crystalTargetTypes",
+          "type": "enum('WEAPON','CONSUMABLE','ARMOR','ACCESSORY','MATERIAL','KEYSTONE','CRYSTAL','OTHER')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bloodlineId": {
+          "name": "bloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "battleUsageType": {
+          "name": "battleUsageType",
+          "type": "enum('PVE','PVP','BOTH')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'BOTH'"
+        }
+      },
+      "indexes": {
+        "Item_name_key": {
+          "name": "Item_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "Item_rarity_idx": {
+          "name": "Item_rarity_idx",
+          "columns": [
+            "rarity"
+          ],
+          "isUnique": false
+        },
+        "Item_itemType_idx": {
+          "name": "Item_itemType_idx",
+          "columns": [
+            "itemType"
+          ],
+          "isUnique": false
+        },
+        "Item_slot_idx": {
+          "name": "Item_slot_idx",
+          "columns": [
+            "slot"
+          ],
+          "isUnique": false
+        },
+        "Item_method_idx": {
+          "name": "Item_method_idx",
+          "columns": [
+            "method"
+          ],
+          "isUnique": false
+        },
+        "Item_target_idx": {
+          "name": "Item_target_idx",
+          "columns": [
+            "target"
+          ],
+          "isUnique": false
+        },
+        "Item_isEventItem_idx": {
+          "name": "Item_isEventItem_idx",
+          "columns": [
+            "isEventItem"
+          ],
+          "isUnique": false
+        },
+        "Item_onlyInShop_idx": {
+          "name": "Item_onlyInShop_idx",
+          "columns": [
+            "inShop"
+          ],
+          "isUnique": false
+        },
+        "Item_cost_idx": {
+          "name": "Item_cost_idx",
+          "columns": [
+            "cost"
+          ],
+          "isUnique": false
+        },
+        "Item_repsCost_idx": {
+          "name": "Item_repsCost_idx",
+          "columns": [
+            "reputationCost"
+          ],
+          "isUnique": false
+        },
+        "Item_requiredLevel_idx": {
+          "name": "Item_requiredLevel_idx",
+          "columns": [
+            "requiredLevel"
+          ],
+          "isUnique": false
+        },
+        "Item_bloodlineId_idx": {
+          "name": "Item_bloodlineId_idx",
+          "columns": [
+            "bloodlineId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Item_id": {
+          "name": "Item_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ItemLoadout": {
+      "name": "ItemLoadout",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "itemData": {
+          "name": "itemData",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "ItemLoadout_userId_idx": {
+          "name": "ItemLoadout_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ItemLoadout_id": {
+          "name": "ItemLoadout_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ItemVariant": {
+      "name": "ItemVariant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "itemId": {
+          "name": "itemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "costType": {
+          "name": "costType",
+          "type": "enum('MONEY','REPUTATION','SEICHI_SILVER','VILLAGE_PRESTIGE','VARIANT_TOKEN')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "order": {
+          "name": "order",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "battleDescription": {
+          "name": "battleDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "ItemVariant_itemId_idx": {
+          "name": "ItemVariant_itemId_idx",
+          "columns": [
+            "itemId"
+          ],
+          "isUnique": false
+        },
+        "ItemVariant_itemId_order_key": {
+          "name": "ItemVariant_itemId_order_key",
+          "columns": [
+            "itemId",
+            "order"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ItemVariant_id": {
+          "name": "ItemVariant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Jutsu": {
+      "name": "Jutsu",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "extraBaseCost": {
+          "name": "extraBaseCost",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "enum('SELF','OTHER_USER','OPPONENT','ALLY','CHARACTER','GROUND','EMPTY_GROUND')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "range": {
+          "name": "range",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cooldown": {
+          "name": "cooldown",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bloodlineId": {
+          "name": "bloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredLevel": {
+          "name": "requiredLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "requiredRank": {
+          "name": "requiredRank",
+          "type": "enum('STUDENT','GENIN','CHUNIN','JONIN','ELITE JONIN','ELDER','NONE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jutsuType": {
+          "name": "jutsuType",
+          "type": "enum('NORMAL','SPECIAL','BLOODLINE','FORBIDDEN','LOYALTY','CLAN','EVENT','AI')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jutsuWeapon": {
+          "name": "jutsuWeapon",
+          "type": "enum('STAFF','AXE','FIST_WEAPON','SHURIKEN','SICKLE','DAGGER','SWORD','POLEARM','FLAIL','CHAIN','FAN','BOW','HAMMER','NONE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "statClassification": {
+          "name": "statClassification",
+          "type": "enum('Highest','Ninjutsu','Genjutsu','Taijutsu','Bukijutsu')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "battleDescription": {
+          "name": "battleDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jutsuRank": {
+          "name": "jutsuRank",
+          "type": "enum('D','C','B','A','S','H')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'D'"
+        },
+        "actionCostPerc": {
+          "name": "actionCostPerc",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 80
+        },
+        "staminaCost": {
+          "name": "staminaCost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.05
+        },
+        "chakraCost": {
+          "name": "chakraCost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.05
+        },
+        "staminaCostReducePerLvl": {
+          "name": "staminaCostReducePerLvl",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "chakraCostReducePerLvl": {
+          "name": "chakraCostReducePerLvl",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "healthCostReducePerLvl": {
+          "name": "healthCostReducePerLvl",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "healthCost": {
+          "name": "healthCost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "enum('SINGLE','ALL','AOE_CIRCLE_SPAWN','AOE_LINE_SHOOT','AOE_WALL_SHOOT','AOE_LARGE_WALL_SHOOT','AOE_CIRCLE_SHOOT','AOE_SPIRAL_SHOOT')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'SINGLE'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "injectableInBattle": {
+          "name": "injectableInBattle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "battleUsageType": {
+          "name": "battleUsageType",
+          "type": "enum('PVE','PVP','BOTH')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'BOTH'"
+        },
+        "parentJutsuId": {
+          "name": "parentJutsuId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredNinjutsuOffence": {
+          "name": "requiredNinjutsuOffence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredNinjutsuDefence": {
+          "name": "requiredNinjutsuDefence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredGenjutsuOffence": {
+          "name": "requiredGenjutsuOffence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredGenjutsuDefence": {
+          "name": "requiredGenjutsuDefence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredTaijutsuOffence": {
+          "name": "requiredTaijutsuOffence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredTaijutsuDefence": {
+          "name": "requiredTaijutsuDefence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredBukijutsuOffence": {
+          "name": "requiredBukijutsuOffence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredBukijutsuDefence": {
+          "name": "requiredBukijutsuDefence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredStrength": {
+          "name": "requiredStrength",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredSpeed": {
+          "name": "requiredSpeed",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredIntelligence": {
+          "name": "requiredIntelligence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredWillpower": {
+          "name": "requiredWillpower",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredBloodlineItemId": {
+          "name": "requiredBloodlineItemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Jutsu_name_key": {
+          "name": "Jutsu_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "Jutsu_image_key": {
+          "name": "Jutsu_image_key",
+          "columns": [
+            "image"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_bloodlineId_idx": {
+          "name": "Jutsu_bloodlineId_idx",
+          "columns": [
+            "bloodlineId"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_villageId_idx": {
+          "name": "Jutsu_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_injectable_idx": {
+          "name": "Jutsu_injectable_idx",
+          "columns": [
+            "injectableInBattle"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_parentJutsuId_idx": {
+          "name": "Jutsu_parentJutsuId_idx",
+          "columns": [
+            "parentJutsuId"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_parentJutsuId_hidden_idx": {
+          "name": "Jutsu_parentJutsuId_hidden_idx",
+          "columns": [
+            "parentJutsuId",
+            "hidden"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_requiredBloodlineItemId_idx": {
+          "name": "Jutsu_requiredBloodlineItemId_idx",
+          "columns": [
+            "requiredBloodlineItemId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Jutsu_id": {
+          "name": "Jutsu_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "JutsuLoadout": {
+      "name": "JutsuLoadout",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "JutsuLoadout_userId_idx": {
+          "name": "JutsuLoadout_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "JutsuLoadout_id": {
+          "name": "JutsuLoadout_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "JutsuReskin": {
+      "name": "JutsuReskin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jutsuId": {
+          "name": "jutsuId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleDescription": {
+          "name": "battleDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "JutsuReskin_userId_idx": {
+          "name": "JutsuReskin_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "JutsuReskin_jutsuId_idx": {
+          "name": "JutsuReskin_jutsuId_idx",
+          "columns": [
+            "jutsuId"
+          ],
+          "isUnique": false
+        },
+        "JutsuReskin_userId_jutsuId_key": {
+          "name": "JutsuReskin_userId_jutsuId_key",
+          "columns": [
+            "userId",
+            "jutsuId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "JutsuReskin_id": {
+          "name": "JutsuReskin_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "KageDefendedChallenges": {
+      "name": "KageDefendedChallenges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kageId": {
+          "name": "kageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "didWin": {
+          "name": "didWin",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "rounds": {
+          "name": "rounds",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "VillageKageChallenges_villageId_idx": {
+          "name": "VillageKageChallenges_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        },
+        "VillageKageChallenges_userId_idx": {
+          "name": "VillageKageChallenges_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "VillageKageChallenges_kageID_idx": {
+          "name": "VillageKageChallenges_kageID_idx",
+          "columns": [
+            "kageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "KageDefendedChallenges_id": {
+          "name": "KageDefendedChallenges_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "LinkPromotion": {
+      "name": "LinkPromotion",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "points": {
+          "name": "points",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "reviewedBy": {
+          "name": "reviewedBy",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewedAt": {
+          "name": "reviewedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "LinkPromotion_userId_idx": {
+          "name": "LinkPromotion_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "LinkPromotion_reviewedBy_idx": {
+          "name": "LinkPromotion_reviewedBy_idx",
+          "columns": [
+            "reviewedBy"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LinkPromotion_id": {
+          "name": "LinkPromotion_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "LogTimeDurations": {
+      "name": "LogTimeDurations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "battleType": {
+          "name": "battleType",
+          "type": "enum('ARENA','COMBAT','SPARRING','KAGE_AI','KAGE_PVP','CLAN_CHALLENGE','CLAN_BATTLE','SHRINE_WAR','TOURNAMENT','QUEST','RANDOM_ENCOUNTER','VILLAGE_PROTECTOR','TRAINING','RANKED_PVP','RANKED_SPARRING','RAID')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "winnerLevel": {
+          "name": "winnerLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "loserLevel": {
+          "name": "loserLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rounds": {
+          "name": "rounds",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "LogBattleLengths_battleType_idx": {
+          "name": "LogBattleLengths_battleType_idx",
+          "columns": [
+            "battleType"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LogTimeDurations_id": {
+          "name": "LogTimeDurations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "uniqueEntry": {
+          "name": "uniqueEntry",
+          "columns": [
+            "battleType",
+            "winnerLevel",
+            "loserLevel",
+            "rounds"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "LogQueueLengths": {
+      "name": "LogQueueLengths",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "rankedRank": {
+          "name": "rankedRank",
+          "type": "enum('Unranked','Wood','Adept','Master','Legend','Sannin')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ceiledMinutes": {
+          "name": "ceiledMinutes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LogQueueLengths_id": {
+          "name": "LogQueueLengths_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "uniqueEntry": {
+          "name": "uniqueEntry",
+          "columns": [
+            "rankedRank",
+            "ceiledMinutes"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "LogRankedPicks": {
+      "name": "LogRankedPicks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('jutsu','item','consumable')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contentId": {
+          "name": "contentId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleType": {
+          "name": "battleType",
+          "type": "enum('ARENA','COMBAT','SPARRING','KAGE_AI','KAGE_PVP','CLAN_CHALLENGE','CLAN_BATTLE','SHRINE_WAR','TOURNAMENT','QUEST','RANDOM_ENCOUNTER','VILLAGE_PROTECTOR','TRAINING','RANKED_PVP','RANKED_SPARRING','RAID')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LogRankedPicks_id": {
+          "name": "LogRankedPicks_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "uniqueContentId": {
+          "name": "uniqueContentId",
+          "columns": [
+            "type",
+            "contentId",
+            "battleType"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "MapAsset": {
+      "name": "MapAsset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "windAffected": {
+          "name": "windAffected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "small": {
+          "name": "small",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "randomRotation": {
+          "name": "randomRotation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "renderScale": {
+          "name": "renderScale",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "licenseDetails": {
+          "name": "licenseDetails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('TNR')"
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "MapAsset_key_key": {
+          "name": "MapAsset_key_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "MapAsset_category_idx": {
+          "name": "MapAsset_category_idx",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "MapAsset_id": {
+          "name": "MapAsset_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "MapTerrain": {
+      "name": "MapTerrain",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "colors": {
+          "name": "colors",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "textureUrl": {
+          "name": "textureUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "swatchColor": {
+          "name": "swatchColor",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleBiome": {
+          "name": "battleBiome",
+          "type": "enum('ocean','ground','dessert','ice','snow','arena','default')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ground'"
+        },
+        "isWater": {
+          "name": "isWater",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "depression": {
+          "name": "depression",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "defaultWalkCost": {
+          "name": "defaultWalkCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "protected": {
+          "name": "protected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "licenseDetails": {
+          "name": "licenseDetails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('TNR')"
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "MapTerrain_key_key": {
+          "name": "MapTerrain_key_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "MapTerrain_id": {
+          "name": "MapTerrain_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "MpvpBattleQueue": {
+      "name": "MpvpBattleQueue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "winnerId": {
+          "name": "winnerId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "battleId": {
+          "name": "battleId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "battleType": {
+          "name": "battleType",
+          "type": "enum('CLAN_BATTLE','SHRINE_BATTLE','RAID_BATTLE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CLAN_BATTLE'"
+        },
+        "attackerEntityId": {
+          "name": "attackerEntityId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "defenderEntityId": {
+          "name": "defenderEntityId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "MpvpBattleQueue_battleId_idx": {
+          "name": "MpvpBattleQueue_battleId_idx",
+          "columns": [
+            "battleId"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleQueue_winnerId_idx": {
+          "name": "MpvpBattleQueue_winnerId_idx",
+          "columns": [
+            "winnerId"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleQueue_battleType_idx": {
+          "name": "MpvpBattleQueue_battleType_idx",
+          "columns": [
+            "battleType"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleQueue_sector_idx": {
+          "name": "MpvpBattleQueue_sector_idx",
+          "columns": [
+            "sector"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleQueue_attackerEntityId_idx": {
+          "name": "MpvpBattleQueue_attackerEntityId_idx",
+          "columns": [
+            "attackerEntityId"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleQueue_defenderEntityId_idx": {
+          "name": "MpvpBattleQueue_defenderEntityId_idx",
+          "columns": [
+            "defenderEntityId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "MpvpBattleQueue_id": {
+          "name": "MpvpBattleQueue_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "MpvpBattleUser": {
+      "name": "MpvpBattleUser",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clanBattleId": {
+          "name": "clanBattleId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "side": {
+          "name": "side",
+          "type": "enum('ATTACKER','DEFENDER')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot": {
+          "name": "slot",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "MpvpBattleUser_clanBattleId_idx": {
+          "name": "MpvpBattleUser_clanBattleId_idx",
+          "columns": [
+            "clanBattleId"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleUser_userId_idx": {
+          "name": "MpvpBattleUser_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleUser_side_idx": {
+          "name": "MpvpBattleUser_side_idx",
+          "columns": [
+            "side"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleUser_clanBattleId_side_slot_key": {
+          "name": "MpvpBattleUser_clanBattleId_side_slot_key",
+          "columns": [
+            "clanBattleId",
+            "side",
+            "slot"
+          ],
+          "isUnique": true
+        },
+        "MpvpBattleUser_userId_key": {
+          "name": "MpvpBattleUser_userId_key",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "MpvpBattleUser_id": {
+          "name": "MpvpBattleUser_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Notification": {
+      "name": "Notification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Notification_createdAt_idx": {
+          "name": "Notification_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Notification_id": {
+          "name": "Notification_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "PaypalSubscription": {
+      "name": "PaypalSubscription",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "affectedUserId": {
+          "name": "affectedUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "federalStatus": {
+          "name": "federalStatus",
+          "type": "enum('NONE','NORMAL','SILVER','GOLD')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "PaypalSubscription_subscriptionId_key": {
+          "name": "PaypalSubscription_subscriptionId_key",
+          "columns": [
+            "subscriptionId"
+          ],
+          "isUnique": true
+        },
+        "PaypalSubscription_orderId_key": {
+          "name": "PaypalSubscription_orderId_key",
+          "columns": [
+            "orderId"
+          ],
+          "isUnique": true
+        },
+        "PaypalSubscription_createdById_idx": {
+          "name": "PaypalSubscription_createdById_idx",
+          "columns": [
+            "createdById"
+          ],
+          "isUnique": false
+        },
+        "PaypalSubscription_affectedUserId_idx": {
+          "name": "PaypalSubscription_affectedUserId_idx",
+          "columns": [
+            "affectedUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "PaypalSubscription_id": {
+          "name": "PaypalSubscription_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "PaypalTransaction": {
+      "name": "PaypalTransaction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "affectedUserId": {
+          "name": "affectedUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transactionId": {
+          "name": "transactionId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transactionUpdatedDate": {
+          "name": "transactionUpdatedDate",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invoiceId": {
+          "name": "invoiceId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('REP_PURCHASE','REFERRAL')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'REP_PURCHASE'"
+        },
+        "reputationPoints": {
+          "name": "reputationPoints",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rawData": {
+          "name": "rawData",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "PaypalTransaction_orderId_key": {
+          "name": "PaypalTransaction_orderId_key",
+          "columns": [
+            "orderId"
+          ],
+          "isUnique": true
+        },
+        "PaypalTransaction_createdById_idx": {
+          "name": "PaypalTransaction_createdById_idx",
+          "columns": [
+            "createdById"
+          ],
+          "isUnique": false
+        },
+        "PaypalTransaction_transactionId_idx": {
+          "name": "PaypalTransaction_transactionId_idx",
+          "columns": [
+            "transactionId"
+          ],
+          "isUnique": false
+        },
+        "PaypalTransaction_invoiceId_idx": {
+          "name": "PaypalTransaction_invoiceId_idx",
+          "columns": [
+            "invoiceId"
+          ],
+          "isUnique": false
+        },
+        "PaypalTransaction_affectedUserId_idx": {
+          "name": "PaypalTransaction_affectedUserId_idx",
+          "columns": [
+            "affectedUserId"
+          ],
+          "isUnique": false
+        },
+        "PaypalTransaction_reputationPoints_idx": {
+          "name": "PaypalTransaction_reputationPoints_idx",
+          "columns": [
+            "reputationPoints"
+          ],
+          "isUnique": false
+        },
+        "PaypalTransaction_type_idx": {
+          "name": "PaypalTransaction_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "PaypalTransaction_amount_idx": {
+          "name": "PaypalTransaction_amount_idx",
+          "columns": [
+            "amount"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "PaypalTransaction_id": {
+          "name": "PaypalTransaction_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "PaypalWebhookMessage": {
+      "name": "PaypalWebhookMessage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rawData": {
+          "name": "rawData",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "handled": {
+          "name": "handled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "PaypalWebhookMessage_id": {
+          "name": "PaypalWebhookMessage_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Poll": {
+      "name": "Poll",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allowCustomOptions": {
+          "name": "allowCustomOptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "Poll_createdByUserId_idx": {
+          "name": "Poll_createdByUserId_idx",
+          "columns": [
+            "createdByUserId"
+          ],
+          "isUnique": false
+        },
+        "Poll_isActive_idx": {
+          "name": "Poll_isActive_idx",
+          "columns": [
+            "isActive"
+          ],
+          "isUnique": false
+        },
+        "Poll_endDate_idx": {
+          "name": "Poll_endDate_idx",
+          "columns": [
+            "endDate"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Poll_id": {
+          "name": "Poll_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "PollOption": {
+      "name": "PollOption",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollId": {
+          "name": "pollId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "optionType": {
+          "name": "optionType",
+          "type": "enum('text','user')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isCustomOption": {
+          "name": "isCustomOption",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "PollOption_pollId_idx": {
+          "name": "PollOption_pollId_idx",
+          "columns": [
+            "pollId"
+          ],
+          "isUnique": false
+        },
+        "PollOption_createdByUserId_idx": {
+          "name": "PollOption_createdByUserId_idx",
+          "columns": [
+            "createdByUserId"
+          ],
+          "isUnique": false
+        },
+        "PollOption_targetUserId_idx": {
+          "name": "PollOption_targetUserId_idx",
+          "columns": [
+            "targetUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "PollOption_id": {
+          "name": "PollOption_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Quest": {
+      "name": "Quest",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(5000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "successDescription": {
+          "name": "successDescription",
+          "type": "varchar(5000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "questRank": {
+          "name": "questRank",
+          "type": "enum('D','C','B','A','S','H')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'D'"
+        },
+        "medicalRank": {
+          "name": "medicalRank",
+          "type": "enum('NONE','NOVICE','APPRENTICE','MASTER','LEGENDARY')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "huntingRank": {
+          "name": "huntingRank",
+          "type": "enum('NONE','D RANK','C RANK','B RANK','A RANK','S RANK')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "gatheringRank": {
+          "name": "gatheringRank",
+          "type": "enum('NONE','D RANK','C RANK','B RANK','A RANK','S RANK')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "requiredLevel": {
+          "name": "requiredLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "prerequisiteQuestId": {
+          "name": "prerequisiteQuestId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tierLevel": {
+          "name": "tierLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "questType": {
+          "name": "questType",
+          "type": "enum('starter','tier','daily','mission','errand','crime','exam','event','story','anbu','medical','hunting','gathering','battlepyramid','pvp','achievement','war','raid')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "consecutiveObjectives": {
+          "name": "consecutiveObjectives",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "requiredVillage": {
+          "name": "requiredVillage",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredBloodlineId": {
+          "name": "requiredBloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "maxLevel": {
+          "name": "maxLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "maxAttempts": {
+          "name": "maxAttempts",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "maxCompletes": {
+          "name": "maxCompletes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "retryDelay": {
+          "name": "retryDelay",
+          "type": "enum('daily','weekly','monthly','none')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "endsAt": {
+          "name": "endsAt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startsAt": {
+          "name": "startsAt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raidBossMaxHealth": {
+          "name": "raidBossMaxHealth",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raidBossCurrentHealth": {
+          "name": "raidBossCurrentHealth",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raidEndsAt": {
+          "name": "raidEndsAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raidCaptureDeadline": {
+          "name": "raidCaptureDeadline",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raidGracePeriodEnd": {
+          "name": "raidGracePeriodEnd",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Quest_questType_idx": {
+          "name": "Quest_questType_idx",
+          "columns": [
+            "questType"
+          ],
+          "isUnique": false
+        },
+        "Quest_questRank_idx": {
+          "name": "Quest_questRank_idx",
+          "columns": [
+            "questRank"
+          ],
+          "isUnique": false
+        },
+        "Quest_requiredLevel_idx": {
+          "name": "Quest_requiredLevel_idx",
+          "columns": [
+            "requiredLevel"
+          ],
+          "isUnique": false
+        },
+        "Quest_maxLevel_idx": {
+          "name": "Quest_maxLevel_idx",
+          "columns": [
+            "maxLevel"
+          ],
+          "isUnique": false
+        },
+        "Quest_requiredVillage_idx": {
+          "name": "Quest_requiredVillage_idx",
+          "columns": [
+            "requiredVillage"
+          ],
+          "isUnique": false
+        },
+        "Quest_requiredBloodline_idx": {
+          "name": "Quest_requiredBloodline_idx",
+          "columns": [
+            "requiredBloodlineId"
+          ],
+          "isUnique": false
+        },
+        "Quest_endsAt_idx": {
+          "name": "Quest_endsAt_idx",
+          "columns": [
+            "endsAt"
+          ],
+          "isUnique": false
+        },
+        "Quest_startsAt_idx": {
+          "name": "Quest_startsAt_idx",
+          "columns": [
+            "startsAt"
+          ],
+          "isUnique": false
+        },
+        "Quest_prerequisiteQuestId_idx": {
+          "name": "Quest_prerequisiteQuestId_idx",
+          "columns": [
+            "prerequisiteQuestId"
+          ],
+          "isUnique": false
+        },
+        "Quest_questType_questRank_requiredLevel_idx": {
+          "name": "Quest_questType_questRank_requiredLevel_idx",
+          "columns": [
+            "questType",
+            "questRank",
+            "requiredLevel"
+          ],
+          "isUnique": false
+        },
+        "Quest_raidEndsAt_idx": {
+          "name": "Quest_raidEndsAt_idx",
+          "columns": [
+            "raidEndsAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Quest_id": {
+          "name": "Quest_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "tierLevel": {
+          "name": "tierLevel",
+          "columns": [
+            "tierLevel"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "QuestHistory": {
+      "name": "QuestHistory",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questId": {
+          "name": "questId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questType": {
+          "name": "questType",
+          "type": "enum('starter','tier','daily','mission','errand','crime','exam','event','story','anbu','medical','hunting','gathering','battlepyramid','pvp','achievement','war','raid')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "previousCompletes": {
+          "name": "previousCompletes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "previousAttempts": {
+          "name": "previousAttempts",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "QuestHistory_userId_idx": {
+          "name": "QuestHistory_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_questType_idx": {
+          "name": "QuestHistory_questType_idx",
+          "columns": [
+            "questType"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_endedAt_idx": {
+          "name": "QuestHistory_endedAt_idx",
+          "columns": [
+            "endedAt"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_questId_idx": {
+          "name": "QuestHistory_questId_idx",
+          "columns": [
+            "questId"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_completed_idx": {
+          "name": "QuestHistory_completed_idx",
+          "columns": [
+            "completed"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_userId_completed_idx": {
+          "name": "QuestHistory_userId_completed_idx",
+          "columns": [
+            "userId",
+            "completed"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_userId_questType_idx": {
+          "name": "QuestHistory_userId_questType_idx",
+          "columns": [
+            "userId",
+            "questType"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_questId_userId_completed_idx": {
+          "name": "QuestHistory_questId_userId_completed_idx",
+          "columns": [
+            "questId",
+            "userId",
+            "completed"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "QuestHistory_id": {
+          "name": "QuestHistory_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "uniqueUserIdQuestId": {
+          "name": "uniqueUserIdQuestId",
+          "columns": [
+            "userId",
+            "questId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "RaidDamageThreshold": {
+      "name": "RaidDamageThreshold",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questId": {
+          "name": "questId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "damageRequired": {
+          "name": "damageRequired",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rewards": {
+          "name": "rewards",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "effectDurationMinutes": {
+          "name": "effectDurationMinutes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "RaidDamageThreshold_questId_idx": {
+          "name": "RaidDamageThreshold_questId_idx",
+          "columns": [
+            "questId"
+          ],
+          "isUnique": false
+        },
+        "RaidDamageThreshold_sortOrder_idx": {
+          "name": "RaidDamageThreshold_sortOrder_idx",
+          "columns": [
+            "sortOrder"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RaidDamageThreshold_id": {
+          "name": "RaidDamageThreshold_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "RaidParticipation": {
+      "name": "RaidParticipation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questId": {
+          "name": "questId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "damageDealt": {
+          "name": "damageDealt",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "battleCount": {
+          "name": "battleCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rewardsClaimed": {
+          "name": "rewardsClaimed",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "RaidParticipation_questId_idx": {
+          "name": "RaidParticipation_questId_idx",
+          "columns": [
+            "questId"
+          ],
+          "isUnique": false
+        },
+        "RaidParticipation_userId_idx": {
+          "name": "RaidParticipation_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "RaidParticipation_damageDealt_idx": {
+          "name": "RaidParticipation_damageDealt_idx",
+          "columns": [
+            "damageDealt"
+          ],
+          "isUnique": false
+        },
+        "RaidParticipation_questId_damageDealt_idx": {
+          "name": "RaidParticipation_questId_damageDealt_idx",
+          "columns": [
+            "questId",
+            "damageDealt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RaidParticipation_id": {
+          "name": "RaidParticipation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "RaidParticipation_questId_userId": {
+          "name": "RaidParticipation_questId_userId",
+          "columns": [
+            "questId",
+            "userId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "RankedLoadout": {
+      "name": "RankedLoadout",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "loadout": {
+          "name": "loadout",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RankedLoadout_id": {
+          "name": "RankedLoadout_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "RankedPvpQueue": {
+      "name": "RankedPvpQueue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rankedLp": {
+          "name": "rankedLp",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "queueStartTime": {
+          "name": "queueStartTime",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "RankedPvpQueue_userId_idx": {
+          "name": "RankedPvpQueue_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "RankedPvpQueue_rankedLp_idx": {
+          "name": "RankedPvpQueue_rankedLp_idx",
+          "columns": [
+            "rankedLp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RankedPvpQueue_id": {
+          "name": "RankedPvpQueue_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "RankedSeason": {
+      "name": "RankedSeason",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewards": {
+          "name": "rewards",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RankedSeason_id": {
+          "name": "RankedSeason_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "RankedUserRewards": {
+      "name": "RankedUserRewards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seasonId": {
+          "name": "seasonId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "enum('Unranked','Wood','Adept','Master','Legend','Sannin')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed": {
+          "name": "claimed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "claimedAt": {
+          "name": "claimedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RankedUserRewards_id": {
+          "name": "RankedUserRewards_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "RecruitmentRewards": {
+      "name": "RecruitmentRewards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('MONEY','REPUTATION','PRESTIGE','CLAN_POINTS')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recruitedUserId": {
+          "name": "recruitedUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "RecruitmentRewards_userId_idx": {
+          "name": "RecruitmentRewards_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "RecruitmentRewards_recruitedUserId_idx": {
+          "name": "RecruitmentRewards_recruitedUserId_idx",
+          "columns": [
+            "recruitedUserId"
+          ],
+          "isUnique": false
+        },
+        "RecruitmentRewards_type_idx": {
+          "name": "RecruitmentRewards_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RecruitmentRewards_id": {
+          "name": "RecruitmentRewards_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ReferralSource": {
+      "name": "ReferralSource",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ReferralSource_userId_idx": {
+          "name": "ReferralSource_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "ReferralSource_source_idx": {
+          "name": "ReferralSource_source_idx",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ReferralSource_id": {
+          "name": "ReferralSource_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ReportLog": {
+      "name": "ReportLog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staffUserId": {
+          "name": "staffUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ReportLog_targetUserId_idx": {
+          "name": "ReportLog_targetUserId_idx",
+          "columns": [
+            "targetUserId"
+          ],
+          "isUnique": false
+        },
+        "ReportLog_staffUserId_idx": {
+          "name": "ReportLog_staffUserId_idx",
+          "columns": [
+            "staffUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ReportLog_id": {
+          "name": "ReportLog_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "RyoTrade": {
+      "name": "RyoTrade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creatorUserId": {
+          "name": "creatorUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repsForSale": {
+          "name": "repsForSale",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requestedRyo": {
+          "name": "requestedRyo",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ryoPerRep": {
+          "name": "ryoPerRep",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purchaserUserId": {
+          "name": "purchaserUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowedPurchaserId": {
+          "name": "allowedPurchaserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "RyoTrade_creatorUserId_idx": {
+          "name": "RyoTrade_creatorUserId_idx",
+          "columns": [
+            "creatorUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RyoTrade_id": {
+          "name": "RyoTrade_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Sector": {
+      "name": "Sector",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "sector": {
+          "name": "sector",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "shrineLevel": {
+          "name": "shrineLevel",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "capturedAt": {
+          "name": "capturedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nextMaintainanceDueDate": {
+          "name": "nextMaintainanceDueDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Sector_sector_key": {
+          "name": "Sector_sector_key",
+          "columns": [
+            "sector"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Sector_id": {
+          "name": "Sector_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SectorMap": {
+      "name": "SectorMap",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('DRAFT','PUBLISHED','ARCHIVED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sourceHash": {
+          "name": "sourceHash",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rawTiledJson": {
+          "name": "rawTiledJson",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "normalizedJson": {
+          "name": "normalizedJson",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publishedByUserId": {
+          "name": "publishedByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "SectorMap_sector_version_key": {
+          "name": "SectorMap_sector_version_key",
+          "columns": [
+            "sector",
+            "version"
+          ],
+          "isUnique": true
+        },
+        "SectorMap_sector_status_idx": {
+          "name": "SectorMap_sector_status_idx",
+          "columns": [
+            "sector",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SectorMap_id": {
+          "name": "SectorMap_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SkillTree": {
+      "name": "SkillTree",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "enum('SELF','ENEMIES','ALLIES')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'SELF'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "requiredSkillIds": {
+          "name": "requiredSkillIds",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "costSkillPoints": {
+          "name": "costSkillPoints",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "skillType": {
+          "name": "skillType",
+          "type": "enum('DEFAULT','SPECIAL')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'DEFAULT'"
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "SkillTree_name_key": {
+          "name": "SkillTree_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "SkillTree_tier_idx": {
+          "name": "SkillTree_tier_idx",
+          "columns": [
+            "tier"
+          ],
+          "isUnique": false
+        },
+        "SkillTree_hidden_idx": {
+          "name": "SkillTree_hidden_idx",
+          "columns": [
+            "hidden"
+          ],
+          "isUnique": false
+        },
+        "SkillTree_skillType_idx": {
+          "name": "SkillTree_skillType_idx",
+          "columns": [
+            "skillType"
+          ],
+          "isUnique": false
+        },
+        "SkillTree_folderId_idx": {
+          "name": "SkillTree_folderId_idx",
+          "columns": [
+            "folderId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SkillTree_id": {
+          "name": "SkillTree_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SkillTreeFolder": {
+      "name": "SkillTreeFolder",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "SkillTreeFolder_name_idx": {
+          "name": "SkillTreeFolder_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "SkillTreeFolder_order_idx": {
+          "name": "SkillTreeFolder_order_idx",
+          "columns": [
+            "order"
+          ],
+          "isUnique": false
+        },
+        "SkillTreeFolder_hidden_idx": {
+          "name": "SkillTreeFolder_hidden_idx",
+          "columns": [
+            "hidden"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SkillTreeFolder_id": {
+          "name": "SkillTreeFolder_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "StaffApplication": {
+      "name": "StaffApplication",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applicantUserId": {
+          "name": "applicantUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetRole": {
+          "name": "targetRole",
+          "type": "enum('USER','OWNER','CODING-ADMIN','CONTENT-ADMIN','EVENT-ADMIN','MODERATOR-ADMIN','HEAD_MODERATOR','MODERATOR','JR_MODERATOR','HEAD_CONTENT','HEAD_BALANCE','CONTENT','BALANCE','HEAD_EVENT','EVENT','CODER')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum('PENDING','APPROVED','REJECTED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING'"
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "StaffApplication_applicantUserId_idx": {
+          "name": "StaffApplication_applicantUserId_idx",
+          "columns": [
+            "applicantUserId"
+          ],
+          "isUnique": false
+        },
+        "StaffApplication_targetRole_idx": {
+          "name": "StaffApplication_targetRole_idx",
+          "columns": [
+            "targetRole"
+          ],
+          "isUnique": false
+        },
+        "StaffApplication_state_idx": {
+          "name": "StaffApplication_state_idx",
+          "columns": [
+            "state"
+          ],
+          "isUnique": false
+        },
+        "StaffApplication_createdAt_idx": {
+          "name": "StaffApplication_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "StaffApplication_id": {
+          "name": "StaffApplication_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "StaffApplicationApproval": {
+      "name": "StaffApplicationApproval",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applicationId": {
+          "name": "applicationId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approverUserId": {
+          "name": "approverUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "enum('EVENT-ADMIN','CODING-ADMIN','MODERATOR-ADMIN','CONTENT-ADMIN')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum('APPROVED','REJECTED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'APPROVED'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "StaffApplicationApproval_applicationId_idx": {
+          "name": "StaffApplicationApproval_applicationId_idx",
+          "columns": [
+            "applicationId"
+          ],
+          "isUnique": false
+        },
+        "StaffApplicationApproval_approverUserId_idx": {
+          "name": "StaffApplicationApproval_approverUserId_idx",
+          "columns": [
+            "approverUserId"
+          ],
+          "isUnique": false
+        },
+        "StaffApplicationApproval_applicationId_group_key": {
+          "name": "StaffApplicationApproval_applicationId_group_key",
+          "columns": [
+            "applicationId",
+            "group"
+          ],
+          "isUnique": true
+        },
+        "StaffApplicationApproval_applicationId_approverUserId_key": {
+          "name": "StaffApplicationApproval_applicationId_approverUserId_key",
+          "columns": [
+            "applicationId",
+            "approverUserId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "StaffApplicationApproval_id": {
+          "name": "StaffApplicationApproval_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SupportReview": {
+      "name": "SupportReview",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "apiRoute": {
+          "name": "apiRoute",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chatHistory": {
+          "name": "chatHistory",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "enum('POSITIVE','NEGATIVE','NEUTRAL')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SupportReview_id": {
+          "name": "SupportReview_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SupportTicket": {
+      "name": "SupportTicket",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "enum('BUG_REPORT','FEATURE_REQUEST','ACCOUNT_ISSUE','GAMEPLAY_QUESTION','PAYMENT_ISSUE','TECHNICAL_SUPPORT','MODERATION_SUPPORT','OTHER')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "enum('LOW','MEDIUM','HIGH','URGENT')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'MEDIUM'"
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('OPEN','IN_PROGRESS','WAITING_FOR_USER','WAITING_FOR_STAFF','RESOLVED','CLOSED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'OPEN'"
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assignedToUserId": {
+          "name": "assignedToUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "githubIssueUrl": {
+          "name": "githubIssueUrl",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "SupportTicket_createdByUserId_idx": {
+          "name": "SupportTicket_createdByUserId_idx",
+          "columns": [
+            "createdByUserId"
+          ],
+          "isUnique": false
+        },
+        "SupportTicket_assignedToUserId_idx": {
+          "name": "SupportTicket_assignedToUserId_idx",
+          "columns": [
+            "assignedToUserId"
+          ],
+          "isUnique": false
+        },
+        "SupportTicket_status_idx": {
+          "name": "SupportTicket_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "SupportTicket_category_idx": {
+          "name": "SupportTicket_category_idx",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        },
+        "SupportTicket_priority_idx": {
+          "name": "SupportTicket_priority_idx",
+          "columns": [
+            "priority"
+          ],
+          "isUnique": false
+        },
+        "SupportTicket_isPublic_idx": {
+          "name": "SupportTicket_isPublic_idx",
+          "columns": [
+            "isPublic"
+          ],
+          "isUnique": false
+        },
+        "SupportTicket_createdAt_idx": {
+          "name": "SupportTicket_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SupportTicket_id": {
+          "name": "SupportTicket_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SupportTicketActivity": {
+      "name": "SupportTicketActivity",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ticketId": {
+          "name": "ticketId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "enum('CREATED','UPDATED','ASSIGNED','UNASSIGNED','STATUS_CHANGED','PRIORITY_CHANGED','CATEGORY_CHANGED','TAGGED','UNTAGGED','MERGED','ESCALATED_TO_GITHUB','COMMENTED','CLOSED','REOPENED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oldValue": {
+          "name": "oldValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "newValue": {
+          "name": "newValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('{}')"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "SupportTicketActivity_ticketId_idx": {
+          "name": "SupportTicketActivity_ticketId_idx",
+          "columns": [
+            "ticketId"
+          ],
+          "isUnique": false
+        },
+        "SupportTicketActivity_authorId_idx": {
+          "name": "SupportTicketActivity_authorId_idx",
+          "columns": [
+            "authorId"
+          ],
+          "isUnique": false
+        },
+        "SupportTicketActivity_action_idx": {
+          "name": "SupportTicketActivity_action_idx",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        },
+        "SupportTicketActivity_createdAt_idx": {
+          "name": "SupportTicketActivity_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SupportTicketActivity_id": {
+          "name": "SupportTicketActivity_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Tournament": {
+      "name": "Tournament",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "round": {
+          "name": "round",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('CLAN')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewards": {
+          "name": "rewards",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3) + INTERVAL 1 DAY )"
+        },
+        "roundStartedAt": {
+          "name": "roundStartedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3) + INTERVAL 1 DAY )"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('OPEN','IN_PROGRESS','COMPLETED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'OPEN'"
+        }
+      },
+      "indexes": {
+        "Tournament_name_key": {
+          "name": "Tournament_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Tournament_id": {
+          "name": "Tournament_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "TournamentMatch": {
+      "name": "TournamentMatch",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tournamentId": {
+          "name": "tournamentId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "round": {
+          "name": "round",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match": {
+          "name": "match",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum('WAITING','PLAYED','NO_SHOW')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'WAITING'"
+        },
+        "winnerId": {
+          "name": "winnerId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "battleId": {
+          "name": "battleId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId1": {
+          "name": "userId1",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId2": {
+          "name": "userId2",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "TournamentMatch_tournamentId_idx": {
+          "name": "TournamentMatch_tournamentId_idx",
+          "columns": [
+            "tournamentId"
+          ],
+          "isUnique": false
+        },
+        "TournamentMatch_userId1_idx": {
+          "name": "TournamentMatch_userId1_idx",
+          "columns": [
+            "userId1"
+          ],
+          "isUnique": false
+        },
+        "TournamentMatch_userId2_idx": {
+          "name": "TournamentMatch_userId2_idx",
+          "columns": [
+            "userId2"
+          ],
+          "isUnique": false
+        },
+        "TournamentMatch_winnerId_idx": {
+          "name": "TournamentMatch_winnerId_idx",
+          "columns": [
+            "winnerId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TournamentMatch_id": {
+          "name": "TournamentMatch_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "TournamentRecord": {
+      "name": "TournamentRecord",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "round": {
+          "name": "round",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('CLAN')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewards": {
+          "name": "rewards",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3) + INTERVAL 1 DAY )"
+        },
+        "winnerId": {
+          "name": "winnerId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "HistoricalTournament_name_key": {
+          "name": "HistoricalTournament_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TournamentRecord_id": {
+          "name": "TournamentRecord_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "TowerDefenseCharacter": {
+      "name": "TowerDefenseCharacter",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isPlayer": {
+          "name": "isPlayer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "baseHealth": {
+          "name": "baseHealth",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "baseSpeed": {
+          "name": "baseSpeed",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.4
+        },
+        "baseDamage": {
+          "name": "baseDamage",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "attackCooldown": {
+          "name": "attackCooldown",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "healthScaling": {
+          "name": "healthScaling",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.15
+        },
+        "speedScaling": {
+          "name": "speedScaling",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.02
+        },
+        "damageScaling": {
+          "name": "damageScaling",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "firstAppearWave": {
+          "name": "firstAppearWave",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "baseCount": {
+          "name": "baseCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "countScaling": {
+          "name": "countScaling",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1.5
+        },
+        "scaleFactor": {
+          "name": "scaleFactor",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2.8
+        },
+        "assetConfig": {
+          "name": "assetConfig",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "('null')"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "TowerDefenseCharacter_name_idx": {
+          "name": "TowerDefenseCharacter_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseCharacter_firstAppearWave_idx": {
+          "name": "TowerDefenseCharacter_firstAppearWave_idx",
+          "columns": [
+            "firstAppearWave"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseCharacter_isPlayer_idx": {
+          "name": "TowerDefenseCharacter_isPlayer_idx",
+          "columns": [
+            "isPlayer"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TowerDefenseCharacter_id": {
+          "name": "TowerDefenseCharacter_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "TowerDefenseRun": {
+      "name": "TowerDefenseRun",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wave": {
+          "name": "wave",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gridSize": {
+          "name": "gridSize",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('ACTIVE','COMPLETED','ABANDONED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "state": {
+          "name": "state",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "TowerDefenseRun_userId_idx": {
+          "name": "TowerDefenseRun_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseRun_status_idx": {
+          "name": "TowerDefenseRun_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseRun_userId_status_idx": {
+          "name": "TowerDefenseRun_userId_status_idx",
+          "columns": [
+            "userId",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseRun_score_idx": {
+          "name": "TowerDefenseRun_score_idx",
+          "columns": [
+            "score"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseRun_startedAt_idx": {
+          "name": "TowerDefenseRun_startedAt_idx",
+          "columns": [
+            "startedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TowerDefenseRun_id": {
+          "name": "TowerDefenseRun_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "TowerDefenseUpgrade": {
+      "name": "TowerDefenseUpgrade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "maxLevel": {
+          "name": "maxLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "baseCost": {
+          "name": "baseCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "costMultiplier": {
+          "name": "costMultiplier",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1.5
+        },
+        "upgradeType": {
+          "name": "upgradeType",
+          "type": "enum('DAMAGE','ATTACK_SPEED','RANGE','CRIT_CHANCE','DAMAGE_PER_TILE','HEALTH','HEALTH_REGEN','DEFENSE_PERCENT','DEFENSE_FLAT','LIFESTEAL','KNOCKBACK_CHANCE','KNOCKBACK_FORCE','TOKENS_PER_WAVE','TOKENS_PER_KILL','INTEREST_PER_WAVE','SKIP_ENEMY_CHANCE','ABILITY_UNLOCK')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effectValue": {
+          "name": "effectValue",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "TowerDefenseUpgrade_name_idx": {
+          "name": "TowerDefenseUpgrade_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseUpgrade_upgradeType_idx": {
+          "name": "TowerDefenseUpgrade_upgradeType_idx",
+          "columns": [
+            "upgradeType"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TowerDefenseUpgrade_id": {
+          "name": "TowerDefenseUpgrade_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "TrainingLog": {
+      "name": "TrainingLog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stat": {
+          "name": "stat",
+          "type": "enum('ninjutsuOffence','taijutsuOffence','genjutsuOffence','bukijutsuOffence','ninjutsuDefence','taijutsuDefence','genjutsuDefence','bukijutsuDefence','intelligence','speed','willpower','strength')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "enum('15min','1hr','4hrs','8hrs','12hrs','24hrs')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trainingFinishedAt": {
+          "name": "trainingFinishedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "TrainingLog_userId_idx": {
+          "name": "TrainingLog_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "TrainingLog_speed_idx": {
+          "name": "TrainingLog_speed_idx",
+          "columns": [
+            "speed"
+          ],
+          "isUnique": false
+        },
+        "TrainingLog_stat_idx": {
+          "name": "TrainingLog_stat_idx",
+          "columns": [
+            "stat"
+          ],
+          "isUnique": false
+        },
+        "TrainingLog_trainingFinishedAt_idx": {
+          "name": "TrainingLog_trainingFinishedAt_idx",
+          "columns": [
+            "trainingFinishedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TrainingLog_id": {
+          "name": "TrainingLog_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UsersInConversation": {
+      "name": "UsersInConversation",
+      "columns": {
+        "conversationId": {
+          "name": "conversationId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assignedAt": {
+          "name": "assignedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "lastReadAt": {
+          "name": "lastReadAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "UsersInConversation_userId_idx": {
+          "name": "UsersInConversation_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UsersInConversation_conversationId_userId_pk": {
+          "name": "UsersInConversation_conversationId_userId_pk",
+          "columns": [
+            "conversationId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserActivityEvent": {
+      "name": "UserActivityEvent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "streak": {
+          "name": "streak",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserActivityEvent_id": {
+          "name": "UserActivityEvent_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserAssociation": {
+      "name": "UserAssociation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userOne": {
+          "name": "userOne",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userTwo": {
+          "name": "userTwo",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "associationType": {
+          "name": "associationType",
+          "type": "enum('MARRIAGE','DIVORCED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'MARRIAGE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserOne_UserTwo_UserAssociation_key": {
+          "name": "UserOne_UserTwo_UserAssociation_key",
+          "columns": [
+            "userOne",
+            "userTwo",
+            "associationType"
+          ],
+          "isUnique": true
+        },
+        "UserAttribute_userOne_idx": {
+          "name": "UserAttribute_userOne_idx",
+          "columns": [
+            "userOne"
+          ],
+          "isUnique": false
+        },
+        "UserAttribute_userTwo_idx": {
+          "name": "UserAttribute_userTwo_idx",
+          "columns": [
+            "userTwo"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserAssociation_id": {
+          "name": "UserAssociation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserAttribute": {
+      "name": "UserAttribute",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attribute": {
+          "name": "attribute",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "UserAttribute_attribute_userId_key": {
+          "name": "UserAttribute_attribute_userId_key",
+          "columns": [
+            "attribute",
+            "userId"
+          ],
+          "isUnique": true
+        },
+        "UserAttribute_userId_idx": {
+          "name": "UserAttribute_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserAttribute_id": {
+          "name": "UserAttribute_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserBadge": {
+      "name": "UserBadge",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "badgeId": {
+          "name": "badgeId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserBadge_userId_idx": {
+          "name": "UserBadge_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserBadge_badgeId_idx": {
+          "name": "UserBadge_badgeId_idx",
+          "columns": [
+            "badgeId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserBlackList": {
+      "name": "UserBlackList",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "creatorUserId": {
+          "name": "creatorUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "BlackList_creatorUserId_idx": {
+          "name": "BlackList_creatorUserId_idx",
+          "columns": [
+            "creatorUserId"
+          ],
+          "isUnique": false
+        },
+        "BlackList_targetUserId_idx": {
+          "name": "BlackList_targetUserId_idx",
+          "columns": [
+            "targetUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserBlackList_id": {
+          "name": "UserBlackList_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserData": {
+      "name": "UserData",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recruiterId": {
+          "name": "recruiterId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anbuId": {
+          "name": "anbuId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "clanId": {
+          "name": "clanId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "jutsuLoadout": {
+          "name": "jutsuLoadout",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "itemLoadout": {
+          "name": "itemLoadout",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rankedLoadout": {
+          "name": "rankedLoadout",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nRecruited": {
+          "name": "nRecruited",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastIp": {
+          "name": "lastIp",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "curHealth": {
+          "name": "curHealth",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "maxHealth": {
+          "name": "maxHealth",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "curChakra": {
+          "name": "curChakra",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "maxChakra": {
+          "name": "maxChakra",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "curStamina": {
+          "name": "curStamina",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "maxStamina": {
+          "name": "maxStamina",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "regeneration": {
+          "name": "regeneration",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "money": {
+          "name": "money",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "bank": {
+          "name": "bank",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "experience": {
+          "name": "experience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "earnedExperience": {
+          "name": "earnedExperience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "rank": {
+          "name": "rank",
+          "type": "enum('STUDENT','GENIN','CHUNIN','JONIN','ELITE JONIN','ELDER','NONE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'STUDENT'"
+        },
+        "isOutlaw": {
+          "name": "isOutlaw",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "level": {
+          "name": "level",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bloodlineId": {
+          "name": "bloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bloodlineReskinId": {
+          "name": "bloodlineReskinId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('AWAKE','HOSPITALIZED','TRAVEL','BATTLE','QUEUED','KAGE_QUEUED','ASLEEP')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'AWAKE'"
+        },
+        "strength": {
+          "name": "strength",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "intelligence": {
+          "name": "intelligence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "willpower": {
+          "name": "willpower",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "speed": {
+          "name": "speed",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "ninjutsuOffence": {
+          "name": "ninjutsuOffence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "ninjutsuDefence": {
+          "name": "ninjutsuDefence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "genjutsuOffence": {
+          "name": "genjutsuOffence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "genjutsuDefence": {
+          "name": "genjutsuDefence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "taijutsuOffence": {
+          "name": "taijutsuOffence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "taijutsuDefence": {
+          "name": "taijutsuDefence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "bukijutsuDefence": {
+          "name": "bukijutsuDefence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "bukijutsuOffence": {
+          "name": "bukijutsuOffence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "statsMultiplier": {
+          "name": "statsMultiplier",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "poolsMultiplier": {
+          "name": "poolsMultiplier",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "primaryElement": {
+          "name": "primaryElement",
+          "type": "enum('Fire','Water','Wind','Earth','Lightning','Ice','Crystal','Dust','Shadow','Wood','Scorch','Storm','Magnet','Yin-Yang','Lava','Explosion','Light','Boil','Metal','Sand','None')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "secondaryElement": {
+          "name": "secondaryElement",
+          "type": "enum('Fire','Water','Wind','Earth','Lightning','Ice','Crystal','Dust','Shadow','Wood','Scorch','Storm','Magnet','Yin-Yang','Lava','Explosion','Light','Boil','Metal','Sand','None')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reputationPoints": {
+          "name": "reputationPoints",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 11
+        },
+        "reputationPointsTotal": {
+          "name": "reputationPointsTotal",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 11
+        },
+        "seichiSilver": {
+          "name": "seichiSilver",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "villagePrestige": {
+          "name": "villagePrestige",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "federalStatus": {
+          "name": "federalStatus",
+          "type": "enum('NONE','NORMAL','SILVER','GOLD')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "approvedTos": {
+          "name": "approvedTos",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatarLight": {
+          "name": "avatarLight",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar3d": {
+          "name": "avatar3d",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 7
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "joinedVillageAt": {
+          "name": "joinedVillageAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3) - INTERVAL 7 DAY)"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "questFinishAt": {
+          "name": "questFinishAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "deletionAt": {
+          "name": "deletionAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "travelFinishAt": {
+          "name": "travelFinishAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isBanned": {
+          "name": "isBanned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isSilenced": {
+          "name": "isSilenced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isWarned": {
+          "name": "isWarned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isTradeBanned": {
+          "name": "isTradeBanned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('USER','OWNER','CODING-ADMIN','CONTENT-ADMIN','EVENT-ADMIN','MODERATOR-ADMIN','HEAD_MODERATOR','MODERATOR','JR_MODERATOR','HEAD_CONTENT','HEAD_BALANCE','CONTENT','BALANCE','HEAD_EVENT','EVENT','CODER')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USER'"
+        },
+        "battleId": {
+          "name": "battleId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isAi": {
+          "name": "isAi",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isSummon": {
+          "name": "isSummon",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isEvent": {
+          "name": "isEvent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "inShrines": {
+          "name": "inShrines",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "inArena": {
+          "name": "inArena",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "inboxNews": {
+          "name": "inboxNews",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "regenAt": {
+          "name": "regenAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "immunityUntil": {
+          "name": "immunityUntil",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "robImmunityUntil": {
+          "name": "robImmunityUntil",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "bracketImmunityLiftedUntil": {
+          "name": "bracketImmunityLiftedUntil",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "warParticipantUntil": {
+          "name": "warParticipantUntil",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "trainingStartedAt": {
+          "name": "trainingStartedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trainingSpeed": {
+          "name": "trainingSpeed",
+          "type": "enum('15min','1hr','4hrs','8hrs','12hrs','24hrs')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'15min'"
+        },
+        "currentlyTraining": {
+          "name": "currentlyTraining",
+          "type": "enum('ninjutsuOffence','taijutsuOffence','genjutsuOffence','bukijutsuOffence','ninjutsuDefence','taijutsuDefence','genjutsuDefence','bukijutsuDefence','intelligence','speed','willpower','strength')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unreadNotifications": {
+          "name": "unreadNotifications",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "unreadNews": {
+          "name": "unreadNews",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "questData": {
+          "name": "questData",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "senseiId": {
+          "name": "senseiId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "medicalExperience": {
+          "name": "medicalExperience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "craftingExperience": {
+          "name": "craftingExperience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "huntingExperience": {
+          "name": "huntingExperience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gatheringExperience": {
+          "name": "gatheringExperience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "preferredStat": {
+          "name": "preferredStat",
+          "type": "enum('Highest','Ninjutsu','Genjutsu','Taijutsu','Bukijutsu')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferredGeneral1": {
+          "name": "preferredGeneral1",
+          "type": "enum('Highest','Strength','Intelligence','Willpower','Speed')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferredGeneral2": {
+          "name": "preferredGeneral2",
+          "type": "enum('Highest','Strength','Intelligence','Willpower','Speed')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "showBattleDescription": {
+          "name": "showBattleDescription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pvpFights": {
+          "name": "pvpFights",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pveFights": {
+          "name": "pveFights",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pvpActivity": {
+          "name": "pvpActivity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pvpStreak": {
+          "name": "pvpStreak",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "errands": {
+          "name": "errands",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionsD": {
+          "name": "missionsD",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionsC": {
+          "name": "missionsC",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionsB": {
+          "name": "missionsB",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionsA": {
+          "name": "missionsA",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionsS": {
+          "name": "missionsS",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionsH": {
+          "name": "missionsH",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crimesD": {
+          "name": "crimesD",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crimesC": {
+          "name": "crimesC",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crimesB": {
+          "name": "crimesB",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crimesA": {
+          "name": "crimesA",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crimesS": {
+          "name": "crimesS",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crimesH": {
+          "name": "crimesH",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyArenaFights": {
+          "name": "dailyArenaFights",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyMissions": {
+          "name": "dailyMissions",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyErrands": {
+          "name": "dailyErrands",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyMedicalMissions": {
+          "name": "dailyMedicalMissions",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyPvpMissions": {
+          "name": "dailyPvpMissions",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyWarMissions": {
+          "name": "dailyWarMissions",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyTrainings": {
+          "name": "dailyTrainings",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "movedTooFastCount": {
+          "name": "movedTooFastCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "extraItemSlots": {
+          "name": "extraItemSlots",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "extraJutsuSlots": {
+          "name": "extraJutsuSlots",
+          "type": "tinyint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "extraReskinSlots": {
+          "name": "extraReskinSlots",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "customTitle": {
+          "name": "customTitle",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "marriageSlots": {
+          "name": "marriageSlots",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "aiProfileId": {
+          "name": "aiProfileId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "openaiCalls": {
+          "name": "openaiCalls",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tavernMessages": {
+          "name": "tavernMessages",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "musicOn": {
+          "name": "musicOn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "sfxOn": {
+          "name": "sfxOn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "buttonSfxOn": {
+          "name": "buttonSfxOn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "iframesMuted": {
+          "name": "iframesMuted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "tutorialStep": {
+          "name": "tutorialStep",
+          "type": "tinyint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tutorialOn": {
+          "name": "tutorialOn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "homeType": {
+          "name": "homeType",
+          "type": "enum('NONE','STUDIO_APARTMENT','ONE_BED_APARTMENT','TWO_BED_HOUSE','TOWN_HOUSE','SMALL_MANSION','SMALL_ESTATE','LARGE_ESTATE','PALACE','MARSHMALLOWOPOLIS')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "staffAccount": {
+          "name": "staffAccount",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rankedLp": {
+          "name": "rankedLp",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rankedBattles": {
+          "name": "rankedBattles",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rankedWins": {
+          "name": "rankedWins",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rankedStreak": {
+          "name": "rankedStreak",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skillPoints": {
+          "name": "skillPoints",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "towerDefensePoints": {
+          "name": "towerDefensePoints",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "enum('GATHERING','HUNTER','CRAFTING')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occupationSignupAt": {
+          "name": "occupationSignupAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stealth": {
+          "name": "stealth",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "sensory": {
+          "name": "sensory",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "stealthActive": {
+          "name": "stealthActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "stealthActivatedAt": {
+          "name": "stealthActivatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stealthCooldownAt": {
+          "name": "stealthCooldownAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastSensoryAt": {
+          "name": "lastSensoryAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "covertTrainingType": {
+          "name": "covertTrainingType",
+          "type": "enum('stealth','sensory')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "covertTrainingStartedAt": {
+          "name": "covertTrainingStartedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "covertTrainingMinutes": {
+          "name": "covertTrainingMinutes",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "UserData_isAi_idx": {
+          "name": "UserData_isAi_idx",
+          "columns": [
+            "isAi"
+          ],
+          "isUnique": false
+        },
+        "UserData_isAi_rankedLp_experience_idx": {
+          "name": "UserData_isAi_rankedLp_experience_idx",
+          "columns": [
+            "isAi",
+            "rankedLp",
+            "experience"
+          ],
+          "isUnique": false
+        },
+        "UserData_isEvent_idx": {
+          "name": "UserData_isEvent_idx",
+          "columns": [
+            "isEvent"
+          ],
+          "isUnique": false
+        },
+        "UserData_inArena_idx": {
+          "name": "UserData_inArena_idx",
+          "columns": [
+            "inArena"
+          ],
+          "isUnique": false
+        },
+        "UserData_inShrines_idx": {
+          "name": "UserData_inShrines_idx",
+          "columns": [
+            "inShrines"
+          ],
+          "isUnique": false
+        },
+        "UserData_isSummon_idx": {
+          "name": "UserData_isSummon_idx",
+          "columns": [
+            "isSummon"
+          ],
+          "isUnique": false
+        },
+        "UserData_rank_idx": {
+          "name": "UserData_rank_idx",
+          "columns": [
+            "rank"
+          ],
+          "isUnique": false
+        },
+        "UserData_role_idx": {
+          "name": "UserData_role_idx",
+          "columns": [
+            "role"
+          ],
+          "isUnique": false
+        },
+        "UserData_clanId_idx": {
+          "name": "UserData_clanId_idx",
+          "columns": [
+            "clanId"
+          ],
+          "isUnique": false
+        },
+        "UserData_anbuId_idx": {
+          "name": "UserData_anbuId_idx",
+          "columns": [
+            "anbuId"
+          ],
+          "isUnique": false
+        },
+        "UserData_jutsuLoadout_idx": {
+          "name": "UserData_jutsuLoadout_idx",
+          "columns": [
+            "jutsuLoadout"
+          ],
+          "isUnique": false
+        },
+        "UserData_rankedLoadout_idx": {
+          "name": "UserData_rankedLoadout_idx",
+          "columns": [
+            "rankedLoadout"
+          ],
+          "isUnique": false
+        },
+        "UserData_rankedLp_idx": {
+          "name": "UserData_rankedLp_idx",
+          "columns": [
+            "rankedLp"
+          ],
+          "isUnique": false
+        },
+        "UserData_experience_idx": {
+          "name": "UserData_experience_idx",
+          "columns": [
+            "experience"
+          ],
+          "isUnique": false
+        },
+        "UserData_level_idx": {
+          "name": "UserData_level_idx",
+          "columns": [
+            "level"
+          ],
+          "isUnique": false
+        },
+        "UserData_username_key": {
+          "name": "UserData_username_key",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "UserData_bloodlineId_idx": {
+          "name": "UserData_bloodlineId_idx",
+          "columns": [
+            "bloodlineId"
+          ],
+          "isUnique": false
+        },
+        "UserData_bloodlineReskinId_idx": {
+          "name": "UserData_bloodlineReskinId_idx",
+          "columns": [
+            "bloodlineReskinId"
+          ],
+          "isUnique": false
+        },
+        "UserData_villageId_idx": {
+          "name": "UserData_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        },
+        "UserData_battleId_idx": {
+          "name": "UserData_battleId_idx",
+          "columns": [
+            "battleId"
+          ],
+          "isUnique": false
+        },
+        "UserData_status_idx": {
+          "name": "UserData_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "UserData_sector_idx": {
+          "name": "UserData_sector_idx",
+          "columns": [
+            "sector"
+          ],
+          "isUnique": false
+        },
+        "UserData_sector_stealthActive_idx": {
+          "name": "UserData_sector_stealthActive_idx",
+          "columns": [
+            "sector",
+            "stealthActive"
+          ],
+          "isUnique": false
+        },
+        "UserData_senseiId_idx": {
+          "name": "UserData_senseiId_idx",
+          "columns": [
+            "senseiId"
+          ],
+          "isUnique": false
+        },
+        "UserData_latitude_idx": {
+          "name": "UserData_latitude_idx",
+          "columns": [
+            "latitude"
+          ],
+          "isUnique": false
+        },
+        "UserData_longitude_idx": {
+          "name": "UserData_longitude_idx",
+          "columns": [
+            "longitude"
+          ],
+          "isUnique": false
+        },
+        "UserData_createdAt_idx": {
+          "name": "UserData_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserData_userId": {
+          "name": "UserData_userId",
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserItem": {
+      "name": "UserItem",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "itemId": {
+          "name": "itemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "equipped": {
+          "name": "equipped",
+          "type": "enum('HEAD','CHEST','LEGS','FEET','HAND_1','HAND_2','THROWN','WAIST','KEYSTONE','ITEM_1','ITEM_2','ITEM_3','ITEM_4','ITEM_5','ITEM_6','NONE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "durability": {
+          "name": "durability",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "storedAtHome": {
+          "name": "storedAtHome",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "craftingFinishedAt": {
+          "name": "craftingFinishedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isInAuction": {
+          "name": "isInAuction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "activeVariantId": {
+          "name": "activeVariantId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dropChancePerc": {
+          "name": "dropChancePerc",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "UserItem_userId_idx": {
+          "name": "UserItem_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserItem_itemId_idx": {
+          "name": "UserItem_itemId_idx",
+          "columns": [
+            "itemId"
+          ],
+          "isUnique": false
+        },
+        "UserItem_quantity_idx": {
+          "name": "UserItem_quantity_idx",
+          "columns": [
+            "quantity"
+          ],
+          "isUnique": false
+        },
+        "UserItem_equipped_idx": {
+          "name": "UserItem_equipped_idx",
+          "columns": [
+            "equipped"
+          ],
+          "isUnique": false
+        },
+        "UserItem_userId_equipped_idx": {
+          "name": "UserItem_userId_equipped_idx",
+          "columns": [
+            "userId",
+            "equipped"
+          ],
+          "isUnique": false
+        },
+        "UserItem_activeVariantId_idx": {
+          "name": "UserItem_activeVariantId_idx",
+          "columns": [
+            "activeVariantId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserItem_id": {
+          "name": "UserItem_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserItemImbuement": {
+      "name": "UserItemImbuement",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userItemId": {
+          "name": "userItemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imbuementItemId": {
+          "name": "imbuementItemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "craftingFinishedAt": {
+          "name": "craftingFinishedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "UserItemImbuement_userItemId_idx": {
+          "name": "UserItemImbuement_userItemId_idx",
+          "columns": [
+            "userItemId"
+          ],
+          "isUnique": false
+        },
+        "UserItemImbuement_imbuementItemId_idx": {
+          "name": "UserItemImbuement_imbuementItemId_idx",
+          "columns": [
+            "imbuementItemId"
+          ],
+          "isUnique": false
+        },
+        "UserItemImbuement_userItem_imbuement_key": {
+          "name": "UserItemImbuement_userItem_imbuement_key",
+          "columns": [
+            "userItemId",
+            "imbuementItemId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserItemImbuement_id": {
+          "name": "UserItemImbuement_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserItemVariant": {
+      "name": "UserItemVariant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variantId": {
+          "name": "variantId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserItemVariant_userId_idx": {
+          "name": "UserItemVariant_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserItemVariant_userId_variantId_key": {
+          "name": "UserItemVariant_userId_variantId_key",
+          "columns": [
+            "userId",
+            "variantId"
+          ],
+          "isUnique": true
+        },
+        "UserItemVariant_variantId_idx": {
+          "name": "UserItemVariant_variantId_idx",
+          "columns": [
+            "variantId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserItemVariant_id": {
+          "name": "UserItemVariant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserJutsu": {
+      "name": "UserJutsu",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jutsuId": {
+          "name": "jutsuId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "level": {
+          "name": "level",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "experience": {
+          "name": "experience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "equipped": {
+          "name": "equipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "finishTraining": {
+          "name": "finishTraining",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reskinId": {
+          "name": "reskinId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "UserJutsu_userId_jutsuId_key": {
+          "name": "UserJutsu_userId_jutsuId_key",
+          "columns": [
+            "userId",
+            "jutsuId"
+          ],
+          "isUnique": true
+        },
+        "UserJutsu_jutsuId_idx": {
+          "name": "UserJutsu_jutsuId_idx",
+          "columns": [
+            "jutsuId"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_equipped_idx": {
+          "name": "Jutsu_equipped_idx",
+          "columns": [
+            "equipped"
+          ],
+          "isUnique": false
+        },
+        "UserJutsu_reskinId_idx": {
+          "name": "UserJutsu_reskinId_idx",
+          "columns": [
+            "reskinId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserJutsu_id": {
+          "name": "UserJutsu_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserLikes": {
+      "name": "UserLikes",
+      "columns": {
+        "type": {
+          "name": "type",
+          "type": "enum('like','love','laugh')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imageId": {
+          "name": "imageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "userLikes_userId_idx": {
+          "name": "userLikes_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "userLikes_imageId_idx": {
+          "name": "userLikes_imageId_idx",
+          "columns": [
+            "imageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserNindo": {
+      "name": "UserNindo",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "UserNindo_userId_idx": {
+          "name": "UserNindo_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserNindo_id": {
+          "name": "UserNindo_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserPollVote": {
+      "name": "UserPollVote",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollId": {
+          "name": "pollId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "optionId": {
+          "name": "optionId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserPollVote_userId_pollId_idx": {
+          "name": "UserPollVote_userId_pollId_idx",
+          "columns": [
+            "userId",
+            "pollId"
+          ],
+          "isUnique": true
+        },
+        "UserPollVote_userId_idx": {
+          "name": "UserPollVote_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserPollVote_pollId_idx": {
+          "name": "UserPollVote_pollId_idx",
+          "columns": [
+            "pollId"
+          ],
+          "isUnique": false
+        },
+        "UserPollVote_optionId_idx": {
+          "name": "UserPollVote_optionId_idx",
+          "columns": [
+            "optionId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserPollVote_id": {
+          "name": "UserPollVote_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserRaidBuff": {
+      "name": "UserRaidBuff",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questId": {
+          "name": "questId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserRaidBuff_userId_idx": {
+          "name": "UserRaidBuff_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserRaidBuff_questId_idx": {
+          "name": "UserRaidBuff_questId_idx",
+          "columns": [
+            "questId"
+          ],
+          "isUnique": false
+        },
+        "UserRaidBuff_expiresAt_idx": {
+          "name": "UserRaidBuff_expiresAt_idx",
+          "columns": [
+            "expiresAt"
+          ],
+          "isUnique": false
+        },
+        "UserRaidBuff_userId_expiresAt_idx": {
+          "name": "UserRaidBuff_userId_expiresAt_idx",
+          "columns": [
+            "userId",
+            "expiresAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserRaidBuff_id": {
+          "name": "UserRaidBuff_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserReport": {
+      "name": "UserReport",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reporterUserId": {
+          "name": "reporterUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reportedUserId": {
+          "name": "reportedUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "system": {
+          "name": "system",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "infraction": {
+          "name": "infraction",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "banEnd": {
+          "name": "banEnd",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "adminResolved": {
+          "name": "adminResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('UNVIEWED','REPORT_CLEARED','BAN_ACTIVATED','SILENCE_ACTIVATED','TIMEOUT_ACTIVATED','BAN_ESCALATED','SILENCE_ESCALATED','OFFICIAL_WARNING','TRADE_BAN_ACTIVATED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UNVIEWED'"
+        },
+        "aiInterpretation": {
+          "name": "aiInterpretation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "predictedStatus": {
+          "name": "predictedStatus",
+          "type": "enum('UNVIEWED','REPORT_CLEARED','BAN_ACTIVATED','SILENCE_ACTIVATED','TIMEOUT_ACTIVATED','BAN_ESCALATED','SILENCE_ESCALATED','OFFICIAL_WARNING','TRADE_BAN_ACTIVATED')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "additionalContext": {
+          "name": "additionalContext",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        }
+      },
+      "indexes": {
+        "UserReport_reporterUserId_idx": {
+          "name": "UserReport_reporterUserId_idx",
+          "columns": [
+            "reporterUserId"
+          ],
+          "isUnique": false
+        },
+        "UserReport_reportedUserId_idx": {
+          "name": "UserReport_reportedUserId_idx",
+          "columns": [
+            "reportedUserId"
+          ],
+          "isUnique": false
+        },
+        "UserReport_status_idx": {
+          "name": "UserReport_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserReport_id": {
+          "name": "UserReport_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserReportComment": {
+      "name": "UserReportComment",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reportId": {
+          "name": "reportId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "enum('UNVIEWED','REPORT_CLEARED','BAN_ACTIVATED','SILENCE_ACTIVATED','TIMEOUT_ACTIVATED','BAN_ESCALATED','SILENCE_ESCALATED','OFFICIAL_WARNING','TRADE_BAN_ACTIVATED')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isReported": {
+          "name": "isReported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "UserReportComment_userId_idx": {
+          "name": "UserReportComment_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserReportComment_reportId_idx": {
+          "name": "UserReportComment_reportId_idx",
+          "columns": [
+            "reportId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserReportComment_id": {
+          "name": "UserReportComment_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserRequest": {
+      "name": "UserRequest",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "receiverId": {
+          "name": "receiverId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('PENDING','ACCEPTED','REJECTED','CANCELLED','EXPIRED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('SPAR','ALLIANCE','SURRENDER','SENSEI','ANBU','CLAN','MARRIAGE','KAGE','WAR_ALLY')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "relatedId": {
+          "name": "relatedId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "useRankedRules": {
+          "name": "useRankedRules",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "spectatable": {
+          "name": "spectatable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserRequest_createdAt_idx": {
+          "name": "UserRequest_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "UserRequest_senderId_idx": {
+          "name": "UserRequest_senderId_idx",
+          "columns": [
+            "senderId"
+          ],
+          "isUnique": false
+        },
+        "UserRequest_receiverId_idx": {
+          "name": "UserRequest_receiverId_idx",
+          "columns": [
+            "receiverId"
+          ],
+          "isUnique": false
+        },
+        "UserRequest_type_idx": {
+          "name": "UserRequest_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserRequest_id": {
+          "name": "UserRequest_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserReview": {
+      "name": "UserReview",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorUserId": {
+          "name": "authorUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "positive": {
+          "name": "positive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorIp": {
+          "name": "authorIp",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserReview_authorUserId_idx": {
+          "name": "UserReview_authorUserId_idx",
+          "columns": [
+            "authorUserId"
+          ],
+          "isUnique": false
+        },
+        "UserReview_targetUserId_idx": {
+          "name": "UserReview_targetUserId_idx",
+          "columns": [
+            "targetUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserReview_id": {
+          "name": "UserReview_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserRewards": {
+      "name": "UserRewards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "awardedById": {
+          "name": "awardedById",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "receiverId": {
+          "name": "receiverId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reputationAmount": {
+          "name": "reputationAmount",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "moneyAmount": {
+          "name": "moneyAmount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserRewards_awardedById_idx": {
+          "name": "UserRewards_awardedById_idx",
+          "columns": [
+            "awardedById"
+          ],
+          "isUnique": false
+        },
+        "UserRewards_receiverId_idx": {
+          "name": "UserRewards_receiverId_idx",
+          "columns": [
+            "receiverId"
+          ],
+          "isUnique": false
+        },
+        "UserRewards_createdAt_idx": {
+          "name": "UserRewards_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserRewards_id": {
+          "name": "UserRewards_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserSkill": {
+      "name": "UserSkill",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skillId": {
+          "name": "skillId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purchasedAt": {
+          "name": "purchasedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "activated": {
+          "name": "activated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "UserSkill_userId_skillId_key": {
+          "name": "UserSkill_userId_skillId_key",
+          "columns": [
+            "userId",
+            "skillId"
+          ],
+          "isUnique": true
+        },
+        "UserSkill_userId_idx": {
+          "name": "UserSkill_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserSkill_skillId_idx": {
+          "name": "UserSkill_skillId_idx",
+          "columns": [
+            "skillId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserSkill_id": {
+          "name": "UserSkill_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserStreakProgress": {
+      "name": "UserStreakProgress",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "configId": {
+          "name": "configId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currentDay": {
+          "name": "currentDay",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastClaimDate": {
+          "name": "lastClaimDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserStreakProgress_userId_idx": {
+          "name": "UserStreakProgress_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserStreakProgress_configId_idx": {
+          "name": "UserStreakProgress_configId_idx",
+          "columns": [
+            "configId"
+          ],
+          "isUnique": false
+        },
+        "UserStreakProgress_userId_configId_key": {
+          "name": "UserStreakProgress_userId_configId_key",
+          "columns": [
+            "userId",
+            "configId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserStreakProgress_id": {
+          "name": "UserStreakProgress_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserTowerDefenseUpgrade": {
+      "name": "UserTowerDefenseUpgrade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upgradeId": {
+          "name": "upgradeId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "purchasedAt": {
+          "name": "purchasedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserTowerDefenseUpgrade_userId_idx": {
+          "name": "UserTowerDefenseUpgrade_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserTowerDefenseUpgrade_upgradeId_idx": {
+          "name": "UserTowerDefenseUpgrade_upgradeId_idx",
+          "columns": [
+            "upgradeId"
+          ],
+          "isUnique": false
+        },
+        "UserTowerDefenseUpgrade_userId_upgradeId_key": {
+          "name": "UserTowerDefenseUpgrade_userId_upgradeId_key",
+          "columns": [
+            "userId",
+            "upgradeId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserTowerDefenseUpgrade_id": {
+          "name": "UserTowerDefenseUpgrade_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserUpload": {
+      "name": "UserUpload",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserUpload_userId_idx": {
+          "name": "UserUpload_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserUpload_id": {
+          "name": "UserUpload_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserVote": {
+      "name": "UserVote",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topWebGames": {
+          "name": "topWebGames",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "top100Arena": {
+          "name": "top100Arena",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "mmoHub": {
+          "name": "mmoHub",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "arenaTop100": {
+          "name": "arenaTop100",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "xtremeTop100": {
+          "name": "xtremeTop100",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "topOnlineMmorpg": {
+          "name": "topOnlineMmorpg",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "browserMmorpg": {
+          "name": "browserMmorpg",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "apexWebGaming": {
+          "name": "apexWebGaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bbogd": {
+          "name": "bbogd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "claimed": {
+          "name": "claimed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "totalClaims": {
+          "name": "totalClaims",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastVoteAt": {
+          "name": "lastVoteAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserVote_userId_idx": {
+          "name": "UserVote_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserVote_id": {
+          "name": "UserVote_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Village": {
+      "name": "Village",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mapName": {
+          "name": "mapName",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "kageId": {
+          "name": "kageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('VILLAGE','OUTLAW','SAFEZONE','HIDEOUT','TOWN')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'VILLAGE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "leaderUpdatedAt": {
+          "name": "leaderUpdatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "hexColor": {
+          "name": "hexColor",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#000000'"
+        },
+        "populationCount": {
+          "name": "populationCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "allianceSystem": {
+          "name": "allianceSystem",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "joinable": {
+          "name": "joinable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pvpDisabled": {
+          "name": "pvpDisabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "villageLogo": {
+          "name": "villageLogo",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "villageGraphic": {
+          "name": "villageGraphic",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "lastMaintenancePaidAt": {
+          "name": "lastMaintenancePaidAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "wasDowngraded": {
+          "name": "wasDowngraded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "openForChallenges": {
+          "name": "openForChallenges",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "openForChallengesAt": {
+          "name": "openForChallengesAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "wallpaperOverwrite": {
+          "name": "wallpaperOverwrite",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warExhaustionEndedAt": {
+          "name": "warExhaustionEndedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastWarEndedAt": {
+          "name": "lastWarEndedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shrineSettings": {
+          "name": "shrineSettings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('{\"unlockedAiIds\":[],\"activeBoosts\":{},\"activeAiIds\":[]}')"
+        }
+      },
+      "indexes": {
+        "Village_name_key": {
+          "name": "Village_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "Village_sector_key": {
+          "name": "Village_sector_key",
+          "columns": [
+            "sector"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Village_id": {
+          "name": "Village_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "VillageAlliance": {
+      "name": "VillageAlliance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageIdA": {
+          "name": "villageIdA",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageIdB": {
+          "name": "villageIdB",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('NEUTRAL','ALLY','ENEMY')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "VillageAlliance_villageIdA_idx": {
+          "name": "VillageAlliance_villageIdA_idx",
+          "columns": [
+            "villageIdA"
+          ],
+          "isUnique": false
+        },
+        "VillageAlliance_villageIdB_idx": {
+          "name": "VillageAlliance_villageIdB_idx",
+          "columns": [
+            "villageIdB"
+          ],
+          "isUnique": false
+        },
+        "VillageAlliance_status_idx": {
+          "name": "VillageAlliance_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "VillageAlliance_id": {
+          "name": "VillageAlliance_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "VillageElderVote": {
+      "name": "VillageElderVote",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('WAR_DECLARATION','KAGE_REMOVAL')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initiatedByUserId": {
+          "name": "initiatedByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetId": {
+          "name": "targetId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warType": {
+          "name": "warType",
+          "type": "enum('VILLAGE_WAR','SECTOR_WAR','WAR_RAID')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "targetStructureRoute": {
+          "name": "targetStructureRoute",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('PENDING','APPROVED','REJECTED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING'"
+        },
+        "activeFlag": {
+          "name": "activeFlag",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "type": "stored",
+            "as": "CASE WHEN `status` = 'PENDING' THEN 1 ELSE NULL END"
+          }
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "endsAt": {
+          "name": "endsAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "VillageElderVote_villageId_idx": {
+          "name": "VillageElderVote_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        },
+        "VillageElderVote_type_idx": {
+          "name": "VillageElderVote_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "VillageElderVote_status_idx": {
+          "name": "VillageElderVote_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "VillageElderVote_endsAt_idx": {
+          "name": "VillageElderVote_endsAt_idx",
+          "columns": [
+            "endsAt"
+          ],
+          "isUnique": false
+        },
+        "VillageElderVote_initiatedByUserId_idx": {
+          "name": "VillageElderVote_initiatedByUserId_idx",
+          "columns": [
+            "initiatedByUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "VillageElderVote_id": {
+          "name": "VillageElderVote_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "VillageElderVote_active_pending_unique": {
+          "name": "VillageElderVote_active_pending_unique",
+          "columns": [
+            "villageId",
+            "type",
+            "targetId",
+            "activeFlag"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "VillageElderVoteEntry": {
+      "name": "VillageElderVoteEntry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voteId": {
+          "name": "voteId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vote": {
+          "name": "vote",
+          "type": "enum('YES','NO')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "VillageElderVoteEntry_voteId_idx": {
+          "name": "VillageElderVoteEntry_voteId_idx",
+          "columns": [
+            "voteId"
+          ],
+          "isUnique": false
+        },
+        "VillageElderVoteEntry_userId_idx": {
+          "name": "VillageElderVoteEntry_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "VillageElderVoteEntry_id": {
+          "name": "VillageElderVoteEntry_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "VillageElderVoteEntry_voteId_userId_unique": {
+          "name": "VillageElderVoteEntry_voteId_userId_unique",
+          "columns": [
+            "voteId",
+            "userId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "VillageStructure": {
+      "name": "VillageStructure",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "route": {
+          "name": "route",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "hasPage": {
+          "name": "hasPage",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "curSp": {
+          "name": "curSp",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "maxSp": {
+          "name": "maxSp",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "allyAccess": {
+          "name": "allyAccess",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "showInVillagePage": {
+          "name": "showInVillagePage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "level": {
+          "name": "level",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "maxLevel": {
+          "name": "maxLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "lastUpgradedAt": {
+          "name": "lastUpgradedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anbuSquadsPerLvl": {
+          "name": "anbuSquadsPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "arenaRewardPerLvl": {
+          "name": "arenaRewardPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bankInterestPerLvl": {
+          "name": "bankInterestPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "blackDiscountPerLvl": {
+          "name": "blackDiscountPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "clansPerLvl": {
+          "name": "clansPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hospitalSpeedupPerLvl": {
+          "name": "hospitalSpeedupPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "itemDiscountPerLvl": {
+          "name": "itemDiscountPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionRewardPerLvl": {
+          "name": "missionRewardPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "patrolsPerLvl": {
+          "name": "patrolsPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "ramenDiscountPerLvl": {
+          "name": "ramenDiscountPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "regenIncreasePerLvl": {
+          "name": "regenIncreasePerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "sleepRegenPerLvl": {
+          "name": "sleepRegenPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "structureDiscountPerLvl": {
+          "name": "structureDiscountPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "trainBoostPerLvl": {
+          "name": "trainBoostPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "villageDefencePerLvl": {
+          "name": "villageDefencePerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "temporaryLevelBonus": {
+          "name": "temporaryLevelBonus",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "temporaryLevelBonusExpiresAt": {
+          "name": "temporaryLevelBonusExpiresAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "VillageStructure_name_villageId_key": {
+          "name": "VillageStructure_name_villageId_key",
+          "columns": [
+            "name",
+            "villageId"
+          ],
+          "isUnique": true
+        },
+        "VillageStructure_villageId_idx": {
+          "name": "VillageStructure_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "VillageStructure_id": {
+          "name": "VillageStructure_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "VisitorLog": {
+      "name": "VisitorLog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref": {
+          "name": "ref",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmSource": {
+          "name": "utmSource",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "VisitorLog_ip_key": {
+          "name": "VisitorLog_ip_key",
+          "columns": [
+            "ip"
+          ],
+          "isUnique": true
+        },
+        "VisitorLog_ref_idx": {
+          "name": "VisitorLog_ref_idx",
+          "columns": [
+            "ref"
+          ],
+          "isUnique": false
+        },
+        "VisitorLog_utmSource_idx": {
+          "name": "VisitorLog_utmSource_idx",
+          "columns": [
+            "utmSource"
+          ],
+          "isUnique": false
+        },
+        "VisitorLog_createdAt_idx": {
+          "name": "VisitorLog_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "VisitorLog_ip_utmSource_idx": {
+          "name": "VisitorLog_ip_utmSource_idx",
+          "columns": [
+            "ip",
+            "utmSource"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "VisitorLog_id": {
+          "name": "VisitorLog_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "War": {
+      "name": "War",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attackerVillageId": {
+          "name": "attackerVillageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "defenderVillageId": {
+          "name": "defenderVillageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('ACTIVE','ATTACKER_VICTORY','DEFENDER_VICTORY','DRAW')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('VILLAGE_WAR','SECTOR_WAR','WAR_RAID')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attackerShrineHp": {
+          "name": "attackerShrineHp",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 500
+        },
+        "attackerShrineMaxHp": {
+          "name": "attackerShrineMaxHp",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 500
+        },
+        "attackerShrineStatus": {
+          "name": "attackerShrineStatus",
+          "type": "enum('ACTIVE','CAPTURED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "defenderShrineHp": {
+          "name": "defenderShrineHp",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3000
+        },
+        "defenderShrineMaxHp": {
+          "name": "defenderShrineMaxHp",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3000
+        },
+        "defenderShrineStatus": {
+          "name": "defenderShrineStatus",
+          "type": "enum('ACTIVE','CAPTURED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "lastTokenReductionAt": {
+          "name": "lastTokenReductionAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "targetStructureRoute": {
+          "name": "targetStructureRoute",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'/townhall'"
+        },
+        "attackerWarHealth": {
+          "name": "attackerWarHealth",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10000
+        },
+        "defenderWarHealth": {
+          "name": "defenderWarHealth",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10000
+        },
+        "attackerWarHealthMax": {
+          "name": "attackerWarHealthMax",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10000
+        },
+        "defenderWarHealthMax": {
+          "name": "defenderWarHealthMax",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10000
+        }
+      },
+      "indexes": {
+        "War_attackerVillageId_idx": {
+          "name": "War_attackerVillageId_idx",
+          "columns": [
+            "attackerVillageId"
+          ],
+          "isUnique": false
+        },
+        "War_defenderVillageId_idx": {
+          "name": "War_defenderVillageId_idx",
+          "columns": [
+            "defenderVillageId"
+          ],
+          "isUnique": false
+        },
+        "War_sector_idx": {
+          "name": "War_sector_idx",
+          "columns": [
+            "sector"
+          ],
+          "isUnique": false
+        },
+        "War_status_idx": {
+          "name": "War_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "War_id": {
+          "name": "War_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "WarAlly": {
+      "name": "WarAlly",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warId": {
+          "name": "warId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supportVillageId": {
+          "name": "supportVillageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tokensPaid": {
+          "name": "tokensPaid",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "joinedAt": {
+          "name": "joinedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "WarAlly_warId_idx": {
+          "name": "WarAlly_warId_idx",
+          "columns": [
+            "warId"
+          ],
+          "isUnique": false
+        },
+        "WarAlly_villageId_idx": {
+          "name": "WarAlly_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "WarAlly_id": {
+          "name": "WarAlly_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "WarKill": {
+      "name": "WarKill",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warId": {
+          "name": "warId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "killerId": {
+          "name": "killerId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "victimId": {
+          "name": "victimId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "killerVillageId": {
+          "name": "killerVillageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "victimVillageId": {
+          "name": "victimVillageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1337
+        },
+        "shrineHpChange": {
+          "name": "shrineHpChange",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1337
+        },
+        "townhallHpChange": {
+          "name": "townhallHpChange",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1337
+        },
+        "killedAt": {
+          "name": "killedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "WarKill_warId_idx": {
+          "name": "WarKill_warId_idx",
+          "columns": [
+            "warId"
+          ],
+          "isUnique": false
+        },
+        "WarKill_killerId_idx": {
+          "name": "WarKill_killerId_idx",
+          "columns": [
+            "killerId"
+          ],
+          "isUnique": false
+        },
+        "WarKill_victimId_idx": {
+          "name": "WarKill_victimId_idx",
+          "columns": [
+            "victimId"
+          ],
+          "isUnique": false
+        },
+        "WarKill_killerVillageId_idx": {
+          "name": "WarKill_killerVillageId_idx",
+          "columns": [
+            "killerVillageId"
+          ],
+          "isUnique": false
+        },
+        "WarKill_victimVillageId_idx": {
+          "name": "WarKill_victimVillageId_idx",
+          "columns": [
+            "victimVillageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "WarKill_id": {
+          "name": "WarKill_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/app/drizzle/migrations/meta/_journal.json
+++ b/app/drizzle/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1784395621841,
       "tag": "0019_even_vision",
       "breakpoints": false
+    },
+    {
+      "idx": 20,
+      "version": "5",
+      "when": 1784555409552,
+      "tag": "0020_broad_princess_powerful",
+      "breakpoints": false
     }
   ]
 }

--- a/app/src/app/api/uploadthing/core.ts
+++ b/app/src/app/api/uploadthing/core.ts
@@ -3,12 +3,13 @@ import { and, eq, gt, isNotNull, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import type { FileRouter } from "uploadthing/next";
 import { createUploadthing } from "uploadthing/next";
-import { UploadThingError, UTApi } from "uploadthing/server";
+import { UploadThingError, UTApi, UTFiles } from "uploadthing/server";
 import { z } from "zod";
 import type { FederalStatuses } from "@/drizzle/constants";
 import { historicalAvatar, userData, userUpload } from "@/drizzle/schema";
 import { classifyNsfwImage } from "@/libs/moderator";
 import { createThumbnail } from "@/libs/replicate";
+import { extensionCustomId, servedUfsUrl } from "@/libs/uploadthing";
 import { insertHistoricalSoundEffect } from "@/server/api/routers/audio";
 import { drizzleDB } from "@/server/db";
 import { getUserFederalStatus } from "@/utils/paypal";
@@ -25,7 +26,18 @@ const f = createUploadthing({
 });
 
 type ImageUploadResult = { fileUrl: string; error?: string };
-type UploadedImage = { key: string; ufsUrl: string };
+type UploadedImage = { key: string; ufsUrl: string; customId?: string | null };
+
+/**
+ * Give every incoming file a customId that carries its extension, so the
+ * served URL path has one and the Bunny CDN optimizer can engage on it.
+ */
+const withExtensionIds = (files: readonly { name: string; type?: string }[]) => ({
+  [UTFiles]: files.map((file) => ({
+    ...file,
+    customId: extensionCustomId(file.name, file.type),
+  })),
+});
 
 const moderateUploadedImage = async (
   file: UploadedImage,
@@ -44,7 +56,7 @@ const moderateUploadedImage = async (
       error: "Unable to validate uploaded image. Please try another image.",
     };
   }
-  return { fileUrl: file.ufsUrl };
+  return { fileUrl: servedUfsUrl(file) };
 };
 
 /**
@@ -75,30 +87,45 @@ const adminMiddleware = async () => {
 
 export const ourFileRouter = {
   imageUploader: f({ image: { maxFileSize: "512KB" } })
-    .middleware(async () => await avatarMiddleware())
+    .middleware(async ({ files }) => ({
+      ...(await avatarMiddleware()),
+      ...withExtensionIds(files),
+    }))
     .onUploadComplete(async ({ file }) => moderateUploadedImage(file)),
   conceptArtFrameUploader: f({ image: { maxFileSize: "256KB" } })
-    .middleware(async () => await avatarMiddleware())
+    .middleware(async ({ files }) => ({
+      ...(await avatarMiddleware()),
+      ...withExtensionIds(files),
+    }))
     .onUploadComplete(async ({ file }) => moderateUploadedImage(file)),
   modelUploader: f({ "model/gltf-binary": { maxFileSize: "256KB" } })
-    .middleware(async () => await avatarMiddleware())
+    .middleware(async ({ files }) => ({
+      ...(await avatarMiddleware()),
+      ...withExtensionIds(files),
+    }))
     .onUploadComplete(({ file }) => {
-      return { fileUrl: file.ufsUrl };
+      return { fileUrl: servedUfsUrl(file) };
     }),
   tavernUploader: f({ image: { maxFileSize: "64KB" } })
-    .middleware(async () => await avatarMiddleware())
+    .middleware(async ({ files }) => ({
+      ...(await avatarMiddleware()),
+      ...withExtensionIds(files),
+    }))
     .onUploadComplete(async ({ metadata, file }) => {
       const moderation = await moderateUploadedImage(file);
       if (moderation.error) return moderation;
       await drizzleDB.insert(userUpload).values({
         id: nanoid(),
         userId: metadata.userId,
-        imageUrl: file.ufsUrl,
+        imageUrl: servedUfsUrl(file),
       });
       return moderation;
     }),
   anbuUploader: f({ image: { maxFileSize: "512KB" } })
-    .middleware(async () => await avatarMiddleware())
+    .middleware(async ({ files }) => ({
+      ...(await avatarMiddleware()),
+      ...withExtensionIds(files),
+    }))
     .onUploadComplete(async ({ file }) => {
       const moderation = await moderateUploadedImage(file);
       if (moderation.error) return moderation;
@@ -106,7 +133,10 @@ export const ourFileRouter = {
       return moderation;
     }),
   clanUploader: f({ image: { maxFileSize: "512KB" } })
-    .middleware(async () => await avatarMiddleware())
+    .middleware(async ({ files }) => ({
+      ...(await avatarMiddleware()),
+      ...withExtensionIds(files),
+    }))
     .onUploadComplete(async ({ file }) => {
       const moderation = await moderateUploadedImage(file);
       if (moderation.error) return moderation;
@@ -114,7 +144,10 @@ export const ourFileRouter = {
       return moderation;
     }),
   tournamentUploader: f({ image: { maxFileSize: "512KB" } })
-    .middleware(async () => await avatarMiddleware())
+    .middleware(async ({ files }) => ({
+      ...(await avatarMiddleware()),
+      ...withExtensionIds(files),
+    }))
     .onUploadComplete(async ({ file }) => {
       const moderation = await moderateUploadedImage(file);
       if (moderation.error) return moderation;
@@ -122,7 +155,10 @@ export const ourFileRouter = {
       return moderation;
     }),
   avatarNormalUploader: f({ image: { maxFileSize: "512KB" } })
-    .middleware(async () => await avatarMiddleware("NORMAL"))
+    .middleware(async ({ files }) => ({
+      ...(await avatarMiddleware("NORMAL")),
+      ...withExtensionIds(files),
+    }))
     .onUploadComplete(async ({ metadata, file }) => {
       const moderation = await moderateUploadedImage(file);
       if (moderation.error) return moderation;
@@ -130,7 +166,10 @@ export const ourFileRouter = {
       return moderation;
     }),
   avatarSilverUploader: f({ image: { maxFileSize: "1MB" } })
-    .middleware(async () => await avatarMiddleware("SILVER"))
+    .middleware(async ({ files }) => ({
+      ...(await avatarMiddleware("SILVER")),
+      ...withExtensionIds(files),
+    }))
     .onUploadComplete(async ({ metadata, file }) => {
       const moderation = await moderateUploadedImage(file);
       if (moderation.error) return moderation;
@@ -138,7 +177,10 @@ export const ourFileRouter = {
       return moderation;
     }),
   avatarGoldUploader: f({ image: { maxFileSize: "2MB" } })
-    .middleware(async () => await avatarMiddleware("GOLD"))
+    .middleware(async ({ files }) => ({
+      ...(await avatarMiddleware("GOLD")),
+      ...withExtensionIds(files),
+    }))
     .onUploadComplete(async ({ metadata, file }) => {
       const moderation = await moderateUploadedImage(file);
       if (moderation.error) return moderation;
@@ -146,56 +188,71 @@ export const ourFileRouter = {
       return moderation;
     }),
   backgroundImageUploader: f({ image: { maxFileSize: "8MB" } })
-    .middleware(adminMiddleware) // Use the adminMiddleware here
+    .middleware(async ({ files }) => ({
+      ...(await adminMiddleware()),
+      ...withExtensionIds(files),
+    })) // Use the adminMiddleware here
     .onUploadComplete(async ({ metadata, file }) => {
-      console.log(`Background image uploaded by ${metadata.userId}: ${file.ufsUrl}`);
+      console.log(
+        `Background image uploaded by ${metadata.userId}: ${servedUfsUrl(file)}`,
+      );
     }),
   // SFX audio (small files)
   audioSfxUploader: f({ audio: { maxFileSize: "64KB" } })
     .input(z.object({ relationId: z.string() }))
-    .middleware(async ({ input }) => {
+    .middleware(async ({ input, files }) => {
       const { userId } = await adminMiddleware();
-      return { userId, relationId: input.relationId };
+      return { userId, relationId: input.relationId, ...withExtensionIds(files) };
     })
     .onUploadComplete(async ({ metadata, file }) => {
-      await insertHistoricalSoundEffect(drizzleDB, metadata.userId, file.ufsUrl, {
-        relationId: metadata.relationId,
-        secondsTotal: 1,
-        prompt: "",
-        negativePrompt: "",
-      });
-      return { fileUrl: file.ufsUrl, userId: metadata.userId };
+      await insertHistoricalSoundEffect(
+        drizzleDB,
+        metadata.userId,
+        servedUfsUrl(file),
+        {
+          relationId: metadata.relationId,
+          secondsTotal: 1,
+          prompt: "",
+          negativePrompt: "",
+        },
+      );
+      return { fileUrl: servedUfsUrl(file), userId: metadata.userId };
     }),
   // MUSIC audio (larger files)
   audioMusicUploader: f({ audio: { maxFileSize: "4MB" } })
     .input(z.object({ relationId: z.string() }))
-    .middleware(async ({ input }) => {
+    .middleware(async ({ input, files }) => {
       const { userId } = await adminMiddleware();
-      return { userId, relationId: input.relationId };
+      return { userId, relationId: input.relationId, ...withExtensionIds(files) };
     })
     .onUploadComplete(async ({ metadata, file }) => {
-      await insertHistoricalSoundEffect(drizzleDB, metadata.userId, file.ufsUrl, {
-        relationId: metadata.relationId,
-        secondsTotal: 1,
-        prompt: "",
-        negativePrompt: "",
-      });
-      return { fileUrl: file.ufsUrl, userId: metadata.userId };
+      await insertHistoricalSoundEffect(
+        drizzleDB,
+        metadata.userId,
+        servedUfsUrl(file),
+        {
+          relationId: metadata.relationId,
+          secondsTotal: 1,
+          prompt: "",
+          negativePrompt: "",
+        },
+      );
+      return { fileUrl: servedUfsUrl(file), userId: metadata.userId };
     }),
   // Tower Defense character animation zip uploader
   towerDefenseCharacterZip: f({
     "application/zip": { maxFileSize: "32MB" },
   })
     .input(z.object({ characterId: z.string() }))
-    .middleware(async ({ input }) => {
+    .middleware(async ({ input, files }) => {
       const { userId } = await adminMiddleware();
-      return { userId, characterId: input.characterId };
+      return { userId, characterId: input.characterId, ...withExtensionIds(files) };
     })
     .onUploadComplete(async ({ metadata, file }) => {
       // The actual processing will be done by a tRPC endpoint
       // This just handles the upload and returns the URL
       return {
-        fileUrl: file.ufsUrl,
+        fileUrl: servedUfsUrl(file),
         userId: metadata.userId,
         characterId: metadata.characterId,
       };
@@ -204,9 +261,12 @@ export const ourFileRouter = {
   towerDefenseFrameUploader: f({
     image: { maxFileSize: "256KB", maxFileCount: 100 },
   })
-    .middleware(adminMiddleware)
+    .middleware(async ({ files }) => ({
+      ...(await adminMiddleware()),
+      ...withExtensionIds(files),
+    }))
     .onUploadComplete(({ file }) => {
-      return { fileUrl: file.ufsUrl };
+      return { fileUrl: servedUfsUrl(file) };
     }),
 } satisfies FileRouter;
 
@@ -255,15 +315,16 @@ const avatarMiddleware = async (fedRequirement?: (typeof FederalStatuses)[number
  * @param userId
  */
 const uploadHistoricalAvatar = async (
-  file: { ufsUrl: string },
+  file: { ufsUrl: string; customId?: string | null },
   userId: string,
   updateUser?: boolean,
 ) => {
-  const thumbnailUrl = await createThumbnail(file.ufsUrl);
+  const fileUrl = servedUfsUrl(file);
+  const thumbnailUrl = await createThumbnail(fileUrl);
   const promises = [
     drizzleDB.insert(historicalAvatar).values({
       replicateId: null,
-      avatar: file.ufsUrl,
+      avatar: fileUrl,
       avatarLight: thumbnailUrl,
       status: "succeeded",
       userId: userId,
@@ -273,7 +334,7 @@ const uploadHistoricalAvatar = async (
       ? [
           drizzleDB
             .update(userData)
-            .set({ avatar: file.ufsUrl, avatarLight: thumbnailUrl })
+            .set({ avatar: fileUrl, avatarLight: thumbnailUrl })
             .where(eq(userData.userId, userId)),
         ]
       : []),

--- a/app/src/layout/Sector.tsx
+++ b/app/src/layout/Sector.tsx
@@ -32,7 +32,7 @@ import {
   MEDNIN_MIN_RANK,
   RANKS_RESTRICTED_FROM_PVP,
   STRUCTURE_ADJACENTS,
-  WAR_SHRINE_IMAGE,
+  WAR_SHRINE_IMAGE_BY_BIOME,
   XP_BRACKETS,
 } from "@/drizzle/constants";
 import type { UserData, VillageStructure } from "@/drizzle/schema";
@@ -84,6 +84,7 @@ import {
 } from "@/libs/threejs/util";
 import { showMutationToast } from "@/libs/toast";
 import { hasRequiredRank } from "@/libs/train";
+import { getBiomeFromTileType } from "@/libs/travel";
 import { isWarAllies } from "@/libs/war";
 import type { UserWithRelations } from "@/routers/profile";
 import { findVillageUserRelationship, getAllyStatus } from "@/utils/alliance";
@@ -360,12 +361,12 @@ const Sector: React.FC<SectorProps> = (props) => {
       createGenericStructure({
         name: "Sector Shrine",
         route: "/shrine",
-        image: WAR_SHRINE_IMAGE,
+        image: WAR_SHRINE_IMAGE_BY_BIOME[getBiomeFromTileType(props.tile.t)],
         longitude: shrineAnchor?.x ?? 10,
         latitude: shrineAnchor?.y ?? 5,
       }),
     ];
-  }, [villageData?.structures, sectorMap.anchors]);
+  }, [villageData?.structures, sectorMap.anchors, props.tile.t]);
 
   // Query for raids in this sector (only when user is in this sector)
   const { data: sectorRaidsData } = api.raids.getAvailableRaids.useQuery(
@@ -1207,7 +1208,7 @@ const Sector: React.FC<SectorProps> = (props) => {
         createGenericStructure({
           name: "Sector Shrine",
           route: "/shrine",
-          image: WAR_SHRINE_IMAGE,
+          image: WAR_SHRINE_IMAGE_BY_BIOME[getBiomeFromTileType(entry.globalTileType)],
           longitude: shrineAnchor?.x ?? 10,
           latitude: shrineAnchor?.y ?? 5,
         }),

--- a/app/src/libs/replicate.ts
+++ b/app/src/libs/replicate.ts
@@ -21,6 +21,7 @@ import { UTApi, UTFile } from "uploadthing/server";
 import type { IMG_ORIENTATION } from "@/drizzle/constants";
 import type { UserData, UserRank } from "@/drizzle/schema";
 import { env } from "@/env/server.mjs";
+import { servedUfsUrl } from "@/libs/uploadthing";
 import type { DrizzleClient } from "@/server/db";
 import type { GenerateAudioInput } from "@/validators/audio";
 import { fetchAttributes } from "../server/api/routers/profile";
@@ -153,12 +154,12 @@ export const uploadToUT = async (url: string) => {
   if (!url.startsWith("http")) {
     const fileBuffer = await fs.promises.readFile(url);
     const uploadedFile = await utapi.uploadFiles(
-      new UTFile([fileBuffer as BlobPart], name),
+      new UTFile([fileBuffer as BlobPart], name, { customId: name }),
     );
-    return uploadedFile.data?.ufsUrl ?? null;
+    return uploadedFile.data ? servedUfsUrl(uploadedFile.data) : null;
   } else {
-    const uploadedFile = await utapi.uploadFilesFromUrl({ url, name });
-    return uploadedFile.data?.ufsUrl ?? null;
+    const uploadedFile = await utapi.uploadFilesFromUrl({ url, name, customId: name });
+    return uploadedFile.data ? servedUfsUrl(uploadedFile.data) : null;
   }
 };
 
@@ -226,7 +227,11 @@ export const fastTxt2imgReplicate = async (config: {
   const replicateUrl = output.url();
   const utapi = new UTApi();
   const name = `preview-${nanoid()}.webp`;
-  const uploadedFile = await utapi.uploadFilesFromUrl({ url: replicateUrl, name });
+  const uploadedFile = await utapi.uploadFilesFromUrl({
+    url: replicateUrl,
+    name,
+    customId: name,
+  });
   return uploadedFile;
 };
 
@@ -299,7 +304,9 @@ export const txt2imgGPT = async (config: Txt2ImgConfig) => {
   });
 
   // Return the URLs of the images
-  return uploadedFiles.map((file) => file.data?.ufsUrl).filter(Boolean) as string[];
+  return uploadedFiles
+    .map((file) => (file.data ? servedUfsUrl(file.data) : null))
+    .filter(Boolean) as string[];
 };
 
 /**
@@ -382,7 +389,7 @@ export const txt2imgNanoBanana = async (config: Txt2ImgConfig) => {
 
   const resizedBlob = new Blob([resultBuffer as BlobPart]);
   const uploaded = await uploadFileFromReplicate("content", resizedBlob, "webp");
-  const url = uploaded.data?.ufsUrl ?? null;
+  const url = uploaded.data ? servedUfsUrl(uploaded.data) : null;
   return url ? [url] : [];
 };
 
@@ -453,16 +460,13 @@ export const uploadImageFromOpenAI = async (config: {
         .resize({ width, height, fit: "inside" })
         .webp({ quality: 70 })
         .toBuffer();
-      return new File([resultBuffer as BlobPart], `${prefix}-${idx}-${i}.webp`);
+      const fileName = `${prefix}-${idx}-${i}.webp`;
+      return new UTFile([resultBuffer as BlobPart], fileName, { customId: fileName });
     }),
   );
   const uploadedFiles = await utapi.uploadFiles(resizedImages);
   return uploadedFiles;
 };
-
-interface FileEsque extends Blob {
-  name: string;
-}
 
 /**
  * Create a thumbnail for the image
@@ -473,11 +477,13 @@ export const createThumbnail = async (url?: string | null) => {
     const res = await fetch(url);
     const blob = await res.arrayBuffer();
     const resultBuffer = await sharp(blob).resize(64, 64).toBuffer();
-    const thumbnail = new Blob([resultBuffer as BlobPart]) as FileEsque;
-    thumbnail.name = "thumbnail.png";
+    const thumbName = `thumbnail-${nanoid()}.png`;
+    const thumbnail = new UTFile([resultBuffer as BlobPart], thumbName, {
+      customId: thumbName,
+    });
     const utapi = new UTApi();
     const response = await utapi.uploadFiles(thumbnail);
-    const imageUrl = response.data?.ufsUrl;
+    const imageUrl = response.data ? servedUfsUrl(response.data) : null;
     return imageUrl ?? url;
   } catch (_error) {
     return url;
@@ -497,7 +503,8 @@ export const uploadFileFromReplicate = async (
   extension = "webp",
 ) => {
   const utapi = new UTApi();
-  const utFiles = new File([blob], `${prefix}-${nanoid()}.${extension}`);
+  const fileName = `${prefix}-${nanoid()}.${extension}`;
+  const utFiles = new UTFile([blob], fileName, { customId: fileName });
   const uploadedFile = await utapi.uploadFiles(utFiles);
   return uploadedFile;
 };
@@ -535,8 +542,8 @@ export const generateAndUploadAudio = async (config: GenerateAudioInput) => {
   const { url } = await generateSoundEffectReplicate(config);
   const utapi = new UTApi();
   const name = `audio-${nanoid()}.mp3`;
-  const uploadedFile = await utapi.uploadFilesFromUrl({ url, name });
-  return uploadedFile.data?.ufsUrl ?? null;
+  const uploadedFile = await utapi.uploadFilesFromUrl({ url, name, customId: name });
+  return uploadedFile.data ? servedUfsUrl(uploadedFile.data) : null;
 };
 
 /**
@@ -676,7 +683,11 @@ export const uploadCompletedVideo = async (outputUrl: string) => {
   const utapi = new UTApi();
   const name = `video-${nanoid()}.mp4`;
   console.log("Uploading video to UploadThing", outputUrl, name);
-  const uploadedFile = await utapi.uploadFilesFromUrl({ url: outputUrl, name });
+  const uploadedFile = await utapi.uploadFilesFromUrl({
+    url: outputUrl,
+    name,
+    customId: name,
+  });
   console.log("Uploaded video to UploadThing", uploadedFile.data?.ufsUrl);
-  return uploadedFile.data?.ufsUrl ?? null;
+  return uploadedFile.data ? servedUfsUrl(uploadedFile.data) : null;
 };

--- a/app/src/libs/sector-map/decorations.ts
+++ b/app/src/libs/sector-map/decorations.ts
@@ -24,95 +24,95 @@ export const DECORATION_ASSETS: DecorationAsset[] = [
   {
     key: "grass.tuft",
     filepath:
-      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJa55Vc5YYfKMcJ2B5EmWt6VsNgqxpG8OSXAQk",
+      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJa55Vc5YYfKMcJ2B5EmWt6VsNgqxpG8OSXAQk.webp",
     windAffected: true,
     small: true,
   },
   {
     key: "grass.sprout",
     filepath:
-      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJlvcZlIrWYxAsuC7ofQn9pM45OD0ERqkdBXJU",
+      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJlvcZlIrWYxAsuC7ofQn9pM45OD0ERqkdBXJU.webp",
     windAffected: true,
     small: true,
   },
   {
     key: "grass.flower",
     filepath:
-      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJcpFFdRSnxBpQqGNDcTHbLmYz8uXAl3oa54ti",
+      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJcpFFdRSnxBpQqGNDcTHbLmYz8uXAl3oa54ti.webp",
     windAffected: true,
     small: true,
   },
   {
     key: "grass.pebble",
     filepath:
-      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJxfrF3oWZsq9k0Von5rUfP6OgQ2TyptCKHS4u",
+      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJxfrF3oWZsq9k0Von5rUfP6OgQ2TyptCKHS4u.webp",
     small: true,
   },
   {
     key: "tree.green.round",
     filepath:
-      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJndYwvrmojJ0EqeDCvBrNmZaXVdY97gSpOWiA",
+      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJndYwvrmojJ0EqeDCvBrNmZaXVdY97gSpOWiA.webp",
     windAffected: true,
   },
   {
     key: "tree.green.tall",
     filepath:
-      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJvFn4sIEmSnXwslYEpV1yOeNL8gMtqhjPdf36",
+      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJvFn4sIEmSnXwslYEpV1yOeNL8gMtqhjPdf36.webp",
     windAffected: true,
   },
   {
     key: "tree.green.wide",
     filepath:
-      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJHl8NCiQvYURJhgs76VZtf9wxpMa13Cq0iOnr",
+      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJHl8NCiQvYURJhgs76VZtf9wxpMa13Cq0iOnr.webp",
     windAffected: true,
   },
   {
     key: "cactus.saguaro",
     filepath:
-      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJe0aIBjyV3OvUJQExAi0bGoIZDF74LqSnHRdp",
+      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJe0aIBjyV3OvUJQExAi0bGoIZDF74LqSnHRdp.webp",
     windAffected: true,
   },
   {
     key: "cactus.barrel",
     filepath:
-      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ7vgcu3XKPBOUWGyFuM4DlL1v5HNTZhkte0z6",
+      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJ7vgcu3XKPBOUWGyFuM4DlL1v5HNTZhkte0z6.webp",
     windAffected: true,
   },
   {
     key: "cactus.cluster",
     filepath:
-      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJvmatJJEmSnXwslYEpV1yOeNL8gMtqhjPdf36",
+      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJvmatJJEmSnXwslYEpV1yOeNL8gMtqhjPdf36.webp",
     windAffected: true,
   },
   {
     key: "rock.sand",
     filepath:
-      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJQlUKaJVjhzBPya1rwfCIqOTU0cV5xgsMeo3u",
+      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJQlUKaJVjhzBPya1rwfCIqOTU0cV5xgsMeo3u.webp",
     small: true,
   },
   {
     key: "rock.grey",
     filepath:
-      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJzLLsgkemvaQu94EYJs8HpxVzofny6iPtbgCZ",
+      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJzLLsgkemvaQu94EYJs8HpxVzofny6iPtbgCZ.webp",
     small: true,
   },
   {
     key: "rock.slate",
     filepath:
-      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJylERmDukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp",
+      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJylERmDukVH2MI5Lo4ehEfAXvZdcmtWqPg7rp.webp",
     small: true,
   },
   {
     key: "ice.floe",
     filepath:
-      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJzJ76QEemvaQu94EYJs8HpxVzofny6iPtbgCZ",
+      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJzJ76QEemvaQu94EYJs8HpxVzofny6iPtbgCZ.webp",
     small: true,
     randomRotation: true,
   },
   {
     key: "tree.snow.pine",
     filepath:
-      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJrtEwSR2huJPmdY8zI2ptZXAoEj1c6BMKvrQO",
+      "https://uploadthing.b-cdn.net/f/Hzww9EQvYURJrtEwSR2huJPmdY8zI2ptZXAoEj1c6BMKvrQO.webp",
     windAffected: true,
   },
 ];

--- a/app/src/libs/sector-map/terrains.ts
+++ b/app/src/libs/sector-map/terrains.ts
@@ -98,6 +98,22 @@ export const BUILTIN_TERRAINS_BY_KEY = new Map(
 export const FALLBACK_TERRAIN_KEY = "ground";
 
 /**
+ * The land terrain drawn under structures per sector biome, overriding the
+ * authored tile. Structure sprites carry baked ground patches (snow, grass,
+ * sand) that must blend with the tiles beneath; water biomes get a sand
+ * island so shrines anchored in the ocean don't float on waves.
+ */
+export const STRUCTURE_GROUND_TERRAIN: Record<CombatBiome, string> = {
+  ocean: "dessert",
+  ground: "ground",
+  dessert: "dessert",
+  ice: "snow",
+  snow: "snow",
+  arena: "ground",
+  default: "ground",
+};
+
+/**
  * Built-ins overlaid with the database terrain library: DB rows win on key
  * collision (so edits to the built-in looks take effect), creator-added kinds
  * extend the map.

--- a/app/src/libs/threejs/sector.ts
+++ b/app/src/libs/threejs/sector.ts
@@ -72,7 +72,7 @@ import {
   getHexPoints,
   mergeBufferGeometries,
 } from "@/libs/threejs/hexgrid";
-import { applyBlurShader, applyWaveShader } from "@/libs/threejs/shaders";
+import { applyWaveShader } from "@/libs/threejs/shaders";
 import type { SectorUser } from "@/libs/threejs/types";
 import { createTexture, loadTexture, profiler } from "@/libs/threejs/util";
 import { hasRequiredRank } from "@/libs/train";
@@ -1194,21 +1194,8 @@ export const drawVillage = (
     if (pos) {
       // Add a structure group
       const { height: h, x, y } = pos;
-      //  Structure shadow in the top of the structure, with edges from the original structure
-      const shadow_texture2 = loadTexture(structure.image, 200);
-      const shadow_material2 = new SpriteMaterial({
-        map: shadow_texture2,
-        color: 0x000000,
-        opacity: 0.3,
-        depthWrite: false,
-        depthTest: false,
-      });
-      applyBlurShader(shadow_material2, 0.01);
-      const shadow_sprite2 = new Sprite(shadow_material2);
-      shadow_sprite2.scale.set(h * 3.3, h * 3.3, 1);
-      shadow_sprite2.position.set(x - 0.2 * h, y + h / 10 + 0.2 * h, ASSETS_LAYER);
-      group.add(shadow_sprite2);
-      // Structure
+      // Structure sprite; cast shadows are baked into the structure art
+      // (sun upper-right, shadow lower-left, matching decoration sprites)
       const texture = loadTexture(structure.image, 200);
       const material = new SpriteMaterial({
         map: texture,

--- a/app/src/libs/threejs/sector.ts
+++ b/app/src/libs/threejs/sector.ts
@@ -47,7 +47,11 @@ import {
   type DecorationAsset,
   resolveDecorationAsset,
 } from "@/libs/sector-map/decorations";
-import { resolveTerrainSpec, type TerrainSpec } from "@/libs/sector-map/terrains";
+import {
+  resolveTerrainSpec,
+  STRUCTURE_GROUND_TERRAIN,
+  type TerrainSpec,
+} from "@/libs/sector-map/terrains";
 import type {
   NormalizedSectorMap,
   NormalizedSectorTile,
@@ -559,6 +563,17 @@ export const drawSector = (
       // Structure tiles stay flat and walkable (includes shrines and other
       // added structures)
       if (structureTileKeys.has(tileKey)) {
+        // Structures always sit on their sector biome's land terrain,
+        // overriding the authored tile: the sprites' baked ground patches
+        // (snow/grass/sand) must blend with what is beneath them, and a
+        // shrine anchored on water gets a sand island instead of floating
+        const groundSpec = resolveTerrainSpec(
+          STRUCTURE_GROUND_TERRAIN[baseBiome],
+          terrainRegistry,
+        );
+        tile.spec = groundSpec;
+        tile.battleBiome = authoredTile?.battleBiome ?? groundSpec.battleBiome;
+        tile.cost = 2;
         // Mid shade so the ground under buildings reads flat and uniform
         tile.level = 0.5;
         tile.hasStructure = true;

--- a/app/src/libs/uploadthing.ts
+++ b/app/src/libs/uploadthing.ts
@@ -1,0 +1,29 @@
+import { nanoid } from "nanoid";
+
+/** The UploadThing app host files are served from */
+export const UPLOADTHING_HOST = "https://ui0arpl8sm.ufs.sh";
+
+/**
+ * File extension for an upload, derived from its name with the MIME type as
+ * fallback. The Bunny CDN optimizer only engages when the served URL path
+ * carries a file extension, so every upload gets one via its customId.
+ */
+const fileExtension = (name: string, type?: string) => {
+  const fromName = name.includes(".") ? name.split(".").pop() : undefined;
+  const fromType = type?.includes("/") ? type.split("/").pop() : undefined;
+  return (fromName || fromType || "bin").toLowerCase().replace(/[^a-z0-9]/g, "");
+};
+
+/** Unique customId carrying the file extension for CDN optimization */
+export const extensionCustomId = (name: string, type?: string) =>
+  `${nanoid()}.${fileExtension(name, type)}`;
+
+/**
+ * Serve URL for an uploaded file: prefers the extension-bearing customId path
+ * (which lets the CDN optimizer resize/compress on the fly), falling back to
+ * the raw key URL for files uploaded without a customId.
+ */
+export const servedUfsUrl = (file: {
+  ufsUrl: string;
+  customId?: string | null;
+}): string => (file.customId ? `${UPLOADTHING_HOST}/f/${file.customId}` : file.ufsUrl);

--- a/app/src/server/api/routers/towerDefense.ts
+++ b/app/src/server/api/routers/towerDefense.ts
@@ -2,7 +2,7 @@ import { timingSafeEqual } from "node:crypto";
 import type { InferSelectModel } from "drizzle-orm";
 import { and, asc, desc, eq, gte, lt, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
-import { UTApi } from "uploadthing/server";
+import { UTApi, UTFile } from "uploadthing/server";
 import { z } from "zod";
 import {
   TD_GRID_EXPAND_EVERY_N_WAVES,
@@ -34,6 +34,7 @@ import {
   directionToSpriteDirection,
   generateRunSeed,
 } from "@/libs/towerDefense/game";
+import { servedUfsUrl } from "@/libs/uploadthing";
 import {
   generateSessionNonce,
   type SessionParams,
@@ -799,7 +800,7 @@ export const towerDefenseRouter = createTRPCRouter({
 
         const utapi = new UTApi();
         const uploadedUrls: Map<string, string> = new Map();
-        const filesToUpload: { path: string; file: File }[] = [];
+        const filesToUpload: { path: string; file: UTFile }[] = [];
 
         // Collect all image files to upload
         for (const path of Object.keys(zip.files)) {
@@ -819,8 +820,10 @@ export const towerDefenseRouter = createTRPCRouter({
                   : "image/png";
             // Convert Uint8Array to Buffer for proper BlobPart compatibility
             const buffer = Buffer.from(content);
-            const file = new File([buffer], path.replace(/\//g, "_"), {
+            const fileName = path.replace(/\//g, "_");
+            const file = new UTFile([buffer], fileName, {
               type: mimeType,
+              customId: `${nanoid()}.${ext}`,
             });
             filesToUpload.push({ path, file });
           }
@@ -836,7 +839,7 @@ export const towerDefenseRouter = createTRPCRouter({
             const result = uploadResults[j];
             const batchItem = batch[j];
             if (result?.data?.ufsUrl && batchItem) {
-              uploadedUrls.set(batchItem.path, result.data.ufsUrl);
+              uploadedUrls.set(batchItem.path, servedUfsUrl(result.data));
             }
           }
         }


### PR DESCRIPTION
## Summary

Full visual refresh of village structure sprites plus the serving-pipeline fixes needed to make them (and all other game images) cheap to deliver.

### 1. Refreshed structure sprites (all villages + outlaw/safezone)
- All 106 structure sprites (9 villages/factions) regenerated with gpt-image-2 from the existing art: square diorama plinths removed, buildings grounded on organic biome-matched terrain patches (snow/grass/sand), consistent ~35° three-quarter camera, and a soft baked cast shadow (sun upper-right, shadow lower-left, matching the existing tree/decoration sprites).
- Every sprite was judge-reviewed for camera/orientation consistency by a fan-out agent workflow; 17 outliers were re-rolled and re-verified.
- The runtime blob shadow (blurred sprite copy offset up-left) is removed from `drawVillage` — shadows now live in the art, so buildings read as part of the terrain instead of stickers.

### 2. Biome grounding + shrine variants
- Tiles under (and adjacent to) any structure now always render the sector biome's land terrain, overriding the authored Tiled map (`STRUCTURE_GROUND_TERRAIN`): snow under Hyorin structures, and a sand island under shrines anchored in water.
- Sector shrines now come in snow/grass/desert variants (`WAR_SHRINE_IMAGE_BY_BIOME`), picked from the sector's globe tile; base shrine art refreshed to match the new sprite set.

### 3. CDN optimization fix (91% payload reduction)
- Bunny's optimizer only engages when the URL path carries a file extension; modern UploadThing keys are extensionless, so every newer asset was silently served **full size** (`?width=` was a no-op).
- Every upload now gets a `customId` of `<id>.<ext>` (files serve at `/f/<customId>`): client file router (via `UTFiles` middleware injection), replicate uploads, and tower-defense zip uploads — so all future assets/avatars/tiles are optimizable.
- Existing assets re-uploaded under `<oldKey>.<ext>` custom ids (new URL = old URL + extension): 232 constants/decoration assets, all 112 structure sprite URLs, plus MapAsset/MapTerrain rows (dev DB updated; prod rows need the same one-off update on deploy).
- Verified logged-in on `/travel`: image payload dropped from **3.83 MB to 0.34 MB (−91%)**.

### Migration
- `0020_broad_princess_powerful.sql` points all `VillageStructure.image` rows at the new extension-bearing sprite URLs (already applied to the dev branch DB; runs on prod via the normal migration flow).

### Deploy notes
- Prod `MapAsset` (16 rows) and `MapTerrain` (3 rows) carry extensionless URLs and need the same append-extension update after merge (scripted, key→customId map preserved).
- Legacy user avatars in old DB rows remain extensionless (new avatar uploads are fixed by the router change); optional batch pass later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added biome-specific shrine visuals and structure ground terrain for more varied sector environments.
  - Updated building, map, decoration, tutorial, badge, and interface imagery with refreshed CDN assets.

- **Improvements**
  - Uploaded images, audio, videos, and other media now use optimized served URLs for more consistent access and delivery.
  - Refreshed existing village structure artwork across factions and locations.
  - Improved structure tile presentation and removed redundant visual shadow effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->