### PR TITLE
Add biome foundations beneath village walls

### DIFF
--- a/app/src/layout/Sector.tsx
+++ b/app/src/layout/Sector.tsx
@@ -1143,6 +1143,7 @@ const Sector: React.FC<SectorProps> = (props) => {
       // ride on the window query, merged once per window (see mergedTerrainsRef)
       mergedDecorationsRef.current,
       mergedTerrainsRef.current,
+      entry.villageType,
     );
     drawVillage(
       groups.group_assets,
@@ -1150,6 +1151,7 @@ const Sector: React.FC<SectorProps> = (props) => {
       groups.honeycombGrid,
       entry.map,
       entry.villageType,
+      groups.villageWallPlan,
     );
     sortSectorAssetsByGroundContact(groups.group_assets);
     groups.group_interaction.children.forEach((mesh) => {

--- a/app/src/layout/SectorPreview.tsx
+++ b/app/src/layout/SectorPreview.tsx
@@ -108,6 +108,7 @@ const SectorPreview: React.FC<SectorPreviewProps> = (props) => {
         map,
         decorationAssets,
         terrainRegistry,
+        villageType ?? null,
       );
       drawVillage(
         groups.group_assets,
@@ -115,6 +116,7 @@ const SectorPreview: React.FC<SectorPreviewProps> = (props) => {
         groups.honeycombGrid,
         map,
         villageType ?? null,
+        groups.villageWallPlan,
       );
       sortSectorAssetsByGroundContact(groups.group_assets);
       scene.add(groups.group_dirt);

--- a/app/src/libs/sector-map/village-walls.ts
+++ b/app/src/libs/sector-map/village-walls.ts
@@ -70,6 +70,14 @@ export const getVillageWallDecorationClearanceKeys = (
   return keys;
 };
 
+/**
+ * Interior boundary tiles whose terrain face sits directly beneath a wall.
+ * Repainting only the village side creates a natural shore/foundation while
+ * preserving the authored terrain immediately outside the enclosure.
+ */
+export const getVillageWallFoundationKeys = (plan: Pick<VillageWallPlan, "edges">) =>
+  new Set(plan.edges.map((edge) => getSectorTileKey(edge.tile.x, edge.tile.y)));
+
 interface VillageWallMap {
   width: number;
   height: number;

--- a/app/src/libs/threejs/sector.ts
+++ b/app/src/libs/threejs/sector.ts
@@ -67,9 +67,11 @@ import {
 } from "@/libs/sector-map/village-wall-assets";
 import {
   getVillageWallDecorationClearanceKeys,
+  getVillageWallFoundationKeys,
   planVillageWalls,
   selectVillageWallTowerVertices,
   usesVillageWalls,
+  type VillageWallPlan,
 } from "@/libs/sector-map/village-walls";
 import {
   getAuthoredTileMaterial,
@@ -404,6 +406,7 @@ export const drawSector = (
   sectorMap: NormalizedSectorMap,
   decorationAssets: Map<string, DecorationAsset>,
   terrainRegistry: Map<string, TerrainSpec>,
+  villageType: string | null,
 ) => {
   const endMark = profiler.mark("drawSector");
   const { width: sectorWidth, height: sectorHeight } = sectorMap;
@@ -439,6 +442,12 @@ export const drawSector = (
       structureTileKeys.add(getSectorMapTileKey(s.longitude + dCol, s.latitude + dRow));
     }
   }
+  const villageWallPlan = usesVillageWalls(villageType)
+    ? planVillageWalls(sectorMap, allStructures)
+    : null;
+  const wallFoundationKeys = villageWallPlan
+    ? getVillageWallFoundationKeys(villageWallPlan)
+    : new Set<string>();
   const grid = new Grid(Tile, rectangle({ width: sectorWidth, height: sectorHeight }))
     .filter((tile) => {
       try {
@@ -472,9 +481,11 @@ export const drawSector = (
       // wins, else the terrain's configured arena
       tile.battleBiome = authoredTile?.battleBiome ?? spec.battleBiome;
 
-      // Structure tiles stay flat and walkable (includes shrines and other
-      // added structures)
-      if (structureTileKeys.has(tileKey)) {
+      const hasStructureFoundation = structureTileKeys.has(tileKey);
+      // Structures and the village-facing tile below each wall segment use a
+      // flat, biome-appropriate foundation. This keeps walls from floating on
+      // recessed water/ice while leaving the exterior terrain untouched.
+      if (hasStructureFoundation || wallFoundationKeys.has(tileKey)) {
         // Preserve authored land beneath structures. Water becomes a small
         // land island and blue ice becomes snow; repainting every footprint
         // from the globe's centre biome caused white patches on Horizon's
@@ -493,8 +504,10 @@ export const drawSector = (
           // intentional foundation instead of noisy fragments.
           tile.level = 0.5;
         }
-        tile.hasStructure = true;
-        tile.blocked = false;
+        if (hasStructureFoundation) {
+          tile.hasStructure = true;
+          tile.blocked = false;
+        }
       }
       return tile;
     });
@@ -736,6 +749,7 @@ export const drawSector = (
     group_interaction,
     animatedMaterials: Array.from(animatedMaterials),
     honeycombGrid: grid,
+    villageWallPlan,
   };
 };
 
@@ -1316,11 +1330,9 @@ export const sortSectorAssetsByGroundContact = (group: Group) => {
 
 const drawVillageWall = (
   group: Group,
-  structures: VillageStructure[],
   grid: Grid<TerrainHex>,
-  sectorMap: NormalizedSectorMap,
+  plan: VillageWallPlan,
 ) => {
-  const plan = planVillageWalls(sectorMap, structures);
   if (plan.edges.length === 0) return;
   const decorationClearance = getVillageWallDecorationClearanceKeys(plan);
   group.children.forEach((child) => {
@@ -1400,11 +1412,12 @@ export const drawVillage = (
   grid: Grid<TerrainHex>,
   sectorMap: NormalizedSectorMap,
   villageType: string | null,
+  wallPlan?: VillageWallPlan | null,
 ) => {
   // Structure-derived modular wall: a connected contour one clear hex beyond
   // every physical structure, with authored road crossings rendered as gates.
   if (usesVillageWalls(villageType)) {
-    drawVillageWall(group, structures, grid, sectorMap);
+    drawVillageWall(group, grid, wallPlan ?? planVillageWalls(sectorMap, structures));
   }
   // Village structures
   for (const structure of structures.filter((s) => s.hasPage !== 0)) {

--- a/app/tests/libs/village-walls.test.ts
+++ b/app/tests/libs/village-walls.test.ts
@@ -4,6 +4,7 @@ import { getNeighborCoordinates, getSectorTileKey } from "@/libs/sector-map/vali
 import {
   getOddQHexDistance,
   getVillageWallDecorationClearanceKeys,
+  getVillageWallFoundationKeys,
   getVillageWallAxis,
   isVillageStructurePlacementAllowed,
   planVillageWalls,
@@ -155,6 +156,19 @@ describe("planVillageWalls", () => {
       }
     }
     expect(clearance.has("5,5")).toBe(false);
+  });
+
+  it("marks the village-side terrain below every wall segment as foundation", () => {
+    const plan = planVillageWalls(makeMap(), [physical(5, 5)]);
+    const foundations = getVillageWallFoundationKeys(plan);
+    expect(foundations.size).toBeGreaterThan(0);
+    for (const edge of plan.edges) {
+      expect(foundations.has(getSectorTileKey(edge.tile.x, edge.tile.y))).toBe(true);
+      const outside = getNeighborCoordinates(edge.tile)[edge.direction];
+      if (outside) {
+        expect(foundations.has(getSectorTileKey(outside.x, outside.y))).toBe(false);
+      }
+    }
   });
 
   it("connects far-apart protected regions into one deterministic enclosure", () => {


### PR DESCRIPTION
# Pull Request

## Summary

- derive a village-side terrain foundation from the planned wall contour
- render those foundation tiles with the same biome-aware land conversion used beneath structures
- keep authored terrain outside the enclosure unchanged
- reuse the wall plan between terrain and sprite rendering instead of calculating it twice
- cover the foundation-side invariant with a regression test

## Root cause

Village walls were added after sector terrain materials had already been chosen. Structure footprints converted recessed water or ice to an appropriate flat land biome, but wall boundary tiles did not, so masonry could render directly over depressed ocean tiles and appear to float.

The fix computes the wall plan before tile material selection. For walled villages and towns, each interior boundary tile is treated as a visual foundation: ocean becomes biome-appropriate sand, ice becomes snow, and existing land remains unchanged. Only the village-facing tile is converted, preserving the exterior shoreline.

## Local reproduction

The development database's Akasumi faction in sector 1335 reproduces the production issue: 72 planned wall edges touch ocean terrain, including 69 ocean-to-ocean runs. Visual comparison confirmed a continuous sand foundation beneath the wall after the change while exterior water and structure islands remain intact.

## Validation

- `bun run typecheck`
- `bun test tests/libs/label-collision.test.ts tests/libs/village-walls.test.ts` — 18 passing tests
- `bunx biome check` on all changed files
- `git diff --check`
- before/after browser verification against local Akasumi sector 1335

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved village wall rendering with more consistent wall foundations and walkable interior boundary tiles.
  * Preserved authored terrain and structure placement around village walls.
  * Added support for reusing planned wall layouts during sector and preview rendering.

* **Bug Fixes**
  * Corrected village wall construction so rendered sectors and previews use the same wall planning data.

* **Tests**
  * Added coverage verifying wall foundation placement along planned village wall edges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->