### PR TITLE
Refine map presentation and global travel

### DIFF
--- a/app/src/app/travel/page.tsx
+++ b/app/src/app/travel/page.tsx
@@ -81,7 +81,7 @@ import { getStealthStatus } from "@/libs/stealth";
 import type { GlobalTile, SectorPoint } from "@/libs/threejs/types";
 import { showMutationToast, showRewardToast } from "@/libs/toast";
 import { hasRequiredRank } from "@/libs/train";
-import { calcGlobalTravelTime, findNearestEdge, isAtEdge } from "@/libs/travel";
+import { calcGlobalTravelTime } from "@/libs/travel";
 import { findVillageUserRelationship } from "@/utils/alliance";
 import { useAwake } from "@/utils/routing";
 import { useRequiredUserData } from "@/utils/UserContext";
@@ -399,10 +399,8 @@ export default function Travel() {
       onSuccess: async (result) => {
         showMutationToast(result);
         if (result.success && result.data) {
-          // The local target was only the departure edge. Clear it before the
-          // destination coordinates enter UserContext, otherwise Sector sees
-          // the stale target after global travel and walks the user back to
-          // that same edge, persisting the wrong arrival position.
+          // Clear any local-sector movement target before the destination
+          // coordinates enter UserContext so it cannot overwrite the arrival.
           setTargetPosition(null);
           setTargetSector(null);
           setShowModal(false);
@@ -563,53 +561,17 @@ export default function Travel() {
           return;
         }
       }
-      // Start global move. Pass the current sector so the server can load its
-      // map in parallel with the user fetch (it re-validates against the DB).
-      if (userData?.sector === undefined) return;
-      startGlobalMove({ sector, curSector: userData.sector });
+      // Stop any local-sector movement and begin global travel immediately.
+      setTargetPosition(null);
+      startGlobalMove({ sector });
     },
-    [currentStep, userData?.tutorialOn, userData?.sector, startGlobalMove],
+    [currentStep, userData?.tutorialOn, startGlobalMove],
   );
 
-  // Convenience variables
-  const currentSectorDimensions = currentSectorMap
-    ? { width: currentSectorMap.width, height: currentSectorMap.height }
-    : undefined;
-  const onEdge = currentSectorDimensions
-    ? isAtEdge(currentPosition, currentSectorDimensions)
-    : false;
   const isGlobal = activeTab === globalLink;
   const showGlobal = villages && globe && isGlobal;
   const showSector =
     villages && hasCurrentSector && currentTile && currentSectorMap && !isGlobal;
-
-  useEffect(() => {
-    // Check if user reached the target position on the current map
-    const atTarget =
-      currentPosition &&
-      targetPosition &&
-      currentPosition.x === targetPosition.x &&
-      currentPosition.y === targetPosition.y;
-    // Auto-initiate global move when: user is at target hex, on sector edge,
-    // target sector differs from current, and not already traveling
-    if (
-      atTarget &&
-      onEdge &&
-      targetSector !== null &&
-      targetSector !== currentSector &&
-      !isStartingTravel
-    ) {
-      handleGlobalMove(targetSector);
-    }
-  }, [
-    currentPosition,
-    targetPosition,
-    targetSector,
-    currentSector,
-    onEdge,
-    isStartingTravel,
-    handleGlobalMove,
-  ]);
 
   // Attack revealed stealthed player after moving to their position
   useEffect(() => {
@@ -1028,17 +990,7 @@ export default function Travel() {
             setIsOpen={setShowModal}
             proceed_label={!isStartingTravel ? "Travel" : undefined}
             isValid={false}
-            onAccept={() => {
-              if (!onEdge && currentPosition && currentSectorDimensions) {
-                setShowModal(false);
-                setTargetPosition(
-                  findNearestEdge(currentPosition, currentSectorDimensions),
-                );
-                setActiveTab(sectorLink);
-              } else {
-                handleGlobalMove(targetSector);
-              }
-            }}
+            onAccept={() => handleGlobalMove(targetSector)}
           >
             {isStartingTravel && <Loader explanation="Preparing to Travel" />}
             {!isStartingTravel && (
@@ -1047,13 +999,6 @@ export default function Travel() {
                 <p className="py-2">
                   The travel time is estimated to be{" "}
                   {calcGlobalTravelTime(userData.sector, targetSector, globe)} seconds.
-                </p>
-                <p className="py-2">
-                  Your character will first have to move to the edge of his current
-                  sector.
-                </p>
-                <p className="pb-2">
-                  Current location: {currentPosition?.x}, {currentPosition?.y}
                 </p>
                 Do you confirm?
               </div>

--- a/app/src/layout/Map.tsx
+++ b/app/src/layout/Map.tsx
@@ -37,7 +37,7 @@ import {
   samplePolarCapColor,
 } from "@/libs/threejs/globe";
 import { TrackballControls } from "@/libs/threejs/TrackBallControls";
-import type { GlobalMapData, GlobalPoint, GlobalTile } from "@/libs/threejs/types";
+import type { GlobalMapData, GlobalTile } from "@/libs/threejs/types";
 import {
   cleanUp,
   createTexture,
@@ -139,7 +139,10 @@ const GlobalMap: React.FC<MapProps> = (props) => {
       const WIDTH = sceneRef.getBoundingClientRect().width;
       const HEIGHT = WIDTH;
 
-      const fov = 75;
+      // A narrower lens reduces the near-vs-limb distortion of the globe. The
+      // camera distance is compensated below so its on-screen size stays put.
+      const originalFov = 75;
+      const fov = 50;
       const aspect = WIDTH / HEIGHT;
       const near = 0.5;
       const far = 1000;
@@ -502,8 +505,8 @@ const GlobalMap: React.FC<MapProps> = (props) => {
         }
       }
 
-      // Dark sector-separation grid overlaid on the globe. The deeper blue-grey
-      // remains legible on snow without overpowering grass, desert, or water.
+      // Soft sector-separation grid overlaid on the globe. A translucent light
+      // grey keeps sectors readable without obscuring the terrain underneath.
       // It is occluded by opaque tiles on the far side (depthTest), so only
       // front edges show.
       if (edgePositions.length > 0) {
@@ -515,9 +518,9 @@ const GlobalMap: React.FC<MapProps> = (props) => {
         const edgeLines = new LineSegments(
           edgeGeometry,
           new LineBasicMaterial({
-            color: 0x243f52,
+            color: 0x4b5563,
             transparent: true,
-            opacity: 0.62,
+            opacity: 0.2,
             depthWrite: false,
           }),
         );
@@ -761,47 +764,66 @@ const GlobalMap: React.FC<MapProps> = (props) => {
         }
       });
 
-      //Enable controls
-      const controls = new TrackballControls(camera, renderer.domElement);
-      controls.noPan = true;
-      controls.staticMoving = true;
-      controls.zoomSpeed = 1.2;
-      const cameraDistance = 22;
-      // At distance 16 the tiles facing the camera render at twice their
-      // default on-screen size, i.e. a 2x zoom - enough to tap the right
-      // sector on mobile without the front village labels filling the view
-      const minCameraDistance = 16;
-      controls.minDistance = minCameraDistance;
-      controls.maxDistance = cameraDistance;
-      let lastTime = Date.now();
-      let sigma = 0;
-      let phi = 0;
+      // Compensate camera distance for the narrower lens using the globe's
+      // projected angular radius. This keeps the established zoom range while
+      // making the globe read flatter.
+      const globeRadius = hexasphere.radius / 3;
+      const compensateDistanceForFov = (originalDistance: number) => {
+        const originalHalfFov = (originalFov * Math.PI) / 360;
+        const nextHalfFov = (fov * Math.PI) / 360;
+        const originalAngularRadius = Math.asin(globeRadius / originalDistance);
+        const projectedRadius =
+          Math.tan(originalAngularRadius) / Math.tan(originalHalfFov);
+        const nextAngularRadius = Math.atan(projectedRadius * Math.tan(nextHalfFov));
+        return globeRadius / Math.sin(nextAngularRadius);
+      };
+      // Distance 16 was the previous maximum zoom; compensate it through the
+      // same projection so mobile tile sizing remains familiar.
+      const minCameraDistance = compensateDistanceForFov(16);
+      // Start fully zoomed in; users can pull back to distance 22 when they
+      // need the complete globe and its surrounding labels in view.
+      const cameraDistance = minCameraDistance;
+      const maxCameraDistance = compensateDistanceForFov(22);
+      const initialCameraDirection = new Vector3(0, 0, 1);
 
       // Initial camera positioning - prioritize focus sector over user location
       if (props.focusSector !== undefined && props.focusSector !== null) {
         const focusSectorData = hexasphere?.tiles[props.focusSector]?.c;
         if (focusSectorData) {
           const { x, y, z } = focusSectorData;
-          sigma = Math.atan2(y, x);
-          phi = Math.acos(z / Math.sqrt(x * x + y * y + z * z));
+          initialCameraDirection.set(x, y, z).normalize();
         }
       } else if (props.userLocation && userData) {
         const sector = hexasphere?.tiles[userData.sector]?.c;
         if (sector) {
           const { x, y, z } = sector;
-          sigma = Math.atan2(y, x);
-          phi = Math.acos(z / Math.sqrt(x * x + y * y + z * z));
+          initialCameraDirection.set(x, y, z).normalize();
         }
       }
 
-      // Place the camera before the first frame; the render loop keeps the
-      // CURRENT distance from then on, so zooming is not undone each frame
-      camera.position.set(
-        cameraDistance * Math.sin(phi) * Math.cos(sigma),
-        cameraDistance * Math.sin(phi) * Math.sin(sigma),
-        cameraDistance * Math.cos(phi),
-      );
+      camera.position.copy(initialCameraDirection.multiplyScalar(cameraDistance));
       camera.lookAt(scene.position);
+
+      // Keep the globe upright while allowing bounded north-south tilt. The
+      // camera can reach every navigable latitude but cannot flip over a pole.
+      const controls = new TrackballControls(camera, renderer.domElement);
+      controls.maxLatitude = ((hexasphere.latitudeLimit ?? 65) * Math.PI) / 180;
+      controls.noPan = true;
+      controls.staticMoving = true;
+      controls.zoomSpeed = 1.2;
+      controls.minDistance = minCameraDistance;
+      controls.maxDistance = maxCameraDistance;
+      let isUserInteracting = false;
+      const onControlStart = () => {
+        isUserInteracting = true;
+      };
+      const onControlEnd = () => {
+        isUserInteracting = false;
+      };
+      controls.addEventListener("start", onControlStart);
+      controls.addEventListener("end", onControlEnd);
+      const worldUp = new Vector3(0, 1, 0);
+      let lastTime = Date.now();
 
       // Zoom helper for the overlay buttons, clamped to the same distance
       // limits as the wheel/pinch zoom
@@ -810,7 +832,7 @@ const GlobalMap: React.FC<MapProps> = (props) => {
         if (distance === 0) return;
         const next = Math.min(
           Math.max(distance * factor, minCameraDistance),
-          cameraDistance,
+          maxCameraDistance,
         );
         camera.position.multiplyScalar(next / distance);
       };
@@ -915,32 +937,14 @@ const GlobalMap: React.FC<MapProps> = (props) => {
           }
         }
 
-        // Rotate the camera, only if trackball not enabled && highlight not selected
-        const current = controls.up0 as GlobalPoint;
-        const previous = controls?.object as { up: GlobalPoint };
-        const isUserInteracting =
-          current.x !== previous.up.x ||
-          current.y !== previous.up.y ||
-          current.z !== previous.up.z;
-
-        // Auto-rotate when not user interacting
+        // Auto-rotate around the same fixed north-south axis as manual drags.
         if (autoRotate && (animationId === 0 || !isTravelStep) && !isUserInteracting) {
           const dt = Date.now() - lastTime;
           const rotateCameraBy = (1 * Math.PI) / (50000 / dt);
-          phi += rotateCameraBy;
-        }
-        lastTime = Date.now();
-
-        // Update camera position when not user interacting. Keep the CURRENT
-        // camera distance rather than the fixed default, so wheel/pinch/button
-        // zoom is not undone on the next frame
-        if (!isUserInteracting) {
-          const distance = camera.position.length() || cameraDistance;
-          camera.position.x = distance * Math.sin(phi) * Math.cos(sigma);
-          camera.position.y = distance * Math.sin(phi) * Math.sin(sigma);
-          camera.position.z = distance * Math.cos(phi);
+          camera.position.applyAxisAngle(worldUp, rotateCameraBy);
           camera.lookAt(scene.position);
         }
+        lastTime = Date.now();
 
         // Trackball updates
         controls.update();
@@ -988,6 +992,8 @@ const GlobalMap: React.FC<MapProps> = (props) => {
               onLabelPointerCancel,
             );
           }
+          controls.removeEventListener("start", onControlStart);
+          controls.removeEventListener("end", onControlEnd);
           controls.dispose();
           window.removeEventListener("resize", handleResize);
           contextHandlers.cleanup();

--- a/app/src/libs/threejs/TrackBallControls.ts
+++ b/app/src/libs/threejs/TrackBallControls.ts
@@ -69,6 +69,9 @@ export class TrackballControls extends EventDispatcher<TrackballControlsEventMap
   noZoom = false;
   noPan = false;
 
+  /** Maximum camera latitude in radians; null keeps trackball rotation unrestricted. */
+  maxLatitude: number | null = null;
+
   staticMoving = false;
   dynamicDampingFactor = 0.2;
 
@@ -271,6 +274,48 @@ export class TrackballControls extends EventDispatcher<TrackballControlsEventMap
   /* -- transform helpers -------------------------------------------------- */
 
   private _rotateCamera(): void {
+    if (this.maxLatitude !== null) {
+      const horizontalAngle = -(this._moveCurr.x - this._movePrev.x) * this.rotateSpeed;
+      const verticalInput = (this._moveCurr.y - this._movePrev.y) * this.rotateSpeed;
+
+      if (horizontalAngle || verticalInput) {
+        this._eye.copy(this.object.position).sub(this.target);
+        const upAxis = this.up0.clone().normalize();
+
+        if (horizontalAngle) {
+          this._eye.applyQuaternion(
+            new Quaternion().setFromAxisAngle(upAxis, horizontalAngle),
+          );
+        }
+
+        if (verticalInput) {
+          const currentLatitude = Math.asin(
+            Math.max(-1, Math.min(1, this._eye.clone().normalize().dot(upAxis))),
+          );
+          const nextLatitude = Math.max(
+            -this.maxLatitude,
+            Math.min(this.maxLatitude, currentLatitude - verticalInput),
+          );
+          const appliedAngle = currentLatitude - nextLatitude;
+          const sidewaysAxis = new Vector3()
+            .crossVectors(upAxis, this._eye)
+            .normalize();
+          this._eye.applyQuaternion(
+            new Quaternion().setFromAxisAngle(sidewaysAxis, appliedAngle),
+          );
+        }
+
+        // Keep north upright instead of rolling the camera as a free trackball
+        // does. Vertical travel is bounded above, so pole-over-pole spins are
+        // impossible while every navigable latitude can still be centered.
+        this.object.up.copy(upAxis);
+        this._lastAngle = 0;
+      }
+
+      this._movePrev.copy(this._moveCurr);
+      return;
+    }
+
     const moveDirection = new Vector3(
       this._moveCurr.x - this._movePrev.x,
       this._moveCurr.y - this._movePrev.y,

--- a/app/src/libs/threejs/sector.ts
+++ b/app/src/libs/threejs/sector.ts
@@ -1083,6 +1083,28 @@ export const wrapStructureLabelWords = (
   return lines;
 };
 
+export const wrapStructureLabelCharacters = (
+  text: string,
+  measureText: (line: string) => number,
+  maxWidth: number,
+) => {
+  if (measureText(text) <= maxWidth) return [text];
+
+  const lines: string[] = [];
+  let currentLine = "";
+  for (const character of text) {
+    const candidate = `${currentLine}${character}`;
+    if (currentLine && measureText(candidate) > maxWidth) {
+      lines.push(currentLine);
+      currentLine = character;
+    } else {
+      currentLine = candidate;
+    }
+  }
+  if (currentLine) lines.push(currentLine);
+  return lines;
+};
+
 export const createStructureLabel = (structure: VillageStructure, h: number) => {
   const canvasWidth = 512;
   const horizontalPadding = 24;
@@ -1115,6 +1137,15 @@ export const createStructureLabel = (structure: VillageStructure, h: number) => 
         maxTextWidth,
       );
     }
+    // A single unbroken word may still be wider than the canvas at the
+    // minimum font size. Split only those remaining oversized lines.
+    lines = lines.flatMap((line) =>
+      wrapStructureLabelCharacters(
+        line,
+        (candidate) => context.measureText(candidate).width,
+        maxTextWidth,
+      ),
+    );
 
     const lineHeight = Math.ceil(fontSize * 1.08);
     canvasHeight = Math.max(96, lines.length * lineHeight + verticalPadding * 2);
@@ -1129,6 +1160,7 @@ export const createStructureLabel = (structure: VillageStructure, h: number) => 
     context.fill();
     context.strokeStyle = "black";
     context.lineWidth = 4;
+    context.stroke();
     context.fillStyle = "white";
     const firstLineY = (canvasHeight - lines.length * lineHeight) / 2 + lineHeight / 2;
     lines.forEach((line, index) => {

--- a/app/src/libs/threejs/sector.ts
+++ b/app/src/libs/threejs/sector.ts
@@ -1085,7 +1085,9 @@ export const wrapStructureLabelWords = (
 
 export const createStructureLabel = (structure: VillageStructure, h: number) => {
   const canvasWidth = 512;
-  const maxTextWidth = canvasWidth - 24;
+  const horizontalPadding = 24;
+  const verticalPadding = 16;
+  const maxTextWidth = canvasWidth - horizontalPadding * 2;
   const canvas = document.createElement("canvas");
   canvas.width = canvasWidth;
   canvas.height = 84;
@@ -1095,7 +1097,7 @@ export const createStructureLabel = (structure: VillageStructure, h: number) => 
     // Wrap long multi-word names before shrinking the font. This preserves a
     // readable type size for labels such as "Administration Building".
     let fontSize = 64;
-    context.font = `bold ${fontSize}px Serif`;
+    context.font = `700 ${fontSize}px sans-serif`;
     let lines = wrapStructureLabelWords(
       structure.name,
       (line) => context.measureText(line).width,
@@ -1106,7 +1108,7 @@ export const createStructureLabel = (structure: VillageStructure, h: number) => 
       lines.some((line) => context.measureText(line).width > maxTextWidth)
     ) {
       fontSize -= 2;
-      context.font = `bold ${fontSize}px Serif`;
+      context.font = `700 ${fontSize}px sans-serif`;
       lines = wrapStructureLabelWords(
         structure.name,
         (line) => context.measureText(line).width,
@@ -1115,14 +1117,18 @@ export const createStructureLabel = (structure: VillageStructure, h: number) => 
     }
 
     const lineHeight = Math.ceil(fontSize * 1.08);
-    canvasHeight = Math.max(84, lines.length * lineHeight + 16);
+    canvasHeight = Math.max(96, lines.length * lineHeight + verticalPadding * 2);
     canvas.height = canvasHeight;
     context.textAlign = "center";
     context.textBaseline = "middle";
-    context.font = `bold ${fontSize}px Serif`;
+    context.font = `700 ${fontSize}px sans-serif`;
     context.lineJoin = "round";
+    context.fillStyle = "rgba(0, 0, 0, 0.72)";
+    context.beginPath();
+    context.roundRect(4, 4, canvasWidth - 8, canvasHeight - 8, 18);
+    context.fill();
     context.strokeStyle = "black";
-    context.lineWidth = 9;
+    context.lineWidth = 4;
     context.fillStyle = "white";
     const firstLineY = (canvasHeight - lines.length * lineHeight) / 2 + lineHeight / 2;
     lines.forEach((line, index) => {
@@ -1144,15 +1150,17 @@ export const createStructureLabel = (structure: VillageStructure, h: number) => 
   // and must be disposed together with the material to avoid leaking GPU memory
   material.userData.ownsMap = true;
   const sprite = new Sprite(material);
-  sprite.scale.set(h * 3.0, h * 3.0 * (canvasHeight / canvasWidth), 1);
+  const labelWidth = h * 5.0;
+  const labelHeight = labelWidth * (canvasHeight / canvasWidth);
+  sprite.scale.set(labelWidth, labelHeight, 1);
   // Anchor at the bottom edge so zoom compensation grows the label upwards,
   // away from the building, instead of over it
   sprite.center.set(0.5, 0);
   sprite.renderOrder = 10;
   sprite.name = `structure-label-${structure.id}`;
   sprite.userData.type = "structureLabel";
-  sprite.userData.baseWidth = h * 3.0;
-  sprite.userData.baseHeight = h * 3.0 * (canvasHeight / canvasWidth);
+  sprite.userData.baseWidth = labelWidth;
+  sprite.userData.baseHeight = labelHeight;
   sprite.visible = false;
   return sprite;
 };

--- a/app/src/libs/threejs/sector.ts
+++ b/app/src/libs/threejs/sector.ts
@@ -1060,32 +1060,76 @@ export const createMultipleUserSprite = (
  * whole label is a single sprite; starts hidden and is toggled by
  * intersectStructures.
  */
+export const wrapStructureLabelWords = (
+  text: string,
+  measureText: (line: string) => number,
+  maxWidth: number,
+) => {
+  const words = text.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return [""];
+
+  const lines: string[] = [];
+  let currentLine = words[0] ?? "";
+  for (const word of words.slice(1)) {
+    const candidate = `${currentLine} ${word}`;
+    if (measureText(candidate) <= maxWidth) {
+      currentLine = candidate;
+    } else {
+      lines.push(currentLine);
+      currentLine = word;
+    }
+  }
+  lines.push(currentLine);
+  return lines;
+};
+
 export const createStructureLabel = (structure: VillageStructure, h: number) => {
   const canvasWidth = 512;
-  const canvasHeight = 84;
+  const maxTextWidth = canvasWidth - 24;
   const canvas = document.createElement("canvas");
   canvas.width = canvasWidth;
-  canvas.height = canvasHeight;
+  canvas.height = 84;
   const context = canvas.getContext("2d");
+  let canvasHeight = canvas.height;
   if (context) {
-    // Building name, shrunk to fit the canvas width
+    // Wrap long multi-word names before shrinking the font. This preserves a
+    // readable type size for labels such as "Administration Building".
     let fontSize = 64;
-    context.textAlign = "center";
-    context.textBaseline = "middle";
     context.font = `bold ${fontSize}px Serif`;
+    let lines = wrapStructureLabelWords(
+      structure.name,
+      (line) => context.measureText(line).width,
+      maxTextWidth,
+    );
     while (
       fontSize > 24 &&
-      context.measureText(structure.name).width > canvasWidth - 16
+      lines.some((line) => context.measureText(line).width > maxTextWidth)
     ) {
       fontSize -= 2;
       context.font = `bold ${fontSize}px Serif`;
+      lines = wrapStructureLabelWords(
+        structure.name,
+        (line) => context.measureText(line).width,
+        maxTextWidth,
+      );
     }
+
+    const lineHeight = Math.ceil(fontSize * 1.08);
+    canvasHeight = Math.max(84, lines.length * lineHeight + 16);
+    canvas.height = canvasHeight;
+    context.textAlign = "center";
+    context.textBaseline = "middle";
+    context.font = `bold ${fontSize}px Serif`;
     context.lineJoin = "round";
     context.strokeStyle = "black";
     context.lineWidth = 9;
-    context.strokeText(structure.name, canvasWidth / 2, canvasHeight / 2);
     context.fillStyle = "white";
-    context.fillText(structure.name, canvasWidth / 2, canvasHeight / 2);
+    const firstLineY = (canvasHeight - lines.length * lineHeight) / 2 + lineHeight / 2;
+    lines.forEach((line, index) => {
+      const y = firstLineY + index * lineHeight;
+      context.strokeText(line, canvasWidth / 2, y);
+      context.fillText(line, canvasWidth / 2, y);
+    });
   }
   const texture = createTexture(canvas);
   texture.generateMipmaps = false;

--- a/app/src/libs/travel.ts
+++ b/app/src/libs/travel.ts
@@ -10,27 +10,6 @@ import {
 } from "@/libs/sector-map/validation";
 import type { GlobalMapData, GlobalTile, SectorPoint } from "@/libs/threejs/types";
 
-export interface SectorDimensions {
-  width: number;
-  height: number;
-}
-
-/**
- * Check if a given position is at the edge of a sector
- */
-export const isAtEdge = (
-  position: SectorPoint | null,
-  dimensions: SectorDimensions,
-) => {
-  return (
-    position &&
-    (position.x === 0 ||
-      position.x === dimensions.width - 1 ||
-      position.y === 0 ||
-      position.y === dimensions.height - 1)
-  );
-};
-
 /**
  * Gets the biome for a globe tile terrain type (0=ocean, 1=land, 2=desert, 3=ice)
  */
@@ -74,18 +53,6 @@ export const getBiomeAtSectorAnchor = (
       ? tile.terrain
       : undefined;
   return visibleBiome ?? tile?.battleBiome ?? getBiomeFromTileType(globalTileType);
-};
-
-/**
- * Based on current position, find the nearest edge
- */
-export const findNearestEdge = (
-  position: SectorPoint,
-  dimensions: SectorDimensions,
-) => {
-  const x = position.x < dimensions.width / 2 ? 0 : dimensions.width - 1;
-  const y = position.y < dimensions.height / 2 ? 0 : dimensions.height - 1;
-  return { x: x, y: y };
 };
 
 /** Center-tile landing point for global travel, adjusted only when blocked. */

--- a/app/src/server/api/routers/travel.ts
+++ b/app/src/server/api/routers/travel.ts
@@ -30,7 +30,6 @@ import {
   calcGlobalTravelTime,
   calcIsInVillage,
   findGlobalTravelDestination,
-  isAtEdge,
   maxDistance,
 } from "@/libs/travel";
 import { initiateBattle } from "@/routers/combat";
@@ -411,9 +410,6 @@ export const travelRouter = createTRPCRouter({
     .meta({
       mcp: { enabled: true, description: "Start global travel to another sector" },
     })
-    // curSector is the client's view of where the player currently stands; it
-    // lets us fetch that sector's map in parallel with the user instead of
-    // waiting to learn user.sector. The guard below rejects a stale/wrong hint.
     .input(startGlobalMoveSchema)
     .output(
       baseServerResponse.extend({
@@ -434,31 +430,17 @@ export const travelRouter = createTRPCRouter({
       if (!targetTile) {
         return { success: false, message: "Target sector does not exist" };
       }
-      // Fetch the user plus both ends of the journey in parallel. The target
-      // map determines a safe center-tile landing position.
-      let [user, currentSectorMap, targetSectorMap] = await Promise.all([
+      // Fetch the user and destination in parallel. Global travel can begin
+      // from any local tile; the target map only determines a safe landing.
+      let [user, targetSectorMap] = await Promise.all([
         fetchUser(ctx.drizzle, ctx.userId),
-        fetchPublishedSectorMap(ctx.drizzle, input.curSector).catch(() => null),
         fetchPublishedSectorMap(ctx.drizzle, input.sector).catch(() => null),
       ]);
-      // Validate the hint: the map we loaded must be the sector the player is
-      // actually in, otherwise the isAtEdge check below would use the wrong map
-      if (user.sector !== input.curSector) {
-        return errorResponse("Your location changed; please reload and try again");
-      }
-      if (!currentSectorMap) {
-        return errorResponse("This sector has no published map yet");
-      }
       if (!targetSectorMap) {
         return errorResponse("The destination sector has no published map yet");
       }
-      if (
-        !isAtEdge(
-          { x: user.longitude, y: user.latitude },
-          { width: currentSectorMap.width, height: currentSectorMap.height },
-        )
-      ) {
-        return { success: false, message: "You are not at the edge of a sector" };
+      if (user.sector === input.sector) {
+        return errorResponse("You are already in that sector");
       }
       if (user.status !== "AWAKE") {
         return { success: false, message: `Status is: ${user.status.toLowerCase()}` };

--- a/app/src/server/api/routers/travel.ts
+++ b/app/src/server/api/routers/travel.ts
@@ -445,8 +445,9 @@ export const travelRouter = createTRPCRouter({
       if (user.status !== "AWAKE") {
         return { success: false, message: `Status is: ${user.status.toLowerCase()}` };
       }
+      const departureSector = user.sector;
       const travelTime = calcGlobalTravelTime(
-        user.sector,
+        departureSector,
         input.sector,
         map as unknown as GlobalMapData,
       );
@@ -464,7 +465,13 @@ export const travelRouter = createTRPCRouter({
           status: "TRAVEL",
           travelFinishAt: endTime,
         })
-        .where(and(eq(userData.userId, ctx.userId), eq(userData.status, "AWAKE")));
+        .where(
+          and(
+            eq(userData.userId, ctx.userId),
+            eq(userData.status, "AWAKE"),
+            eq(userData.sector, departureSector),
+          ),
+        );
       if (result.rowsAffected === 1) {
         user.sector = input.sector;
         user.longitude = destination.x;
@@ -492,6 +499,11 @@ export const travelRouter = createTRPCRouter({
           return {
             success: false,
             message: `Status is: ${user.status.toLowerCase()}`,
+          };
+        } else if (user.sector !== departureSector) {
+          return {
+            success: false,
+            message: "Your location changed; please try again",
           };
         } else {
           return { success: false, message: "Failed to start travel" };

--- a/app/src/validators/travel.ts
+++ b/app/src/validators/travel.ts
@@ -8,13 +8,11 @@ export const sectorIdSchema = z.coerce
   .max(MAP_SECTOR_ID_MAX);
 
 /**
- * Global travel accepts sector identities only. Strict mode rejects injected
- * landing coordinates (or any other unknown fields); the server derives the
- * destination coordinate from the center of the published target map.
+ * Global travel accepts only the target sector. Strict mode rejects injected
+ * coordinates or stale client-side location hints; the server derives the
+ * player's departure and landing state itself.
  */
-export const startGlobalMoveSchema = z
-  .object({ sector: sectorIdSchema, curSector: sectorIdSchema })
-  .strict();
+export const startGlobalMoveSchema = z.object({ sector: sectorIdSchema }).strict();
 
 export const quickTravelSchema = z.object({ sector: sectorIdSchema });
 export type QuickTravelSchemaInput = z.input<typeof quickTravelSchema>;

--- a/app/tests/libs/structure-label.test.ts
+++ b/app/tests/libs/structure-label.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { wrapStructureLabelWords } from "@/libs/threejs/sector";
+import {
+  wrapStructureLabelCharacters,
+  wrapStructureLabelWords,
+} from "@/libs/threejs/sector";
 
 const measureText = (text: string) => text.length * 10;
 
@@ -20,5 +23,15 @@ describe("wrapStructureLabelWords", () => {
     expect(
       wrapStructureLabelWords("Center Science Building", measureText, 140),
     ).toEqual(["Center Science", "Building"]);
+  });
+});
+
+describe("wrapStructureLabelCharacters", () => {
+  it("keeps every fallback line within the available width", () => {
+    expect(wrapStructureLabelCharacters("ABCDEFGHIJK", measureText, 50)).toEqual([
+      "ABCDE",
+      "FGHIJ",
+      "K",
+    ]);
   });
 });

--- a/app/tests/libs/structure-label.test.ts
+++ b/app/tests/libs/structure-label.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { wrapStructureLabelWords } from "@/libs/threejs/sector";
+
+const measureText = (text: string) => text.length * 10;
+
+describe("wrapStructureLabelWords", () => {
+  it("keeps a short label on one line", () => {
+    expect(wrapStructureLabelWords("Town Hall", measureText, 120)).toEqual([
+      "Town Hall",
+    ]);
+  });
+
+  it("wraps a long label at word boundaries", () => {
+    expect(
+      wrapStructureLabelWords("Administration Building", measureText, 150),
+    ).toEqual(["Administration", "Building"]);
+  });
+
+  it("packs as many complete words as fit on each line", () => {
+    expect(
+      wrapStructureLabelWords("Center Science Building", measureText, 140),
+    ).toEqual(["Center Science", "Building"]);
+  });
+});

--- a/app/tests/validators/travel.test.ts
+++ b/app/tests/validators/travel.test.ts
@@ -30,17 +30,27 @@ test("sectorIdSchema coerces string numbers", () => {
   expect(result.data).toBe(200);
 });
 
-test("startGlobalMoveSchema accepts only current and target sectors", () => {
-  expect(startGlobalMoveSchema.parse({ sector: 1649, curSector: 1631 })).toEqual({
-    sector: 1649,
-    curSector: 1631,
-  });
+test("startGlobalMoveSchema accepts only the target sector", () => {
+  expect(startGlobalMoveSchema.parse({ sector: 1649 })).toEqual({ sector: 1649 });
+});
+
+test("startGlobalMoveSchema rejects a client-supplied current sector", () => {
+  const result = startGlobalMoveSchema.safeParse({ sector: 1649, curSector: 1631 });
+
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({
+        code: "unrecognized_keys",
+        keys: expect.arrayContaining(["curSector"]),
+      }),
+    );
+  }
 });
 
 test("startGlobalMoveSchema rejects client-supplied landing coordinates", () => {
   const result = startGlobalMoveSchema.safeParse({
     sector: 1649,
-    curSector: 1631,
     longitude: 0,
     latitude: 0,
   });


### PR DESCRIPTION
## Summary

- reduce globe perspective distortion with a narrower FOV and load at the closest supported zoom
- keep zoom-out available and allow bounded north-south tilt without pole-over-pole rotation
- soften sector boundaries with a dark gray grid at 20% opacity
- wrap long multi-word structure labels onto readable lines
- start global travel immediately instead of first walking the player to a sector edge
- keep departure and landing validation server-controlled

## Impact

The globe opens with a closer, flatter framing while retaining access to every navigable latitude. Map geography remains visible beneath a subtler grid, long structure names are readable on hover, and global movement no longer requires an unnecessary local edge traversal.

## Validation

- `bun test tests/libs/travel.test.ts tests/validators/travel.test.ts tests/libs/structure-label.test.ts`
- `bun run typecheck`
- Biome checks on all changed TypeScript files
- `git diff --check`
- live browser checks for globe framing, zoom, bounded rotation, structure-label wrapping, and console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional limit to vertical globe rotation to prevent excessive tilting.
  * Structure labels now automatically wrap by words and, when needed, by characters for better readability.
* **Bug Fixes / Improvements**
  * Improved globe camera behavior with more stable interaction-driven auto-rotation.
  * Global travel no longer requires starting from a sector edge; arrival uses destination data for safe landing.
  * Travel start input handling is now stricter, and the confirmation flow is simplified.
* **Tests**
  * Added/updated tests for structure label wrapping and travel schema validation.
* **Style**
  * Updated sector grid appearance to be lighter and more translucent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->