### PR TITLE
Inventory improvements

### DIFF
--- a/app/src/app/home/page.tsx
+++ b/app/src/app/home/page.tsx
@@ -32,8 +32,10 @@ import ContentBox from "@/layout/ContentBox";
 import Image from "@/layout/Image";
 import ItemWithEffects from "@/layout/ItemWithEffects";
 import Loader from "@/layout/Loader";
+import { MergeAllStacksButton } from "@/layout/MergeAllStacksButton";
 import Modal2 from "@/layout/Modal2";
 import {
+  byItemName,
   calcMaxHouseMaterials,
   showsItemLevelBadge,
   userItemActionBadges,
@@ -109,25 +111,31 @@ export default function HomePage() {
   );
   // Filter normal items (non-materials)
   const storedItems =
-    filteredItems?.filter(
-      (useritem) => useritem.storedAtHome && useritem.item.itemType !== "MATERIAL",
-    ) ?? [];
+    filteredItems
+      ?.filter(
+        (useritem) => useritem.storedAtHome && useritem.item.itemType !== "MATERIAL",
+      )
+      .sort(byItemName) ?? [];
   const nonStoredItems =
     filteredItems
       ?.filter((useritem) => !useritem.storedAtHome)
       .filter((useritem) => useritem.equipped === "NONE")
-      .filter((useritem) => useritem.item.itemType !== "MATERIAL") ?? [];
+      .filter((useritem) => useritem.item.itemType !== "MATERIAL")
+      .sort(byItemName) ?? [];
 
   // Filter materials separately
   const storedMaterials =
-    filteredItems?.filter(
-      (useritem) => useritem.storedAtHome && useritem.item.itemType === "MATERIAL",
-    ) ?? [];
+    filteredItems
+      ?.filter(
+        (useritem) => useritem.storedAtHome && useritem.item.itemType === "MATERIAL",
+      )
+      .sort(byItemName) ?? [];
   const nonStoredMaterials =
     filteredItems
       ?.filter((useritem) => !useritem.storedAtHome)
       .filter((useritem) => useritem.equipped === "NONE")
-      .filter((useritem) => useritem.item.itemType === "MATERIAL") ?? [];
+      .filter((useritem) => useritem.item.itemType === "MATERIAL")
+      .sort(byItemName) ?? [];
 
   const canStoreMoreItems = storedItems.length < homeStorage;
   const canStoreMoreMaterials =
@@ -377,6 +385,17 @@ export default function HomePage() {
             title="Item Storage"
             subtitle={`Items in home (${totalStoredItems}/${homeStorage} slots used) | Materials in home (${storedMaterials.length}/${userData && homeData ? calcMaxHouseMaterials(userData, homeData.storage) : 0} slots used)`}
             initialBreak={true}
+            topRightContent={
+              homeData?.homeType !== "NONE" ? (
+                <MergeAllStacksButton
+                  storedAtHome={true}
+                  onMerged={() => {
+                    setSelectedItem(undefined);
+                    setIsModalOpen(false);
+                  }}
+                />
+              ) : undefined
+            }
           >
             {isHomeLoading || isItemsLoading ? (
               <Loader explanation="Loading item storage data" />

--- a/app/src/app/home/page.tsx
+++ b/app/src/app/home/page.tsx
@@ -386,7 +386,7 @@ export default function HomePage() {
             subtitle={`Items in home (${totalStoredItems}/${homeStorage} slots used) | Materials in home (${storedMaterials.length}/${userData && homeData ? calcMaxHouseMaterials(userData, homeData.storage) : 0} slots used)`}
             initialBreak={true}
             topRightContent={
-              homeData?.homeType !== "NONE" ? (
+              homeData && homeData.homeType !== "NONE" ? (
                 <MergeAllStacksButton
                   storedAtHome={true}
                   onMerged={() => {

--- a/app/src/app/items/page.tsx
+++ b/app/src/app/items/page.tsx
@@ -849,6 +849,8 @@ const Backpack: React.FC<BackpackProps> = (props) => {
     (userItem: UserItemWithRelations) =>
       userItem.item?.effects?.some((e: { type: string }) => e.type === "repair") &&
       userItem.quantity > 0 &&
+      !userItem.storedAtHome &&
+      !userItem.isInAuction &&
       (!userItem.craftingFinishedAt || userItem.craftingFinishedAt < new Date()),
   );
 
@@ -1269,6 +1271,8 @@ const Character: React.FC<CharacterProps> = (props) => {
     (userItem: UserItemWithRelations) =>
       userItem.item?.effects?.some((e: { type: string }) => e.type === "repair") &&
       userItem.quantity > 0 &&
+      !userItem.storedAtHome &&
+      !userItem.isInAuction &&
       (!userItem.craftingFinishedAt || userItem.craftingFinishedAt < new Date()),
   );
 

--- a/app/src/app/items/page.tsx
+++ b/app/src/app/items/page.tsx
@@ -314,6 +314,7 @@ export default function MyItems() {
                 canRepairWithKits && !isRepairAllPending ? "Repair with Kits" : null
               }
               isValid={canRepairWithKits && !isRepairAllPending}
+              disabled={isRepairAllPending}
               button={
                 <Button disabled={isRepairAllPending} variant="outline">
                   <Wrench className="mr-2 h-4 w-4" />

--- a/app/src/app/items/page.tsx
+++ b/app/src/app/items/page.tsx
@@ -47,11 +47,14 @@ import Image from "@/layout/Image";
 import ItemLoadoutSelector from "@/layout/ItemLoadoutSelector";
 import ItemWithEffects from "@/layout/ItemWithEffects";
 import Loader from "@/layout/Loader";
+import { MergeAllStacksButton } from "@/layout/MergeAllStacksButton";
 import Modal2 from "@/layout/Modal2";
 import NavTabs from "@/layout/NavTabs";
 import { applyActiveVariant } from "@/libs/combat/util";
 import { meetsEvolutionStatRequirements } from "@/libs/evolution";
 import {
+  byItemName,
+  calcItemRepairCost,
   calcItemSellingPrice,
   calcMaxEventItems,
   calcMaxItems,
@@ -111,24 +114,24 @@ export default function MyItems() {
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
-          await utils.item.getUserItemsWithVariants.invalidate();
-          await utils.profile.getUser.invalidate();
+          await Promise.all([
+            utils.item.getUserItemsWithVariants.invalidate(),
+            utils.profile.getUser.invalidate(),
+          ]);
         }
       },
     });
 
-  const { mutate: mergeAllStacks, isPending: isMergingAllStacks } =
-    api.item.mergeAllStacks.useMutation({
+  const { mutate: mutateRepairAllRyo, isPending: isRepairingAllRyo } =
+    api.item.repairAll.useMutation({
       onSuccess: async (data) => {
         showMutationToast(data);
-        await utils.item.getUserItemsWithVariants.invalidate();
-      },
-      onError: (error) => {
-        showMutationToast({
-          success: false,
-          message: error.message,
-          variant: "destructive",
-        });
+        if (data.success) {
+          await Promise.all([
+            utils.item.getUserItemsWithVariants.invalidate(),
+            utils.profile.getUser.invalidate(),
+          ]);
+        }
       },
     });
 
@@ -190,6 +193,13 @@ export default function MyItems() {
       useritem.item.maxDurability > 0,
   );
   const repairKits = getRepairKits(userItems);
+  const isCrafter = userData.occupation === "CRAFTING";
+  const totalRyoRepairCost = itemsNeedingRepair.reduce(
+    (total, useritem) => total + calcItemRepairCost(useritem),
+    0,
+  );
+  const canAffordRyoRepair = userData.money >= totalRyoRepairCost;
+  const isRepairAllPending = isRepairingAll || isRepairingAllRyo;
 
   // Calculate which kits will be used (shared with item.useRepairAll)
   const repairKitCalculation = calculateKitsToUse(
@@ -199,6 +209,7 @@ export default function MyItems() {
   );
 
   const repairAllInfo = repairKitCalculation;
+  const canRepairWithKits = repairKits.length > 0 && repairAllInfo.canRepairAll;
 
   return (
     <>
@@ -252,38 +263,13 @@ export default function MyItems() {
             <div className="w-full basis-1/2 p-3">
               <h2 className="font-bold text-2xl text-foreground">Equipped</h2>
               <div className="relative">
-                <Character useritems={userItems} />
+                <Character useritems={userItems} userData={userData} />
               </div>
             </div>
             <div className="max-h-full basis-1/2 overflow-y-scroll border-t-2 border-dashed bg-poppopover p-3 sm:max-h-[600px] sm:border-t-0 sm:border-l-2">
               <div className="mb-2 flex flex-row flex-wrap items-center justify-between gap-2">
                 <h2 className="font-bold text-2xl text-foreground">Backpack</h2>
-                <Confirm2
-                  title="Merge all stacks"
-                  proceed_label={isMergingAllStacks ? undefined : "Merge all stacks"}
-                  isValid={!isMergingAllStacks}
-                  button={
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      disabled={isMergingAllStacks}
-                    >
-                      <Merge className="mr-2 h-4 w-4" />
-                      {isMergingAllStacks ? "Merging..." : "Merge all stacks"}
-                    </Button>
-                  }
-                  onAccept={(e) => {
-                    e.preventDefault();
-                    mergeAllStacks();
-                  }}
-                >
-                  <p>
-                    Consolidate stackable items in your carried inventory (backpack and
-                    equipped slots) into the fewest possible stacks. Home storage is not
-                    affected. This cannot be automatically undone.
-                  </p>
-                </Confirm2>
+                <MergeAllStacksButton storedAtHome={false} />
               </div>
               <Backpack
                 userData={userData}
@@ -325,64 +311,106 @@ export default function MyItems() {
           </Confirm2>
         </div>
         <div className="flex gap-2">
-          {itemsNeedingRepair.length > 0 && repairKits.length > 0 && (
+          {itemsNeedingRepair.length > 0 && (repairKits.length > 0 || isCrafter) && (
             <Confirm2
               title="Repair All Items"
               proceed_label={
-                repairAllInfo.canRepairAll
-                  ? isRepairingAll
-                    ? undefined
-                    : "Repair All"
-                  : undefined
+                canRepairWithKits && !isRepairAllPending ? "Repair with Kits" : null
               }
-              isValid={repairAllInfo.canRepairAll && !isRepairingAll}
+              isValid={canRepairWithKits && !isRepairAllPending}
               button={
-                <Button disabled={isRepairingAll} variant="outline">
+                <Button disabled={isRepairAllPending} variant="outline">
                   <Wrench className="mr-2 h-4 w-4" />
-                  {isRepairingAll ? "Repairing..." : "Repair All"}
+                  {isRepairAllPending ? "Repairing..." : "Repair All"}
                 </Button>
               }
               onAccept={(e) => {
                 e.preventDefault();
-                if (repairAllInfo.canRepairAll) {
+                if (canRepairWithKits) {
                   mutateRepairAll();
                 }
               }}
+              footerExtra={
+                isCrafter
+                  ? ({ close }) => (
+                      <Button
+                        variant="default"
+                        disabled={!canAffordRyoRepair || isRepairAllPending}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          mutateRepairAllRyo();
+                          close();
+                        }}
+                      >
+                        <CircleDollarSign className="mr-2 h-4 w-4" />
+                        Repair with Ryo ({totalRyoRepairCost.toLocaleString()})
+                      </Button>
+                    )
+                  : undefined
+              }
             >
               <div className="space-y-3">
-                {repairAllInfo.canRepairAll ? (
-                  <>
-                    <p>
-                      You are about to repair all {itemsNeedingRepair.length} item
-                      {itemsNeedingRepair.length !== 1 ? "s" : ""} using repair kits.
-                    </p>
-                    {repairAllInfo.kitsToUse.length > 0 && (
-                      <div>
-                        <p className="mb-2 font-semibold">Repair kits to be used:</p>
-                        <div className="space-y-1">
-                          {repairAllInfo.kitsToUse.map((kit) => (
-                            <div
-                              key={kit.repairItemId}
-                              className="flex items-center justify-between text-sm"
-                            >
-                              <span>{kit.repairItemName}</span>
-                              <span className="font-medium">x{kit.quantityUsed}</span>
-                            </div>
-                          ))}
+                {repairKits.length > 0 ? (
+                  canRepairWithKits ? (
+                    <>
+                      <p>
+                        You are about to repair all {itemsNeedingRepair.length} item
+                        {itemsNeedingRepair.length !== 1 ? "s" : ""} using repair kits.
+                      </p>
+                      {repairAllInfo.kitsToUse.length > 0 && (
+                        <div>
+                          <p className="mb-2 font-semibold">Repair kits to be used:</p>
+                          <div className="space-y-1">
+                            {repairAllInfo.kitsToUse.map((kit) => (
+                              <div
+                                key={kit.repairItemId}
+                                className="flex items-center justify-between text-sm"
+                              >
+                                <span>{kit.repairItemName}</span>
+                                <span className="font-medium">x{kit.quantityUsed}</span>
+                              </div>
+                            ))}
+                          </div>
                         </div>
-                      </div>
-                    )}
-                  </>
+                      )}
+                    </>
+                  ) : (
+                    <div>
+                      <p className="mb-2 font-semibold text-red-600">
+                        Not enough repair kits
+                      </p>
+                      <p className="text-muted-foreground text-sm">
+                        You have {itemsNeedingRepair.length} damaged item
+                        {itemsNeedingRepair.length !== 1 ? "s" : ""} that need{" "}
+                        {repairAllInfo.totalDurabilityNeeded} total durability, but you
+                        don&apos;t have enough repair kits to repair all of them.
+                      </p>
+                    </div>
+                  )
                 ) : (
-                  <div>
-                    <p className="mb-2 font-semibold text-red-600">
-                      Not enough repair kits
-                    </p>
-                    <p className="text-muted-foreground text-sm">
-                      You have {itemsNeedingRepair.length} damaged item
-                      {itemsNeedingRepair.length !== 1 ? "s" : ""} that need{" "}
-                      {repairAllInfo.totalDurabilityNeeded} total durability, but you
-                      don&apos;t have enough repair kits to repair all of them.
+                  <p className="text-muted-foreground text-sm">
+                    You don&apos;t have any repair kits. As a crafter, you can repair
+                    with ryo instead.
+                  </p>
+                )}
+                {isCrafter && (
+                  <div className="rounded-lg border bg-muted/50 p-3 text-sm">
+                    <p className="font-semibold">Repair with ryo</p>
+                    <p className="text-muted-foreground">
+                      Total cost:{" "}
+                      <span
+                        className={
+                          canAffordRyoRepair ? "text-green-600" : "text-red-600"
+                        }
+                      >
+                        {totalRyoRepairCost.toLocaleString()} ryo
+                      </span>
+                      {!canAffordRyoRepair && (
+                        <span className="ml-2">
+                          (You have {userData.money.toLocaleString()} ryo)
+                        </span>
+                      )}
                     </p>
                   </div>
                 )}
@@ -563,6 +591,83 @@ function RepairModalWrapper({
 }
 
 /**
+ * Shared per-item durability repair actions (kit + ryo).
+ * Used by both Backpack and Character item-details modals.
+ */
+interface ItemDurabilityRepairActionsProps {
+  useritem: UserItemWithRelations;
+  userData: NonNullable<UserWithRelations>;
+  repairItemsCount: number;
+  onOpenRepairModal: () => void;
+  onRepairWithRyo: (userItemId: string) => void;
+  isRepairingWithRyo?: boolean;
+}
+
+function ItemDurabilityRepairActions({
+  useritem,
+  userData,
+  repairItemsCount,
+  onOpenRepairModal,
+  onRepairWithRyo,
+  isRepairingWithRyo = false,
+}: ItemDurabilityRepairActionsProps) {
+  if (
+    useritem.durability >= useritem.item.maxDurability ||
+    useritem.item.maxDurability <= 0
+  ) {
+    return null;
+  }
+
+  const isCrafter = userData.occupation === "CRAFTING";
+  const ryoRepairCost = calcItemRepairCost(useritem);
+  const canAffordItemRyoRepair = userData.money >= ryoRepairCost;
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        onClick={onOpenRepairModal}
+        disabled={repairItemsCount === 0}
+      >
+        <Wrench className="mr-2 h-5 w-5" />
+        Use Repair Item
+      </Button>
+      {isCrafter && (
+        <Confirm2
+          title="Repair with Ryo"
+          proceed_label={
+            canAffordItemRyoRepair && !isRepairingWithRyo
+              ? `Repair for ${ryoRepairCost.toLocaleString()} ryo`
+              : null
+          }
+          isValid={canAffordItemRyoRepair && !isRepairingWithRyo}
+          button={
+            <Button variant="outline" disabled={isRepairingWithRyo}>
+              <CircleDollarSign className="mr-2 h-5 w-5" />
+              Repair with Ryo
+            </Button>
+          }
+          onAccept={(e) => {
+            e.preventDefault();
+            onRepairWithRyo(useritem.id);
+          }}
+        >
+          <p>
+            Repair <strong>{useritem.item.name}</strong> for{" "}
+            <strong>{ryoRepairCost.toLocaleString()} ryo</strong>?
+            {!canAffordItemRyoRepair && (
+              <span className="mt-2 block text-red-600">
+                You only have {userData.money.toLocaleString()} ryo.
+              </span>
+            )}
+          </p>
+        </Confirm2>
+      )}
+    </>
+  );
+}
+
+/**
  * Backpack Screen
  */
 interface BackpackProps {
@@ -669,8 +774,24 @@ const Backpack: React.FC<BackpackProps> = (props) => {
         showMutationToast(data);
         if (data.success) {
           setIsRepairModalOpen(false);
-          await utils.item.getUserItemsWithVariants.invalidate();
-          await utils.profile.getUser.invalidate();
+          await Promise.all([
+            utils.item.getUserItemsWithVariants.invalidate(),
+            utils.profile.getUser.invalidate(),
+          ]);
+        }
+      },
+    });
+
+  const { mutate: mutateRepairWithRyo, isPending: isRepairingWithRyo } =
+    api.item.repair.useMutation({
+      onSuccess: async (data) => {
+        showMutationToast(data);
+        if (data.success) {
+          onSettled();
+          await Promise.all([
+            utils.item.getUserItemsWithVariants.invalidate(),
+            utils.profile.getUser.invalidate(),
+          ]);
         }
       },
     });
@@ -717,11 +838,14 @@ const Backpack: React.FC<BackpackProps> = (props) => {
     isSplitting ||
     isUsingRepairItem ||
     isEvolving ||
-    isRemovingImbuement;
-  const items = useritems?.map((useritem) => ({
-    ...applyActiveVariant(useritem as UserItemWithVariants),
-    ...useritem,
-  }));
+    isRemovingImbuement ||
+    isRepairingWithRyo;
+  const items = useritems
+    ?.map((useritem) => ({
+      ...applyActiveVariant(useritem as UserItemWithVariants),
+      ...useritem,
+    }))
+    .sort(byItemName);
   const itemBadges = userItemActionBadges(useritems);
   const sellPrice = calcItemSellingPrice(userData, useritem, structures);
   const repairItems = (useritems || []).filter(
@@ -885,17 +1009,14 @@ const Backpack: React.FC<BackpackProps> = (props) => {
                   Consume
                 </Button>
               )}
-              {useritem.durability < useritem.item.maxDurability &&
-                useritem.item.maxDurability > 0 && (
-                  <Button
-                    variant="outline"
-                    onClick={() => setIsRepairModalOpen(true)}
-                    disabled={repairItems.length === 0}
-                  >
-                    <Wrench className="mr-2 h-5 w-5" />
-                    Use Repair Item
-                  </Button>
-                )}
+              <ItemDurabilityRepairActions
+                useritem={useritem}
+                userData={userData}
+                repairItemsCount={repairItems.length}
+                onOpenRepairModal={() => setIsRepairModalOpen(true)}
+                onRepairWithRyo={(userItemId) => mutateRepairWithRyo({ userItemId })}
+                isRepairingWithRyo={isRepairingWithRyo}
+              />
               {((useritem as UserItemWithVariants).item.variants?.length ?? 0) > 0 && (
                 <Button
                   variant="info"
@@ -1029,6 +1150,9 @@ const Backpack: React.FC<BackpackProps> = (props) => {
           {isSelling && <Loader explanation={`Selling ${useritem.item.name}`} />}
           {isEquipping && <Loader explanation={`Equipping ${useritem.item.name}`} />}
           {isEvolving && <Loader explanation={`Evolving ${useritem.item.name}`} />}
+          {isRepairingWithRyo && (
+            <Loader explanation={`Repairing ${useritem.item.name}`} />
+          )}
         </Modal2>
       )}
       {isSplitDialogOpen && useritem && (
@@ -1116,11 +1240,12 @@ const Backpack: React.FC<BackpackProps> = (props) => {
  */
 interface CharacterProps {
   useritems: UserItemWithRelations[] | undefined;
+  userData: NonNullable<UserWithRelations>;
 }
 
 const Character: React.FC<CharacterProps> = (props) => {
   // Set state
-  const { useritems } = props;
+  const { useritems, userData } = props;
   const [slot, setSlot] = useState<ItemSlot | undefined>(undefined);
   const [useritem, setUserItem] = useState<UserItemWithRelations | undefined>(
     undefined,
@@ -1135,10 +1260,12 @@ const Character: React.FC<CharacterProps> = (props) => {
   // The item on the current slot
 
   // Collapse UserItem and Item
-  const items = useritems?.map((useritem) => ({
-    ...applyActiveVariant(useritem as UserItemWithVariants),
-    ...useritem,
-  }));
+  const items = useritems
+    ?.map((useritem) => ({
+      ...applyActiveVariant(useritem as UserItemWithVariants),
+      ...useritem,
+    }))
+    .sort(byItemName);
   const itemBadges = userItemActionBadges(useritems);
   const equipped = items?.find((item) => item.equipped === slot);
   const repairItems = (useritems || []).filter(
@@ -1185,8 +1312,25 @@ const Character: React.FC<CharacterProps> = (props) => {
         showMutationToast(data);
         if (data.success) {
           setIsRepairModalOpen(false);
-          await utils.item.getUserItemsWithVariants.invalidate();
-          await utils.profile.getUser.invalidate();
+          await Promise.all([
+            utils.item.getUserItemsWithVariants.invalidate(),
+            utils.profile.getUser.invalidate(),
+          ]);
+        }
+      },
+    });
+
+  const { mutate: mutateRepairWithRyo, isPending: isRepairingWithRyo } =
+    api.item.repair.useMutation({
+      onSuccess: async (data) => {
+        showMutationToast(data);
+        if (data.success) {
+          setShowItemDetails(false);
+          setUserItem(undefined);
+          await Promise.all([
+            utils.item.getUserItemsWithVariants.invalidate(),
+            utils.profile.getUser.invalidate(),
+          ]);
         }
       },
     });
@@ -1289,8 +1433,8 @@ const Character: React.FC<CharacterProps> = (props) => {
               key={useritem.id}
               showStatistic="item"
             />
-            {!isEquipping && !isUsingRepairItem && (
-              <div className="mt-2 flex flex-row gap-1">
+            {!isEquipping && !isUsingRepairItem && !isRepairingWithRyo && (
+              <div className="mt-2 flex flex-row flex-wrap gap-1">
                 <Button
                   variant="info"
                   onClick={() => {
@@ -1301,17 +1445,14 @@ const Character: React.FC<CharacterProps> = (props) => {
                   <Shirt className="mr-2 h-4 w-4" />
                   Unequip
                 </Button>
-                {useritem.durability < useritem.item.maxDurability &&
-                  useritem.item.maxDurability > 0 && (
-                    <Button
-                      variant="outline"
-                      onClick={() => setIsRepairModalOpen(true)}
-                      disabled={repairItems.length === 0}
-                    >
-                      <Wrench className="mr-2 h-4 w-4" />
-                      Use Repair Item
-                    </Button>
-                  )}
+                <ItemDurabilityRepairActions
+                  useritem={useritem}
+                  userData={userData}
+                  repairItemsCount={repairItems.length}
+                  onOpenRepairModal={() => setIsRepairModalOpen(true)}
+                  onRepairWithRyo={(userItemId) => mutateRepairWithRyo({ userItemId })}
+                  isRepairingWithRyo={isRepairingWithRyo}
+                />
                 {((useritem as UserItemWithVariants).item.variants?.length ?? 0) >
                   0 && (
                   <Button
@@ -1329,7 +1470,7 @@ const Character: React.FC<CharacterProps> = (props) => {
                 <div className="grow"></div>
               </div>
             )}
-            {(isEquipping || isUsingRepairItem) && (
+            {(isEquipping || isUsingRepairItem || isRepairingWithRyo) && (
               <Loader
                 explanation={`${isEquipping ? "Unequipping" : "Repairing"} ${useritem.item.name}`}
               />

--- a/app/src/app/items/page.tsx
+++ b/app/src/app/items/page.tsx
@@ -65,7 +65,7 @@ import {
   showsItemLevelBadge,
   userItemActionBadges,
 } from "@/libs/item";
-import { calculateKitsToUse, getRepairKits } from "@/libs/repair";
+import { calculateKitsToUse, getRepairKits, needsInventoryRepair } from "@/libs/repair";
 import { showMutationToast, showRewardToast } from "@/libs/toast";
 import { hasRequiredLevel, remainingXpToLevel } from "@/libs/train";
 import type { UserWithRelations } from "@/routers/profile";
@@ -187,11 +187,7 @@ export default function MyItems() {
     userData.reputationPoints && userData.reputationPoints >= COST_EXTRA_ITEM_SLOT;
 
   // Calculate items needing repair and which kits will be used
-  const itemsNeedingRepair = (userItems || []).filter(
-    (useritem) =>
-      useritem.durability < useritem.item.maxDurability &&
-      useritem.item.maxDurability > 0,
-  );
+  const itemsNeedingRepair = (userItems || []).filter(needsInventoryRepair);
   const repairKits = getRepairKits(userItems);
   const isCrafter = userData.occupation === "CRAFTING";
   const totalRyoRepairCost = itemsNeedingRepair.reduce(

--- a/app/src/app/items/page.tsx
+++ b/app/src/app/items/page.tsx
@@ -379,7 +379,8 @@ export default function MyItems() {
                       </p>
                       <p className="text-muted-foreground text-sm">
                         You have {itemsNeedingRepair.length} damaged item
-                        {itemsNeedingRepair.length !== 1 ? "s" : ""} that need{" "}
+                        {itemsNeedingRepair.length !== 1 ? "s" : ""} that need
+                        {itemsNeedingRepair.length === 1 ? "s" : ""}{" "}
                         {repairAllInfo.totalDurabilityNeeded} total durability, but you
                         don&apos;t have enough repair kits to repair all of them.
                       </p>

--- a/app/src/layout/Confirm2.tsx
+++ b/app/src/layout/Confirm2.tsx
@@ -17,6 +17,8 @@ interface Confirm2Props {
   isValid?: boolean;
   confirmDisabled?: boolean;
   disabled?: boolean;
+  /** Extra footer controls before Close. Pass a function to receive `close`. */
+  footerExtra?: React.ReactNode | ((args: { close: () => void }) => React.ReactNode);
   onAccept?: (
     e:
       | React.MouseEvent<HTMLButtonElement, MouseEvent>
@@ -27,6 +29,10 @@ interface Confirm2Props {
 
 const Confirm2: React.FC<Confirm2Props> = (props) => {
   const [showModal, setShowModal] = useState<boolean>(false);
+  const footerExtra =
+    typeof props.footerExtra === "function"
+      ? props.footerExtra({ close: () => setShowModal(false) })
+      : props.footerExtra;
   return (
     <>
       {/* biome-ignore lint/a11y/useSemanticElements: wrapper for button children - using button would create invalid nested buttons */}
@@ -66,6 +72,7 @@ const Confirm2: React.FC<Confirm2Props> = (props) => {
         isValid={props.isValid}
         proceedDisabled={props.confirmDisabled}
         onClose={props.onClose}
+        footerExtra={footerExtra}
       >
         {props.children}
       </Modal2>

--- a/app/src/layout/MergeAllStacksButton.tsx
+++ b/app/src/layout/MergeAllStacksButton.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Merge } from "lucide-react";
+import type React from "react";
+import { api } from "@/app/_trpc/client";
+import { Button } from "@/components/ui/button";
+import Confirm2 from "@/layout/Confirm2";
+import { showMutationToast } from "@/libs/toast";
+
+interface MergeAllStacksButtonProps {
+  storedAtHome: boolean;
+  onMerged?: () => void;
+}
+
+export const MergeAllStacksButton: React.FC<MergeAllStacksButtonProps> = ({
+  storedAtHome,
+  onMerged,
+}) => {
+  const utils = api.useUtils();
+
+  const { mutate: mergeAllStacks, isPending } = api.item.mergeAllStacks.useMutation({
+    onSuccess: async (data) => {
+      showMutationToast(data);
+      if (data.success) {
+        await Promise.all([
+          utils.item.getUserItemsWithVariants.invalidate(),
+          utils.item.getUserItems.invalidate(),
+        ]);
+        onMerged?.();
+      }
+    },
+    onError: (error) => {
+      showMutationToast({
+        success: false,
+        message: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  return (
+    <Confirm2
+      title="Merge all stacks"
+      proceed_label={isPending ? undefined : "Merge all stacks"}
+      isValid={!isPending}
+      button={
+        <Button type="button" variant="outline" size="sm" disabled={isPending}>
+          <Merge className="mr-2 h-4 w-4" />
+          {isPending ? "Merging..." : "Merge all stacks"}
+        </Button>
+      }
+      onAccept={(e) => {
+        e.preventDefault();
+        mergeAllStacks({ storedAtHome });
+      }}
+    >
+      <p>
+        {storedAtHome
+          ? "Consolidate stackable items in your home storage (stored items and materials) into the fewest possible stacks. Carried inventory is not affected. This cannot be automatically undone."
+          : "Consolidate stackable items in your carried inventory (backpack and equipped slots) into the fewest possible stacks. Home storage is not affected. This cannot be automatically undone."}
+      </p>
+    </Confirm2>
+  );
+};

--- a/app/src/layout/MergeAllStacksButton.tsx
+++ b/app/src/layout/MergeAllStacksButton.tsx
@@ -21,11 +21,13 @@ export const MergeAllStacksButton: React.FC<MergeAllStacksButtonProps> = ({
   const { mutate: mergeAllStacks, isPending } = api.item.mergeAllStacks.useMutation({
     onSuccess: async (data) => {
       showMutationToast(data);
+      // Invalidate even on failure responses: a partial merge reports success=false
+      // after having already mutated some stacks, and the UI must not go stale.
+      await Promise.all([
+        utils.item.getUserItemsWithVariants.invalidate(),
+        utils.item.getUserItems.invalidate(),
+      ]);
       if (data.success) {
-        await Promise.all([
-          utils.item.getUserItemsWithVariants.invalidate(),
-          utils.item.getUserItems.invalidate(),
-        ]);
         onMerged?.();
       }
     },

--- a/app/src/layout/MergeAllStacksButton.tsx
+++ b/app/src/layout/MergeAllStacksButton.tsx
@@ -43,6 +43,7 @@ export const MergeAllStacksButton: React.FC<MergeAllStacksButtonProps> = ({
       title="Merge all stacks"
       proceed_label={isPending ? undefined : "Merge all stacks"}
       isValid={!isPending}
+      disabled={isPending}
       button={
         <Button type="button" variant="outline" size="sm" disabled={isPending}>
           <Merge className="mr-2 h-4 w-4" />

--- a/app/src/layout/OccupationCrafting.tsx
+++ b/app/src/layout/OccupationCrafting.tsx
@@ -27,6 +27,7 @@ import {
   getEffectiveMaxImbuements,
 } from "@/libs/crafting";
 import { calcItemRepairCost } from "@/libs/item";
+import { needsInventoryRepair } from "@/libs/repair";
 import { showMutationToast } from "@/libs/toast";
 import { canChangeContent } from "@/utils/permissions";
 import { capitalizeFirstLetter } from "@/utils/sanitize";
@@ -631,11 +632,7 @@ export default function OccupationCrafting() {
 
         {/* Repair Items */}
         {(() => {
-          const itemsNeedingRepair = (userItems || []).filter(
-            (userItem) =>
-              userItem.durability < userItem.item.maxDurability &&
-              userItem.item.maxDurability > 0,
-          );
+          const itemsNeedingRepair = (userItems || []).filter(needsInventoryRepair);
 
           return itemsNeedingRepair.length > 0 ? (
             <Card>

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
+import { and, eq, gt, inArray, isNull, lt, or, sql } from "drizzle-orm";
 import type { AnyMySqlColumn } from "drizzle-orm/mysql-core";
 import { nanoid } from "nanoid";
 import type { BattleDataEntryType, BattleTypes } from "@/drizzle/constants";
@@ -460,19 +460,23 @@ export const updateKage = async (
 
     ...(deleteItems.length > 0
       ? [
-          client.delete(userItem).where(inArray(userItem.id, deleteItems)),
+          client
+            .delete(userItem)
+            .where(and(inArray(userItem.id, deleteItems), gt(userItem.quantity, 0))),
           client
             .delete(userItemImbuement)
             .where(inArray(userItemImbuement.userItemId, deleteItems)),
         ]
       : []),
 
+    // The quantity guard skips rows a stack merge has claimed or already folded away, so this
+    // absolute snapshot write can never resurrect a merge tombstone or stomp a claim.
     ...(updateItems.length > 0
       ? updateItems.map((ui) =>
           client
             .update(userItem)
             .set({ quantity: ui.quantity })
-            .where(eq(userItem.id, ui.id)),
+            .where(and(eq(userItem.id, ui.id), gt(userItem.quantity, 0))),
         )
       : []),
 
@@ -1429,19 +1433,23 @@ export const updateUser = async (
       // Delete items
       ...(deleteItems.length > 0
         ? [
-            client.delete(userItem).where(inArray(userItem.id, deleteItems)),
+            client
+              .delete(userItem)
+              .where(and(inArray(userItem.id, deleteItems), gt(userItem.quantity, 0))),
             client
               .delete(userItemImbuement)
               .where(inArray(userItemImbuement.userItemId, deleteItems)),
           ]
         : []),
-      // Update items quantity
+      // Update items quantity. The quantity guard skips rows a stack merge has claimed or
+      // already folded away, so this absolute snapshot write can never resurrect a merge
+      // tombstone or stomp a claim.
       ...(updateItems.length > 0
         ? updateItems.map((ui) =>
             client
               .update(userItem)
               .set({ quantity: ui.quantity, durability: ui.durability })
-              .where(eq(userItem.id, ui.id)),
+              .where(and(eq(userItem.id, ui.id), gt(userItem.quantity, 0))),
           )
         : []),
       // Jutsu experience & level from experience

--- a/app/src/libs/item.ts
+++ b/app/src/libs/item.ts
@@ -485,7 +485,7 @@ export const showsItemLevelBadge = (item: {
 
 /**
  * ActionSelector badge lists for user items: amber stack quantity (bottom-right)
- * for non-leveling stacks, red ownership level (bottom-left) for leveling gear.
+ * for every stack, red ownership level (bottom-left) for leveling gear.
  */
 export const userItemActionBadges = <
   T extends {
@@ -501,7 +501,7 @@ export const userItemActionBadges = <
   levels: { id: string; level: number }[] | undefined;
 } => ({
   counts: userItems
-    ?.filter((ui) => !showsItemLevelBadge(ui.item) && ui.quantity > 1)
+    ?.filter((ui) => ui.quantity > 1)
     .map((ui) => ({ id: ui.id, quantity: ui.quantity })),
   levels: userItems
     ?.filter((ui) => showsItemLevelBadge(ui.item))

--- a/app/src/libs/item.ts
+++ b/app/src/libs/item.ts
@@ -229,6 +229,16 @@ export const isImbuing = (
 ): boolean =>
   ui.imbuements.some((im) => im.craftingFinishedAt && im.craftingFinishedAt > now);
 
+/**
+ * Locale-aware comparator for displayed item names.
+ * Prefers top-level `name` (e.g. after applyActiveVariant flatten) so variant
+ * overrides match what ActionSelector renders; falls back to nested `item.name`.
+ */
+export const byItemName = (
+  a: { name?: string; item?: { name: string } },
+  b: { name?: string; item?: { name: string } },
+) => (a.name ?? a.item?.name ?? "").localeCompare(b.name ?? b.item?.name ?? "");
+
 export interface EquipConstraintInfo {
   itemId: string;
   bloodlineId: string | null;

--- a/app/src/libs/repair.ts
+++ b/app/src/libs/repair.ts
@@ -22,6 +22,22 @@ export interface RepairKitCalculationResult {
 }
 
 /**
+ * Whether a user item is eligible for inventory / crafting-occupation repair flows.
+ * Excludes home-stored and auction-listed items so bulk repair never charges for
+ * items the player cannot see on the inventory page.
+ */
+export const needsInventoryRepair = (ui: {
+  storedAtHome: boolean;
+  isInAuction: boolean;
+  durability: number;
+  item: { maxDurability: number };
+}): boolean =>
+  !ui.storedAtHome &&
+  !ui.isInAuction &&
+  ui.item.maxDurability > 0 &&
+  ui.durability < ui.item.maxDurability;
+
+/**
  * Gets all repair kits from user items. Shared by the inventory UI and
  * `item.useRepairAll` so preview and mutation pick the same stacks.
  */

--- a/app/src/libs/repair.ts
+++ b/app/src/libs/repair.ts
@@ -40,6 +40,8 @@ export const needsInventoryRepair = (ui: {
 /**
  * Gets all repair kits from user items. Shared by the inventory UI and
  * `item.useRepairAll` so preview and mutation pick the same stacks.
+ * Excludes home-stored and auction-listed kits — `item.useRepairItem` rejects
+ * those, and bulk repair must never consume a stack backing a live listing.
  */
 export const getRepairKits = (
   userItems: UserItemWithRelations[] | undefined,
@@ -49,6 +51,8 @@ export const getRepairKits = (
       (userItem) =>
         userItem.item?.effects?.some((e) => e.type === "repair") &&
         userItem.quantity > 0 &&
+        !userItem.storedAtHome &&
+        !userItem.isInAuction &&
         (!userItem.craftingFinishedAt || userItem.craftingFinishedAt < new Date()),
     )
     .map((userItem) => {

--- a/app/src/server/api/routers/auction.ts
+++ b/app/src/server/api/routers/auction.ts
@@ -3,6 +3,7 @@ import {
   desc,
   eq,
   exists,
+  gt,
   gte,
   inArray,
   isNull,
@@ -313,6 +314,7 @@ export const auctionRouter = createTRPCRouter({
           where: and(
             eq(userItem.id, userItemId),
             eq(userItem.userId, ctx.userId),
+            gt(userItem.quantity, 0),
             eq(userItem.equipped, "NONE"),
             eq(userItem.isInAuction, false),
             or(
@@ -411,7 +413,9 @@ export const auctionRouter = createTRPCRouter({
       const expiresAt = new Date();
       expiresAt.setHours(expiresAt.getHours() + durationHours);
 
-      // Write-time guard: set isInAuction only if item still has no active imbuement (atomic)
+      // Write-time guard: set isInAuction only if item still has no active imbuement (atomic).
+      // The quantity guard also refuses rows held by a stack-merge claim (negative) or left as
+      // a merge tombstone (zero), so a listing can never break an in-flight merge publish.
       const markInAuctionResult = await ctx.drizzle
         .update(userItem)
         .set({
@@ -422,6 +426,7 @@ export const auctionRouter = createTRPCRouter({
           and(
             eq(userItem.id, auctionUserItemId),
             eq(userItem.userId, ctx.userId),
+            gt(userItem.quantity, 0),
             eq(userItem.isInAuction, false),
             sql`NOT EXISTS (SELECT 1 FROM UserItemImbuement WHERE UserItemImbuement.userItemId = ${auctionUserItemId} AND UserItemImbuement.craftingFinishedAt > NOW())`,
           ),

--- a/app/src/server/api/routers/home.ts
+++ b/app/src/server/api/routers/home.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte, sql } from "drizzle-orm";
+import { and, eq, gt, gte, sql } from "drizzle-orm";
 import { z } from "zod";
 import type { UserStatus } from "@/drizzle/constants";
 import {
@@ -298,10 +298,20 @@ export const homeRouter = createTRPCRouter({
         ) {
           return errorResponse("Materials inventory is full");
         }
-        await ctx.drizzle
+        const result = await ctx.drizzle
           .update(userItem)
           .set({ storedAtHome: false })
-          .where(eq(userItem.id, input.userItemId));
+          .where(
+            and(
+              eq(userItem.id, input.userItemId),
+              eq(userItem.userId, ctx.userId),
+              eq(userItem.storedAtHome, true),
+              gt(userItem.quantity, 0),
+            ),
+          );
+        if (result.rowsAffected !== 1) {
+          return errorResponse("Inventory changed, please refresh and try again");
+        }
         return { success: true, message: "Item retrieved from your home." };
       } else {
         // Check storage limits based on item type
@@ -323,10 +333,20 @@ export const homeRouter = createTRPCRouter({
             return errorResponse("Your home storage is full");
           }
         }
-        await ctx.drizzle
+        const result = await ctx.drizzle
           .update(userItem)
           .set({ storedAtHome: true })
-          .where(eq(userItem.id, input.userItemId));
+          .where(
+            and(
+              eq(userItem.id, input.userItemId),
+              eq(userItem.userId, ctx.userId),
+              eq(userItem.storedAtHome, false),
+              gt(userItem.quantity, 0),
+            ),
+          );
+        if (result.rowsAffected !== 1) {
+          return errorResponse("Inventory changed, please refresh and try again");
+        }
         return { success: true, message: "Item stored in your home." };
       }
     }),

--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -97,11 +97,7 @@ import {
   objectiveContentIds,
   postProcessRewards,
 } from "@/libs/quest";
-import {
-  calculateKitsToUse,
-  getRepairKits,
-  needsInventoryRepair,
-} from "@/libs/repair";
+import { calculateKitsToUse, getRepairKits, needsInventoryRepair } from "@/libs/repair";
 import {
   fetchSageModeRolls,
   fetchSageModes,
@@ -114,7 +110,10 @@ import { fetchUpdatedUser, fetchUser } from "@/routers/profile";
 import { fetchUserSkills } from "@/routers/skillTree";
 import { fetchStructures } from "@/routers/village";
 import type { DrizzleClient } from "@/server/db";
-import { consumeUserItemAtomically } from "@/server/utils/concurrency";
+import {
+  consumeUserItemAtomically,
+  refundUserItemQuantityAtomically,
+} from "@/server/utils/concurrency";
 import {
   applyLoadoutRename,
   backfillLoadouts,
@@ -2369,7 +2368,7 @@ export const itemRouter = createTRPCRouter({
         kitsToUse.map(async ({ repairItemId, quantityUsed }) => {
           const repairKitRow = useritems.find((ui) => ui.id === repairItemId);
           if (!repairKitRow || quantityUsed <= 0 || !repairKitRow.item.destroyOnUse) {
-            return true;
+            return null;
           }
           if (repairKitRow.quantity <= quantityUsed) {
             const result = await ctx.drizzle
@@ -2381,7 +2380,7 @@ export const itemRouter = createTRPCRouter({
                   eq(userItem.quantity, repairKitRow.quantity),
                 ),
               );
-            return result.rowsAffected === 1;
+            return result.rowsAffected === 1 ? { repairKitRow, quantityUsed } : false;
           }
           const result = await ctx.drizzle
             .update(userItem)
@@ -2393,12 +2392,12 @@ export const itemRouter = createTRPCRouter({
                 eq(userItem.quantity, repairKitRow.quantity),
               ),
             );
-          return result.rowsAffected === 1;
+          return result.rowsAffected === 1 ? { repairKitRow, quantityUsed } : false;
         }),
       );
-      if (kitConsumeResults.some((ok) => !ok)) {
-        await Promise.all(
-          itemsNeedingRepair.map((useritem) =>
+      if (kitConsumeResults.some((result) => result === false)) {
+        await Promise.all([
+          ...itemsNeedingRepair.map((useritem) =>
             ctx.drizzle
               .update(userItem)
               .set({ durability: useritem.durability })
@@ -2410,7 +2409,18 @@ export const itemRouter = createTRPCRouter({
                 ),
               ),
           ),
-        );
+          ...kitConsumeResults.flatMap((result) =>
+            result
+              ? [
+                  refundUserItemQuantityAtomically({
+                    client: ctx.drizzle,
+                    itemSnapshot: result.repairKitRow,
+                    quantity: result.quantityUsed,
+                  }),
+                ]
+              : [],
+          ),
+        ]);
         return errorResponse(
           "Could not consume repair kits — inventory changed, please try again",
         );

--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -1416,15 +1416,17 @@ export const itemRouter = createTRPCRouter({
       mcp: {
         enabled: true,
         description:
-          "Merge all mergeable item stacks in carried inventory (excludes home storage)",
+          "Merge all mergeable item stacks in carried inventory (storedAtHome=false) or home storage (storedAtHome=true)",
       },
     })
+    .input(z.object({ storedAtHome: z.boolean().optional() }).optional())
     .output(baseServerResponse)
-    .mutation(async ({ ctx }) => {
+    .mutation(async ({ ctx, input }) => {
+      const storedAtHome = input?.storedAtHome ?? false;
       const userItemsAll = await ctx.drizzle.query.userItem.findMany({
         where: and(
           eq(userItem.userId, ctx.userId),
-          eq(userItem.storedAtHome, false),
+          eq(userItem.storedAtHome, storedAtHome),
           eq(userItem.isInAuction, false),
           or(
             isNull(userItem.craftingFinishedAt),
@@ -3475,12 +3477,13 @@ async function executeMergeStacksForItemBucket(
  * Merge stacks for one item type (`mergeStacks`, `mergeAllStacks`).
  *
  * **Carried inventory:** Without `preloaded`, the query uses `storedAtHome === false` only.
- * Home storage is not merged here; players move items to carried first.
+ * Use `mergeAllStacks({ storedAtHome: true })` with preloaded home rows to merge storage.
  *
  * **Buckets:** Each `(storedAtHome, equipped)` group merges separately so equipped and
  * backpack rows are never consolidated into one row.
  *
- * **mergeAllStacks** passes `preloaded` rows already limited to carried, non-auction stacks.
+ * **mergeAllStacks** passes `preloaded` rows already limited to the requested scope
+ * (carried or home), non-auction stacks.
  */
 async function executeMergeStacksForItem(
   drizzle: DrizzleClient,

--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -113,9 +113,11 @@ import { fetchStructures } from "@/routers/village";
 import type { DrizzleClient } from "@/server/db";
 import {
   consumeUserItemAtomically,
+  MERGE_STACK_CLAIM_TIMEOUT_MS,
   refundUserItemQuantityAtomically,
   restoreStaleUserItemMergeClaims,
-  userItemMergePublishQuantity,
+  updateUserItemQuantityAtomically,
+  userItemMergeQuantityCase,
 } from "@/server/utils/concurrency";
 import {
   applyLoadoutRename,
@@ -908,7 +910,7 @@ export const itemRouter = createTRPCRouter({
           message: "You can only view your own items",
         });
       }
-      await restoreStaleMergeStackClaims(ctx.drizzle, input.userId);
+      // fetchUserItems self-heals stale merge claims for the viewed user.
       return await fetchUserItems(ctx.drizzle, input.userId, {
         includeHidden: true,
       });
@@ -1403,6 +1405,10 @@ export const itemRouter = createTRPCRouter({
     .input(z.object({ itemId: z.string() }))
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
+      const user = await fetchUser(ctx.drizzle, ctx.userId);
+      if (user.status !== "AWAKE") {
+        return errorResponse(`Cannot merge items while ${user.status.toLowerCase()}`);
+      }
       const result = await executeMergeStacksForItem(
         ctx.drizzle,
         ctx.userId,
@@ -1429,7 +1435,13 @@ export const itemRouter = createTRPCRouter({
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
       const storedAtHome = input?.storedAtHome ?? false;
-      await restoreStaleMergeStackClaims(ctx.drizzle, ctx.userId);
+      const [user] = await Promise.all([
+        fetchUser(ctx.drizzle, ctx.userId),
+        restoreStaleMergeStackClaims(ctx.drizzle, ctx.userId),
+      ]);
+      if (user.status !== "AWAKE") {
+        return errorResponse(`Cannot merge items while ${user.status.toLowerCase()}`);
+      }
       const userItemsAll = await ctx.drizzle.query.userItem.findMany({
         where: and(
           eq(userItem.userId, ctx.userId),
@@ -2395,40 +2407,23 @@ export const itemRouter = createTRPCRouter({
         );
       }
 
-      // Consume repair kits only after every target write succeeded
+      // Consume repair kits only after every target write succeeded. calculateKitsToUse clamps
+      // quantityUsed to the stack quantity, so the helper's delete-at-zero branch covers the
+      // full-stack case.
       const kitConsumeResults = await Promise.all(
         kitsToUse.map(async ({ repairItemId, quantityUsed }) => {
           const repairKitRow = useritems.find((ui) => ui.id === repairItemId);
           if (!repairKitRow || quantityUsed <= 0 || !repairKitRow.item.destroyOnUse) {
             return null;
           }
-          if (repairKitRow.quantity <= quantityUsed) {
-            const result = await ctx.drizzle
-              .delete(userItem)
-              .where(
-                and(
-                  eq(userItem.id, repairItemId),
-                  eq(userItem.userId, ctx.userId),
-                  eq(userItem.quantity, repairKitRow.quantity),
-                ),
-              );
-            return result.rowsAffected === 1
-              ? { repairKitRow, quantityConsumed: repairKitRow.quantity }
-              : false;
-          }
-          const result = await ctx.drizzle
-            .update(userItem)
-            .set({ quantity: sql`${userItem.quantity} - ${quantityUsed}` })
-            .where(
-              and(
-                eq(userItem.id, repairItemId),
-                eq(userItem.userId, ctx.userId),
-                eq(userItem.quantity, repairKitRow.quantity),
-              ),
-            );
-          return result.rowsAffected === 1
-            ? { repairKitRow, quantityConsumed: quantityUsed }
-            : false;
+          const consumed = await updateUserItemQuantityAtomically({
+            client: ctx.drizzle,
+            userId: ctx.userId,
+            userItemId: repairItemId,
+            expectedQuantity: repairKitRow.quantity,
+            nextQuantity: repairKitRow.quantity - quantityUsed,
+          });
+          return consumed ? { repairKitRow, quantityConsumed: quantityUsed } : false;
         }),
       );
       if (kitConsumeResults.some((result) => result === false)) {
@@ -3062,10 +3057,6 @@ export const fetchItemWithCraftingRequirements = async (
   });
 };
 
-// Merge claims normally live for only a few database round trips. After this timeout a negative
-// quantity is considered abandoned and can be restored from its encoded original value.
-const MERGE_STACK_CLAIM_TIMEOUT_MS = 30_000;
-
 const restoreStaleMergeStackClaims = async (client: DrizzleClient, userId: string) =>
   restoreStaleUserItemMergeClaims({
     client,
@@ -3073,18 +3064,43 @@ const restoreStaleMergeStackClaims = async (client: DrizzleClient, userId: strin
     staleBefore: new Date(Date.now() - MERGE_STACK_CLAIM_TIMEOUT_MS),
   });
 
+/**
+ * Self-heals abandoned stack-merge state on the primary inventory reads: rows are fetched
+ * without a quantity filter, and only when a stale claim/tombstone is actually present (a merge
+ * died mid-protocol — rare) does the reaper run followed by one refetch. The common case pays no
+ * extra round trip, and a crashed merge recovers on the player's next inventory load instead of
+ * leaving their stacks invisible until they press merge again.
+ */
+const withStaleMergeClaimRecovery = async <
+  T extends { quantity: number; updatedAt: Date },
+>(
+  client: DrizzleClient,
+  userId: string,
+  fetchRows: () => Promise<T[]>,
+): Promise<T[]> => {
+  let rows = await fetchRows();
+  const staleBefore = new Date(Date.now() - MERGE_STACK_CLAIM_TIMEOUT_MS);
+  if (rows.some((row) => row.quantity <= 0 && row.updatedAt <= staleBefore)) {
+    await restoreStaleUserItemMergeClaims({ client, userId, staleBefore });
+    rows = await fetchRows();
+  }
+  return rows.filter((row) => row.quantity > 0);
+};
+
 export const fetchUserItems = async (
   client: DrizzleClient,
   userId: string,
   options?: { includeHidden?: boolean },
 ) => {
-  const useritems = await client.query.userItem.findMany({
-    where: and(eq(userItem.userId, userId), gt(userItem.quantity, 0)),
-    with: {
-      item: true,
-      imbuements: { with: { item: true } },
-    },
-  });
+  const useritems = await withStaleMergeClaimRecovery(client, userId, () =>
+    client.query.userItem.findMany({
+      where: eq(userItem.userId, userId),
+      with: {
+        item: true,
+        imbuements: { with: { item: true } },
+      },
+    }),
+  );
   return useritems.filter(
     (ui) => ui.item && (options?.includeHidden || !ui.item.hidden),
   );
@@ -3094,13 +3110,15 @@ export const fetchUserItemsWithVariants = async (
   client: DrizzleClient,
   userId: string,
 ) => {
-  const useritems = await client.query.userItem.findMany({
-    where: and(eq(userItem.userId, userId), gt(userItem.quantity, 0)),
-    with: {
-      item: { with: { variants: { orderBy: (v, { asc }) => [asc(v.order)] } } },
-      imbuements: { with: { item: true } },
-    },
-  });
+  const useritems = await withStaleMergeClaimRecovery(client, userId, () =>
+    client.query.userItem.findMany({
+      where: eq(userItem.userId, userId),
+      with: {
+        item: { with: { variants: { orderBy: (v, { asc }) => [asc(v.order)] } } },
+        imbuements: { with: { item: true } },
+      },
+    }),
+  );
   return useritems.filter((ui) => ui.item && !ui.item.hidden);
 };
 
@@ -3540,17 +3558,31 @@ export const splitItemStack = async (
       updatedAt: new Date(),
     });
   } catch {
-    await client
-      .update(userItem)
-      .set({ quantity: currentUserItem.quantity })
-      .where(
-        and(
-          eq(userItem.id, userItemId),
-          eq(userItem.userId, userId),
-          eq(userItem.quantity, quantityToKeep),
-        ),
-      );
-    return { success: false, message: "Could not create the split stack" };
+    // A thrown insert is ambiguous on PlanetScale's HTTP driver (the row may have committed
+    // before the response was lost), so verify before compensating — restoring the source while
+    // the new row exists would duplicate the split quantity.
+    const inserted = await client.query.userItem.findFirst({
+      where: eq(userItem.id, newUserItemId),
+      columns: { id: true },
+    });
+    if (!inserted) {
+      const restored = await client
+        .update(userItem)
+        .set({ quantity: currentUserItem.quantity })
+        .where(
+          and(
+            eq(userItem.id, userItemId),
+            eq(userItem.userId, userId),
+            eq(userItem.quantity, quantityToKeep),
+          ),
+        );
+      if (restored.rowsAffected !== 1) {
+        console.error(
+          `splitItemStack: failed to restore source stack ${userItemId} after insert failure`,
+        );
+      }
+      return { success: false, message: "Could not create the split stack" };
+    }
   }
 
   return {
@@ -3707,74 +3739,110 @@ async function executeMergeStacksForItemBucket(
   const conflictMessage = `Failed to merge stacks of ${itemName} — inventory changed, please try again`;
 
   const claimedAt = new Date();
+  const publishTargets = sortedItems.map((item, index) => ({
+    id: item.id,
+    quantity: index < targetStacks ? targetQuantityForKeepIndex(index) : 0,
+  }));
 
-  // Phase 1: claim every row (qty → -qty) so no subset of later writes can commit alone while
-  // retaining enough information for a later request to recover an abandoned claim.
-  const claimResults = await Promise.all(
-    sortedItems.map((item) =>
-      drizzle
-        .update(userItem)
-        .set({ quantity: -item.quantity, updatedAt: claimedAt })
-        .where(mergeStackRowGuard(userId, item, item.quantity)),
-    ),
-  );
-
-  if (claimResults.some((result) => result.rowsAffected !== 1)) {
-    await Promise.all(
-      sortedItems.map((item, index) =>
-        claimResults[index]?.rowsAffected === 1
-          ? drizzle
-              .update(userItem)
-              .set({ quantity: item.quantity, updatedAt: item.updatedAt })
-              .where(
-                and(
-                  eq(userItem.id, item.id),
-                  eq(userItem.userId, userId),
+  // Restores every row this attempt touched back to its original quantity in one UPDATE. The
+  // `updatedAt = claimedAt` stamp scopes the write to our own claims/publishes, and the per-row
+  // quantity guard matches both a still-claimed row (-q) and an already-published one (its
+  // target), so even a partially applied publish is fully undone. `updatedAt` intentionally stays
+  // at `claimedAt`: positive rows are never touched by the stale-claim reaper, and the tombstone
+  // delete additionally guards on quantity 0.
+  const restoreOriginalQuantities = () =>
+    drizzle
+      .update(userItem)
+      .set({
+        quantity: userItemMergeQuantityCase(
+          sortedItems.map((item) => ({ id: item.id, quantity: item.quantity })),
+        ),
+      })
+      .where(
+        and(
+          eq(userItem.userId, userId),
+          eq(userItem.updatedAt, claimedAt),
+          or(
+            ...sortedItems.map((item, index) =>
+              and(
+                eq(userItem.id, item.id),
+                or(
                   eq(userItem.quantity, -item.quantity),
+                  eq(userItem.quantity, publishTargets[index]?.quantity ?? 0),
                 ),
-              )
-          : Promise.resolve(),
-      ),
-    );
-    return { success: false, didMerge: false, message: conflictMessage };
-  }
-
-  // Phase 2: atomically publish every keeper and convert extras to hidden tombstones. One UPDATE
-  // means a process crash cannot commit only a subset of the target quantities/deletions.
-  const targetQuantityById = new Map(
-    itemsToKeep.map((item, index) => [item.id, targetQuantityForKeepIndex(index)]),
-  );
-  const publishResult = await drizzle
-    .update(userItem)
-    .set({
-      quantity: userItemMergePublishQuantity(
-        sortedItems.map((item) => ({
-          id: item.id,
-          quantity: targetQuantityById.get(item.id) ?? 0,
-        })),
-      ),
-    })
-    .where(
-      or(
-        ...sortedItems.map((item) => mergeStackRowGuard(userId, item, -item.quantity)),
-      ),
-    );
-
-  if (publishResult.rowsAffected !== sortedItems.length) {
-    await Promise.all(
-      sortedItems.map((item) =>
-        drizzle
-          .update(userItem)
-          .set({ quantity: item.quantity, updatedAt: item.updatedAt })
-          .where(
-            and(
-              eq(userItem.id, item.id),
-              eq(userItem.userId, userId),
-              eq(userItem.quantity, -item.quantity),
+              ),
             ),
           ),
-      ),
-    );
+        ),
+      );
+
+  let publishedRows = 0;
+  try {
+    // Phase 1: claim every row (qty → -qty) in ONE statement so a partial claim volley cannot
+    // exist, while retaining enough information to recover an abandoned claim.
+    const claimResult = await drizzle
+      .update(userItem)
+      .set({
+        quantity: userItemMergeQuantityCase(
+          sortedItems.map((item) => ({ id: item.id, quantity: -item.quantity })),
+        ),
+        updatedAt: claimedAt,
+      })
+      .where(
+        or(
+          ...sortedItems.map((item) => mergeStackRowGuard(userId, item, item.quantity)),
+        ),
+      );
+
+    if (claimResult.rowsAffected !== sortedItems.length) {
+      await restoreOriginalQuantities();
+      return { success: false, didMerge: false, message: conflictMessage };
+    }
+
+    // Phase 2: atomically publish every keeper and convert extras to hidden tombstones in one
+    // UPDATE, so a process crash cannot commit only a subset of the target quantities/deletions.
+    const publishResult = await drizzle
+      .update(userItem)
+      .set({ quantity: userItemMergeQuantityCase(publishTargets) })
+      .where(
+        or(
+          ...sortedItems.map((item) =>
+            mergeStackRowGuard(userId, item, -item.quantity),
+          ),
+        ),
+      );
+    publishedRows = publishResult.rowsAffected;
+
+    if (publishedRows !== sortedItems.length) {
+      const restored = await restoreOriginalQuantities();
+      // rowsAffected counts changed rows only; a published row whose target equals its
+      // original quantity restores without changing, so subtract those before comparing.
+      const unchangedByRestore = sortedItems.filter(
+        (item, index) => (publishTargets[index]?.quantity ?? 0) === item.quantity,
+      ).length;
+      if (
+        publishedRows > 0 &&
+        restored.rowsAffected < sortedItems.length - unchangedByRestore
+      ) {
+        // A concurrent writer moved a row out of both recoverable states mid-protocol; surface
+        // it loudly since quantities may need manual reconciliation.
+        console.error(
+          `mergeStacks: partial publish of ${itemName} for ${userId} restored ${restored.rowsAffected}/${sortedItems.length} rows`,
+        );
+      }
+      return { success: false, didMerge: false, message: conflictMessage };
+    }
+  } catch (err) {
+    // A rejected statement leaves unknown state (it may or may not have applied); the restore's
+    // claim-scoped guards make it safe either way, and the stale reaper covers anything left.
+    try {
+      await restoreOriginalQuantities();
+    } catch {
+      // Stale-claim recovery on the next inventory read handles any remaining claims.
+    }
+    if (err instanceof TypeError || err instanceof ReferenceError) {
+      throw err;
+    }
     return { success: false, didMerge: false, message: conflictMessage };
   }
 
@@ -3836,19 +3904,22 @@ async function executeMergeStacksForItem(
       (r) => r.userId === userId && r.itemId === itemId && r.quantity > 0,
     );
   } else {
-    await restoreStaleMergeStackClaims(drizzle, userId);
+    // fetchItem is independent of the user's claim state, so it runs in parallel with the
+    // reaper → items chain instead of serializing behind it.
     const [fetchedInfo, fetchedUserItems] = await Promise.all([
       fetchItem(drizzle, itemId),
-      drizzle.query.userItem.findMany({
-        where: and(
-          eq(userItem.userId, userId),
-          eq(userItem.itemId, itemId),
-          gt(userItem.quantity, 0),
-          eq(userItem.storedAtHome, false),
-          eq(userItem.isInAuction, false),
-        ),
-        with: { imbuements: true },
-      }),
+      restoreStaleMergeStackClaims(drizzle, userId).then(() =>
+        drizzle.query.userItem.findMany({
+          where: and(
+            eq(userItem.userId, userId),
+            eq(userItem.itemId, itemId),
+            gt(userItem.quantity, 0),
+            eq(userItem.storedAtHome, false),
+            eq(userItem.isInAuction, false),
+          ),
+          with: { imbuements: true },
+        }),
+      ),
     ]);
     info = fetchedInfo ?? undefined;
     userItems = fetchedUserItems;

--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -97,7 +97,11 @@ import {
   objectiveContentIds,
   postProcessRewards,
 } from "@/libs/quest";
-import { calculateKitsToUse, getRepairKits } from "@/libs/repair";
+import {
+  calculateKitsToUse,
+  getRepairKits,
+  needsInventoryRepair,
+} from "@/libs/repair";
 import {
   fetchSageModeRolls,
   fetchSageModes,
@@ -2052,6 +2056,12 @@ export const itemRouter = createTRPCRouter({
       if (useritem.durability >= useritem.item.maxDurability) {
         return errorResponse("Item is already at full durability");
       }
+      if (useritem.storedAtHome) {
+        return errorResponse("Fetch at home first");
+      }
+      if (useritem.isInAuction) {
+        return errorResponse("Cannot repair items that are in auction");
+      }
       // Calculate repair cost
       const repairCost = calcItemRepairCost(useritem);
       if (user.money < repairCost) {
@@ -2093,12 +2103,8 @@ export const itemRouter = createTRPCRouter({
       if (user.status !== "AWAKE") {
         return errorResponse(`Cannot repair items while ${user.status.toLowerCase()}`);
       }
-      // Filter items that need repair
-      const itemsNeedingRepair = useritems.filter(
-        (useritem) =>
-          useritem.durability < useritem.item.maxDurability &&
-          useritem.item.maxDurability > 0,
-      );
+      // Filter items that need repair (carried inventory only — not home/auction)
+      const itemsNeedingRepair = useritems.filter(needsInventoryRepair);
       if (itemsNeedingRepair.length === 0) {
         return errorResponse("No items need repair");
       }
@@ -2171,6 +2177,12 @@ export const itemRouter = createTRPCRouter({
       }
       if (targetUserItem.durability >= targetUserItem.item.maxDurability) {
         return errorResponse("Item is already at full durability");
+      }
+      if (targetUserItem.storedAtHome) {
+        return errorResponse("Fetch at home first");
+      }
+      if (targetUserItem.isInAuction) {
+        return errorResponse("Cannot repair items that are in auction");
       }
       // Check if repair item has repair tag
       const repairEffect = repairUserItem.item.effects.find((e) => e.type === "repair");
@@ -2246,12 +2258,8 @@ export const itemRouter = createTRPCRouter({
       if (user.status !== "AWAKE") {
         return errorResponse(`Cannot use items while ${user.status.toLowerCase()}`);
       }
-      // Filter items that need repair
-      const itemsNeedingRepair = useritems.filter(
-        (useritem) =>
-          useritem.durability < useritem.item.maxDurability &&
-          useritem.item.maxDurability > 0,
-      );
+      // Filter items that need repair (carried inventory only — not home/auction)
+      const itemsNeedingRepair = useritems.filter(needsInventoryRepair);
       if (itemsNeedingRepair.length === 0) {
         return errorResponse("No items need repair");
       }

--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -114,10 +114,7 @@ import { fetchUpdatedUser, fetchUser } from "@/routers/profile";
 import { fetchUserSkills } from "@/routers/skillTree";
 import { fetchStructures } from "@/routers/village";
 import type { DrizzleClient } from "@/server/db";
-import {
-  consumeUserItemAtomically,
-  updateUserItemQuantityAtomically,
-} from "@/server/utils/concurrency";
+import { consumeUserItemAtomically } from "@/server/utils/concurrency";
 import {
   applyLoadoutRename,
   backfillLoadouts,
@@ -2075,11 +2072,19 @@ export const itemRouter = createTRPCRouter({
       if (moneyUpdateResult.rowsAffected !== 1) {
         return errorResponse("Insufficient funds for this repair");
       }
-      // Update item durability
-      await ctx.drizzle
-        .update(userItem)
-        .set({ durability: useritem.item.maxDurability })
-        .where(eq(userItem.id, input.userItemId));
+      // CAS durability write — refund if item left inventory / changed concurrently
+      const repaired = await tryRepairUserItemDurability(
+        ctx.drizzle,
+        ctx.userId,
+        useritem,
+        useritem.item.maxDurability,
+      );
+      if (!repaired) {
+        await refundUserMoney(ctx.drizzle, ctx.userId, repairCost);
+        return errorResponse(
+          "Could not repair item — it may have been stored, auctioned, or already repaired",
+        );
+      }
       return {
         success: true,
         message: `Repaired ${useritem.item.name} for ${repairCost} ryo`,
@@ -2129,18 +2134,39 @@ export const itemRouter = createTRPCRouter({
       if (moneyUpdateResult.rowsAffected !== 1) {
         return errorResponse("Insufficient funds for this repair");
       }
-      // Update item durabilities
-      await Promise.all(
-        itemsNeedingRepair.map((useritem) =>
-          ctx.drizzle
-            .update(userItem)
-            .set({ durability: useritem.item.maxDurability })
-            .where(eq(userItem.id, useritem.id)),
-        ),
+      // CAS each durability write; refund cost for any item that left inventory
+      const repairOutcomes = await Promise.all(
+        itemsNeedingRepair.map(async (useritem) => {
+          const repaired = await tryRepairUserItemDurability(
+            ctx.drizzle,
+            ctx.userId,
+            useritem,
+            useritem.item.maxDurability,
+          );
+          return { useritem, repaired, cost: calcItemRepairCost(useritem) };
+        }),
       );
+      const succeeded = repairOutcomes.filter((o) => o.repaired);
+      const failed = repairOutcomes.filter((o) => !o.repaired);
+      const refundAmount = failed.reduce((sum, o) => sum + o.cost, 0);
+      if (refundAmount > 0) {
+        await refundUserMoney(ctx.drizzle, ctx.userId, refundAmount);
+      }
+      if (succeeded.length === 0) {
+        return errorResponse(
+          "Could not repair items — they may have been stored, auctioned, or already repaired",
+        );
+      }
+      const charged = totalRepairCost - refundAmount;
+      if (failed.length > 0) {
+        return {
+          success: true,
+          message: `Repaired ${succeeded.length} item${succeeded.length !== 1 ? "s" : ""} for ${charged.toLocaleString()} ryo (${failed.length} skipped — stored, auctioned, or changed)`,
+        };
+      }
       return {
         success: true,
-        message: `Repaired ${itemsNeedingRepair.length} item${itemsNeedingRepair.length !== 1 ? "s" : ""} for ${totalRepairCost.toLocaleString()} ryo`,
+        message: `Repaired ${succeeded.length} item${succeeded.length !== 1 ? "s" : ""} for ${charged.toLocaleString()} ryo`,
       };
     }),
   // Use repair item on another item
@@ -2203,29 +2229,43 @@ export const itemRouter = createTRPCRouter({
       if (actualRepair <= 0) {
         return errorResponse("Item is already at full durability");
       }
-      // Mutate
-      const promises: Promise<any>[] = [
-        ctx.drizzle
-          .update(userItem)
-          .set({ durability: newDurability })
-          .where(eq(userItem.id, input.targetItemId)),
-      ];
+      // CAS target durability first — never consume a kit if the write fails
+      const repaired = await tryRepairUserItemDurability(
+        ctx.drizzle,
+        ctx.userId,
+        targetUserItem,
+        newDurability,
+      );
+      if (!repaired) {
+        return errorResponse(
+          "Could not repair item — it may have been stored, auctioned, or already repaired",
+        );
+      }
       // Consume repair item if it's consumable
       if (repairUserItem.item.destroyOnUse) {
-        if (repairUserItem.quantity <= 1) {
-          promises.push(
-            ctx.drizzle.delete(userItem).where(eq(userItem.id, input.repairItemId)),
-          );
-        } else {
-          promises.push(
-            ctx.drizzle
-              .update(userItem)
-              .set({ quantity: sql`${userItem.quantity} - 1` })
-              .where(eq(userItem.id, input.repairItemId)),
+        const consumed = await consumeUserItemAtomically({
+          client: ctx.drizzle,
+          userId: ctx.userId,
+          userItemId: input.repairItemId,
+          expectedQuantity: repairUserItem.quantity,
+        });
+        if (!consumed) {
+          // Roll back durability so a kit race does not grant a free repair
+          await ctx.drizzle
+            .update(userItem)
+            .set({ durability: targetUserItem.durability })
+            .where(
+              and(
+                eq(userItem.id, input.targetItemId),
+                eq(userItem.userId, ctx.userId),
+                eq(userItem.durability, newDurability),
+              ),
+            );
+          return errorResponse(
+            "Could not consume repair kit — inventory changed, please try again",
           );
         }
       }
-      await Promise.all(promises);
       return {
         success: true,
         message: `Repaired ${targetUserItem.item.name} by ${actualRepair} durability using ${repairUserItem.item.name}`,
@@ -2285,34 +2325,96 @@ export const itemRouter = createTRPCRouter({
         );
       }
 
-      // Apply repairs and consume destroyOnUse kits together. PlanetScale cannot
-      // roll back a committed stack update, so pairing the writes avoids the
-      // consume-then-abort path that can spend kits without repairing.
-      await Promise.all([
-        ...itemsNeedingRepair.map((useritem) =>
-          ctx.drizzle
-            .update(userItem)
-            .set({ durability: useritem.item.maxDurability })
-            .where(eq(userItem.id, useritem.id)),
-        ),
-        ...kitsToUse.flatMap((kit) => {
-          const repairUserItem = useritems.find((ui) => ui.id === kit.repairItemId);
-          if (!repairUserItem?.item.destroyOnUse) return [];
-          return [
-            updateUserItemQuantityAtomically({
-              client: ctx.drizzle,
-              userId: ctx.userId,
-              userItemId: kit.repairItemId,
-              expectedQuantity: repairUserItem.quantity,
-              nextQuantity: repairUserItem.quantity - kit.quantityUsed,
-            }),
-          ];
-        }),
-      ]);
-
       const kitsUsedSummary = kitsToUse
         .map((kit) => `${kit.quantityUsed}x ${kit.repairItemName}`)
         .join(", ");
+
+      // Apply repairs with CAS; roll back and abort if any target left inventory
+      const repairOutcomes = await Promise.all(
+        itemsNeedingRepair.map(async (useritem) => {
+          const repaired = await tryRepairUserItemDurability(
+            ctx.drizzle,
+            ctx.userId,
+            useritem,
+            useritem.item.maxDurability,
+          );
+          return { useritem, repaired };
+        }),
+      );
+      const failedRepairs = repairOutcomes.filter((o) => !o.repaired);
+      if (failedRepairs.length > 0) {
+        await Promise.all(
+          repairOutcomes
+            .filter((o) => o.repaired)
+            .map((o) =>
+              ctx.drizzle
+                .update(userItem)
+                .set({ durability: o.useritem.durability })
+                .where(
+                  and(
+                    eq(userItem.id, o.useritem.id),
+                    eq(userItem.userId, ctx.userId),
+                    eq(userItem.durability, o.useritem.item.maxDurability),
+                  ),
+                ),
+            ),
+        );
+        return errorResponse(
+          "Could not repair all items — one or more were stored, auctioned, or changed. No kits were consumed.",
+        );
+      }
+
+      // Consume repair kits only after every target write succeeded
+      const kitConsumeResults = await Promise.all(
+        kitsToUse.map(async ({ repairItemId, quantityUsed }) => {
+          const repairKitRow = useritems.find((ui) => ui.id === repairItemId);
+          if (!repairKitRow || quantityUsed <= 0 || !repairKitRow.item.destroyOnUse) {
+            return true;
+          }
+          if (repairKitRow.quantity <= quantityUsed) {
+            const result = await ctx.drizzle
+              .delete(userItem)
+              .where(
+                and(
+                  eq(userItem.id, repairItemId),
+                  eq(userItem.userId, ctx.userId),
+                  eq(userItem.quantity, repairKitRow.quantity),
+                ),
+              );
+            return result.rowsAffected === 1;
+          }
+          const result = await ctx.drizzle
+            .update(userItem)
+            .set({ quantity: sql`${userItem.quantity} - ${quantityUsed}` })
+            .where(
+              and(
+                eq(userItem.id, repairItemId),
+                eq(userItem.userId, ctx.userId),
+                eq(userItem.quantity, repairKitRow.quantity),
+              ),
+            );
+          return result.rowsAffected === 1;
+        }),
+      );
+      if (kitConsumeResults.some((ok) => !ok)) {
+        await Promise.all(
+          itemsNeedingRepair.map((useritem) =>
+            ctx.drizzle
+              .update(userItem)
+              .set({ durability: useritem.durability })
+              .where(
+                and(
+                  eq(userItem.id, useritem.id),
+                  eq(userItem.userId, ctx.userId),
+                  eq(userItem.durability, useritem.item.maxDurability),
+                ),
+              ),
+          ),
+        );
+        return errorResponse(
+          "Could not consume repair kits — inventory changed, please try again",
+        );
+      }
 
       return {
         success: true,
@@ -3339,23 +3441,50 @@ export const splitItemStack = async (
   };
 };
 
+/**
+ * CAS durability write for inventory repair: only succeeds while the item is still
+ * owned, carried (not home), not auctioned, and at the expected durability.
+ */
+const tryRepairUserItemDurability = async (
+  drizzle: DrizzleClient,
+  userId: string,
+  target: { id: string; durability: number },
+  newDurability: number,
+) => {
+  const result = await drizzle
+    .update(userItem)
+    .set({ durability: newDurability })
+    .where(
+      and(
+        eq(userItem.id, target.id),
+        eq(userItem.userId, userId),
+        eq(userItem.storedAtHome, false),
+        eq(userItem.isInAuction, false),
+        eq(userItem.durability, target.durability),
+      ),
+    );
+  return result.rowsAffected === 1;
+};
+
+const refundUserMoney = async (
+  drizzle: DrizzleClient,
+  userId: string,
+  amount: number,
+) => {
+  if (amount <= 0) return;
+  await drizzle
+    .update(userData)
+    .set({ money: sql`${userData.money} + ${amount}` })
+    .where(eq(userData.userId, userId));
+};
+
 // --- Stack merge (used by mergeStacks / mergeAllStacks; kept at bottom with other helpers)
 
 type ItemRowForMerge = NonNullable<Awaited<ReturnType<typeof fetchItem>>>;
 
-type MergeEligibleUserItemForStackMerge = Pick<
-  UserItem,
-  | "id"
-  | "itemId"
-  | "userId"
-  | "quantity"
-  | "level"
-  | "equipped"
-  | "storedAtHome"
-  | "activeVariantId"
-  | "craftingFinishedAt"
-  | "isInAuction"
-> & { imbuements: readonly unknown[] };
+type MergeEligibleUserItemForStackMerge = UserItem & {
+  imbuements: readonly unknown[];
+};
 
 type PreloadedStackMergePayload = {
   userItems: MergeEligibleUserItemForStackMerge[];
@@ -3368,7 +3497,19 @@ type MergeStacksExecutionResult =
 
 type UserItemMergeBucketRow = Pick<
   UserItem,
-  "id" | "quantity" | "level" | "equipped" | "storedAtHome" | "activeVariantId"
+  | "id"
+  | "createdAt"
+  | "updatedAt"
+  | "itemId"
+  | "quantity"
+  | "level"
+  | "experience"
+  | "equipped"
+  | "storedAtHome"
+  | "activeVariantId"
+  | "durability"
+  | "craftingFinishedAt"
+  | "dropChancePerc"
 >;
 
 // activeVariantId is part of the bucket key so two stacks of the same item with
@@ -3385,9 +3526,28 @@ const mergeStacksBucketKey = (
 ) =>
   `${row.storedAtHome ? "home" : "carry"}:${row.equipped}:${row.activeVariantId ?? "none"}:${row.level}`;
 
+const mergeStackRowGuard = (
+  userId: string,
+  item: Pick<UserItemMergeBucketRow, "id" | "equipped" | "storedAtHome">,
+  quantity: number,
+) =>
+  and(
+    eq(userItem.id, item.id),
+    eq(userItem.userId, userId),
+    eq(userItem.isInAuction, false),
+    eq(userItem.quantity, quantity),
+    eq(userItem.equipped, item.equipped),
+    eq(userItem.storedAtHome, item.storedAtHome),
+  );
+
 /**
  * Merges stacks only within the same inventory bucket (`storedAtHome` + `equipped`) so
  * merge never deletes an equipped row while keeping a backpack copy (or mixes home vs carried).
+ *
+ * Protocol (PlanetScale has no transactions): claim every row in the bucket to quantity 0
+ * with CAS guards, then write targets / delete extras. If any step fails, restore original
+ * quantities (and re-insert deleted rows) so a concurrent store/retrieve cannot leave a
+ * partial merge that duplicates items.
  */
 async function executeMergeStacksForItemBucket(
   drizzle: DrizzleClient,
@@ -3421,59 +3581,98 @@ async function executeMergeStacksForItemBucket(
     return { success: true, didMerge: false, message: "" };
   }
 
-  const updatePromises = itemsToKeep.flatMap((item, index) => {
-    const targetQuantity = targetQuantityForKeepIndex(index);
-    if (item.quantity === targetQuantity) {
-      return [];
-    }
-    return [
+  const conflictMessage = `Failed to merge stacks of ${itemName} — inventory changed, please try again`;
+
+  // Phase 1: claim every row (qty → 0) so no subset of later writes can commit alone.
+  const claimResults = await Promise.all(
+    sortedItems.map((item) =>
       drizzle
         .update(userItem)
-        .set({ quantity: targetQuantity })
-        .where(
-          and(
-            eq(userItem.id, item.id),
-            eq(userItem.userId, userId),
-            eq(userItem.isInAuction, false),
-            eq(userItem.quantity, item.quantity),
-            eq(userItem.equipped, item.equipped),
-            eq(userItem.storedAtHome, item.storedAtHome),
-          ),
-        ),
-    ];
-  });
-
-  const deletePromises = itemsToDelete.map((item) =>
-    drizzle
-      .delete(userItem)
-      .where(
-        and(
-          eq(userItem.id, item.id),
-          eq(userItem.userId, userId),
-          eq(userItem.isInAuction, false),
-          eq(userItem.quantity, item.quantity),
-          eq(userItem.equipped, item.equipped),
-          eq(userItem.storedAtHome, item.storedAtHome),
-        ),
-      ),
+        .set({ quantity: 0 })
+        .where(mergeStackRowGuard(userId, item, item.quantity)),
+    ),
   );
 
-  // rowsAffected may be 0 if another request already merged (same guarded WHERE); still success.
-  try {
-    await Promise.all([...updatePromises, ...deletePromises]);
-  } catch (err: unknown) {
-    if (err instanceof TypeError || err instanceof ReferenceError) {
-      throw err;
-    }
-    if (err instanceof Error) {
-      return {
-        success: false,
-        didMerge: false,
-        message: `Failed to merge stacks of ${itemName}`,
-      };
-    }
-    throw err;
+  if (claimResults.some((result) => result.rowsAffected !== 1)) {
+    await Promise.all(
+      sortedItems.map((item, index) =>
+        claimResults[index]?.rowsAffected === 1
+          ? drizzle
+              .update(userItem)
+              .set({ quantity: item.quantity })
+              .where(
+                and(
+                  eq(userItem.id, item.id),
+                  eq(userItem.userId, userId),
+                  eq(userItem.quantity, 0),
+                ),
+              )
+          : Promise.resolve(),
+      ),
+    );
+    return { success: false, didMerge: false, message: conflictMessage };
   }
+
+  // Phase 2: write keeper targets and delete claimed extras.
+  const applyResults = await Promise.all([
+    ...itemsToKeep.map((item, index) =>
+      drizzle
+        .update(userItem)
+        .set({ quantity: targetQuantityForKeepIndex(index) })
+        .where(mergeStackRowGuard(userId, item, 0)),
+    ),
+    ...itemsToDelete.map((item) =>
+      drizzle.delete(userItem).where(mergeStackRowGuard(userId, item, 0)),
+    ),
+  ]);
+
+  if (applyResults.some((result) => result.rowsAffected !== 1)) {
+    // Restore any surviving rows to their pre-merge quantities.
+    await Promise.all(
+      sortedItems.map((item) =>
+        drizzle
+          .update(userItem)
+          .set({ quantity: item.quantity })
+          .where(and(eq(userItem.id, item.id), eq(userItem.userId, userId))),
+      ),
+    );
+    // Re-insert rows that were deleted before a sibling write failed.
+    const surviving = await drizzle.query.userItem.findMany({
+      where: and(
+        eq(userItem.userId, userId),
+        inArray(
+          userItem.id,
+          sortedItems.map((item) => item.id),
+        ),
+      ),
+      columns: { id: true },
+    });
+    const survivingIds = new Set(surviving.map((row) => row.id));
+    const missing = sortedItems.filter((item) => !survivingIds.has(item.id));
+    if (missing.length > 0) {
+      await drizzle.insert(userItem).values(
+        missing.map((item) => ({
+          id: item.id,
+          createdAt: item.createdAt,
+          updatedAt: item.updatedAt,
+          userId,
+          itemId: item.itemId,
+          quantity: item.quantity,
+          level: item.level,
+          experience: item.experience,
+          durability: item.durability,
+          equipped: item.equipped,
+          storedAtHome: item.storedAtHome,
+          isInAuction: false,
+          activeVariantId: item.activeVariantId,
+          craftingFinishedAt: item.craftingFinishedAt,
+          dropChancePerc: item.dropChancePerc,
+        })),
+      );
+    }
+    return { success: false, didMerge: false, message: conflictMessage };
+  }
+
   return {
     success: true,
     didMerge: true,
@@ -3489,6 +3688,10 @@ async function executeMergeStacksForItemBucket(
  *
  * **Buckets:** Each `(storedAtHome, equipped)` group merges separately so equipped and
  * backpack rows are never consolidated into one row.
+ *
+ * **Concurrency:** Each bucket uses a claim-then-commit protocol (see
+ * `executeMergeStacksForItemBucket`) so concurrent store/retrieve cannot leave a
+ * partial merge that duplicates quantities.
  *
  * **mergeAllStacks** passes `preloaded` rows already limited to the requested scope
  * (carried or home), non-auction stacks.

--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -5,6 +5,7 @@ import {
   count,
   eq,
   exists,
+  gt,
   gte,
   inArray,
   isNotNull,
@@ -113,6 +114,8 @@ import type { DrizzleClient } from "@/server/db";
 import {
   consumeUserItemAtomically,
   refundUserItemQuantityAtomically,
+  restoreStaleUserItemMergeClaims,
+  userItemMergePublishQuantity,
 } from "@/server/utils/concurrency";
 import {
   applyLoadoutRename,
@@ -864,6 +867,7 @@ export const itemRouter = createTRPCRouter({
   getUserItemCounts: protectedProcedure
     .meta({ mcp: { enabled: true, description: "Get user item counts by item ID" } })
     .query(async ({ ctx }) => {
+      await restoreStaleMergeStackClaims(ctx.drizzle, ctx.userId);
       const counts = await ctx.drizzle
         .select({
           count: sql<number>`count(${userItem.id})`,
@@ -871,7 +875,7 @@ export const itemRouter = createTRPCRouter({
           quantity: sql<number>`sum(${userItem.quantity})`,
         })
         .from(userItem)
-        .where(eq(userItem.userId, ctx.userId))
+        .where(and(eq(userItem.userId, ctx.userId), gt(userItem.quantity, 0)))
         .groupBy(userItem.itemId);
       return counts.map((c) => ({ id: c.itemId, quantity: c.quantity ?? 0 }));
     }),
@@ -879,6 +883,7 @@ export const itemRouter = createTRPCRouter({
   getUserItems: protectedProcedure
     .meta({ mcp: { enabled: true, description: "Get all user items" } })
     .query(async ({ ctx }) => {
+      await restoreStaleMergeStackClaims(ctx.drizzle, ctx.userId);
       return await fetchUserItems(ctx.drizzle, ctx.userId);
     }),
   getUserItemsWithVariants: protectedProcedure
@@ -886,16 +891,14 @@ export const itemRouter = createTRPCRouter({
       mcp: { enabled: true, description: "Get all user items including variant data" },
     })
     .query(async ({ ctx }) => {
+      await restoreStaleMergeStackClaims(ctx.drizzle, ctx.userId);
       return await fetchUserItemsWithVariants(ctx.drizzle, ctx.userId);
     }),
   // Get items of public user (staff edit)
   getPublicUserItems: protectedProcedure
     .input(getPublicUserItemsSchema)
     .query(async ({ ctx, input }) => {
-      const [user, userItems] = await Promise.all([
-        fetchUser(ctx.drizzle, ctx.userId),
-        fetchUserItems(ctx.drizzle, input.userId, { includeHidden: true }),
-      ]);
+      const user = await fetchUser(ctx.drizzle, ctx.userId);
       if (!canEditItems(user.role)) {
         throw new TRPCError({
           code: "UNAUTHORIZED",
@@ -908,7 +911,10 @@ export const itemRouter = createTRPCRouter({
           message: "You can only view your own items",
         });
       }
-      return userItems;
+      await restoreStaleMergeStackClaims(ctx.drizzle, input.userId);
+      return await fetchUserItems(ctx.drizzle, input.userId, {
+        includeHidden: true,
+      });
     }),
   // Adjust item level of public user
   adjustUserItem: protectedProcedure
@@ -921,6 +927,7 @@ export const itemRouter = createTRPCRouter({
           where: and(
             eq(userItem.id, input.userItemId),
             eq(userItem.userId, input.userId),
+            gt(userItem.quantity, 0),
           ),
           with: { item: true },
         }),
@@ -947,6 +954,7 @@ export const itemRouter = createTRPCRouter({
             eq(userItem.userId, input.userId),
             eq(userItem.level, owned.level),
             eq(userItem.experience, owned.experience),
+            gt(userItem.quantity, 0),
           ),
         );
       if (updateResult.rowsAffected === 0) {
@@ -1240,6 +1248,7 @@ export const itemRouter = createTRPCRouter({
           and(
             eq(userItem.id, input.userItemId),
             eq(userItem.userId, ctx.userId),
+            gt(userItem.quantity, 0),
             ...(input.variantId
               ? [
                   exists(
@@ -1423,9 +1432,11 @@ export const itemRouter = createTRPCRouter({
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
       const storedAtHome = input?.storedAtHome ?? false;
+      await restoreStaleMergeStackClaims(ctx.drizzle, ctx.userId);
       const userItemsAll = await ctx.drizzle.query.userItem.findMany({
         where: and(
           eq(userItem.userId, ctx.userId),
+          gt(userItem.quantity, 0),
           eq(userItem.storedAtHome, storedAtHome),
           eq(userItem.isInAuction, false),
           or(
@@ -1537,9 +1548,25 @@ export const itemRouter = createTRPCRouter({
       }
       // Derived
       const cost = calcItemSellingPrice(user, useritem, structures);
-      // Mutate
+      // Claim the positive stack before granting proceeds. A merge claim negates quantity, so the
+      // CAS cannot delete or pay for a row while it belongs to an in-flight merge.
+      const deleteResult = await ctx.drizzle
+        .delete(userItem)
+        .where(
+          and(
+            eq(userItem.id, input.userItemId),
+            eq(userItem.userId, ctx.userId),
+            eq(userItem.quantity, useritem.quantity),
+            gt(userItem.quantity, 0),
+            eq(userItem.isInAuction, false),
+          ),
+        );
+      if (deleteResult.rowsAffected !== 1) {
+        return errorResponse("Inventory changed, please refresh and try again");
+      }
+
+      // Mutate dependent state only after the inventory CAS succeeds.
       await Promise.all([
-        ctx.drizzle.delete(userItem).where(eq(userItem.id, input.userItemId)),
         ctx.drizzle
           .delete(userItemImbuement)
           .where(eq(userItemImbuement.userItemId, input.userItemId)),
@@ -1632,6 +1659,7 @@ export const itemRouter = createTRPCRouter({
             eq(userItem.userId, ctx.userId),
             ne(userItem.equipped, "NONE"),
             eq(userItem.isInAuction, false),
+            gt(userItem.quantity, 0),
           ),
         }),
       ]);
@@ -1669,6 +1697,7 @@ export const itemRouter = createTRPCRouter({
                 eq(userItem.userId, ctx.userId),
                 ne(userItem.equipped, "NONE"),
                 eq(userItem.isInAuction, false),
+                gt(userItem.quantity, 0),
               ),
             ),
         );
@@ -2190,6 +2219,12 @@ export const itemRouter = createTRPCRouter({
         return errorResponse("Not your target item");
       if (user.status !== "AWAKE") {
         return errorResponse(`Cannot use items while ${user.status.toLowerCase()}`);
+      }
+      if (repairUserItem.storedAtHome) {
+        return errorResponse("Fetch the repair item from home storage first");
+      }
+      if (repairUserItem.isInAuction) {
+        return errorResponse("Cannot use a repair item listed in an auction");
       }
       if (
         repairUserItem.craftingFinishedAt &&
@@ -3026,13 +3061,24 @@ export const fetchItemWithCraftingRequirements = async (
   });
 };
 
+// Merge claims normally live for only a few database round trips. After this timeout a negative
+// quantity is considered abandoned and can be restored from its encoded original value.
+const MERGE_STACK_CLAIM_TIMEOUT_MS = 30_000;
+
+const restoreStaleMergeStackClaims = async (client: DrizzleClient, userId: string) =>
+  restoreStaleUserItemMergeClaims({
+    client,
+    userId,
+    staleBefore: new Date(Date.now() - MERGE_STACK_CLAIM_TIMEOUT_MS),
+  });
+
 export const fetchUserItems = async (
   client: DrizzleClient,
   userId: string,
   options?: { includeHidden?: boolean },
 ) => {
   const useritems = await client.query.userItem.findMany({
-    where: and(eq(userItem.userId, userId)),
+    where: and(eq(userItem.userId, userId), gt(userItem.quantity, 0)),
     with: {
       item: true,
       imbuements: { with: { item: true } },
@@ -3048,7 +3094,7 @@ export const fetchUserItemsWithVariants = async (
   userId: string,
 ) => {
   const useritems = await client.query.userItem.findMany({
-    where: and(eq(userItem.userId, userId)),
+    where: and(eq(userItem.userId, userId), gt(userItem.quantity, 0)),
     with: {
       item: { with: { variants: { orderBy: (v, { asc }) => [asc(v.order)] } } },
       imbuements: { with: { item: true } },
@@ -3063,7 +3109,11 @@ export const fetchUserItem = async (
   userItemId: string,
 ) => {
   return await client.query.userItem.findFirst({
-    where: and(eq(userItem.userId, userId), eq(userItem.id, userItemId)),
+    where: and(
+      eq(userItem.userId, userId),
+      eq(userItem.id, userItemId),
+      gt(userItem.quantity, 0),
+    ),
     with: { item: true },
   });
 };
@@ -3074,7 +3124,11 @@ export const fetchUserItemWithVariants = async (
   userItemId: string,
 ) => {
   return await client.query.userItem.findFirst({
-    where: and(eq(userItem.userId, userId), eq(userItem.id, userItemId)),
+    where: and(
+      eq(userItem.userId, userId),
+      eq(userItem.id, userItemId),
+      gt(userItem.quantity, 0),
+    ),
     with: { item: { with: { variants: { orderBy: (v, { asc }) => [asc(v.order)] } } } },
   });
 };
@@ -3097,7 +3151,13 @@ export const fetchVariantOwnership = async (
     .select({ id: userItem.id })
     .from(userItem)
     .innerJoin(itemVariant, eq(userItem.itemId, itemVariant.itemId))
-    .where(and(eq(userItem.userId, userId), eq(itemVariant.id, variantId)))
+    .where(
+      and(
+        eq(userItem.userId, userId),
+        eq(itemVariant.id, variantId),
+        gt(userItem.quantity, 0),
+      ),
+    )
     .limit(1);
 };
 
@@ -3211,13 +3271,25 @@ export const toggleEquipItem = async (
       client
         .update(userItem)
         .set({ equipped: newEquipSlot })
-        .where(eq(userItem.id, useritem.id)),
+        .where(
+          and(
+            eq(userItem.id, useritem.id),
+            eq(userItem.userId, user.userId),
+            gt(userItem.quantity, 0),
+          ),
+        ),
       ...(userItemInSlot
         ? [
             client
               .update(userItem)
               .set({ equipped: "NONE" })
-              .where(eq(userItem.id, userItemInSlot.id)),
+              .where(
+                and(
+                  eq(userItem.id, userItemInSlot.id),
+                  eq(userItem.userId, user.userId),
+                  gt(userItem.quantity, 0),
+                ),
+              ),
           ]
         : []),
     ];
@@ -3228,7 +3300,13 @@ export const toggleEquipItem = async (
       client
         .update(userItem)
         .set({ equipped: "NONE" })
-        .where(eq(userItem.id, useritem.id)),
+        .where(
+          and(
+            eq(userItem.id, useritem.id),
+            eq(userItem.userId, user.userId),
+            gt(userItem.quantity, 0),
+          ),
+        ),
     ];
     message = `Unequipped ${info.name}`;
   }
@@ -3372,7 +3450,11 @@ export const splitItemStack = async (
 > => {
   // Fetch the user item to verify ownership
   const currentUserItem = await client.query.userItem.findFirst({
-    where: and(eq(userItem.id, userItemId), eq(userItem.userId, userId)),
+    where: and(
+      eq(userItem.id, userItemId),
+      eq(userItem.userId, userId),
+      gt(userItem.quantity, 0),
+    ),
     with: { item: true, imbuements: true },
   });
 
@@ -3415,13 +3497,28 @@ export const splitItemStack = async (
   const quantityToSplit = currentUserItem.quantity - quantityToKeep;
   const newUserItemId = nanoid();
 
-  // Update current stack and create new stack in parallel
-  await Promise.all([
-    client
-      .update(userItem)
-      .set({ quantity: quantityToKeep })
-      .where(eq(userItem.id, userItemId)),
-    client.insert(userItem).values({
+  // Claim the source quantity before inserting the new row. This CAS cannot match a negative
+  // merge claim and prevents a concurrent merge from turning a failed split into duplicated items.
+  const updateResult = await client
+    .update(userItem)
+    .set({ quantity: quantityToKeep })
+    .where(
+      and(
+        eq(userItem.id, userItemId),
+        eq(userItem.userId, userId),
+        eq(userItem.quantity, currentUserItem.quantity),
+        gt(userItem.quantity, 0),
+        eq(userItem.isInAuction, false),
+        eq(userItem.equipped, currentUserItem.equipped),
+        eq(userItem.storedAtHome, currentUserItem.storedAtHome),
+      ),
+    );
+  if (updateResult.rowsAffected !== 1) {
+    return { success: false, message: "Inventory changed, please try again" };
+  }
+
+  try {
+    await client.insert(userItem).values({
       id: newUserItemId,
       userId: currentUserItem.userId,
       itemId: currentUserItem.itemId,
@@ -3440,8 +3537,20 @@ export const splitItemStack = async (
       dropChancePerc: currentUserItem.dropChancePerc,
       createdAt: new Date(),
       updatedAt: new Date(),
-    }),
-  ]);
+    });
+  } catch {
+    await client
+      .update(userItem)
+      .set({ quantity: currentUserItem.quantity })
+      .where(
+        and(
+          eq(userItem.id, userItemId),
+          eq(userItem.userId, userId),
+          eq(userItem.quantity, quantityToKeep),
+        ),
+      );
+    return { success: false, message: "Could not create the split stack" };
+  }
 
   return {
     success: true,
@@ -3470,6 +3579,7 @@ const tryRepairUserItemDurability = async (
         eq(userItem.userId, userId),
         eq(userItem.storedAtHome, false),
         eq(userItem.isInAuction, false),
+        gt(userItem.quantity, 0),
         eq(userItem.durability, target.durability),
       ),
     );
@@ -3554,10 +3664,12 @@ const mergeStackRowGuard = (
  * Merges stacks only within the same inventory bucket (`storedAtHome` + `equipped`) so
  * merge never deletes an equipped row while keeping a backpack copy (or mixes home vs carried).
  *
- * Protocol (PlanetScale has no transactions): claim every row in the bucket to quantity 0
- * with CAS guards, then write targets / delete extras. If any step fails, restore original
- * quantities (and re-insert deleted rows) so a concurrent store/retrieve cannot leave a
- * partial merge that duplicates items.
+ * Protocol (PlanetScale has no transactions): claim every row in the bucket by negating its
+ * quantity with CAS guards, then atomically publish every keeper target and zero-quantity
+ * tombstone in one UPDATE. The negative value preserves the original quantity if the process
+ * crashes before publish; a crash after publish leaves the correct positive inventory and only
+ * hidden tombstones for stale cleanup. If a normal claim/publish conflict occurs, restore the
+ * original quantities.
  */
 async function executeMergeStacksForItemBucket(
   drizzle: DrizzleClient,
@@ -3593,12 +3705,15 @@ async function executeMergeStacksForItemBucket(
 
   const conflictMessage = `Failed to merge stacks of ${itemName} — inventory changed, please try again`;
 
-  // Phase 1: claim every row (qty → 0) so no subset of later writes can commit alone.
+  const claimedAt = new Date();
+
+  // Phase 1: claim every row (qty → -qty) so no subset of later writes can commit alone while
+  // retaining enough information for a later request to recover an abandoned claim.
   const claimResults = await Promise.all(
     sortedItems.map((item) =>
       drizzle
         .update(userItem)
-        .set({ quantity: 0 })
+        .set({ quantity: -item.quantity, updatedAt: claimedAt })
         .where(mergeStackRowGuard(userId, item, item.quantity)),
     ),
   );
@@ -3609,12 +3724,12 @@ async function executeMergeStacksForItemBucket(
         claimResults[index]?.rowsAffected === 1
           ? drizzle
               .update(userItem)
-              .set({ quantity: item.quantity })
+              .set({ quantity: item.quantity, updatedAt: item.updatedAt })
               .where(
                 and(
                   eq(userItem.id, item.id),
                   eq(userItem.userId, userId),
-                  eq(userItem.quantity, 0),
+                  eq(userItem.quantity, -item.quantity),
                 ),
               )
           : Promise.resolve(),
@@ -3623,64 +3738,57 @@ async function executeMergeStacksForItemBucket(
     return { success: false, didMerge: false, message: conflictMessage };
   }
 
-  // Phase 2: write keeper targets and delete claimed extras.
-  const applyResults = await Promise.all([
-    ...itemsToKeep.map((item, index) =>
-      drizzle
-        .update(userItem)
-        .set({ quantity: targetQuantityForKeepIndex(index) })
-        .where(mergeStackRowGuard(userId, item, 0)),
-    ),
-    ...itemsToDelete.map((item) =>
-      drizzle.delete(userItem).where(mergeStackRowGuard(userId, item, 0)),
-    ),
-  ]);
+  // Phase 2: atomically publish every keeper and convert extras to hidden tombstones. One UPDATE
+  // means a process crash cannot commit only a subset of the target quantities/deletions.
+  const targetQuantityById = new Map(
+    itemsToKeep.map((item, index) => [item.id, targetQuantityForKeepIndex(index)]),
+  );
+  const publishResult = await drizzle
+    .update(userItem)
+    .set({
+      quantity: userItemMergePublishQuantity(
+        sortedItems.map((item) => ({
+          id: item.id,
+          quantity: targetQuantityById.get(item.id) ?? 0,
+        })),
+      ),
+    })
+    .where(
+      or(
+        ...sortedItems.map((item) => mergeStackRowGuard(userId, item, -item.quantity)),
+      ),
+    );
 
-  if (applyResults.some((result) => result.rowsAffected !== 1)) {
-    // Restore any surviving rows to their pre-merge quantities.
+  if (publishResult.rowsAffected !== sortedItems.length) {
     await Promise.all(
       sortedItems.map((item) =>
         drizzle
           .update(userItem)
-          .set({ quantity: item.quantity })
+          .set({ quantity: item.quantity, updatedAt: item.updatedAt })
           .where(and(eq(userItem.id, item.id), eq(userItem.userId, userId))),
       ),
     );
-    // Re-insert rows that were deleted before a sibling write failed.
-    const surviving = await drizzle.query.userItem.findMany({
-      where: and(
-        eq(userItem.userId, userId),
-        inArray(
-          userItem.id,
-          sortedItems.map((item) => item.id),
-        ),
-      ),
-      columns: { id: true },
-    });
-    const survivingIds = new Set(surviving.map((row) => row.id));
-    const missing = sortedItems.filter((item) => !survivingIds.has(item.id));
-    if (missing.length > 0) {
-      await drizzle.insert(userItem).values(
-        missing.map((item) => ({
-          id: item.id,
-          createdAt: item.createdAt,
-          updatedAt: item.updatedAt,
-          userId,
-          itemId: item.itemId,
-          quantity: item.quantity,
-          level: item.level,
-          experience: item.experience,
-          durability: item.durability,
-          equipped: item.equipped,
-          storedAtHome: item.storedAtHome,
-          isInAuction: false,
-          activeVariantId: item.activeVariantId,
-          craftingFinishedAt: item.craftingFinishedAt,
-          dropChancePerc: item.dropChancePerc,
-        })),
-      );
-    }
     return { success: false, didMerge: false, message: conflictMessage };
+  }
+
+  // Physical deletion is cleanup only; zero rows are already excluded everywhere and the stale
+  // claim reaper will remove them if this request dies or the best-effort delete fails.
+  if (itemsToDelete.length > 0) {
+    try {
+      await drizzle.delete(userItem).where(
+        and(
+          eq(userItem.userId, userId),
+          inArray(
+            userItem.id,
+            itemsToDelete.map((item) => item.id),
+          ),
+          eq(userItem.quantity, 0),
+          eq(userItem.updatedAt, claimedAt),
+        ),
+      );
+    } catch {
+      // The logical merge already committed; stale cleanup will retry this tombstone deletion.
+    }
   }
 
   return {
@@ -3718,15 +3826,17 @@ async function executeMergeStacksForItem(
   if (preloaded) {
     info = preloaded.item;
     userItems = preloaded.userItems.filter(
-      (r) => r.userId === userId && r.itemId === itemId,
+      (r) => r.userId === userId && r.itemId === itemId && r.quantity > 0,
     );
   } else {
+    await restoreStaleMergeStackClaims(drizzle, userId);
     const [fetchedInfo, fetchedUserItems] = await Promise.all([
       fetchItem(drizzle, itemId),
       drizzle.query.userItem.findMany({
         where: and(
           eq(userItem.userId, userId),
           eq(userItem.itemId, itemId),
+          gt(userItem.quantity, 0),
           eq(userItem.storedAtHome, false),
           eq(userItem.isInAuction, false),
         ),

--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -867,7 +867,6 @@ export const itemRouter = createTRPCRouter({
   getUserItemCounts: protectedProcedure
     .meta({ mcp: { enabled: true, description: "Get user item counts by item ID" } })
     .query(async ({ ctx }) => {
-      await restoreStaleMergeStackClaims(ctx.drizzle, ctx.userId);
       const counts = await ctx.drizzle
         .select({
           count: sql<number>`count(${userItem.id})`,
@@ -883,7 +882,6 @@ export const itemRouter = createTRPCRouter({
   getUserItems: protectedProcedure
     .meta({ mcp: { enabled: true, description: "Get all user items" } })
     .query(async ({ ctx }) => {
-      await restoreStaleMergeStackClaims(ctx.drizzle, ctx.userId);
       return await fetchUserItems(ctx.drizzle, ctx.userId);
     }),
   getUserItemsWithVariants: protectedProcedure
@@ -891,7 +889,6 @@ export const itemRouter = createTRPCRouter({
       mcp: { enabled: true, description: "Get all user items including variant data" },
     })
     .query(async ({ ctx }) => {
-      await restoreStaleMergeStackClaims(ctx.drizzle, ctx.userId);
       return await fetchUserItemsWithVariants(ctx.drizzle, ctx.userId);
     }),
   // Get items of public user (staff edit)
@@ -2415,7 +2412,9 @@ export const itemRouter = createTRPCRouter({
                   eq(userItem.quantity, repairKitRow.quantity),
                 ),
               );
-            return result.rowsAffected === 1 ? { repairKitRow, quantityUsed } : false;
+            return result.rowsAffected === 1
+              ? { repairKitRow, quantityConsumed: repairKitRow.quantity }
+              : false;
           }
           const result = await ctx.drizzle
             .update(userItem)
@@ -2427,7 +2426,9 @@ export const itemRouter = createTRPCRouter({
                 eq(userItem.quantity, repairKitRow.quantity),
               ),
             );
-          return result.rowsAffected === 1 ? { repairKitRow, quantityUsed } : false;
+          return result.rowsAffected === 1
+            ? { repairKitRow, quantityConsumed: quantityUsed }
+            : false;
         }),
       );
       if (kitConsumeResults.some((result) => result === false)) {
@@ -2450,7 +2451,7 @@ export const itemRouter = createTRPCRouter({
                   refundUserItemQuantityAtomically({
                     client: ctx.drizzle,
                     itemSnapshot: result.repairKitRow,
-                    quantity: result.quantityUsed,
+                    quantity: result.quantityConsumed,
                   }),
                 ]
               : [],
@@ -3765,7 +3766,13 @@ async function executeMergeStacksForItemBucket(
         drizzle
           .update(userItem)
           .set({ quantity: item.quantity, updatedAt: item.updatedAt })
-          .where(and(eq(userItem.id, item.id), eq(userItem.userId, userId))),
+          .where(
+            and(
+              eq(userItem.id, item.id),
+              eq(userItem.userId, userId),
+              eq(userItem.quantity, -item.quantity),
+            ),
+          ),
       ),
     );
     return { success: false, didMerge: false, message: conflictMessage };

--- a/app/src/server/api/routers/occupation.ts
+++ b/app/src/server/api/routers/occupation.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, ne, or, sql } from "drizzle-orm";
+import { and, eq, gt, isNull, ne, or, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import {
@@ -467,7 +467,9 @@ export const occupationRouter = createTRPCRouter({
         );
       }
 
-      // Write-time guard: only proceed if item is still not in auction (atomic)
+      // Write-time guard: only proceed if item is still not in auction (atomic). The quantity
+      // guard also refuses rows held by a stack-merge claim or left as a merge tombstone, so an
+      // imbuement is never attached to a row the merge protocol is about to fold away or delete.
       const notInAuctionGuard = await ctx.drizzle
         .update(userItem)
         .set({ updatedAt: new Date() })
@@ -475,6 +477,7 @@ export const occupationRouter = createTRPCRouter({
           and(
             eq(userItem.id, input.userItemId),
             eq(userItem.userId, ctx.userId),
+            gt(userItem.quantity, 0),
             eq(userItem.isInAuction, false),
           ),
         );

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -2403,7 +2403,7 @@ export const fetchUpdatedUser = async (props: {
           limit: 1,
         },
         items: {
-          where: ne(userItem.equipped, "NONE"),
+          where: and(ne(userItem.equipped, "NONE"), gt(userItem.quantity, 0)),
           with: {
             item: { columns: { id: true, itemType: true, maxDurability: true } },
           },

--- a/app/src/server/api/routers/quests.ts
+++ b/app/src/server/api/routers/quests.ts
@@ -3,6 +3,7 @@ import {
   asc,
   eq,
   getTableColumns,
+  gt,
   gte,
   inArray,
   isNull,
@@ -1521,9 +1522,7 @@ export const updateRewards = async (info: {
   // Recording history without equipping would permanently burn that id (no swap path).
   // COALESCE still protects an empty-slot race from double-equipping.
   const rolledSageMode =
-    !user.sageModeId && sageModes.length > 0
-      ? getRandomElement(sageModes)
-      : undefined;
+    !user.sageModeId && sageModes.length > 0 ? getRandomElement(sageModes) : undefined;
 
   const updatedUserData: Record<string, unknown> = {
     questData: user.questData,
@@ -2727,7 +2726,15 @@ const executeClaimedQuestConsequences = async ({
         ]
       : []),
     ...(removedUserItemIds.length > 0
-      ? [client.delete(userItem).where(inArray(userItem.id, removedUserItemIds))]
+      ? [
+          // The quantity guard refuses rows held by a stack-merge claim (negative quantity), so
+          // this delete can never break an in-flight merge publish and duplicate the stack.
+          client
+            .delete(userItem)
+            .where(
+              and(inArray(userItem.id, removedUserItemIds), gt(userItem.quantity, 0)),
+            ),
+        ]
       : []),
     ...[
       opponent

--- a/app/src/server/api/routers/staff.ts
+++ b/app/src/server/api/routers/staff.ts
@@ -2,7 +2,7 @@ import { Client as PlanetScaleClient } from "@planetscale/database";
 import * as Sentry from "@sentry/nextjs";
 import type { inferRouterOutputs } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
-import { and, desc, eq, inArray, ne, sql } from "drizzle-orm";
+import { and, desc, eq, gt, inArray, ne, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { after } from "next/server";
 import { z } from "zod";
@@ -329,6 +329,9 @@ export const staffRouter = createTRPCRouter({
           .where(
             and(
               ne(userItem.equipped, "NONE"),
+              // Skip rows held by a stack-merge claim (negative quantity) so this bulk write
+              // cannot change a claimed row's equipped slot mid-merge-publish.
+              gt(userItem.quantity, 0),
               sql`${userItem.userId} NOT IN (
                 SELECT ${userData.userId} FROM ${userData} WHERE ${userData.isAi} = true
               )`,

--- a/app/src/server/utils/concurrency.ts
+++ b/app/src/server/utils/concurrency.ts
@@ -22,6 +22,7 @@ import {
   ne,
   sql,
 } from "drizzle-orm";
+import { nanoid } from "nanoid";
 import type { BattleType } from "@/drizzle/constants";
 import type { UserItem } from "@/drizzle/schema";
 import {
@@ -131,6 +132,12 @@ export const consumeUserItemAtomically = async ({
   });
 };
 
+/**
+ * How long a stack-merge claim (negative quantity) may exist before it is considered abandoned
+ * and safe to restore. Claims normally live for only a few database round trips.
+ */
+export const MERGE_STACK_CLAIM_TIMEOUT_MS = 30_000;
+
 type RefundUserItemQuantityAtomicallyParams = {
   client: DrizzleClient;
   itemSnapshot: UserItem;
@@ -140,8 +147,9 @@ type RefundUserItemQuantityAtomicallyParams = {
 /**
  * Compensates a successful item consume. If the consume decremented the stack, the duplicate-key
  * branch adds the quantity back; if it deleted the stack, the insert branch recreates the original
- * row with only the refunded quantity. A negative quantity belongs to an active stack merge, so
- * the guarded upsert refuses to change it, recovers the merge claims, and retries the refund.
+ * row with only the refunded quantity. A negative quantity belongs to an active stack merge whose
+ * publish would overwrite any value we set, so the guarded upsert refuses to touch it and the
+ * refund lands in a fresh row instead — the next merge folds it back into the stack.
  */
 export const refundUserItemQuantityAtomically = async ({
   client,
@@ -150,43 +158,26 @@ export const refundUserItemQuantityAtomically = async ({
 }: RefundUserItemQuantityAtomicallyParams) => {
   if (quantity <= 0) return;
 
-  const refund = () =>
-    client
-      .insert(userItem)
-      .values({
-        id: itemSnapshot.id,
-        createdAt: itemSnapshot.createdAt,
-        updatedAt: itemSnapshot.updatedAt,
-        userId: itemSnapshot.userId,
-        itemId: itemSnapshot.itemId,
-        quantity,
-        level: itemSnapshot.level,
-        experience: itemSnapshot.experience,
-        equipped: itemSnapshot.equipped,
-        durability: itemSnapshot.durability,
-        storedAtHome: itemSnapshot.storedAtHome,
-        craftingFinishedAt: itemSnapshot.craftingFinishedAt,
-        isInAuction: itemSnapshot.isInAuction,
-        activeVariantId: itemSnapshot.activeVariantId,
-        dropChancePerc: itemSnapshot.dropChancePerc,
-      })
-      .onDuplicateKeyUpdate({
-        set: {
-          quantity: sql`IF(${userItem.quantity} >= 0, ${userItem.quantity} + ${quantity}, ${userItem.quantity})`,
-        },
-      });
-
-  const result = await refund();
+  const result = await client
+    .insert(userItem)
+    .values({ ...itemSnapshot, quantity })
+    .onDuplicateKeyUpdate({
+      set: {
+        quantity: sql`IF(${userItem.quantity} >= 0, ${userItem.quantity} + ${quantity}, ${userItem.quantity})`,
+      },
+    });
   if (result.rowsAffected > 0) return;
 
-  // A no-op duplicate update means the row is held by a merge claim. Recover every row in that
-  // merge before retrying so its pending publish cannot overwrite the refunded quantity.
-  await restoreStaleUserItemMergeClaims({
-    client,
-    userId: itemSnapshot.userId,
-    staleBefore: new Date(),
+  // The claimed original keeps its equipped slot when the merge publishes it back, so the
+  // refund row must start unequipped — two rows can never share one slot.
+  await client.insert(userItem).values({
+    ...itemSnapshot,
+    id: nanoid(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    equipped: "NONE",
+    quantity,
   });
-  await refund();
 };
 
 type RestoreStaleUserItemMergeClaimsParams = {
@@ -232,8 +223,11 @@ export const restoreStaleUserItemMergeClaims = async ({
   ]);
 };
 
-/** Builds the single-statement CASE expression used to atomically publish a stack merge. */
-export const userItemMergePublishQuantity = (
+/**
+ * Builds the per-row CASE expression used by the stack-merge protocol so one UPDATE can set a
+ * different quantity per row (claim negation, publish targets, and conflict restores).
+ */
+export const userItemMergeQuantityCase = (
   targets: readonly { id: string; quantity: number }[],
 ) =>
   sql<number>`CASE ${userItem.id} ${sql.join(

--- a/app/src/server/utils/concurrency.ts
+++ b/app/src/server/utils/concurrency.ts
@@ -11,6 +11,7 @@
  */
 import { and, eq, exists, gt, gte, inArray, isNull, ne, sql } from "drizzle-orm";
 import type { BattleType } from "@/drizzle/constants";
+import type { UserItem } from "@/drizzle/schema";
 import {
   bloodlineRolls,
   rankedPvpQueue,
@@ -116,6 +117,48 @@ export const consumeUserItemAtomically = async ({
     expectedQuantity,
     nextQuantity: expectedQuantity - 1,
   });
+};
+
+type RefundUserItemQuantityAtomicallyParams = {
+  client: DrizzleClient;
+  itemSnapshot: UserItem;
+  quantity: number;
+};
+
+/**
+ * Compensates a successful item consume in one statement. If the consume decremented the stack,
+ * the duplicate-key branch adds the quantity back; if it deleted the stack, the insert branch
+ * recreates the original row with only the refunded quantity.
+ */
+export const refundUserItemQuantityAtomically = async ({
+  client,
+  itemSnapshot,
+  quantity,
+}: RefundUserItemQuantityAtomicallyParams) => {
+  if (quantity <= 0) return;
+
+  await client
+    .insert(userItem)
+    .values({
+      id: itemSnapshot.id,
+      createdAt: itemSnapshot.createdAt,
+      updatedAt: itemSnapshot.updatedAt,
+      userId: itemSnapshot.userId,
+      itemId: itemSnapshot.itemId,
+      quantity,
+      level: itemSnapshot.level,
+      experience: itemSnapshot.experience,
+      equipped: itemSnapshot.equipped,
+      durability: itemSnapshot.durability,
+      storedAtHome: itemSnapshot.storedAtHome,
+      craftingFinishedAt: itemSnapshot.craftingFinishedAt,
+      isInAuction: itemSnapshot.isInAuction,
+      activeVariantId: itemSnapshot.activeVariantId,
+      dropChancePerc: itemSnapshot.dropChancePerc,
+    })
+    .onDuplicateKeyUpdate({
+      set: { quantity: sql`${userItem.quantity} + ${quantity}` },
+    });
 };
 
 type AdjustSeichiSilverParams = {

--- a/app/src/server/utils/concurrency.ts
+++ b/app/src/server/utils/concurrency.ts
@@ -138,9 +138,10 @@ type RefundUserItemQuantityAtomicallyParams = {
 };
 
 /**
- * Compensates a successful item consume in one statement. If the consume decremented the stack,
- * the duplicate-key branch adds the quantity back; if it deleted the stack, the insert branch
- * recreates the original row with only the refunded quantity.
+ * Compensates a successful item consume. If the consume decremented the stack, the duplicate-key
+ * branch adds the quantity back; if it deleted the stack, the insert branch recreates the original
+ * row with only the refunded quantity. A negative quantity belongs to an active stack merge, so
+ * the guarded upsert refuses to change it, recovers the merge claims, and retries the refund.
  */
 export const refundUserItemQuantityAtomically = async ({
   client,
@@ -149,28 +150,43 @@ export const refundUserItemQuantityAtomically = async ({
 }: RefundUserItemQuantityAtomicallyParams) => {
   if (quantity <= 0) return;
 
-  await client
-    .insert(userItem)
-    .values({
-      id: itemSnapshot.id,
-      createdAt: itemSnapshot.createdAt,
-      updatedAt: itemSnapshot.updatedAt,
-      userId: itemSnapshot.userId,
-      itemId: itemSnapshot.itemId,
-      quantity,
-      level: itemSnapshot.level,
-      experience: itemSnapshot.experience,
-      equipped: itemSnapshot.equipped,
-      durability: itemSnapshot.durability,
-      storedAtHome: itemSnapshot.storedAtHome,
-      craftingFinishedAt: itemSnapshot.craftingFinishedAt,
-      isInAuction: itemSnapshot.isInAuction,
-      activeVariantId: itemSnapshot.activeVariantId,
-      dropChancePerc: itemSnapshot.dropChancePerc,
-    })
-    .onDuplicateKeyUpdate({
-      set: { quantity: sql`${userItem.quantity} + ${quantity}` },
-    });
+  const refund = () =>
+    client
+      .insert(userItem)
+      .values({
+        id: itemSnapshot.id,
+        createdAt: itemSnapshot.createdAt,
+        updatedAt: itemSnapshot.updatedAt,
+        userId: itemSnapshot.userId,
+        itemId: itemSnapshot.itemId,
+        quantity,
+        level: itemSnapshot.level,
+        experience: itemSnapshot.experience,
+        equipped: itemSnapshot.equipped,
+        durability: itemSnapshot.durability,
+        storedAtHome: itemSnapshot.storedAtHome,
+        craftingFinishedAt: itemSnapshot.craftingFinishedAt,
+        isInAuction: itemSnapshot.isInAuction,
+        activeVariantId: itemSnapshot.activeVariantId,
+        dropChancePerc: itemSnapshot.dropChancePerc,
+      })
+      .onDuplicateKeyUpdate({
+        set: {
+          quantity: sql`IF(${userItem.quantity} >= 0, ${userItem.quantity} + ${quantity}, ${userItem.quantity})`,
+        },
+      });
+
+  const result = await refund();
+  if (result.rowsAffected > 0) return;
+
+  // A no-op duplicate update means the row is held by a merge claim. Recover every row in that
+  // merge before retrying so its pending publish cannot overwrite the refunded quantity.
+  await restoreStaleUserItemMergeClaims({
+    client,
+    userId: itemSnapshot.userId,
+    staleBefore: new Date(),
+  });
+  await refund();
 };
 
 type RestoreStaleUserItemMergeClaimsParams = {

--- a/app/src/server/utils/concurrency.ts
+++ b/app/src/server/utils/concurrency.ts
@@ -9,7 +9,19 @@
  * Failed CAS (`success: false` / `false`) means another request mutated the row first — return a
  * safe client error and retry-friendly message.
  */
-import { and, eq, exists, gt, gte, inArray, isNull, ne, sql } from "drizzle-orm";
+import {
+  and,
+  eq,
+  exists,
+  gt,
+  gte,
+  inArray,
+  isNull,
+  lt,
+  lte,
+  ne,
+  sql,
+} from "drizzle-orm";
 import type { BattleType } from "@/drizzle/constants";
 import type { UserItem } from "@/drizzle/schema";
 import {
@@ -160,6 +172,58 @@ export const refundUserItemQuantityAtomically = async ({
       set: { quantity: sql`${userItem.quantity} + ${quantity}` },
     });
 };
+
+type RestoreStaleUserItemMergeClaimsParams = {
+  client: DrizzleClient;
+  userId: string;
+  staleBefore: Date;
+};
+
+/**
+ * Cleans up abandoned stack-merge state. A merge claims a row by negating its quantity, so the
+ * original value remains recoverable after a process crash. Its atomic publish turns obsolete
+ * rows into zero-quantity tombstones, which are safe to delete once stale. Fresh non-positive rows
+ * are left alone for the active merge; callers exclude them from inventory reads and writes.
+ */
+export const restoreStaleUserItemMergeClaims = async ({
+  client,
+  userId,
+  staleBefore,
+}: RestoreStaleUserItemMergeClaimsParams) => {
+  await Promise.all([
+    client
+      .update(userItem)
+      .set({
+        quantity: sql`-${userItem.quantity}`,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(userItem.userId, userId),
+          lt(userItem.quantity, 0),
+          lte(userItem.updatedAt, staleBefore),
+        ),
+      ),
+    client
+      .delete(userItem)
+      .where(
+        and(
+          eq(userItem.userId, userId),
+          eq(userItem.quantity, 0),
+          lte(userItem.updatedAt, staleBefore),
+        ),
+      ),
+  ]);
+};
+
+/** Builds the single-statement CASE expression used to atomically publish a stack merge. */
+export const userItemMergePublishQuantity = (
+  targets: readonly { id: string; quantity: number }[],
+) =>
+  sql<number>`CASE ${userItem.id} ${sql.join(
+    targets.map((target) => sql`WHEN ${target.id} THEN ${target.quantity}`),
+    sql.raw(" "),
+  )} ELSE ${userItem.quantity} END`;
 
 type AdjustSeichiSilverParams = {
   client: DrizzleClient;

--- a/app/tests/libs/item.test.ts
+++ b/app/tests/libs/item.test.ts
@@ -8,6 +8,7 @@ import {
   type EquippedAssignment,
   type EquippedConstraintState,
   isEquippableUserItem,
+  userItemActionBadges,
 } from "@/libs/item";
 import type { ItemSlot } from "@/drizzle/constants";
 import type { UserItemWithRelations } from "@/drizzle/schema";
@@ -63,6 +64,36 @@ describe("isEquippableUserItem", () => {
         NOW,
       ),
     ).toBe(true);
+  });
+});
+
+describe("userItemActionBadges", () => {
+  it("shows both quantity and level badges for a stack of leveling equipment", () => {
+    const badges = userItemActionBadges([
+      {
+        id: "stacked-weapon",
+        quantity: 5,
+        level: 12,
+        item: { itemType: "WEAPON", slot: "HAND" },
+      },
+    ]);
+
+    expect(badges.counts).toEqual([{ id: "stacked-weapon", quantity: 5 }]);
+    expect(badges.levels).toEqual([{ id: "stacked-weapon", level: 12 }]);
+  });
+
+  it("does not show a quantity badge for a single leveling item", () => {
+    const badges = userItemActionBadges([
+      {
+        id: "single-weapon",
+        quantity: 1,
+        level: 12,
+        item: { itemType: "WEAPON", slot: "HAND" },
+      },
+    ]);
+
+    expect(badges.counts).toEqual([]);
+    expect(badges.levels).toEqual([{ id: "single-weapon", level: 12 }]);
   });
 });
 

--- a/app/tests/server/utils/concurrency.test.ts
+++ b/app/tests/server/utils/concurrency.test.ts
@@ -11,7 +11,9 @@ import {
   clearActiveNpcQuest,
   consumeUserItemAtomically,
   refundUserItemQuantityAtomically,
+  restoreStaleUserItemMergeClaims,
   updateUserItemQuantityAtomically,
+  userItemMergePublishQuantity,
 } from "@/server/utils/concurrency";
 
 describe("concurrency helpers", () => {
@@ -160,6 +162,49 @@ describe("concurrency helpers", () => {
     });
 
     expect(client.insert).not.toHaveBeenCalled();
+  });
+
+  it("restores stale negative merge claims and deletes stale zero tombstones", async () => {
+    const updateWhere = vi.fn().mockResolvedValue({ rowsAffected: 1 });
+    const deleteWhere = vi.fn().mockResolvedValue({ rowsAffected: 1 });
+    const set = vi.fn().mockReturnValue({ where: updateWhere });
+    const client = {
+      update: vi.fn().mockReturnValue({ set }),
+      delete: vi.fn().mockReturnValue({ where: deleteWhere }),
+    };
+    const staleBefore = new Date("2026-08-18T10:00:00.000Z");
+
+    await restoreStaleUserItemMergeClaims({
+      client: client as never,
+      userId: "user-1",
+      staleBefore,
+    });
+
+    expect(client.update).toHaveBeenCalledWith(userItem);
+    expect(client.delete).toHaveBeenCalledWith(userItem);
+    expect(updateWhere).toHaveBeenCalledOnce();
+    expect(deleteWhere).toHaveBeenCalledOnce();
+
+    const restoredQuantity = set.mock.calls[0]?.[0].quantity as SQL;
+    const rendered = new QueryBuilder()
+      .select({ quantity: restoredQuantity })
+      .from(userItem)
+      .toSQL();
+    expect(rendered.sql).toMatch(/-.*quantity/i);
+  });
+
+  it("builds one CASE expression for keeper quantities and zero tombstones", () => {
+    const expression = userItemMergePublishQuantity([
+      { id: "keeper-row", quantity: 5 },
+      { id: "obsolete-row", quantity: 0 },
+    ]);
+    const rendered = new QueryBuilder()
+      .select({ quantity: expression })
+      .from(userItem)
+      .toSQL();
+
+    expect(rendered.sql).toMatch(/case.*when.*then.*when.*then.*else.*end/i);
+    expect(rendered.params).toEqual(["keeper-row", 5, "obsolete-row", 0]);
   });
 });
 

--- a/app/tests/server/utils/concurrency.test.ts
+++ b/app/tests/server/utils/concurrency.test.ts
@@ -10,6 +10,7 @@ import {
   claimUserSnapshot,
   clearActiveNpcQuest,
   consumeUserItemAtomically,
+  refundUserItemQuantityAtomically,
   updateUserItemQuantityAtomically,
 } from "@/server/utils/concurrency";
 
@@ -103,6 +104,62 @@ describe("concurrency helpers", () => {
     });
     expect(result).toBe(false);
     expect(client.update).not.toHaveBeenCalled();
+  });
+
+  it("atomically refunds a consumed item whether its stack survived or was deleted", async () => {
+    const onDuplicateKeyUpdate = vi.fn().mockResolvedValue(undefined);
+    const values = vi.fn().mockReturnValue({ onDuplicateKeyUpdate });
+    const client = { insert: vi.fn().mockReturnValue({ values }) };
+    const itemSnapshot = {
+      id: "item-row-1",
+      createdAt: new Date("2026-08-18T10:00:00.000Z"),
+      updatedAt: new Date("2026-08-18T10:00:00.000Z"),
+      userId: "user-1",
+      itemId: "repair-kit-1",
+      quantity: 5,
+      level: 1,
+      experience: 0,
+      equipped: "NONE",
+      durability: 100,
+      storedAtHome: false,
+      craftingFinishedAt: null,
+      isInAuction: false,
+      activeVariantId: null,
+      dropChancePerc: 0,
+    } as const;
+
+    await refundUserItemQuantityAtomically({
+      client: client as never,
+      itemSnapshot,
+      quantity: 2,
+    });
+
+    expect(client.insert).toHaveBeenCalledWith(userItem);
+    expect(values).toHaveBeenCalledWith({ ...itemSnapshot, quantity: 2 });
+    expect(onDuplicateKeyUpdate).toHaveBeenCalledOnce();
+    expect(onDuplicateKeyUpdate).toHaveBeenCalledWith({
+      set: { quantity: expect.anything() },
+    });
+    const increment = onDuplicateKeyUpdate.mock.calls[0]?.[0].set.quantity as SQL;
+    const rendered = new QueryBuilder()
+      .select({ quantity: increment })
+      .from(userItem)
+      .toSQL();
+    expect(rendered.sql).toMatch(/quantity.*\+\s*\?/i);
+    expect(rendered.params).toEqual([2]);
+  });
+
+  it("does not issue a refund statement for a non-positive quantity", async () => {
+    const client = { insert: vi.fn() };
+    const itemSnapshot = { id: "item-row-1" };
+
+    await refundUserItemQuantityAtomically({
+      client: client as never,
+      itemSnapshot: itemSnapshot as never,
+      quantity: 0,
+    });
+
+    expect(client.insert).not.toHaveBeenCalled();
   });
 });
 

--- a/app/tests/server/utils/concurrency.test.ts
+++ b/app/tests/server/utils/concurrency.test.ts
@@ -13,7 +13,7 @@ import {
   refundUserItemQuantityAtomically,
   restoreStaleUserItemMergeClaims,
   updateUserItemQuantityAtomically,
-  userItemMergePublishQuantity,
+  userItemMergeQuantityCase,
 } from "@/server/utils/concurrency";
 
 describe("concurrency helpers", () => {
@@ -151,21 +151,13 @@ describe("concurrency helpers", () => {
     expect(rendered.params).toEqual([2]);
   });
 
-  it("recovers a negative merge claim before retrying an item refund", async () => {
-    const onDuplicateKeyUpdate = vi
+  it("refunds into a fresh row when the original is held by a merge claim", async () => {
+    const onDuplicateKeyUpdate = vi.fn().mockResolvedValue({ rowsAffected: 0 });
+    const values = vi
       .fn()
-      .mockResolvedValueOnce({ rowsAffected: 0 })
-      .mockResolvedValueOnce({ rowsAffected: 2 });
-    const values = vi.fn().mockReturnValue({ onDuplicateKeyUpdate });
-    const updateWhere = vi.fn().mockResolvedValue({ rowsAffected: 1 });
-    const deleteWhere = vi.fn().mockResolvedValue({ rowsAffected: 0 });
-    const client = {
-      insert: vi.fn().mockReturnValue({ values }),
-      update: vi.fn().mockReturnValue({
-        set: vi.fn().mockReturnValue({ where: updateWhere }),
-      }),
-      delete: vi.fn().mockReturnValue({ where: deleteWhere }),
-    };
+      .mockReturnValueOnce({ onDuplicateKeyUpdate })
+      .mockReturnValueOnce(Promise.resolve({ rowsAffected: 1 }));
+    const client = { insert: vi.fn().mockReturnValue({ values }) };
     const itemSnapshot = {
       id: "item-row-1",
       createdAt: new Date("2026-08-18T10:00:00.000Z"),
@@ -190,9 +182,19 @@ describe("concurrency helpers", () => {
       quantity: 2,
     });
 
-    expect(onDuplicateKeyUpdate).toHaveBeenCalledTimes(2);
-    expect(client.update).toHaveBeenCalledWith(userItem);
-    expect(client.delete).toHaveBeenCalledWith(userItem);
+    // First attempt is the guarded upsert on the original row; the claimed row
+    // no-ops it, and the fallback inserts the refund as a brand-new row that an
+    // in-flight merge publish cannot overwrite.
+    expect(client.insert).toHaveBeenCalledTimes(2);
+    expect(onDuplicateKeyUpdate).toHaveBeenCalledOnce();
+    const fallbackRow = values.mock.calls[1]?.[0] as {
+      id: string;
+      quantity: number;
+      itemId: string;
+    };
+    expect(fallbackRow.quantity).toBe(2);
+    expect(fallbackRow.itemId).toBe("repair-kit-1");
+    expect(fallbackRow.id).not.toBe("item-row-1");
   });
 
   it("does not issue a refund statement for a non-positive quantity", async () => {
@@ -238,7 +240,7 @@ describe("concurrency helpers", () => {
   });
 
   it("builds one CASE expression for keeper quantities and zero tombstones", () => {
-    const expression = userItemMergePublishQuantity([
+    const expression = userItemMergeQuantityCase([
       { id: "keeper-row", quantity: 5 },
       { id: "obsolete-row", quantity: 0 },
     ]);

--- a/app/tests/server/utils/concurrency.test.ts
+++ b/app/tests/server/utils/concurrency.test.ts
@@ -109,7 +109,7 @@ describe("concurrency helpers", () => {
   });
 
   it("atomically refunds a consumed item whether its stack survived or was deleted", async () => {
-    const onDuplicateKeyUpdate = vi.fn().mockResolvedValue(undefined);
+    const onDuplicateKeyUpdate = vi.fn().mockResolvedValue({ rowsAffected: 2 });
     const values = vi.fn().mockReturnValue({ onDuplicateKeyUpdate });
     const client = { insert: vi.fn().mockReturnValue({ values }) };
     const itemSnapshot = {
@@ -147,8 +147,52 @@ describe("concurrency helpers", () => {
       .select({ quantity: increment })
       .from(userItem)
       .toSQL();
-    expect(rendered.sql).toMatch(/quantity.*\+\s*\?/i);
+    expect(rendered.sql).toMatch(/if\s*\(.*quantity.*>=\s*0.*quantity.*\+\s*\?/i);
     expect(rendered.params).toEqual([2]);
+  });
+
+  it("recovers a negative merge claim before retrying an item refund", async () => {
+    const onDuplicateKeyUpdate = vi
+      .fn()
+      .mockResolvedValueOnce({ rowsAffected: 0 })
+      .mockResolvedValueOnce({ rowsAffected: 2 });
+    const values = vi.fn().mockReturnValue({ onDuplicateKeyUpdate });
+    const updateWhere = vi.fn().mockResolvedValue({ rowsAffected: 1 });
+    const deleteWhere = vi.fn().mockResolvedValue({ rowsAffected: 0 });
+    const client = {
+      insert: vi.fn().mockReturnValue({ values }),
+      update: vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({ where: updateWhere }),
+      }),
+      delete: vi.fn().mockReturnValue({ where: deleteWhere }),
+    };
+    const itemSnapshot = {
+      id: "item-row-1",
+      createdAt: new Date("2026-08-18T10:00:00.000Z"),
+      updatedAt: new Date("2026-08-18T10:00:00.000Z"),
+      userId: "user-1",
+      itemId: "repair-kit-1",
+      quantity: 5,
+      level: 1,
+      experience: 0,
+      equipped: "NONE",
+      durability: 100,
+      storedAtHome: false,
+      craftingFinishedAt: null,
+      isInAuction: false,
+      activeVariantId: null,
+      dropChancePerc: 0,
+    } as const;
+
+    await refundUserItemQuantityAtomically({
+      client: client as never,
+      itemSnapshot,
+      quantity: 2,
+    });
+
+    expect(onDuplicateKeyUpdate).toHaveBeenCalledTimes(2);
+    expect(client.update).toHaveBeenCalledWith(userItem);
+    expect(client.delete).toHaveBeenCalledWith(userItem);
   });
 
   it("does not issue a refund statement for a non-positive quantity", async () => {


### PR DESCRIPTION
# Pull Request

Changes:
- Inventory sorts alphabetically
- Home storage sorts alphabetically
- added merge option to home storage
- Added ryo payment for repairs to the inventory page for crafters

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Merge all stacks” for items stored at home and in carried inventory.
  * Added “Repair All Items” using repair kits or Ryo, with cost and affordability details.
  * Added per-item repair options for damaged equipped and backpack items.

* **Improvements**
  * Repair actions now show availability, costs, and progress states.
  * Home, backpack, and character inventories sort items by name.
  * Repair actions exclude ineligible or auctioned items.
  * Stacked leveling equipment now displays quantity and level badges.
  * Confirmation dialogs support optional extra footer actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->