### PR TITLE
Apply limit on heal jutsu

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -490,6 +490,16 @@ export const JutsuTypes = [
 ] as const;
 export type JutsuType = (typeof JutsuTypes)[number];
 
+/** Jutsu types that cannot be initially learned via training grounds (leveling owned ones is allowed). */
+export const JUTSU_TRAIN_TO_LEARN_RESTRICTED_TYPES = [
+  "EVENT",
+  "LOYALTY",
+  "SPECIAL",
+  "FORBIDDEN",
+] as const satisfies readonly JutsuType[];
+export type JutsuTrainToLearnRestrictedType =
+  (typeof JUTSU_TRAIN_TO_LEARN_RESTRICTED_TYPES)[number];
+
 export const UserStatNames = [
   "ninjutsuOffence",
   "taijutsuOffence",
@@ -698,9 +708,11 @@ export type TrainingSpeed = (typeof TrainingSpeeds)[number];
 export const JUTSU_MAX_RESIDUAL_EQUIPPED = 4;
 export const JUTSU_MAX_PIERCE_EQUIPPED = 9999;
 export const JUTSU_MAX_EVENT_EQUIPPED = 2;
+export const JUTSU_MAX_FORBIDDEN_EQUIPPED = 1;
 export const JUTSU_MAX_BARRIER_EQUIPPED = 1;
 export const JUTSU_MAX_STUN_EQUIPPED = 2;
 export const JUTSU_MAX_SHIELD_EQUIPPED = 2;
+export const JUTSU_MAX_HEAL_EQUIPPED = 3;
 
 // Content difficulty ratings
 export const BloodlineDifficultyRatings = ["Easy", "Medium", "Hard", "Expert"] as const;
@@ -1737,6 +1749,7 @@ export const RANKED_LOADOUT_MAX_SUMMON_JUTSUS = 0;
 export const RANKED_LOADOUT_MAX_BARRIER_JUTSUS = 1;
 export const RANKED_LOADOUT_MAX_STUN_JUTSUS = 2;
 export const RANKED_LOADOUT_MAX_SHIELD_JUTSUS = 2;
+export const RANKED_LOADOUT_MAX_HEAL_JUTSUS = 3;
 
 // Game assets
 export const ID_ANIMATION_SMOKE = "gkYHdSzsHu";

--- a/app/drizzle/migrations/0026_blushing_gauntlet.sql
+++ b/app/drizzle/migrations/0026_blushing_gauntlet.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `UserJutsu_userId_equipped_idx` ON `UserJutsu` (`userId`,`equipped`);

--- a/app/drizzle/migrations/meta/0026_snapshot.json
+++ b/app/drizzle/migrations/meta/0026_snapshot.json
@@ -1,0 +1,15202 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "77546387-a222-4e08-a86e-415b02c7fe13",
+  "prevId": "07e91165-e19e-47b2-a261-b41c7c24b51a",
+  "tables": {
+    "AbEvent": {
+      "name": "AbEvent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "experiment": {
+          "name": "experiment",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "AbEvent_userId_idx": {
+          "name": "AbEvent_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "AbEvent_experiment_idx": {
+          "name": "AbEvent_experiment_idx",
+          "columns": [
+            "experiment"
+          ],
+          "isUnique": false
+        },
+        "AbEvent_event_idx": {
+          "name": "AbEvent_event_idx",
+          "columns": [
+            "event"
+          ],
+          "isUnique": false
+        },
+        "AbEvent_source_idx": {
+          "name": "AbEvent_source_idx",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "AbEvent_experiment_event_ip_key": {
+          "name": "AbEvent_experiment_event_ip_key",
+          "columns": [
+            "experiment",
+            "event",
+            "ip"
+          ],
+          "isUnique": true
+        },
+        "AbEvent_createdAt_idx": {
+          "name": "AbEvent_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AbEvent_id": {
+          "name": "AbEvent_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ActionLog": {
+      "name": "ActionLog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "tableName": {
+          "name": "tableName",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relatedId": {
+          "name": "relatedId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "relatedText": {
+          "name": "relatedText",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "relatedImage": {
+          "name": "relatedImage",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "relatedValue": {
+          "name": "relatedValue",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ActionLog_userId_idx": {
+          "name": "ActionLog_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "ActionLog_relatedId_idx": {
+          "name": "ActionLog_relatedId_idx",
+          "columns": [
+            "relatedId"
+          ],
+          "isUnique": false
+        },
+        "ActionLog_tableName_idx": {
+          "name": "ActionLog_tableName_idx",
+          "columns": [
+            "tableName"
+          ],
+          "isUnique": false
+        },
+        "ActionLog_createdAt_idx": {
+          "name": "ActionLog_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ActionLog_id": {
+          "name": "ActionLog_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ActivityStreakConfig": {
+      "name": "ActivityStreakConfig",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "totalDays": {
+          "name": "totalDays",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 14
+        },
+        "streakType": {
+          "name": "streakType",
+          "type": "enum('RECURRING','EVENT_PASS')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'RECURRING'"
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "ryoCost": {
+          "name": "ryoCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "repsCost": {
+          "name": "repsCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "seichiSilverCost": {
+          "name": "seichiSilverCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ActivityStreakConfig_id": {
+          "name": "ActivityStreakConfig_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ActivityStreakReward": {
+      "name": "ActivityStreakReward",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "configId": {
+          "name": "configId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dayNumber": {
+          "name": "dayNumber",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewards": {
+          "name": "rewards",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "ActivityStreakReward_configId_idx": {
+          "name": "ActivityStreakReward_configId_idx",
+          "columns": [
+            "configId"
+          ],
+          "isUnique": false
+        },
+        "ActivityStreakReward_dayNumber_idx": {
+          "name": "ActivityStreakReward_dayNumber_idx",
+          "columns": [
+            "dayNumber"
+          ],
+          "isUnique": false
+        },
+        "ActivityStreakReward_configId_dayNumber_key": {
+          "name": "ActivityStreakReward_configId_dayNumber_key",
+          "columns": [
+            "configId",
+            "dayNumber"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ActivityStreakReward_id": {
+          "name": "ActivityStreakReward_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "AiProfile": {
+      "name": "AiProfile",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "includeDefaultRules": {
+          "name": "includeDefaultRules",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "AiProfile_userId_idx": {
+          "name": "AiProfile_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AiProfile_id": {
+          "name": "AiProfile_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "AnbuSquad": {
+      "name": "AnbuSquad",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "leaderId": {
+          "name": "leaderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pvpActivity": {
+          "name": "pvpActivity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "kageOrderId": {
+          "name": "kageOrderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "points": {
+          "name": "points",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "espionageLevel": {
+          "name": "espionageLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stealthLevel": {
+          "name": "stealthLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "leaderOrderId": {
+          "name": "leaderOrderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "AnbuSquad_name_key": {
+          "name": "AnbuSquad_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "AnbuSquad_leaderId_idx": {
+          "name": "AnbuSquad_leaderId_idx",
+          "columns": [
+            "leaderId"
+          ],
+          "isUnique": false
+        },
+        "AnbuSquad_villageId_idx": {
+          "name": "AnbuSquad_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AnbuSquad_id": {
+          "name": "AnbuSquad_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "AuctionBid": {
+      "name": "AuctionBid",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auctionId": {
+          "name": "auctionId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bidderId": {
+          "name": "bidderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('ACTIVE','REFUNDED','WON')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "AuctionBid_auctionId_idx": {
+          "name": "AuctionBid_auctionId_idx",
+          "columns": [
+            "auctionId"
+          ],
+          "isUnique": false
+        },
+        "AuctionBid_bidderId_idx": {
+          "name": "AuctionBid_bidderId_idx",
+          "columns": [
+            "bidderId"
+          ],
+          "isUnique": false
+        },
+        "AuctionBid_amount_idx": {
+          "name": "AuctionBid_amount_idx",
+          "columns": [
+            "amount"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AuctionBid_id": {
+          "name": "AuctionBid_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "AuctionListing": {
+      "name": "AuctionListing",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sellerId": {
+          "name": "sellerId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "buyerId": {
+          "name": "buyerId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userItemId": {
+          "name": "userItemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "listingType": {
+          "name": "listingType",
+          "type": "enum('AUCTION','DIRECT')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startingPrice": {
+          "name": "startingPrice",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "buyoutPrice": {
+          "name": "buyoutPrice",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currentPrice": {
+          "name": "currentPrice",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currencyType": {
+          "name": "currencyType",
+          "type": "enum('MONEY','REPUTATION')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'MONEY'"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('ACTIVE','SOLD','EXPIRED','CANCELLED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "bidderMinLevel": {
+          "name": "bidderMinLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "bidderMaxLevel": {
+          "name": "bidderMaxLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "AuctionListing_sellerId_idx": {
+          "name": "AuctionListing_sellerId_idx",
+          "columns": [
+            "sellerId"
+          ],
+          "isUnique": false
+        },
+        "AuctionListing_buyerId_idx": {
+          "name": "AuctionListing_buyerId_idx",
+          "columns": [
+            "buyerId"
+          ],
+          "isUnique": false
+        },
+        "AuctionListing_userItemId_idx": {
+          "name": "AuctionListing_userItemId_idx",
+          "columns": [
+            "userItemId"
+          ],
+          "isUnique": false
+        },
+        "AuctionListing_targetUserId_idx": {
+          "name": "AuctionListing_targetUserId_idx",
+          "columns": [
+            "targetUserId"
+          ],
+          "isUnique": false
+        },
+        "AuctionListing_status_idx": {
+          "name": "AuctionListing_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "AuctionListing_expiresAt_idx": {
+          "name": "AuctionListing_expiresAt_idx",
+          "columns": [
+            "expiresAt"
+          ],
+          "isUnique": false
+        },
+        "AuctionListing_status_listingType_bidderLevels_idx": {
+          "name": "AuctionListing_status_listingType_bidderLevels_idx",
+          "columns": [
+            "status",
+            "listingType",
+            "bidderMinLevel",
+            "bidderMaxLevel"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AuctionListing_id": {
+          "name": "AuctionListing_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "AutomatedModeration": {
+      "name": "AutomatedModeration",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relationType": {
+          "name": "relationType",
+          "type": "enum('comment','privateMessage','forumPost','userReport','userNindo','clanOrder','anbuOrder','kageOrder','userAvatar')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sexual": {
+          "name": "sexual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sexual_minors": {
+          "name": "sexual_minors",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "harassment": {
+          "name": "harassment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "harassment_threatening": {
+          "name": "harassment_threatening",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hate": {
+          "name": "hate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hate_threatening": {
+          "name": "hate_threatening",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "illicit": {
+          "name": "illicit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "illicit_violent": {
+          "name": "illicit_violent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "self_harm": {
+          "name": "self_harm",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "self_harm_intent": {
+          "name": "self_harm_intent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "self_harm_instructions": {
+          "name": "self_harm_instructions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "violence": {
+          "name": "violence",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "violence_graphic": {
+          "name": "violence_graphic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "AutoMod_userId_idx": {
+          "name": "AutoMod_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "AutoMod_relationType_idx": {
+          "name": "AutoMod_relationType_idx",
+          "columns": [
+            "relationType"
+          ],
+          "isUnique": false
+        },
+        "AutoMod_createdAt_idx": {
+          "name": "AutoMod_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AutomatedModeration_id": {
+          "name": "AutomatedModeration_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Badge": {
+      "name": "Badge",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "Badge_name_key": {
+          "name": "Badge_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Badge_id": {
+          "name": "Badge_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BankTransfers": {
+      "name": "BankTransfers",
+      "columns": {
+        "senderId": {
+          "name": "senderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "receiverId": {
+          "name": "receiverId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('bank','sensei','recruiter')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'bank'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "BankTransfers_senderId_idx": {
+          "name": "BankTransfers_senderId_idx",
+          "columns": [
+            "senderId"
+          ],
+          "isUnique": false
+        },
+        "BankTransfers_receiverId_idx": {
+          "name": "BankTransfers_receiverId_idx",
+          "columns": [
+            "receiverId"
+          ],
+          "isUnique": false
+        },
+        "BankTransfers_senderId_receiverId_idx": {
+          "name": "BankTransfers_senderId_receiverId_idx",
+          "columns": [
+            "senderId",
+            "receiverId"
+          ],
+          "isUnique": false
+        },
+        "BankTransfers_createdAt_idx": {
+          "name": "BankTransfers_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Battle": {
+      "name": "Battle",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "roundStartAt": {
+          "name": "roundStartAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "background": {
+          "name": "background",
+          "type": "enum('ocean','ground','dessert','ice','snow','arena','default')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 13
+        },
+        "height": {
+          "name": "height",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 9
+        },
+        "battleType": {
+          "name": "battleType",
+          "type": "enum('ARENA','COMBAT','SPARRING','KAGE_AI','KAGE_PVP','CLAN_CHALLENGE','CLAN_BATTLE','SHRINE_WAR','TOURNAMENT','QUEST','RANDOM_ENCOUNTER','VILLAGE_PROTECTOR','TRAINING','RANKED_PVP','RANKED_SPARRING','RAID')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usersState": {
+          "name": "usersState",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usersEffects": {
+          "name": "usersEffects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "groundEffects": {
+          "name": "groundEffects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extraState": {
+          "name": "extraState",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewardScaling": {
+          "name": "rewardScaling",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "version": {
+          "name": "version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "round": {
+          "name": "round",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "forceKeepPools": {
+          "name": "forceKeepPools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "activeUserId": {
+          "name": "activeUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Battle_id_version_key": {
+          "name": "Battle_id_version_key",
+          "columns": [
+            "id",
+            "version"
+          ],
+          "isUnique": true
+        },
+        "Battle_updatedAt_idx": {
+          "name": "Battle_updatedAt_idx",
+          "columns": [
+            "updatedAt"
+          ],
+          "isUnique": false
+        },
+        "Battle_battleType_createdAt_idx": {
+          "name": "Battle_battleType_createdAt_idx",
+          "columns": [
+            "battleType",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Battle_id": {
+          "name": "Battle_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BattleAction": {
+      "name": "BattleAction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "battleId": {
+          "name": "battleId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleVersion": {
+          "name": "battleVersion",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleRound": {
+          "name": "battleRound",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "actionId": {
+          "name": "actionId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appliedEffects": {
+          "name": "appliedEffects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "BattleAction_round_key": {
+          "name": "BattleAction_round_key",
+          "columns": [
+            "battleId",
+            "battleVersion",
+            "battleRound"
+          ],
+          "isUnique": true
+        },
+        "BattleAction_createdAt_idx": {
+          "name": "BattleAction_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "BattleAction_battleId_idx": {
+          "name": "BattleAction_battleId_idx",
+          "columns": [
+            "battleId"
+          ],
+          "isUnique": false
+        },
+        "BattleAction_updatedAt_battleId_idx": {
+          "name": "BattleAction_updatedAt_battleId_idx",
+          "columns": [
+            "updatedAt",
+            "battleId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BattleAction_id": {
+          "name": "BattleAction_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BattleHistory": {
+      "name": "BattleHistory",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "battleId": {
+          "name": "battleId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleType": {
+          "name": "battleType",
+          "type": "enum('ARENA','COMBAT','SPARRING','KAGE_AI','KAGE_PVP','CLAN_CHALLENGE','CLAN_BATTLE','SHRINE_WAR','TOURNAMENT','QUEST','RANDOM_ENCOUNTER','VILLAGE_PROTECTOR','TRAINING','RANKED_PVP','RANKED_SPARRING','RAID')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attackedId": {
+          "name": "attackedId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "defenderId": {
+          "name": "defenderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "BattleHistory_createdAt_idx": {
+          "name": "BattleHistory_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "BattleHistory_battleId_idx": {
+          "name": "BattleHistory_battleId_idx",
+          "columns": [
+            "battleId"
+          ],
+          "isUnique": false
+        },
+        "BattleHistory_battleType_idx": {
+          "name": "BattleHistory_battleType_idx",
+          "columns": [
+            "battleType"
+          ],
+          "isUnique": false
+        },
+        "BattleHistory_attackedId_idx": {
+          "name": "BattleHistory_attackedId_idx",
+          "columns": [
+            "attackedId"
+          ],
+          "isUnique": false
+        },
+        "BattleHistory_defenderId_idx": {
+          "name": "BattleHistory_defenderId_idx",
+          "columns": [
+            "defenderId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BattleHistory_id": {
+          "name": "BattleHistory_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Bloodline": {
+      "name": "Bloodline",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "statClassification": {
+          "name": "statClassification",
+          "type": "enum('Highest','Ninjutsu','Genjutsu','Taijutsu','Bukijutsu')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "regenIncrease": {
+          "name": "regenIncrease",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "NULL"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "enum('D','C','B','A','S','H')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "enum('Easy','Medium','Hard','Expert')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "traits": {
+          "name": "traits",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Bloodline_name_key": {
+          "name": "Bloodline_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "Bloodline_image_key": {
+          "name": "Bloodline_image_key",
+          "columns": [
+            "image"
+          ],
+          "isUnique": false
+        },
+        "Bloodline_village_idx": {
+          "name": "Bloodline_village_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        },
+        "Bloodline_rank_idx": {
+          "name": "Bloodline_rank_idx",
+          "columns": [
+            "rank"
+          ],
+          "isUnique": false
+        },
+        "Bloodline_difficulty_idx": {
+          "name": "Bloodline_difficulty_idx",
+          "columns": [
+            "difficulty"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Bloodline_id": {
+          "name": "Bloodline_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BloodlineReskin": {
+      "name": "BloodlineReskin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bloodlineId": {
+          "name": "bloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "BloodlineReskin_bloodlineId_idx": {
+          "name": "BloodlineReskin_bloodlineId_idx",
+          "columns": [
+            "bloodlineId"
+          ],
+          "isUnique": false
+        },
+        "BloodlineReskin_createdBy_idx": {
+          "name": "BloodlineReskin_createdBy_idx",
+          "columns": [
+            "createdBy"
+          ],
+          "isUnique": false
+        },
+        "BloodlineReskin_bloodlineId_name_key": {
+          "name": "BloodlineReskin_bloodlineId_name_key",
+          "columns": [
+            "bloodlineId",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BloodlineReskin_id": {
+          "name": "BloodlineReskin_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BloodlineRolls": {
+      "name": "BloodlineRolls",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bloodlineId": {
+          "name": "bloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used": {
+          "name": "used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pityRolls": {
+          "name": "pityRolls",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('NATURAL','ITEM','PITY','DIRECT','QUEST','REGISTRATION')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NATURAL'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "enum('D','C','B','A','S','H')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "naturalRollDedupeKey": {
+          "name": "naturalRollDedupeKey",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "CASE WHEN `type` = 'NATURAL' THEN `userId` ELSE NULL END",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "BloodlineRolls_userId_idx": {
+          "name": "BloodlineRolls_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "BloodlineRolls_bloodlineId_idx": {
+          "name": "BloodlineRolls_bloodlineId_idx",
+          "columns": [
+            "bloodlineId"
+          ],
+          "isUnique": false
+        },
+        "BloodlineRolls_natural_roll_per_user_key": {
+          "name": "BloodlineRolls_natural_roll_per_user_key",
+          "columns": [
+            "naturalRollDedupeKey"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BloodlineRolls_id": {
+          "name": "BloodlineRolls_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Bounty": {
+      "name": "Bounty",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creatorUserId": {
+          "name": "creatorUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amountRyo": {
+          "name": "amountRyo",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "originalAmountRyo": {
+          "name": "originalAmountRyo",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('OPEN','CLAIMED','EXPIRED','CANCELLED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'OPEN'"
+        },
+        "claimedByUserId": {
+          "name": "claimedByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "collectedAt": {
+          "name": "collectedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimedAt": {
+          "name": "claimedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "Bounty_targetUserId_idx": {
+          "name": "Bounty_targetUserId_idx",
+          "columns": [
+            "targetUserId"
+          ],
+          "isUnique": false
+        },
+        "Bounty_creatorUserId_idx": {
+          "name": "Bounty_creatorUserId_idx",
+          "columns": [
+            "creatorUserId"
+          ],
+          "isUnique": false
+        },
+        "Bounty_status_idx": {
+          "name": "Bounty_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Bounty_id": {
+          "name": "Bounty_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BountyContribution": {
+      "name": "BountyContribution",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bountyId": {
+          "name": "bountyId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contributorUserId": {
+          "name": "contributorUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amountRyo": {
+          "name": "amountRyo",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "BountyContribution_bountyId_idx": {
+          "name": "BountyContribution_bountyId_idx",
+          "columns": [
+            "bountyId"
+          ],
+          "isUnique": false
+        },
+        "BountyContribution_contributorUserId_idx": {
+          "name": "BountyContribution_contributorUserId_idx",
+          "columns": [
+            "contributorUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BountyContribution_id": {
+          "name": "BountyContribution_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BountySignup": {
+      "name": "BountySignup",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bountyId": {
+          "name": "bountyId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hunterUserId": {
+          "name": "hunterUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "BountySignup_bounty_hunter_key": {
+          "name": "BountySignup_bounty_hunter_key",
+          "columns": [
+            "bountyId",
+            "hunterUserId"
+          ],
+          "isUnique": true
+        },
+        "BountySignup_bountyId_idx": {
+          "name": "BountySignup_bountyId_idx",
+          "columns": [
+            "bountyId"
+          ],
+          "isUnique": false
+        },
+        "BountySignup_hunterUserId_idx": {
+          "name": "BountySignup_hunterUserId_idx",
+          "columns": [
+            "hunterUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BountySignup_id": {
+          "name": "BountySignup_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "CannedResponse": {
+      "name": "CannedResponse",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "CannedResponse_createdByUserId_idx": {
+          "name": "CannedResponse_createdByUserId_idx",
+          "columns": [
+            "createdByUserId"
+          ],
+          "isUnique": false
+        },
+        "CannedResponse_title_idx": {
+          "name": "CannedResponse_title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "CannedResponse_id": {
+          "name": "CannedResponse_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Captcha": {
+      "name": "Captcha",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "captcha": {
+          "name": "captcha",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3) + INTERVAL 1 DAY )"
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "Captcha_userId_key": {
+          "name": "Captcha_userId_key",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "Captcha_used_idx": {
+          "name": "Captcha_used_idx",
+          "columns": [
+            "used"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Captcha_id": {
+          "name": "Captcha_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Clan": {
+      "name": "Clan",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "founderId": {
+          "name": "founderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "leaderId": {
+          "name": "leaderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "coLeader1": {
+          "name": "coLeader1",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coLeader2": {
+          "name": "coLeader2",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coLeader3": {
+          "name": "coLeader3",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin1": {
+          "name": "assassin1",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin2": {
+          "name": "assassin2",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin3": {
+          "name": "assassin3",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin4": {
+          "name": "assassin4",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin5": {
+          "name": "assassin5",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin6": {
+          "name": "assassin6",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin7": {
+          "name": "assassin7",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin8": {
+          "name": "assassin8",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin9": {
+          "name": "assassin9",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin10": {
+          "name": "assassin10",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "leaderOrderId": {
+          "name": "leaderOrderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trainingBoost": {
+          "name": "trainingBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "ryoBoost": {
+          "name": "ryoBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "regenBoost": {
+          "name": "regenBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionRewardBoost": {
+          "name": "missionRewardBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "craftingTimeBoost": {
+          "name": "craftingTimeBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "craftingExpBoost": {
+          "name": "craftingExpBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hunterExpBoost": {
+          "name": "hunterExpBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gathererExpBoost": {
+          "name": "gathererExpBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "elderNomineeId": {
+          "name": "elderNomineeId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "elderCutoffMonth": {
+          "name": "elderCutoffMonth",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "elderCutoffYear": {
+          "name": "elderCutoffYear",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "elderCutoffRank": {
+          "name": "elderCutoffRank",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "activityPoints": {
+          "name": "activityPoints",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "points": {
+          "name": "points",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bank": {
+          "name": "bank",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pvpActivity": {
+          "name": "pvpActivity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "repTreasury": {
+          "name": "repTreasury",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hasHideout": {
+          "name": "hasHideout",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "Clan_name_key": {
+          "name": "Clan_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "Clan_village_idx": {
+          "name": "Clan_village_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Clan_id": {
+          "name": "Clan_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ConceptImage": {
+      "name": "ConceptImage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video": {
+          "name": "video",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mediaType": {
+          "name": "mediaType",
+          "type": "enum('image','video')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'image'"
+        },
+        "replicateId": {
+          "name": "replicateId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'started'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "varchar(5000)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "negative_prompt": {
+          "name": "negative_prompt",
+          "type": "varchar(5000)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "seed": {
+          "name": "seed",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 42
+        },
+        "guidance_scale": {
+          "name": "guidance_scale",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 4
+        },
+        "n_likes": {
+          "name": "n_likes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "n_loves": {
+          "name": "n_loves",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "n_laugh": {
+          "name": "n_laugh",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "n_comments": {
+          "name": "n_comments",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "concept_image_key": {
+          "name": "concept_image_key",
+          "columns": [
+            "image"
+          ],
+          "isUnique": true
+        },
+        "image_done_idx": {
+          "name": "image_done_idx",
+          "columns": [
+            "done"
+          ],
+          "isUnique": false
+        },
+        "image_userId_idx": {
+          "name": "image_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ConceptImage_id": {
+          "name": "ConceptImage_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ContentBackup": {
+      "name": "ContentBackup",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('bloodline','jutsu','item','ai')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sqlText": {
+          "name": "sqlText",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "ContentBackup_type_idx": {
+          "name": "ContentBackup_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "ContentBackup_createdAt_idx": {
+          "name": "ContentBackup_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ContentBackup_id": {
+          "name": "ContentBackup_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ContentTag": {
+      "name": "ContentTag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ContentTag_name_key": {
+          "name": "ContentTag_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ContentTag_id": {
+          "name": "ContentTag_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Conversation": {
+      "name": "Conversation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "isLocked": {
+          "name": "isLocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "isStaffAvailable": {
+          "name": "isStaffAvailable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "Conversation_title_key": {
+          "name": "Conversation_title_key",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "Conversation_createdById_idx": {
+          "name": "Conversation_createdById_idx",
+          "columns": [
+            "createdById"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Conversation_id": {
+          "name": "Conversation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ConversationComment": {
+      "name": "ConversationComment",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reactions": {
+          "name": "reactions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('{}')"
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isReported": {
+          "name": "isReported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isStaffOnly": {
+          "name": "isStaffOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "ConversationComment_userId_idx": {
+          "name": "ConversationComment_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "ConversationComment_createdAt_idx": {
+          "name": "ConversationComment_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "ConversationComment_conversationId_idx": {
+          "name": "ConversationComment_conversationId_idx",
+          "columns": [
+            "conversationId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ConversationComment_id": {
+          "name": "ConversationComment_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "CraftingRequirement": {
+      "name": "CraftingRequirement",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "craftItemId": {
+          "name": "craftItemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requirementItemId": {
+          "name": "requirementItemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "CraftingRequirement_craftItemId_idx": {
+          "name": "CraftingRequirement_craftItemId_idx",
+          "columns": [
+            "craftItemId"
+          ],
+          "isUnique": false
+        },
+        "CraftingRequirement_requirementItemId_idx": {
+          "name": "CraftingRequirement_requirementItemId_idx",
+          "columns": [
+            "requirementItemId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "CraftingRequirement_id": {
+          "name": "CraftingRequirement_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "DailyBankInterest": {
+      "name": "DailyBankInterest",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed": {
+          "name": "claimed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "interestPercent": {
+          "name": "interestPercent",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "DailyBankInterest_userId_idx": {
+          "name": "DailyBankInterest_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "DailyBankInterest_updatedAt_idx": {
+          "name": "DailyBankInterest_updatedAt_idx",
+          "columns": [
+            "updatedAt"
+          ],
+          "isUnique": false
+        },
+        "DailyBankInterest_claimed_updatedAt_idx": {
+          "name": "DailyBankInterest_claimed_updatedAt_idx",
+          "columns": [
+            "claimed",
+            "updatedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "DailyBankInterest_id": {
+          "name": "DailyBankInterest_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "DailyBankInterest_userId_date_key": {
+          "name": "DailyBankInterest_userId_date_key",
+          "columns": [
+            "userId",
+            "date"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "DamageCalculation": {
+      "name": "DamageCalculation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "state": {
+          "name": "state",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "DamageCalculation_userId_idx": {
+          "name": "DamageCalculation_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "DamageCalculation_createdAt_idx": {
+          "name": "DamageCalculation_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "DamageCalculation_id": {
+          "name": "DamageCalculation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "DataBattleAction": {
+      "name": "DataBattleAction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('jutsu','item','bloodline','basic','ai')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contentId": {
+          "name": "contentId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relatedBloodlineId": {
+          "name": "relatedBloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "battleType": {
+          "name": "battleType",
+          "type": "enum('ARENA','COMBAT','SPARRING','KAGE_AI','KAGE_PVP','CLAN_CHALLENGE','CLAN_BATTLE','SHRINE_WAR','TOURNAMENT','QUEST','RANDOM_ENCOUNTER','VILLAGE_PROTECTOR','TRAINING','RANKED_PVP','RANKED_SPARRING','RAID')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "battleWon": {
+          "name": "battleWon",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "DataBattleActions_type_idx": {
+          "name": "DataBattleActions_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "DataBattleActions_battleWon_idx": {
+          "name": "DataBattleActions_battleWon_idx",
+          "columns": [
+            "battleWon"
+          ],
+          "isUnique": false
+        },
+        "DataBattleActions_battleType_idx": {
+          "name": "DataBattleActions_battleType_idx",
+          "columns": [
+            "battleType"
+          ],
+          "isUnique": false
+        },
+        "DataBattleActions_contentId_idx": {
+          "name": "DataBattleActions_contentId_idx",
+          "columns": [
+            "contentId"
+          ],
+          "isUnique": false
+        },
+        "DataBattleActions_count_idx": {
+          "name": "DataBattleActions_count_idx",
+          "columns": [
+            "count"
+          ],
+          "isUnique": false
+        },
+        "DataBattleActions_createdAt": {
+          "name": "DataBattleActions_createdAt",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "DataBattleActions_updatedAt_idx": {
+          "name": "DataBattleActions_updatedAt_idx",
+          "columns": [
+            "updatedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "DataBattleAction_id": {
+          "name": "DataBattleAction_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "uniqueContentId": {
+          "name": "uniqueContentId",
+          "columns": [
+            "type",
+            "contentId",
+            "battleType",
+            "battleWon",
+            "relatedBloodlineId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "EmailReminder": {
+      "name": "EmailReminder",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callName": {
+          "name": "callName",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latestRejoinRequest": {
+          "name": "latestRejoinRequest",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastActivity": {
+          "name": "lastActivity",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "validated": {
+          "name": "validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "EmailReminder_userId_idx": {
+          "name": "EmailReminder_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "EmailReminder_id": {
+          "name": "EmailReminder_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ForumBoard": {
+      "name": "ForumBoard",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "nPosts": {
+          "name": "nPosts",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "nThreads": {
+          "name": "nThreads",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ForumBoard_name_key": {
+          "name": "ForumBoard_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ForumBoard_id": {
+          "name": "ForumBoard_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ForumPost": {
+      "name": "ForumPost",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isReported": {
+          "name": "isReported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "ForumPost_userId_idx": {
+          "name": "ForumPost_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "ForumPost_threadId_idx": {
+          "name": "ForumPost_threadId_idx",
+          "columns": [
+            "threadId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ForumPost_id": {
+          "name": "ForumPost_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ForumThread": {
+      "name": "ForumThread",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "boardId": {
+          "name": "boardId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nPosts": {
+          "name": "nPosts",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isLocked": {
+          "name": "isLocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "ForumThread_boardId_idx": {
+          "name": "ForumThread_boardId_idx",
+          "columns": [
+            "boardId"
+          ],
+          "isUnique": false
+        },
+        "ForumThread_userId_idx": {
+          "name": "ForumThread_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ForumThread_id": {
+          "name": "ForumThread_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "GameAsset": {
+      "name": "GameAsset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('STATIC','ANIMATION','SCENE_BACKGROUND','SCENE_CHARACTER','SFX','MUSIC')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "frames": {
+          "name": "frames",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "speed": {
+          "name": "speed",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "folder": {
+          "name": "folder",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "licenseDetails": {
+          "name": "licenseDetails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('TNR')"
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "onInitialBattleField": {
+          "name": "onInitialBattleField",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "GameAsset_type_idx": {
+          "name": "GameAsset_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "GameAsset_id": {
+          "name": "GameAsset_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "GameAssetTag": {
+      "name": "GameAssetTag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "GameAssetTag_assetId_tag_key": {
+          "name": "GameAssetTag_assetId_tag_key",
+          "columns": [
+            "assetId",
+            "tagId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "GameAssetTag_id": {
+          "name": "GameAssetTag_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "GameSetting": {
+      "name": "GameSetting",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "name": {
+          "name": "name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "GameSetting_id": {
+          "name": "GameSetting_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "HistoricalAvatar": {
+      "name": "HistoricalAvatar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatarLight": {
+          "name": "avatarLight",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replicateId": {
+          "name": "replicateId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'started'"
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "HistoricalAvatar_replicateId_key": {
+          "name": "HistoricalAvatar_replicateId_key",
+          "columns": [
+            "replicateId"
+          ],
+          "isUnique": true
+        },
+        "HistoricalAvatar_avatar_key": {
+          "name": "HistoricalAvatar_avatar_key",
+          "columns": [
+            "avatar"
+          ],
+          "isUnique": true
+        },
+        "HistoricalAvatar_done_idx": {
+          "name": "HistoricalAvatar_done_idx",
+          "columns": [
+            "done"
+          ],
+          "isUnique": false
+        },
+        "HistoricalAvatar_status_idx": {
+          "name": "HistoricalAvatar_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "HistoricalAvatar_userId_idx": {
+          "name": "HistoricalAvatar_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "HistoricalAvatar_id": {
+          "name": "HistoricalAvatar_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "HistoricalIp": {
+      "name": "HistoricalIp",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usedAt": {
+          "name": "usedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "HistoricalIp_userId_ip_key": {
+          "name": "HistoricalIp_userId_ip_key",
+          "columns": [
+            "userId",
+            "ip"
+          ],
+          "isUnique": true
+        },
+        "HistoricalIp_userId_idx": {
+          "name": "HistoricalIp_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "HistoricalIp_userIp_idx": {
+          "name": "HistoricalIp_userIp_idx",
+          "columns": [
+            "ip"
+          ],
+          "isUnique": false
+        },
+        "HistoricalIp_usedAt_idx": {
+          "name": "HistoricalIp_usedAt_idx",
+          "columns": [
+            "usedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "HistoricalIp_id": {
+          "name": "HistoricalIp_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "HistoricalSoundEffect": {
+      "name": "HistoricalSoundEffect",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "relationId": {
+          "name": "relationId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replicateId": {
+          "name": "replicateId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "secondsTotal": {
+          "name": "secondsTotal",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "negativePrompt": {
+          "name": "negativePrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'started'"
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "HistoricalSoundEffect_replicateId_idx": {
+          "name": "HistoricalSoundEffect_replicateId_idx",
+          "columns": [
+            "replicateId"
+          ],
+          "isUnique": false
+        },
+        "HistoricalSoundEffect_relationId_idx": {
+          "name": "HistoricalSoundEffect_relationId_idx",
+          "columns": [
+            "relationId"
+          ],
+          "isUnique": false
+        },
+        "HistoricalSoundEffect_userId_idx": {
+          "name": "HistoricalSoundEffect_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "HistoricalSoundEffect_done_idx": {
+          "name": "HistoricalSoundEffect_done_idx",
+          "columns": [
+            "done"
+          ],
+          "isUnique": false
+        },
+        "HistoricalSoundEffect_status_idx": {
+          "name": "HistoricalSoundEffect_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "HistoricalSoundEffect_id": {
+          "name": "HistoricalSoundEffect_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Item": {
+      "name": "Item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "expireFromStoreAt": {
+          "name": "expireFromStoreAt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "itemType": {
+          "name": "itemType",
+          "type": "enum('WEAPON','CONSUMABLE','ARMOR','ACCESSORY','MATERIAL','KEYSTONE','CRYSTAL','OTHER')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "enum('COMMON','RARE','EPIC','LEGENDARY')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot": {
+          "name": "slot",
+          "type": "enum('HEAD','CHEST','LEGS','FEET','HAND','THROWN','ITEM','WAIST','KEYSTONE','NONE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cooldown": {
+          "name": "cooldown",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "weaponType": {
+          "name": "weaponType",
+          "type": "enum('STAFF','AXE','FIST_WEAPON','SHURIKEN','SICKLE','DAGGER','SWORD','POLEARM','FLAIL','CHAIN','FAN','BOW','HAMMER','NONE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "target": {
+          "name": "target",
+          "type": "enum('SELF','OTHER_USER','OPPONENT','ALLY','CHARACTER','GROUND','EMPTY_GROUND')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "enum('SINGLE','ALL','AOE_CIRCLE_SPAWN','AOE_LINE_SHOOT','AOE_WALL_SHOOT','AOE_LARGE_WALL_SHOOT','AOE_CIRCLE_SHOOT','AOE_SPIRAL_SHOOT')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'SINGLE'"
+        },
+        "cost": {
+          "name": "cost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "reputationCost": {
+          "name": "reputationCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "seichiSilverCost": {
+          "name": "seichiSilverCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stackSize": {
+          "name": "stackSize",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destroyOnUse": {
+          "name": "destroyOnUse",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "range": {
+          "name": "range",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "chakraCost": {
+          "name": "chakraCost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "staminaCost": {
+          "name": "staminaCost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "healthCost": {
+          "name": "healthCost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "staminaCostReducePerLvl": {
+          "name": "staminaCostReducePerLvl",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "chakraCostReducePerLvl": {
+          "name": "chakraCostReducePerLvl",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "healthCostReducePerLvl": {
+          "name": "healthCostReducePerLvl",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "actionCostPerc": {
+          "name": "actionCostPerc",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "battleDescription": {
+          "name": "battleDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('')"
+        },
+        "canStack": {
+          "name": "canStack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "maxImbueNumber": {
+          "name": "maxImbueNumber",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "maxDurability": {
+          "name": "maxDurability",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "inShop": {
+          "name": "inShop",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "isEventItem": {
+          "name": "isEventItem",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "maxEquips": {
+          "name": "maxEquips",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "preventBattleUsage": {
+          "name": "preventBattleUsage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "requiredLevel": {
+          "name": "requiredLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "canBeCrafted": {
+          "name": "canBeCrafted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "canBeImbued": {
+          "name": "canBeImbued",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "canBeHunted": {
+          "name": "canBeHunted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "canBeGathered": {
+          "name": "canBeGathered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "canBeTraded": {
+          "name": "canBeTraded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "craftingExperience": {
+          "name": "craftingExperience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crystalTargetTypes": {
+          "name": "crystalTargetTypes",
+          "type": "enum('WEAPON','CONSUMABLE','ARMOR','ACCESSORY','MATERIAL','KEYSTONE','CRYSTAL','OTHER')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bloodlineId": {
+          "name": "bloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "battleUsageType": {
+          "name": "battleUsageType",
+          "type": "enum('PVE','PVP','BOTH')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'BOTH'"
+        }
+      },
+      "indexes": {
+        "Item_name_key": {
+          "name": "Item_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "Item_rarity_idx": {
+          "name": "Item_rarity_idx",
+          "columns": [
+            "rarity"
+          ],
+          "isUnique": false
+        },
+        "Item_itemType_idx": {
+          "name": "Item_itemType_idx",
+          "columns": [
+            "itemType"
+          ],
+          "isUnique": false
+        },
+        "Item_slot_idx": {
+          "name": "Item_slot_idx",
+          "columns": [
+            "slot"
+          ],
+          "isUnique": false
+        },
+        "Item_method_idx": {
+          "name": "Item_method_idx",
+          "columns": [
+            "method"
+          ],
+          "isUnique": false
+        },
+        "Item_target_idx": {
+          "name": "Item_target_idx",
+          "columns": [
+            "target"
+          ],
+          "isUnique": false
+        },
+        "Item_isEventItem_idx": {
+          "name": "Item_isEventItem_idx",
+          "columns": [
+            "isEventItem"
+          ],
+          "isUnique": false
+        },
+        "Item_onlyInShop_idx": {
+          "name": "Item_onlyInShop_idx",
+          "columns": [
+            "inShop"
+          ],
+          "isUnique": false
+        },
+        "Item_cost_idx": {
+          "name": "Item_cost_idx",
+          "columns": [
+            "cost"
+          ],
+          "isUnique": false
+        },
+        "Item_repsCost_idx": {
+          "name": "Item_repsCost_idx",
+          "columns": [
+            "reputationCost"
+          ],
+          "isUnique": false
+        },
+        "Item_requiredLevel_idx": {
+          "name": "Item_requiredLevel_idx",
+          "columns": [
+            "requiredLevel"
+          ],
+          "isUnique": false
+        },
+        "Item_bloodlineId_idx": {
+          "name": "Item_bloodlineId_idx",
+          "columns": [
+            "bloodlineId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Item_id": {
+          "name": "Item_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ItemLoadout": {
+      "name": "ItemLoadout",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "itemData": {
+          "name": "itemData",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "ItemLoadout_userId_idx": {
+          "name": "ItemLoadout_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ItemLoadout_id": {
+          "name": "ItemLoadout_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ItemVariant": {
+      "name": "ItemVariant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "itemId": {
+          "name": "itemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "costType": {
+          "name": "costType",
+          "type": "enum('MONEY','REPUTATION','SEICHI_SILVER','VILLAGE_PRESTIGE','VARIANT_TOKEN')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "order": {
+          "name": "order",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "battleDescription": {
+          "name": "battleDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "ItemVariant_itemId_idx": {
+          "name": "ItemVariant_itemId_idx",
+          "columns": [
+            "itemId"
+          ],
+          "isUnique": false
+        },
+        "ItemVariant_itemId_order_key": {
+          "name": "ItemVariant_itemId_order_key",
+          "columns": [
+            "itemId",
+            "order"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ItemVariant_id": {
+          "name": "ItemVariant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Jutsu": {
+      "name": "Jutsu",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "extraBaseCost": {
+          "name": "extraBaseCost",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "enum('SELF','OTHER_USER','OPPONENT','ALLY','CHARACTER','GROUND','EMPTY_GROUND')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "range": {
+          "name": "range",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cooldown": {
+          "name": "cooldown",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bloodlineId": {
+          "name": "bloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredLevel": {
+          "name": "requiredLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "requiredRank": {
+          "name": "requiredRank",
+          "type": "enum('STUDENT','GENIN','CHUNIN','JONIN','ELITE JONIN','ELDER','NONE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jutsuType": {
+          "name": "jutsuType",
+          "type": "enum('NORMAL','SPECIAL','BLOODLINE','FORBIDDEN','LOYALTY','CLAN','EVENT','AI')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jutsuWeapon": {
+          "name": "jutsuWeapon",
+          "type": "enum('STAFF','AXE','FIST_WEAPON','SHURIKEN','SICKLE','DAGGER','SWORD','POLEARM','FLAIL','CHAIN','FAN','BOW','HAMMER','NONE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "statClassification": {
+          "name": "statClassification",
+          "type": "enum('Highest','Ninjutsu','Genjutsu','Taijutsu','Bukijutsu')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "battleDescription": {
+          "name": "battleDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jutsuRank": {
+          "name": "jutsuRank",
+          "type": "enum('D','C','B','A','S','H')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'D'"
+        },
+        "actionCostPerc": {
+          "name": "actionCostPerc",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 80
+        },
+        "staminaCost": {
+          "name": "staminaCost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.05
+        },
+        "chakraCost": {
+          "name": "chakraCost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.05
+        },
+        "staminaCostReducePerLvl": {
+          "name": "staminaCostReducePerLvl",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "chakraCostReducePerLvl": {
+          "name": "chakraCostReducePerLvl",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "healthCostReducePerLvl": {
+          "name": "healthCostReducePerLvl",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "healthCost": {
+          "name": "healthCost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "enum('SINGLE','ALL','AOE_CIRCLE_SPAWN','AOE_LINE_SHOOT','AOE_WALL_SHOOT','AOE_LARGE_WALL_SHOOT','AOE_CIRCLE_SHOOT','AOE_SPIRAL_SHOOT')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'SINGLE'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "injectableInBattle": {
+          "name": "injectableInBattle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "battleUsageType": {
+          "name": "battleUsageType",
+          "type": "enum('PVE','PVP','BOTH')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'BOTH'"
+        },
+        "parentJutsuId": {
+          "name": "parentJutsuId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredNinjutsuOffence": {
+          "name": "requiredNinjutsuOffence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredNinjutsuDefence": {
+          "name": "requiredNinjutsuDefence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredGenjutsuOffence": {
+          "name": "requiredGenjutsuOffence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredGenjutsuDefence": {
+          "name": "requiredGenjutsuDefence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredTaijutsuOffence": {
+          "name": "requiredTaijutsuOffence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredTaijutsuDefence": {
+          "name": "requiredTaijutsuDefence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredBukijutsuOffence": {
+          "name": "requiredBukijutsuOffence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredBukijutsuDefence": {
+          "name": "requiredBukijutsuDefence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredStrength": {
+          "name": "requiredStrength",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredSpeed": {
+          "name": "requiredSpeed",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredIntelligence": {
+          "name": "requiredIntelligence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredWillpower": {
+          "name": "requiredWillpower",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredBloodlineItemId": {
+          "name": "requiredBloodlineItemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Jutsu_name_key": {
+          "name": "Jutsu_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "Jutsu_image_key": {
+          "name": "Jutsu_image_key",
+          "columns": [
+            "image"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_bloodlineId_idx": {
+          "name": "Jutsu_bloodlineId_idx",
+          "columns": [
+            "bloodlineId"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_villageId_idx": {
+          "name": "Jutsu_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_injectable_idx": {
+          "name": "Jutsu_injectable_idx",
+          "columns": [
+            "injectableInBattle"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_parentJutsuId_idx": {
+          "name": "Jutsu_parentJutsuId_idx",
+          "columns": [
+            "parentJutsuId"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_parentJutsuId_hidden_idx": {
+          "name": "Jutsu_parentJutsuId_hidden_idx",
+          "columns": [
+            "parentJutsuId",
+            "hidden"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_requiredBloodlineItemId_idx": {
+          "name": "Jutsu_requiredBloodlineItemId_idx",
+          "columns": [
+            "requiredBloodlineItemId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Jutsu_id": {
+          "name": "Jutsu_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "JutsuLoadout": {
+      "name": "JutsuLoadout",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "JutsuLoadout_userId_idx": {
+          "name": "JutsuLoadout_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "JutsuLoadout_id": {
+          "name": "JutsuLoadout_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "JutsuReskin": {
+      "name": "JutsuReskin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jutsuId": {
+          "name": "jutsuId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleDescription": {
+          "name": "battleDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "JutsuReskin_userId_idx": {
+          "name": "JutsuReskin_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "JutsuReskin_jutsuId_idx": {
+          "name": "JutsuReskin_jutsuId_idx",
+          "columns": [
+            "jutsuId"
+          ],
+          "isUnique": false
+        },
+        "JutsuReskin_userId_jutsuId_key": {
+          "name": "JutsuReskin_userId_jutsuId_key",
+          "columns": [
+            "userId",
+            "jutsuId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "JutsuReskin_id": {
+          "name": "JutsuReskin_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "KageDefendedChallenges": {
+      "name": "KageDefendedChallenges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kageId": {
+          "name": "kageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "didWin": {
+          "name": "didWin",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "rounds": {
+          "name": "rounds",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "VillageKageChallenges_villageId_idx": {
+          "name": "VillageKageChallenges_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        },
+        "VillageKageChallenges_userId_idx": {
+          "name": "VillageKageChallenges_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "VillageKageChallenges_kageID_idx": {
+          "name": "VillageKageChallenges_kageID_idx",
+          "columns": [
+            "kageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "KageDefendedChallenges_id": {
+          "name": "KageDefendedChallenges_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "LinkPromotion": {
+      "name": "LinkPromotion",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "points": {
+          "name": "points",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "reviewedBy": {
+          "name": "reviewedBy",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewedAt": {
+          "name": "reviewedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "LinkPromotion_userId_idx": {
+          "name": "LinkPromotion_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "LinkPromotion_reviewedBy_idx": {
+          "name": "LinkPromotion_reviewedBy_idx",
+          "columns": [
+            "reviewedBy"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LinkPromotion_id": {
+          "name": "LinkPromotion_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "LogTimeDurations": {
+      "name": "LogTimeDurations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "battleType": {
+          "name": "battleType",
+          "type": "enum('ARENA','COMBAT','SPARRING','KAGE_AI','KAGE_PVP','CLAN_CHALLENGE','CLAN_BATTLE','SHRINE_WAR','TOURNAMENT','QUEST','RANDOM_ENCOUNTER','VILLAGE_PROTECTOR','TRAINING','RANKED_PVP','RANKED_SPARRING','RAID')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "winnerLevel": {
+          "name": "winnerLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "loserLevel": {
+          "name": "loserLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rounds": {
+          "name": "rounds",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "LogBattleLengths_battleType_idx": {
+          "name": "LogBattleLengths_battleType_idx",
+          "columns": [
+            "battleType"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LogTimeDurations_id": {
+          "name": "LogTimeDurations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "uniqueEntry": {
+          "name": "uniqueEntry",
+          "columns": [
+            "battleType",
+            "winnerLevel",
+            "loserLevel",
+            "rounds"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "LogQueueLengths": {
+      "name": "LogQueueLengths",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "rankedRank": {
+          "name": "rankedRank",
+          "type": "enum('Unranked','Wood','Adept','Master','Legend','Sannin')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ceiledMinutes": {
+          "name": "ceiledMinutes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LogQueueLengths_id": {
+          "name": "LogQueueLengths_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "uniqueEntry": {
+          "name": "uniqueEntry",
+          "columns": [
+            "rankedRank",
+            "ceiledMinutes"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "LogRankedPicks": {
+      "name": "LogRankedPicks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('jutsu','item','consumable')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contentId": {
+          "name": "contentId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleType": {
+          "name": "battleType",
+          "type": "enum('ARENA','COMBAT','SPARRING','KAGE_AI','KAGE_PVP','CLAN_CHALLENGE','CLAN_BATTLE','SHRINE_WAR','TOURNAMENT','QUEST','RANDOM_ENCOUNTER','VILLAGE_PROTECTOR','TRAINING','RANKED_PVP','RANKED_SPARRING','RAID')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LogRankedPicks_id": {
+          "name": "LogRankedPicks_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "uniqueContentId": {
+          "name": "uniqueContentId",
+          "columns": [
+            "type",
+            "contentId",
+            "battleType"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "MapAsset": {
+      "name": "MapAsset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "windAffected": {
+          "name": "windAffected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "small": {
+          "name": "small",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "randomRotation": {
+          "name": "randomRotation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "renderScale": {
+          "name": "renderScale",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "licenseDetails": {
+          "name": "licenseDetails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('TNR')"
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "MapAsset_key_key": {
+          "name": "MapAsset_key_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "MapAsset_category_idx": {
+          "name": "MapAsset_category_idx",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "MapAsset_id": {
+          "name": "MapAsset_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "MapTerrain": {
+      "name": "MapTerrain",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "colors": {
+          "name": "colors",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "textureUrl": {
+          "name": "textureUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "swatchColor": {
+          "name": "swatchColor",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleBiome": {
+          "name": "battleBiome",
+          "type": "enum('ocean','ground','dessert','ice','snow','arena','default')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ground'"
+        },
+        "isWater": {
+          "name": "isWater",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "depression": {
+          "name": "depression",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "defaultWalkCost": {
+          "name": "defaultWalkCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "protected": {
+          "name": "protected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "licenseDetails": {
+          "name": "licenseDetails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('TNR')"
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "MapTerrain_key_key": {
+          "name": "MapTerrain_key_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "MapTerrain_id": {
+          "name": "MapTerrain_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "MpvpBattleQueue": {
+      "name": "MpvpBattleQueue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "winnerId": {
+          "name": "winnerId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "battleId": {
+          "name": "battleId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "battleType": {
+          "name": "battleType",
+          "type": "enum('CLAN_BATTLE','SHRINE_BATTLE','RAID_BATTLE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CLAN_BATTLE'"
+        },
+        "attackerEntityId": {
+          "name": "attackerEntityId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "defenderEntityId": {
+          "name": "defenderEntityId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "MpvpBattleQueue_battleId_idx": {
+          "name": "MpvpBattleQueue_battleId_idx",
+          "columns": [
+            "battleId"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleQueue_winnerId_idx": {
+          "name": "MpvpBattleQueue_winnerId_idx",
+          "columns": [
+            "winnerId"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleQueue_battleType_idx": {
+          "name": "MpvpBattleQueue_battleType_idx",
+          "columns": [
+            "battleType"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleQueue_sector_idx": {
+          "name": "MpvpBattleQueue_sector_idx",
+          "columns": [
+            "sector"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleQueue_attackerEntityId_idx": {
+          "name": "MpvpBattleQueue_attackerEntityId_idx",
+          "columns": [
+            "attackerEntityId"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleQueue_defenderEntityId_idx": {
+          "name": "MpvpBattleQueue_defenderEntityId_idx",
+          "columns": [
+            "defenderEntityId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "MpvpBattleQueue_id": {
+          "name": "MpvpBattleQueue_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "MpvpBattleUser": {
+      "name": "MpvpBattleUser",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clanBattleId": {
+          "name": "clanBattleId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "side": {
+          "name": "side",
+          "type": "enum('ATTACKER','DEFENDER')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot": {
+          "name": "slot",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "MpvpBattleUser_clanBattleId_idx": {
+          "name": "MpvpBattleUser_clanBattleId_idx",
+          "columns": [
+            "clanBattleId"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleUser_userId_idx": {
+          "name": "MpvpBattleUser_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleUser_side_idx": {
+          "name": "MpvpBattleUser_side_idx",
+          "columns": [
+            "side"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleUser_clanBattleId_side_slot_key": {
+          "name": "MpvpBattleUser_clanBattleId_side_slot_key",
+          "columns": [
+            "clanBattleId",
+            "side",
+            "slot"
+          ],
+          "isUnique": true
+        },
+        "MpvpBattleUser_userId_key": {
+          "name": "MpvpBattleUser_userId_key",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "MpvpBattleUser_id": {
+          "name": "MpvpBattleUser_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Notification": {
+      "name": "Notification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Notification_createdAt_idx": {
+          "name": "Notification_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Notification_id": {
+          "name": "Notification_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "PaypalSubscription": {
+      "name": "PaypalSubscription",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "affectedUserId": {
+          "name": "affectedUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "federalStatus": {
+          "name": "federalStatus",
+          "type": "enum('NONE','NORMAL','SILVER','GOLD')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "PaypalSubscription_subscriptionId_key": {
+          "name": "PaypalSubscription_subscriptionId_key",
+          "columns": [
+            "subscriptionId"
+          ],
+          "isUnique": true
+        },
+        "PaypalSubscription_orderId_key": {
+          "name": "PaypalSubscription_orderId_key",
+          "columns": [
+            "orderId"
+          ],
+          "isUnique": true
+        },
+        "PaypalSubscription_createdById_idx": {
+          "name": "PaypalSubscription_createdById_idx",
+          "columns": [
+            "createdById"
+          ],
+          "isUnique": false
+        },
+        "PaypalSubscription_affectedUserId_idx": {
+          "name": "PaypalSubscription_affectedUserId_idx",
+          "columns": [
+            "affectedUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "PaypalSubscription_id": {
+          "name": "PaypalSubscription_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "PaypalTransaction": {
+      "name": "PaypalTransaction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "affectedUserId": {
+          "name": "affectedUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transactionId": {
+          "name": "transactionId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transactionUpdatedDate": {
+          "name": "transactionUpdatedDate",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invoiceId": {
+          "name": "invoiceId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('REP_PURCHASE','REFERRAL')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'REP_PURCHASE'"
+        },
+        "reputationPoints": {
+          "name": "reputationPoints",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rawData": {
+          "name": "rawData",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "PaypalTransaction_orderId_key": {
+          "name": "PaypalTransaction_orderId_key",
+          "columns": [
+            "orderId"
+          ],
+          "isUnique": true
+        },
+        "PaypalTransaction_createdById_idx": {
+          "name": "PaypalTransaction_createdById_idx",
+          "columns": [
+            "createdById"
+          ],
+          "isUnique": false
+        },
+        "PaypalTransaction_transactionId_idx": {
+          "name": "PaypalTransaction_transactionId_idx",
+          "columns": [
+            "transactionId"
+          ],
+          "isUnique": false
+        },
+        "PaypalTransaction_invoiceId_idx": {
+          "name": "PaypalTransaction_invoiceId_idx",
+          "columns": [
+            "invoiceId"
+          ],
+          "isUnique": false
+        },
+        "PaypalTransaction_affectedUserId_idx": {
+          "name": "PaypalTransaction_affectedUserId_idx",
+          "columns": [
+            "affectedUserId"
+          ],
+          "isUnique": false
+        },
+        "PaypalTransaction_reputationPoints_idx": {
+          "name": "PaypalTransaction_reputationPoints_idx",
+          "columns": [
+            "reputationPoints"
+          ],
+          "isUnique": false
+        },
+        "PaypalTransaction_type_idx": {
+          "name": "PaypalTransaction_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "PaypalTransaction_amount_idx": {
+          "name": "PaypalTransaction_amount_idx",
+          "columns": [
+            "amount"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "PaypalTransaction_id": {
+          "name": "PaypalTransaction_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "PaypalWebhookMessage": {
+      "name": "PaypalWebhookMessage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rawData": {
+          "name": "rawData",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "handled": {
+          "name": "handled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "PaypalWebhookMessage_id": {
+          "name": "PaypalWebhookMessage_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Poll": {
+      "name": "Poll",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allowCustomOptions": {
+          "name": "allowCustomOptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "Poll_createdByUserId_idx": {
+          "name": "Poll_createdByUserId_idx",
+          "columns": [
+            "createdByUserId"
+          ],
+          "isUnique": false
+        },
+        "Poll_isActive_idx": {
+          "name": "Poll_isActive_idx",
+          "columns": [
+            "isActive"
+          ],
+          "isUnique": false
+        },
+        "Poll_endDate_idx": {
+          "name": "Poll_endDate_idx",
+          "columns": [
+            "endDate"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Poll_id": {
+          "name": "Poll_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "PollOption": {
+      "name": "PollOption",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollId": {
+          "name": "pollId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "optionType": {
+          "name": "optionType",
+          "type": "enum('text','user')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isCustomOption": {
+          "name": "isCustomOption",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "PollOption_pollId_idx": {
+          "name": "PollOption_pollId_idx",
+          "columns": [
+            "pollId"
+          ],
+          "isUnique": false
+        },
+        "PollOption_createdByUserId_idx": {
+          "name": "PollOption_createdByUserId_idx",
+          "columns": [
+            "createdByUserId"
+          ],
+          "isUnique": false
+        },
+        "PollOption_targetUserId_idx": {
+          "name": "PollOption_targetUserId_idx",
+          "columns": [
+            "targetUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "PollOption_id": {
+          "name": "PollOption_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Quest": {
+      "name": "Quest",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(5000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "successDescription": {
+          "name": "successDescription",
+          "type": "varchar(5000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "questRank": {
+          "name": "questRank",
+          "type": "enum('D','C','B','A','S','H')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'D'"
+        },
+        "medicalRank": {
+          "name": "medicalRank",
+          "type": "enum('NONE','NOVICE','APPRENTICE','MASTER','LEGENDARY')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "huntingRank": {
+          "name": "huntingRank",
+          "type": "enum('NONE','D RANK','C RANK','B RANK','A RANK','S RANK')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "gatheringRank": {
+          "name": "gatheringRank",
+          "type": "enum('NONE','D RANK','C RANK','B RANK','A RANK','S RANK')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "requiredLevel": {
+          "name": "requiredLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "prerequisiteQuestId": {
+          "name": "prerequisiteQuestId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tierLevel": {
+          "name": "tierLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "questType": {
+          "name": "questType",
+          "type": "enum('starter','tier','daily','mission','errand','crime','exam','event','story','anbu','medical','hunting','gathering','battlepyramid','pvp','achievement','war','raid')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "consecutiveObjectives": {
+          "name": "consecutiveObjectives",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "requiredVillage": {
+          "name": "requiredVillage",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredBloodlineId": {
+          "name": "requiredBloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "maxLevel": {
+          "name": "maxLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "maxAttempts": {
+          "name": "maxAttempts",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "maxCompletes": {
+          "name": "maxCompletes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "retryDelay": {
+          "name": "retryDelay",
+          "type": "enum('daily','weekly','monthly','none')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "endsAt": {
+          "name": "endsAt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startsAt": {
+          "name": "startsAt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raidBossMaxHealth": {
+          "name": "raidBossMaxHealth",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raidBossCurrentHealth": {
+          "name": "raidBossCurrentHealth",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raidEndsAt": {
+          "name": "raidEndsAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raidCaptureDeadline": {
+          "name": "raidCaptureDeadline",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raidGracePeriodEnd": {
+          "name": "raidGracePeriodEnd",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Quest_questType_idx": {
+          "name": "Quest_questType_idx",
+          "columns": [
+            "questType"
+          ],
+          "isUnique": false
+        },
+        "Quest_questRank_idx": {
+          "name": "Quest_questRank_idx",
+          "columns": [
+            "questRank"
+          ],
+          "isUnique": false
+        },
+        "Quest_requiredLevel_idx": {
+          "name": "Quest_requiredLevel_idx",
+          "columns": [
+            "requiredLevel"
+          ],
+          "isUnique": false
+        },
+        "Quest_maxLevel_idx": {
+          "name": "Quest_maxLevel_idx",
+          "columns": [
+            "maxLevel"
+          ],
+          "isUnique": false
+        },
+        "Quest_requiredVillage_idx": {
+          "name": "Quest_requiredVillage_idx",
+          "columns": [
+            "requiredVillage"
+          ],
+          "isUnique": false
+        },
+        "Quest_requiredBloodline_idx": {
+          "name": "Quest_requiredBloodline_idx",
+          "columns": [
+            "requiredBloodlineId"
+          ],
+          "isUnique": false
+        },
+        "Quest_endsAt_idx": {
+          "name": "Quest_endsAt_idx",
+          "columns": [
+            "endsAt"
+          ],
+          "isUnique": false
+        },
+        "Quest_startsAt_idx": {
+          "name": "Quest_startsAt_idx",
+          "columns": [
+            "startsAt"
+          ],
+          "isUnique": false
+        },
+        "Quest_prerequisiteQuestId_idx": {
+          "name": "Quest_prerequisiteQuestId_idx",
+          "columns": [
+            "prerequisiteQuestId"
+          ],
+          "isUnique": false
+        },
+        "Quest_questType_questRank_requiredLevel_idx": {
+          "name": "Quest_questType_questRank_requiredLevel_idx",
+          "columns": [
+            "questType",
+            "questRank",
+            "requiredLevel"
+          ],
+          "isUnique": false
+        },
+        "Quest_raidEndsAt_idx": {
+          "name": "Quest_raidEndsAt_idx",
+          "columns": [
+            "raidEndsAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Quest_id": {
+          "name": "Quest_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "tierLevel": {
+          "name": "tierLevel",
+          "columns": [
+            "tierLevel"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "QuestHistory": {
+      "name": "QuestHistory",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questId": {
+          "name": "questId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questType": {
+          "name": "questType",
+          "type": "enum('starter','tier','daily','mission','errand','crime','exam','event','story','anbu','medical','hunting','gathering','battlepyramid','pvp','achievement','war','raid')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "previousCompletes": {
+          "name": "previousCompletes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "previousAttempts": {
+          "name": "previousAttempts",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "QuestHistory_userId_idx": {
+          "name": "QuestHistory_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_questType_idx": {
+          "name": "QuestHistory_questType_idx",
+          "columns": [
+            "questType"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_endedAt_idx": {
+          "name": "QuestHistory_endedAt_idx",
+          "columns": [
+            "endedAt"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_questId_idx": {
+          "name": "QuestHistory_questId_idx",
+          "columns": [
+            "questId"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_completed_idx": {
+          "name": "QuestHistory_completed_idx",
+          "columns": [
+            "completed"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_userId_completed_idx": {
+          "name": "QuestHistory_userId_completed_idx",
+          "columns": [
+            "userId",
+            "completed"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_userId_questType_idx": {
+          "name": "QuestHistory_userId_questType_idx",
+          "columns": [
+            "userId",
+            "questType"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_questId_userId_completed_idx": {
+          "name": "QuestHistory_questId_userId_completed_idx",
+          "columns": [
+            "questId",
+            "userId",
+            "completed"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "QuestHistory_id": {
+          "name": "QuestHistory_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "uniqueUserIdQuestId": {
+          "name": "uniqueUserIdQuestId",
+          "columns": [
+            "userId",
+            "questId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "RaidDamageThreshold": {
+      "name": "RaidDamageThreshold",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questId": {
+          "name": "questId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "damageRequired": {
+          "name": "damageRequired",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rewards": {
+          "name": "rewards",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "effectDurationMinutes": {
+          "name": "effectDurationMinutes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "RaidDamageThreshold_questId_idx": {
+          "name": "RaidDamageThreshold_questId_idx",
+          "columns": [
+            "questId"
+          ],
+          "isUnique": false
+        },
+        "RaidDamageThreshold_sortOrder_idx": {
+          "name": "RaidDamageThreshold_sortOrder_idx",
+          "columns": [
+            "sortOrder"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RaidDamageThreshold_id": {
+          "name": "RaidDamageThreshold_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "RaidParticipation": {
+      "name": "RaidParticipation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questId": {
+          "name": "questId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "damageDealt": {
+          "name": "damageDealt",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "battleCount": {
+          "name": "battleCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rewardsClaimed": {
+          "name": "rewardsClaimed",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "RaidParticipation_questId_idx": {
+          "name": "RaidParticipation_questId_idx",
+          "columns": [
+            "questId"
+          ],
+          "isUnique": false
+        },
+        "RaidParticipation_userId_idx": {
+          "name": "RaidParticipation_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "RaidParticipation_damageDealt_idx": {
+          "name": "RaidParticipation_damageDealt_idx",
+          "columns": [
+            "damageDealt"
+          ],
+          "isUnique": false
+        },
+        "RaidParticipation_questId_damageDealt_idx": {
+          "name": "RaidParticipation_questId_damageDealt_idx",
+          "columns": [
+            "questId",
+            "damageDealt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RaidParticipation_id": {
+          "name": "RaidParticipation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "RaidParticipation_questId_userId": {
+          "name": "RaidParticipation_questId_userId",
+          "columns": [
+            "questId",
+            "userId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "RankedLoadout": {
+      "name": "RankedLoadout",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "loadout": {
+          "name": "loadout",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RankedLoadout_id": {
+          "name": "RankedLoadout_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "RankedPvpQueue": {
+      "name": "RankedPvpQueue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rankedLp": {
+          "name": "rankedLp",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "queueStartTime": {
+          "name": "queueStartTime",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "RankedPvpQueue_userId_idx": {
+          "name": "RankedPvpQueue_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "RankedPvpQueue_rankedLp_idx": {
+          "name": "RankedPvpQueue_rankedLp_idx",
+          "columns": [
+            "rankedLp"
+          ],
+          "isUnique": false
+        },
+        "RankedPvpQueue_createdAt_idx": {
+          "name": "RankedPvpQueue_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RankedPvpQueue_id": {
+          "name": "RankedPvpQueue_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "RankedSeason": {
+      "name": "RankedSeason",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewards": {
+          "name": "rewards",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RankedSeason_id": {
+          "name": "RankedSeason_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "RankedUserRewards": {
+      "name": "RankedUserRewards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seasonId": {
+          "name": "seasonId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "enum('Unranked','Wood','Adept','Master','Legend','Sannin')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed": {
+          "name": "claimed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "claimedAt": {
+          "name": "claimedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RankedUserRewards_id": {
+          "name": "RankedUserRewards_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "RecruitmentRewards": {
+      "name": "RecruitmentRewards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('MONEY','REPUTATION','PRESTIGE','CLAN_POINTS')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recruitedUserId": {
+          "name": "recruitedUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "RecruitmentRewards_userId_idx": {
+          "name": "RecruitmentRewards_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "RecruitmentRewards_recruitedUserId_idx": {
+          "name": "RecruitmentRewards_recruitedUserId_idx",
+          "columns": [
+            "recruitedUserId"
+          ],
+          "isUnique": false
+        },
+        "RecruitmentRewards_type_idx": {
+          "name": "RecruitmentRewards_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RecruitmentRewards_id": {
+          "name": "RecruitmentRewards_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ReferralSource": {
+      "name": "ReferralSource",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ReferralSource_userId_idx": {
+          "name": "ReferralSource_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "ReferralSource_source_idx": {
+          "name": "ReferralSource_source_idx",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ReferralSource_id": {
+          "name": "ReferralSource_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ReportLog": {
+      "name": "ReportLog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staffUserId": {
+          "name": "staffUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ReportLog_targetUserId_idx": {
+          "name": "ReportLog_targetUserId_idx",
+          "columns": [
+            "targetUserId"
+          ],
+          "isUnique": false
+        },
+        "ReportLog_staffUserId_idx": {
+          "name": "ReportLog_staffUserId_idx",
+          "columns": [
+            "staffUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ReportLog_id": {
+          "name": "ReportLog_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "RyoTrade": {
+      "name": "RyoTrade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creatorUserId": {
+          "name": "creatorUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repsForSale": {
+          "name": "repsForSale",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requestedRyo": {
+          "name": "requestedRyo",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ryoPerRep": {
+          "name": "ryoPerRep",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purchaserUserId": {
+          "name": "purchaserUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowedPurchaserId": {
+          "name": "allowedPurchaserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "RyoTrade_creatorUserId_idx": {
+          "name": "RyoTrade_creatorUserId_idx",
+          "columns": [
+            "creatorUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RyoTrade_id": {
+          "name": "RyoTrade_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Sector": {
+      "name": "Sector",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "sector": {
+          "name": "sector",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "shrineLevel": {
+          "name": "shrineLevel",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "capturedAt": {
+          "name": "capturedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nextMaintainanceDueDate": {
+          "name": "nextMaintainanceDueDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Sector_sector_key": {
+          "name": "Sector_sector_key",
+          "columns": [
+            "sector"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Sector_id": {
+          "name": "Sector_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SectorMap": {
+      "name": "SectorMap",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('DRAFT','PUBLISHED','ARCHIVED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sourceHash": {
+          "name": "sourceHash",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rawTiledJson": {
+          "name": "rawTiledJson",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "normalizedJson": {
+          "name": "normalizedJson",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publishedByUserId": {
+          "name": "publishedByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "SectorMap_sector_version_key": {
+          "name": "SectorMap_sector_version_key",
+          "columns": [
+            "sector",
+            "version"
+          ],
+          "isUnique": true
+        },
+        "SectorMap_sector_status_idx": {
+          "name": "SectorMap_sector_status_idx",
+          "columns": [
+            "sector",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SectorMap_id": {
+          "name": "SectorMap_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SkillTree": {
+      "name": "SkillTree",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "enum('SELF','ENEMIES','ALLIES')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'SELF'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "requiredSkillIds": {
+          "name": "requiredSkillIds",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "costSkillPoints": {
+          "name": "costSkillPoints",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "skillType": {
+          "name": "skillType",
+          "type": "enum('DEFAULT','SPECIAL')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'DEFAULT'"
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "SkillTree_name_key": {
+          "name": "SkillTree_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "SkillTree_tier_idx": {
+          "name": "SkillTree_tier_idx",
+          "columns": [
+            "tier"
+          ],
+          "isUnique": false
+        },
+        "SkillTree_hidden_idx": {
+          "name": "SkillTree_hidden_idx",
+          "columns": [
+            "hidden"
+          ],
+          "isUnique": false
+        },
+        "SkillTree_skillType_idx": {
+          "name": "SkillTree_skillType_idx",
+          "columns": [
+            "skillType"
+          ],
+          "isUnique": false
+        },
+        "SkillTree_folderId_idx": {
+          "name": "SkillTree_folderId_idx",
+          "columns": [
+            "folderId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SkillTree_id": {
+          "name": "SkillTree_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SkillTreeFolder": {
+      "name": "SkillTreeFolder",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "SkillTreeFolder_name_idx": {
+          "name": "SkillTreeFolder_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "SkillTreeFolder_order_idx": {
+          "name": "SkillTreeFolder_order_idx",
+          "columns": [
+            "order"
+          ],
+          "isUnique": false
+        },
+        "SkillTreeFolder_hidden_idx": {
+          "name": "SkillTreeFolder_hidden_idx",
+          "columns": [
+            "hidden"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SkillTreeFolder_id": {
+          "name": "SkillTreeFolder_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "StaffApplication": {
+      "name": "StaffApplication",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applicantUserId": {
+          "name": "applicantUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetRole": {
+          "name": "targetRole",
+          "type": "enum('USER','OWNER','CODING-ADMIN','CONTENT-ADMIN','EVENT-ADMIN','MODERATOR-ADMIN','HEAD_MODERATOR','MODERATOR','JR_MODERATOR','HEAD_CONTENT','HEAD_BALANCE','CONTENT','BALANCE','HEAD_EVENT','EVENT','CODER')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum('PENDING','APPROVED','REJECTED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING'"
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "StaffApplication_applicantUserId_idx": {
+          "name": "StaffApplication_applicantUserId_idx",
+          "columns": [
+            "applicantUserId"
+          ],
+          "isUnique": false
+        },
+        "StaffApplication_targetRole_idx": {
+          "name": "StaffApplication_targetRole_idx",
+          "columns": [
+            "targetRole"
+          ],
+          "isUnique": false
+        },
+        "StaffApplication_state_idx": {
+          "name": "StaffApplication_state_idx",
+          "columns": [
+            "state"
+          ],
+          "isUnique": false
+        },
+        "StaffApplication_createdAt_idx": {
+          "name": "StaffApplication_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "StaffApplication_id": {
+          "name": "StaffApplication_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "StaffApplicationApproval": {
+      "name": "StaffApplicationApproval",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applicationId": {
+          "name": "applicationId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approverUserId": {
+          "name": "approverUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "enum('EVENT-ADMIN','CODING-ADMIN','MODERATOR-ADMIN','CONTENT-ADMIN')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum('APPROVED','REJECTED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'APPROVED'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "StaffApplicationApproval_applicationId_idx": {
+          "name": "StaffApplicationApproval_applicationId_idx",
+          "columns": [
+            "applicationId"
+          ],
+          "isUnique": false
+        },
+        "StaffApplicationApproval_approverUserId_idx": {
+          "name": "StaffApplicationApproval_approverUserId_idx",
+          "columns": [
+            "approverUserId"
+          ],
+          "isUnique": false
+        },
+        "StaffApplicationApproval_applicationId_group_key": {
+          "name": "StaffApplicationApproval_applicationId_group_key",
+          "columns": [
+            "applicationId",
+            "group"
+          ],
+          "isUnique": true
+        },
+        "StaffApplicationApproval_applicationId_approverUserId_key": {
+          "name": "StaffApplicationApproval_applicationId_approverUserId_key",
+          "columns": [
+            "applicationId",
+            "approverUserId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "StaffApplicationApproval_id": {
+          "name": "StaffApplicationApproval_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SupportReview": {
+      "name": "SupportReview",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "apiRoute": {
+          "name": "apiRoute",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chatHistory": {
+          "name": "chatHistory",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "enum('POSITIVE','NEGATIVE','NEUTRAL')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SupportReview_id": {
+          "name": "SupportReview_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SupportTicket": {
+      "name": "SupportTicket",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "enum('BUG_REPORT','FEATURE_REQUEST','ACCOUNT_ISSUE','GAMEPLAY_QUESTION','PAYMENT_ISSUE','TECHNICAL_SUPPORT','MODERATION_SUPPORT','OTHER')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "enum('LOW','MEDIUM','HIGH','URGENT')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'MEDIUM'"
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('OPEN','IN_PROGRESS','WAITING_FOR_USER','WAITING_FOR_STAFF','RESOLVED','CLOSED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'OPEN'"
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assignedToUserId": {
+          "name": "assignedToUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "githubIssueUrl": {
+          "name": "githubIssueUrl",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "SupportTicket_createdByUserId_idx": {
+          "name": "SupportTicket_createdByUserId_idx",
+          "columns": [
+            "createdByUserId"
+          ],
+          "isUnique": false
+        },
+        "SupportTicket_assignedToUserId_idx": {
+          "name": "SupportTicket_assignedToUserId_idx",
+          "columns": [
+            "assignedToUserId"
+          ],
+          "isUnique": false
+        },
+        "SupportTicket_status_idx": {
+          "name": "SupportTicket_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "SupportTicket_category_idx": {
+          "name": "SupportTicket_category_idx",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        },
+        "SupportTicket_priority_idx": {
+          "name": "SupportTicket_priority_idx",
+          "columns": [
+            "priority"
+          ],
+          "isUnique": false
+        },
+        "SupportTicket_isPublic_idx": {
+          "name": "SupportTicket_isPublic_idx",
+          "columns": [
+            "isPublic"
+          ],
+          "isUnique": false
+        },
+        "SupportTicket_createdAt_idx": {
+          "name": "SupportTicket_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SupportTicket_id": {
+          "name": "SupportTicket_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SupportTicketActivity": {
+      "name": "SupportTicketActivity",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ticketId": {
+          "name": "ticketId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "enum('CREATED','UPDATED','ASSIGNED','UNASSIGNED','STATUS_CHANGED','PRIORITY_CHANGED','CATEGORY_CHANGED','TAGGED','UNTAGGED','MERGED','ESCALATED_TO_GITHUB','COMMENTED','CLOSED','REOPENED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oldValue": {
+          "name": "oldValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "newValue": {
+          "name": "newValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('{}')"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "SupportTicketActivity_ticketId_idx": {
+          "name": "SupportTicketActivity_ticketId_idx",
+          "columns": [
+            "ticketId"
+          ],
+          "isUnique": false
+        },
+        "SupportTicketActivity_authorId_idx": {
+          "name": "SupportTicketActivity_authorId_idx",
+          "columns": [
+            "authorId"
+          ],
+          "isUnique": false
+        },
+        "SupportTicketActivity_action_idx": {
+          "name": "SupportTicketActivity_action_idx",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        },
+        "SupportTicketActivity_createdAt_idx": {
+          "name": "SupportTicketActivity_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SupportTicketActivity_id": {
+          "name": "SupportTicketActivity_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Tournament": {
+      "name": "Tournament",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "round": {
+          "name": "round",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('CLAN')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewards": {
+          "name": "rewards",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3) + INTERVAL 1 DAY )"
+        },
+        "roundStartedAt": {
+          "name": "roundStartedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3) + INTERVAL 1 DAY )"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('OPEN','IN_PROGRESS','COMPLETED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'OPEN'"
+        }
+      },
+      "indexes": {
+        "Tournament_name_key": {
+          "name": "Tournament_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Tournament_id": {
+          "name": "Tournament_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "TournamentMatch": {
+      "name": "TournamentMatch",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tournamentId": {
+          "name": "tournamentId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "round": {
+          "name": "round",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match": {
+          "name": "match",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum('WAITING','PLAYED','NO_SHOW')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'WAITING'"
+        },
+        "winnerId": {
+          "name": "winnerId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "battleId": {
+          "name": "battleId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId1": {
+          "name": "userId1",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId2": {
+          "name": "userId2",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "TournamentMatch_tournamentId_idx": {
+          "name": "TournamentMatch_tournamentId_idx",
+          "columns": [
+            "tournamentId"
+          ],
+          "isUnique": false
+        },
+        "TournamentMatch_userId1_idx": {
+          "name": "TournamentMatch_userId1_idx",
+          "columns": [
+            "userId1"
+          ],
+          "isUnique": false
+        },
+        "TournamentMatch_userId2_idx": {
+          "name": "TournamentMatch_userId2_idx",
+          "columns": [
+            "userId2"
+          ],
+          "isUnique": false
+        },
+        "TournamentMatch_winnerId_idx": {
+          "name": "TournamentMatch_winnerId_idx",
+          "columns": [
+            "winnerId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TournamentMatch_id": {
+          "name": "TournamentMatch_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "TournamentRecord": {
+      "name": "TournamentRecord",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "round": {
+          "name": "round",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('CLAN')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewards": {
+          "name": "rewards",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3) + INTERVAL 1 DAY )"
+        },
+        "winnerId": {
+          "name": "winnerId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "HistoricalTournament_name_key": {
+          "name": "HistoricalTournament_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TournamentRecord_id": {
+          "name": "TournamentRecord_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "TowerDefenseCharacter": {
+      "name": "TowerDefenseCharacter",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isPlayer": {
+          "name": "isPlayer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "baseHealth": {
+          "name": "baseHealth",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "baseSpeed": {
+          "name": "baseSpeed",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.4
+        },
+        "baseDamage": {
+          "name": "baseDamage",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "attackCooldown": {
+          "name": "attackCooldown",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "healthScaling": {
+          "name": "healthScaling",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.15
+        },
+        "speedScaling": {
+          "name": "speedScaling",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.02
+        },
+        "damageScaling": {
+          "name": "damageScaling",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "firstAppearWave": {
+          "name": "firstAppearWave",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "baseCount": {
+          "name": "baseCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "countScaling": {
+          "name": "countScaling",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1.5
+        },
+        "scaleFactor": {
+          "name": "scaleFactor",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2.8
+        },
+        "assetConfig": {
+          "name": "assetConfig",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "('null')"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "TowerDefenseCharacter_name_idx": {
+          "name": "TowerDefenseCharacter_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseCharacter_firstAppearWave_idx": {
+          "name": "TowerDefenseCharacter_firstAppearWave_idx",
+          "columns": [
+            "firstAppearWave"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseCharacter_isPlayer_idx": {
+          "name": "TowerDefenseCharacter_isPlayer_idx",
+          "columns": [
+            "isPlayer"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TowerDefenseCharacter_id": {
+          "name": "TowerDefenseCharacter_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "TowerDefenseRun": {
+      "name": "TowerDefenseRun",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wave": {
+          "name": "wave",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gridSize": {
+          "name": "gridSize",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('ACTIVE','COMPLETED','ABANDONED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "state": {
+          "name": "state",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "TowerDefenseRun_userId_idx": {
+          "name": "TowerDefenseRun_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseRun_status_idx": {
+          "name": "TowerDefenseRun_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseRun_userId_status_idx": {
+          "name": "TowerDefenseRun_userId_status_idx",
+          "columns": [
+            "userId",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseRun_score_idx": {
+          "name": "TowerDefenseRun_score_idx",
+          "columns": [
+            "score"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseRun_startedAt_idx": {
+          "name": "TowerDefenseRun_startedAt_idx",
+          "columns": [
+            "startedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TowerDefenseRun_id": {
+          "name": "TowerDefenseRun_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "TowerDefenseUpgrade": {
+      "name": "TowerDefenseUpgrade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "maxLevel": {
+          "name": "maxLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "baseCost": {
+          "name": "baseCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "costMultiplier": {
+          "name": "costMultiplier",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1.5
+        },
+        "upgradeType": {
+          "name": "upgradeType",
+          "type": "enum('DAMAGE','ATTACK_SPEED','RANGE','CRIT_CHANCE','DAMAGE_PER_TILE','HEALTH','HEALTH_REGEN','DEFENSE_PERCENT','DEFENSE_FLAT','LIFESTEAL','KNOCKBACK_CHANCE','KNOCKBACK_FORCE','TOKENS_PER_WAVE','TOKENS_PER_KILL','INTEREST_PER_WAVE','SKIP_ENEMY_CHANCE','ABILITY_UNLOCK')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effectValue": {
+          "name": "effectValue",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "TowerDefenseUpgrade_name_idx": {
+          "name": "TowerDefenseUpgrade_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseUpgrade_upgradeType_idx": {
+          "name": "TowerDefenseUpgrade_upgradeType_idx",
+          "columns": [
+            "upgradeType"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TowerDefenseUpgrade_id": {
+          "name": "TowerDefenseUpgrade_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "TrainingLog": {
+      "name": "TrainingLog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stat": {
+          "name": "stat",
+          "type": "enum('ninjutsuOffence','taijutsuOffence','genjutsuOffence','bukijutsuOffence','ninjutsuDefence','taijutsuDefence','genjutsuDefence','bukijutsuDefence','intelligence','speed','willpower','strength')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "enum('15min','1hr','4hrs','8hrs','12hrs','24hrs')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trainingFinishedAt": {
+          "name": "trainingFinishedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "TrainingLog_userId_idx": {
+          "name": "TrainingLog_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "TrainingLog_speed_idx": {
+          "name": "TrainingLog_speed_idx",
+          "columns": [
+            "speed"
+          ],
+          "isUnique": false
+        },
+        "TrainingLog_stat_idx": {
+          "name": "TrainingLog_stat_idx",
+          "columns": [
+            "stat"
+          ],
+          "isUnique": false
+        },
+        "TrainingLog_trainingFinishedAt_idx": {
+          "name": "TrainingLog_trainingFinishedAt_idx",
+          "columns": [
+            "trainingFinishedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TrainingLog_id": {
+          "name": "TrainingLog_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UsersInConversation": {
+      "name": "UsersInConversation",
+      "columns": {
+        "conversationId": {
+          "name": "conversationId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assignedAt": {
+          "name": "assignedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "lastReadAt": {
+          "name": "lastReadAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "UsersInConversation_userId_idx": {
+          "name": "UsersInConversation_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UsersInConversation_conversationId_userId_pk": {
+          "name": "UsersInConversation_conversationId_userId_pk",
+          "columns": [
+            "conversationId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserActivityEvent": {
+      "name": "UserActivityEvent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "streak": {
+          "name": "streak",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserActivityEvent_createdAt_idx": {
+          "name": "UserActivityEvent_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserActivityEvent_id": {
+          "name": "UserActivityEvent_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserAssociation": {
+      "name": "UserAssociation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userOne": {
+          "name": "userOne",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userTwo": {
+          "name": "userTwo",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "associationType": {
+          "name": "associationType",
+          "type": "enum('MARRIAGE','DIVORCED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'MARRIAGE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserOne_UserTwo_UserAssociation_key": {
+          "name": "UserOne_UserTwo_UserAssociation_key",
+          "columns": [
+            "userOne",
+            "userTwo",
+            "associationType"
+          ],
+          "isUnique": true
+        },
+        "UserAttribute_userOne_idx": {
+          "name": "UserAttribute_userOne_idx",
+          "columns": [
+            "userOne"
+          ],
+          "isUnique": false
+        },
+        "UserAttribute_userTwo_idx": {
+          "name": "UserAttribute_userTwo_idx",
+          "columns": [
+            "userTwo"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserAssociation_id": {
+          "name": "UserAssociation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserAttribute": {
+      "name": "UserAttribute",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attribute": {
+          "name": "attribute",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "UserAttribute_attribute_userId_key": {
+          "name": "UserAttribute_attribute_userId_key",
+          "columns": [
+            "attribute",
+            "userId"
+          ],
+          "isUnique": true
+        },
+        "UserAttribute_userId_idx": {
+          "name": "UserAttribute_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserAttribute_id": {
+          "name": "UserAttribute_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserBadge": {
+      "name": "UserBadge",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "badgeId": {
+          "name": "badgeId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserBadge_userId_idx": {
+          "name": "UserBadge_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserBadge_badgeId_idx": {
+          "name": "UserBadge_badgeId_idx",
+          "columns": [
+            "badgeId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserBlackList": {
+      "name": "UserBlackList",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "creatorUserId": {
+          "name": "creatorUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "BlackList_creatorUserId_idx": {
+          "name": "BlackList_creatorUserId_idx",
+          "columns": [
+            "creatorUserId"
+          ],
+          "isUnique": false
+        },
+        "BlackList_targetUserId_idx": {
+          "name": "BlackList_targetUserId_idx",
+          "columns": [
+            "targetUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserBlackList_id": {
+          "name": "UserBlackList_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserData": {
+      "name": "UserData",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recruiterId": {
+          "name": "recruiterId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anbuId": {
+          "name": "anbuId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "clanId": {
+          "name": "clanId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "jutsuLoadout": {
+          "name": "jutsuLoadout",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "itemLoadout": {
+          "name": "itemLoadout",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rankedLoadout": {
+          "name": "rankedLoadout",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nRecruited": {
+          "name": "nRecruited",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastIp": {
+          "name": "lastIp",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "curHealth": {
+          "name": "curHealth",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "maxHealth": {
+          "name": "maxHealth",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "curChakra": {
+          "name": "curChakra",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "maxChakra": {
+          "name": "maxChakra",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "curStamina": {
+          "name": "curStamina",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "maxStamina": {
+          "name": "maxStamina",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "regeneration": {
+          "name": "regeneration",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "money": {
+          "name": "money",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "bank": {
+          "name": "bank",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "experience": {
+          "name": "experience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "earnedExperience": {
+          "name": "earnedExperience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "rank": {
+          "name": "rank",
+          "type": "enum('STUDENT','GENIN','CHUNIN','JONIN','ELITE JONIN','ELDER','NONE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'STUDENT'"
+        },
+        "isOutlaw": {
+          "name": "isOutlaw",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "level": {
+          "name": "level",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bloodlineId": {
+          "name": "bloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bloodlineReskinId": {
+          "name": "bloodlineReskinId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('AWAKE','HOSPITALIZED','TRAVEL','BATTLE','QUEUED','KAGE_QUEUED','ASLEEP')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'AWAKE'"
+        },
+        "strength": {
+          "name": "strength",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "intelligence": {
+          "name": "intelligence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "willpower": {
+          "name": "willpower",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "speed": {
+          "name": "speed",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "ninjutsuOffence": {
+          "name": "ninjutsuOffence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "ninjutsuDefence": {
+          "name": "ninjutsuDefence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "genjutsuOffence": {
+          "name": "genjutsuOffence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "genjutsuDefence": {
+          "name": "genjutsuDefence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "taijutsuOffence": {
+          "name": "taijutsuOffence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "taijutsuDefence": {
+          "name": "taijutsuDefence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "bukijutsuDefence": {
+          "name": "bukijutsuDefence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "bukijutsuOffence": {
+          "name": "bukijutsuOffence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "statsMultiplier": {
+          "name": "statsMultiplier",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "poolsMultiplier": {
+          "name": "poolsMultiplier",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "primaryElement": {
+          "name": "primaryElement",
+          "type": "enum('Fire','Water','Wind','Earth','Lightning','Ice','Crystal','Dust','Shadow','Wood','Scorch','Storm','Magnet','Yin-Yang','Lava','Explosion','Light','Boil','Metal','Sand','None')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "secondaryElement": {
+          "name": "secondaryElement",
+          "type": "enum('Fire','Water','Wind','Earth','Lightning','Ice','Crystal','Dust','Shadow','Wood','Scorch','Storm','Magnet','Yin-Yang','Lava','Explosion','Light','Boil','Metal','Sand','None')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reputationPoints": {
+          "name": "reputationPoints",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 11
+        },
+        "reputationPointsTotal": {
+          "name": "reputationPointsTotal",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 11
+        },
+        "seichiSilver": {
+          "name": "seichiSilver",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "villagePrestige": {
+          "name": "villagePrestige",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "federalStatus": {
+          "name": "federalStatus",
+          "type": "enum('NONE','NORMAL','SILVER','GOLD')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "approvedTos": {
+          "name": "approvedTos",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatarLight": {
+          "name": "avatarLight",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar3d": {
+          "name": "avatar3d",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 7
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "joinedVillageAt": {
+          "name": "joinedVillageAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3) - INTERVAL 7 DAY)"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "questFinishAt": {
+          "name": "questFinishAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "deletionAt": {
+          "name": "deletionAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "travelFinishAt": {
+          "name": "travelFinishAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isBanned": {
+          "name": "isBanned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isSilenced": {
+          "name": "isSilenced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isWarned": {
+          "name": "isWarned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isTradeBanned": {
+          "name": "isTradeBanned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('USER','OWNER','CODING-ADMIN','CONTENT-ADMIN','EVENT-ADMIN','MODERATOR-ADMIN','HEAD_MODERATOR','MODERATOR','JR_MODERATOR','HEAD_CONTENT','HEAD_BALANCE','CONTENT','BALANCE','HEAD_EVENT','EVENT','CODER')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USER'"
+        },
+        "battleId": {
+          "name": "battleId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isAi": {
+          "name": "isAi",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isSummon": {
+          "name": "isSummon",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isEvent": {
+          "name": "isEvent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "inShrines": {
+          "name": "inShrines",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "inArena": {
+          "name": "inArena",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "inboxNews": {
+          "name": "inboxNews",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "regenAt": {
+          "name": "regenAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "immunityUntil": {
+          "name": "immunityUntil",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "robImmunityUntil": {
+          "name": "robImmunityUntil",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "bracketImmunityLiftedUntil": {
+          "name": "bracketImmunityLiftedUntil",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "warParticipantUntil": {
+          "name": "warParticipantUntil",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "trainingStartedAt": {
+          "name": "trainingStartedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trainingSpeed": {
+          "name": "trainingSpeed",
+          "type": "enum('15min','1hr','4hrs','8hrs','12hrs','24hrs')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'15min'"
+        },
+        "currentlyTraining": {
+          "name": "currentlyTraining",
+          "type": "enum('ninjutsuOffence','taijutsuOffence','genjutsuOffence','bukijutsuOffence','ninjutsuDefence','taijutsuDefence','genjutsuDefence','bukijutsuDefence','intelligence','speed','willpower','strength')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unreadNotifications": {
+          "name": "unreadNotifications",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "unreadNews": {
+          "name": "unreadNews",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "questData": {
+          "name": "questData",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "senseiId": {
+          "name": "senseiId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "medicalExperience": {
+          "name": "medicalExperience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "craftingExperience": {
+          "name": "craftingExperience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "huntingExperience": {
+          "name": "huntingExperience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gatheringExperience": {
+          "name": "gatheringExperience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "preferredStat": {
+          "name": "preferredStat",
+          "type": "enum('Highest','Ninjutsu','Genjutsu','Taijutsu','Bukijutsu')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferredGeneral1": {
+          "name": "preferredGeneral1",
+          "type": "enum('Highest','Strength','Intelligence','Willpower','Speed')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferredGeneral2": {
+          "name": "preferredGeneral2",
+          "type": "enum('Highest','Strength','Intelligence','Willpower','Speed')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "showBattleDescription": {
+          "name": "showBattleDescription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pvpFights": {
+          "name": "pvpFights",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pveFights": {
+          "name": "pveFights",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pvpActivity": {
+          "name": "pvpActivity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pvpStreak": {
+          "name": "pvpStreak",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "errands": {
+          "name": "errands",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionsD": {
+          "name": "missionsD",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionsC": {
+          "name": "missionsC",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionsB": {
+          "name": "missionsB",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionsA": {
+          "name": "missionsA",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionsS": {
+          "name": "missionsS",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionsH": {
+          "name": "missionsH",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crimesD": {
+          "name": "crimesD",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crimesC": {
+          "name": "crimesC",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crimesB": {
+          "name": "crimesB",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crimesA": {
+          "name": "crimesA",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crimesS": {
+          "name": "crimesS",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crimesH": {
+          "name": "crimesH",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyArenaFights": {
+          "name": "dailyArenaFights",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyMissions": {
+          "name": "dailyMissions",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyErrands": {
+          "name": "dailyErrands",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyMedicalMissions": {
+          "name": "dailyMedicalMissions",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyPvpMissions": {
+          "name": "dailyPvpMissions",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyWarMissions": {
+          "name": "dailyWarMissions",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyTrainings": {
+          "name": "dailyTrainings",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "movedTooFastCount": {
+          "name": "movedTooFastCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "extraItemSlots": {
+          "name": "extraItemSlots",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "extraJutsuSlots": {
+          "name": "extraJutsuSlots",
+          "type": "tinyint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "extraReskinSlots": {
+          "name": "extraReskinSlots",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "customTitle": {
+          "name": "customTitle",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "marriageSlots": {
+          "name": "marriageSlots",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "aiProfileId": {
+          "name": "aiProfileId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "openaiCalls": {
+          "name": "openaiCalls",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tavernMessages": {
+          "name": "tavernMessages",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "musicOn": {
+          "name": "musicOn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "sfxOn": {
+          "name": "sfxOn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "buttonSfxOn": {
+          "name": "buttonSfxOn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "iframesMuted": {
+          "name": "iframesMuted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "tutorialStep": {
+          "name": "tutorialStep",
+          "type": "tinyint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tutorialOn": {
+          "name": "tutorialOn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "homeType": {
+          "name": "homeType",
+          "type": "enum('NONE','STUDIO_APARTMENT','ONE_BED_APARTMENT','TWO_BED_HOUSE','TOWN_HOUSE','SMALL_MANSION','SMALL_ESTATE','LARGE_ESTATE','PALACE','MARSHMALLOWOPOLIS')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "staffAccount": {
+          "name": "staffAccount",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rankedLp": {
+          "name": "rankedLp",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rankedBattles": {
+          "name": "rankedBattles",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rankedWins": {
+          "name": "rankedWins",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rankedStreak": {
+          "name": "rankedStreak",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skillPoints": {
+          "name": "skillPoints",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "towerDefensePoints": {
+          "name": "towerDefensePoints",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "enum('GATHERING','HUNTER','CRAFTING')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occupationSignupAt": {
+          "name": "occupationSignupAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stealth": {
+          "name": "stealth",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "sensory": {
+          "name": "sensory",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "stealthActive": {
+          "name": "stealthActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "stealthActivatedAt": {
+          "name": "stealthActivatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stealthCooldownAt": {
+          "name": "stealthCooldownAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastSensoryAt": {
+          "name": "lastSensoryAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "covertTrainingType": {
+          "name": "covertTrainingType",
+          "type": "enum('stealth','sensory')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "covertTrainingStartedAt": {
+          "name": "covertTrainingStartedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "covertTrainingMinutes": {
+          "name": "covertTrainingMinutes",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "UserData_isAi_idx": {
+          "name": "UserData_isAi_idx",
+          "columns": [
+            "isAi"
+          ],
+          "isUnique": false
+        },
+        "UserData_isAi_rankedLp_experience_idx": {
+          "name": "UserData_isAi_rankedLp_experience_idx",
+          "columns": [
+            "isAi",
+            "rankedLp",
+            "experience"
+          ],
+          "isUnique": false
+        },
+        "UserData_isEvent_idx": {
+          "name": "UserData_isEvent_idx",
+          "columns": [
+            "isEvent"
+          ],
+          "isUnique": false
+        },
+        "UserData_inArena_idx": {
+          "name": "UserData_inArena_idx",
+          "columns": [
+            "inArena"
+          ],
+          "isUnique": false
+        },
+        "UserData_inShrines_idx": {
+          "name": "UserData_inShrines_idx",
+          "columns": [
+            "inShrines"
+          ],
+          "isUnique": false
+        },
+        "UserData_isSummon_idx": {
+          "name": "UserData_isSummon_idx",
+          "columns": [
+            "isSummon"
+          ],
+          "isUnique": false
+        },
+        "UserData_rank_idx": {
+          "name": "UserData_rank_idx",
+          "columns": [
+            "rank"
+          ],
+          "isUnique": false
+        },
+        "UserData_role_idx": {
+          "name": "UserData_role_idx",
+          "columns": [
+            "role"
+          ],
+          "isUnique": false
+        },
+        "UserData_clanId_idx": {
+          "name": "UserData_clanId_idx",
+          "columns": [
+            "clanId"
+          ],
+          "isUnique": false
+        },
+        "UserData_anbuId_idx": {
+          "name": "UserData_anbuId_idx",
+          "columns": [
+            "anbuId"
+          ],
+          "isUnique": false
+        },
+        "UserData_jutsuLoadout_idx": {
+          "name": "UserData_jutsuLoadout_idx",
+          "columns": [
+            "jutsuLoadout"
+          ],
+          "isUnique": false
+        },
+        "UserData_rankedLoadout_idx": {
+          "name": "UserData_rankedLoadout_idx",
+          "columns": [
+            "rankedLoadout"
+          ],
+          "isUnique": false
+        },
+        "UserData_rankedLp_idx": {
+          "name": "UserData_rankedLp_idx",
+          "columns": [
+            "rankedLp"
+          ],
+          "isUnique": false
+        },
+        "UserData_experience_idx": {
+          "name": "UserData_experience_idx",
+          "columns": [
+            "experience"
+          ],
+          "isUnique": false
+        },
+        "UserData_level_idx": {
+          "name": "UserData_level_idx",
+          "columns": [
+            "level"
+          ],
+          "isUnique": false
+        },
+        "UserData_username_key": {
+          "name": "UserData_username_key",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "UserData_bloodlineId_idx": {
+          "name": "UserData_bloodlineId_idx",
+          "columns": [
+            "bloodlineId"
+          ],
+          "isUnique": false
+        },
+        "UserData_bloodlineReskinId_idx": {
+          "name": "UserData_bloodlineReskinId_idx",
+          "columns": [
+            "bloodlineReskinId"
+          ],
+          "isUnique": false
+        },
+        "UserData_villageId_idx": {
+          "name": "UserData_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        },
+        "UserData_battleId_idx": {
+          "name": "UserData_battleId_idx",
+          "columns": [
+            "battleId"
+          ],
+          "isUnique": false
+        },
+        "UserData_status_idx": {
+          "name": "UserData_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "UserData_sector_idx": {
+          "name": "UserData_sector_idx",
+          "columns": [
+            "sector"
+          ],
+          "isUnique": false
+        },
+        "UserData_sector_stealthActive_idx": {
+          "name": "UserData_sector_stealthActive_idx",
+          "columns": [
+            "sector",
+            "stealthActive"
+          ],
+          "isUnique": false
+        },
+        "UserData_senseiId_idx": {
+          "name": "UserData_senseiId_idx",
+          "columns": [
+            "senseiId"
+          ],
+          "isUnique": false
+        },
+        "UserData_latitude_idx": {
+          "name": "UserData_latitude_idx",
+          "columns": [
+            "latitude"
+          ],
+          "isUnique": false
+        },
+        "UserData_longitude_idx": {
+          "name": "UserData_longitude_idx",
+          "columns": [
+            "longitude"
+          ],
+          "isUnique": false
+        },
+        "UserData_createdAt_idx": {
+          "name": "UserData_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserData_userId": {
+          "name": "UserData_userId",
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserItem": {
+      "name": "UserItem",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "itemId": {
+          "name": "itemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "equipped": {
+          "name": "equipped",
+          "type": "enum('HEAD','CHEST','LEGS','FEET','HAND_1','HAND_2','THROWN','WAIST','KEYSTONE','ITEM_1','ITEM_2','ITEM_3','ITEM_4','ITEM_5','ITEM_6','NONE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "durability": {
+          "name": "durability",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "storedAtHome": {
+          "name": "storedAtHome",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "craftingFinishedAt": {
+          "name": "craftingFinishedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isInAuction": {
+          "name": "isInAuction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "activeVariantId": {
+          "name": "activeVariantId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dropChancePerc": {
+          "name": "dropChancePerc",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "UserItem_userId_idx": {
+          "name": "UserItem_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserItem_itemId_idx": {
+          "name": "UserItem_itemId_idx",
+          "columns": [
+            "itemId"
+          ],
+          "isUnique": false
+        },
+        "UserItem_quantity_idx": {
+          "name": "UserItem_quantity_idx",
+          "columns": [
+            "quantity"
+          ],
+          "isUnique": false
+        },
+        "UserItem_equipped_idx": {
+          "name": "UserItem_equipped_idx",
+          "columns": [
+            "equipped"
+          ],
+          "isUnique": false
+        },
+        "UserItem_userId_equipped_idx": {
+          "name": "UserItem_userId_equipped_idx",
+          "columns": [
+            "userId",
+            "equipped"
+          ],
+          "isUnique": false
+        },
+        "UserItem_activeVariantId_idx": {
+          "name": "UserItem_activeVariantId_idx",
+          "columns": [
+            "activeVariantId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserItem_id": {
+          "name": "UserItem_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserItemImbuement": {
+      "name": "UserItemImbuement",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userItemId": {
+          "name": "userItemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imbuementItemId": {
+          "name": "imbuementItemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "craftingFinishedAt": {
+          "name": "craftingFinishedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "UserItemImbuement_userItemId_idx": {
+          "name": "UserItemImbuement_userItemId_idx",
+          "columns": [
+            "userItemId"
+          ],
+          "isUnique": false
+        },
+        "UserItemImbuement_imbuementItemId_idx": {
+          "name": "UserItemImbuement_imbuementItemId_idx",
+          "columns": [
+            "imbuementItemId"
+          ],
+          "isUnique": false
+        },
+        "UserItemImbuement_userItem_imbuement_key": {
+          "name": "UserItemImbuement_userItem_imbuement_key",
+          "columns": [
+            "userItemId",
+            "imbuementItemId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserItemImbuement_id": {
+          "name": "UserItemImbuement_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserItemVariant": {
+      "name": "UserItemVariant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variantId": {
+          "name": "variantId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserItemVariant_userId_idx": {
+          "name": "UserItemVariant_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserItemVariant_userId_variantId_key": {
+          "name": "UserItemVariant_userId_variantId_key",
+          "columns": [
+            "userId",
+            "variantId"
+          ],
+          "isUnique": true
+        },
+        "UserItemVariant_variantId_idx": {
+          "name": "UserItemVariant_variantId_idx",
+          "columns": [
+            "variantId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserItemVariant_id": {
+          "name": "UserItemVariant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserJutsu": {
+      "name": "UserJutsu",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jutsuId": {
+          "name": "jutsuId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "level": {
+          "name": "level",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "experience": {
+          "name": "experience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "equipped": {
+          "name": "equipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "finishTraining": {
+          "name": "finishTraining",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reskinId": {
+          "name": "reskinId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "UserJutsu_userId_jutsuId_key": {
+          "name": "UserJutsu_userId_jutsuId_key",
+          "columns": [
+            "userId",
+            "jutsuId"
+          ],
+          "isUnique": true
+        },
+        "UserJutsu_jutsuId_idx": {
+          "name": "UserJutsu_jutsuId_idx",
+          "columns": [
+            "jutsuId"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_equipped_idx": {
+          "name": "Jutsu_equipped_idx",
+          "columns": [
+            "equipped"
+          ],
+          "isUnique": false
+        },
+        "UserJutsu_userId_equipped_idx": {
+          "name": "UserJutsu_userId_equipped_idx",
+          "columns": [
+            "userId",
+            "equipped"
+          ],
+          "isUnique": false
+        },
+        "UserJutsu_reskinId_idx": {
+          "name": "UserJutsu_reskinId_idx",
+          "columns": [
+            "reskinId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserJutsu_id": {
+          "name": "UserJutsu_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserLikes": {
+      "name": "UserLikes",
+      "columns": {
+        "type": {
+          "name": "type",
+          "type": "enum('like','love','laugh')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imageId": {
+          "name": "imageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "userLikes_userId_idx": {
+          "name": "userLikes_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "userLikes_imageId_idx": {
+          "name": "userLikes_imageId_idx",
+          "columns": [
+            "imageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserNindo": {
+      "name": "UserNindo",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "UserNindo_userId_idx": {
+          "name": "UserNindo_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserNindo_id": {
+          "name": "UserNindo_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserPollVote": {
+      "name": "UserPollVote",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollId": {
+          "name": "pollId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "optionId": {
+          "name": "optionId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserPollVote_userId_pollId_idx": {
+          "name": "UserPollVote_userId_pollId_idx",
+          "columns": [
+            "userId",
+            "pollId"
+          ],
+          "isUnique": true
+        },
+        "UserPollVote_userId_idx": {
+          "name": "UserPollVote_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserPollVote_pollId_idx": {
+          "name": "UserPollVote_pollId_idx",
+          "columns": [
+            "pollId"
+          ],
+          "isUnique": false
+        },
+        "UserPollVote_optionId_idx": {
+          "name": "UserPollVote_optionId_idx",
+          "columns": [
+            "optionId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserPollVote_id": {
+          "name": "UserPollVote_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserRaidBuff": {
+      "name": "UserRaidBuff",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questId": {
+          "name": "questId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserRaidBuff_userId_idx": {
+          "name": "UserRaidBuff_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserRaidBuff_questId_idx": {
+          "name": "UserRaidBuff_questId_idx",
+          "columns": [
+            "questId"
+          ],
+          "isUnique": false
+        },
+        "UserRaidBuff_expiresAt_idx": {
+          "name": "UserRaidBuff_expiresAt_idx",
+          "columns": [
+            "expiresAt"
+          ],
+          "isUnique": false
+        },
+        "UserRaidBuff_userId_expiresAt_idx": {
+          "name": "UserRaidBuff_userId_expiresAt_idx",
+          "columns": [
+            "userId",
+            "expiresAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserRaidBuff_id": {
+          "name": "UserRaidBuff_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserReport": {
+      "name": "UserReport",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reporterUserId": {
+          "name": "reporterUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reportedUserId": {
+          "name": "reportedUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "system": {
+          "name": "system",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "infraction": {
+          "name": "infraction",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "banEnd": {
+          "name": "banEnd",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "adminResolved": {
+          "name": "adminResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('UNVIEWED','REPORT_CLEARED','BAN_ACTIVATED','SILENCE_ACTIVATED','TIMEOUT_ACTIVATED','BAN_ESCALATED','SILENCE_ESCALATED','OFFICIAL_WARNING','TRADE_BAN_ACTIVATED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UNVIEWED'"
+        },
+        "aiInterpretation": {
+          "name": "aiInterpretation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "predictedStatus": {
+          "name": "predictedStatus",
+          "type": "enum('UNVIEWED','REPORT_CLEARED','BAN_ACTIVATED','SILENCE_ACTIVATED','TIMEOUT_ACTIVATED','BAN_ESCALATED','SILENCE_ESCALATED','OFFICIAL_WARNING','TRADE_BAN_ACTIVATED')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "additionalContext": {
+          "name": "additionalContext",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        }
+      },
+      "indexes": {
+        "UserReport_reporterUserId_idx": {
+          "name": "UserReport_reporterUserId_idx",
+          "columns": [
+            "reporterUserId"
+          ],
+          "isUnique": false
+        },
+        "UserReport_reportedUserId_idx": {
+          "name": "UserReport_reportedUserId_idx",
+          "columns": [
+            "reportedUserId"
+          ],
+          "isUnique": false
+        },
+        "UserReport_status_idx": {
+          "name": "UserReport_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserReport_id": {
+          "name": "UserReport_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserReportComment": {
+      "name": "UserReportComment",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reportId": {
+          "name": "reportId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "enum('UNVIEWED','REPORT_CLEARED','BAN_ACTIVATED','SILENCE_ACTIVATED','TIMEOUT_ACTIVATED','BAN_ESCALATED','SILENCE_ESCALATED','OFFICIAL_WARNING','TRADE_BAN_ACTIVATED')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isReported": {
+          "name": "isReported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "UserReportComment_userId_idx": {
+          "name": "UserReportComment_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserReportComment_reportId_idx": {
+          "name": "UserReportComment_reportId_idx",
+          "columns": [
+            "reportId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserReportComment_id": {
+          "name": "UserReportComment_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserRequest": {
+      "name": "UserRequest",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "receiverId": {
+          "name": "receiverId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('PENDING','ACCEPTED','REJECTED','CANCELLED','EXPIRED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('SPAR','ALLIANCE','SURRENDER','SENSEI','ANBU','CLAN','MARRIAGE','KAGE','WAR_ALLY')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "relatedId": {
+          "name": "relatedId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "useRankedRules": {
+          "name": "useRankedRules",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "spectatable": {
+          "name": "spectatable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserRequest_createdAt_idx": {
+          "name": "UserRequest_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "UserRequest_senderId_idx": {
+          "name": "UserRequest_senderId_idx",
+          "columns": [
+            "senderId"
+          ],
+          "isUnique": false
+        },
+        "UserRequest_receiverId_idx": {
+          "name": "UserRequest_receiverId_idx",
+          "columns": [
+            "receiverId"
+          ],
+          "isUnique": false
+        },
+        "UserRequest_type_idx": {
+          "name": "UserRequest_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserRequest_id": {
+          "name": "UserRequest_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserReview": {
+      "name": "UserReview",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorUserId": {
+          "name": "authorUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "positive": {
+          "name": "positive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorIp": {
+          "name": "authorIp",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserReview_authorUserId_idx": {
+          "name": "UserReview_authorUserId_idx",
+          "columns": [
+            "authorUserId"
+          ],
+          "isUnique": false
+        },
+        "UserReview_targetUserId_idx": {
+          "name": "UserReview_targetUserId_idx",
+          "columns": [
+            "targetUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserReview_id": {
+          "name": "UserReview_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserRewards": {
+      "name": "UserRewards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "awardedById": {
+          "name": "awardedById",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "receiverId": {
+          "name": "receiverId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reputationAmount": {
+          "name": "reputationAmount",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "moneyAmount": {
+          "name": "moneyAmount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserRewards_awardedById_idx": {
+          "name": "UserRewards_awardedById_idx",
+          "columns": [
+            "awardedById"
+          ],
+          "isUnique": false
+        },
+        "UserRewards_receiverId_idx": {
+          "name": "UserRewards_receiverId_idx",
+          "columns": [
+            "receiverId"
+          ],
+          "isUnique": false
+        },
+        "UserRewards_createdAt_idx": {
+          "name": "UserRewards_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserRewards_id": {
+          "name": "UserRewards_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserSkill": {
+      "name": "UserSkill",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skillId": {
+          "name": "skillId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purchasedAt": {
+          "name": "purchasedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "activated": {
+          "name": "activated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "UserSkill_userId_skillId_key": {
+          "name": "UserSkill_userId_skillId_key",
+          "columns": [
+            "userId",
+            "skillId"
+          ],
+          "isUnique": true
+        },
+        "UserSkill_userId_idx": {
+          "name": "UserSkill_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserSkill_skillId_idx": {
+          "name": "UserSkill_skillId_idx",
+          "columns": [
+            "skillId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserSkill_id": {
+          "name": "UserSkill_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserStreakProgress": {
+      "name": "UserStreakProgress",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "configId": {
+          "name": "configId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currentDay": {
+          "name": "currentDay",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastClaimDate": {
+          "name": "lastClaimDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserStreakProgress_userId_idx": {
+          "name": "UserStreakProgress_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserStreakProgress_configId_idx": {
+          "name": "UserStreakProgress_configId_idx",
+          "columns": [
+            "configId"
+          ],
+          "isUnique": false
+        },
+        "UserStreakProgress_userId_configId_key": {
+          "name": "UserStreakProgress_userId_configId_key",
+          "columns": [
+            "userId",
+            "configId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserStreakProgress_id": {
+          "name": "UserStreakProgress_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserTowerDefenseUpgrade": {
+      "name": "UserTowerDefenseUpgrade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upgradeId": {
+          "name": "upgradeId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "purchasedAt": {
+          "name": "purchasedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserTowerDefenseUpgrade_userId_idx": {
+          "name": "UserTowerDefenseUpgrade_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserTowerDefenseUpgrade_upgradeId_idx": {
+          "name": "UserTowerDefenseUpgrade_upgradeId_idx",
+          "columns": [
+            "upgradeId"
+          ],
+          "isUnique": false
+        },
+        "UserTowerDefenseUpgrade_userId_upgradeId_key": {
+          "name": "UserTowerDefenseUpgrade_userId_upgradeId_key",
+          "columns": [
+            "userId",
+            "upgradeId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserTowerDefenseUpgrade_id": {
+          "name": "UserTowerDefenseUpgrade_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserUpload": {
+      "name": "UserUpload",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserUpload_userId_idx": {
+          "name": "UserUpload_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserUpload_id": {
+          "name": "UserUpload_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserVote": {
+      "name": "UserVote",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topWebGames": {
+          "name": "topWebGames",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "top100Arena": {
+          "name": "top100Arena",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "mmoHub": {
+          "name": "mmoHub",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "arenaTop100": {
+          "name": "arenaTop100",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "xtremeTop100": {
+          "name": "xtremeTop100",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "topOnlineMmorpg": {
+          "name": "topOnlineMmorpg",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "browserMmorpg": {
+          "name": "browserMmorpg",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "apexWebGaming": {
+          "name": "apexWebGaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bbogd": {
+          "name": "bbogd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "claimed": {
+          "name": "claimed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "totalClaims": {
+          "name": "totalClaims",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastVoteAt": {
+          "name": "lastVoteAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserVote_userId_idx": {
+          "name": "UserVote_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserVote_id": {
+          "name": "UserVote_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Village": {
+      "name": "Village",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mapName": {
+          "name": "mapName",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "kageId": {
+          "name": "kageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('VILLAGE','OUTLAW','SAFEZONE','HIDEOUT','TOWN')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'VILLAGE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "leaderUpdatedAt": {
+          "name": "leaderUpdatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "hexColor": {
+          "name": "hexColor",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#000000'"
+        },
+        "populationCount": {
+          "name": "populationCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "allianceSystem": {
+          "name": "allianceSystem",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "joinable": {
+          "name": "joinable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pvpDisabled": {
+          "name": "pvpDisabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "villageLogo": {
+          "name": "villageLogo",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "villageGraphic": {
+          "name": "villageGraphic",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "lastMaintenancePaidAt": {
+          "name": "lastMaintenancePaidAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "wasDowngraded": {
+          "name": "wasDowngraded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "openForChallenges": {
+          "name": "openForChallenges",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "openForChallengesAt": {
+          "name": "openForChallengesAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "wallpaperOverwrite": {
+          "name": "wallpaperOverwrite",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warExhaustionEndedAt": {
+          "name": "warExhaustionEndedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastWarEndedAt": {
+          "name": "lastWarEndedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shrineSettings": {
+          "name": "shrineSettings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('{\"unlockedAiIds\":[],\"activeBoosts\":{},\"activeAiIds\":[]}')"
+        }
+      },
+      "indexes": {
+        "Village_name_key": {
+          "name": "Village_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "Village_sector_key": {
+          "name": "Village_sector_key",
+          "columns": [
+            "sector"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Village_id": {
+          "name": "Village_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "VillageAlliance": {
+      "name": "VillageAlliance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageIdA": {
+          "name": "villageIdA",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageIdB": {
+          "name": "villageIdB",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('NEUTRAL','ALLY','ENEMY')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "VillageAlliance_villageIdA_idx": {
+          "name": "VillageAlliance_villageIdA_idx",
+          "columns": [
+            "villageIdA"
+          ],
+          "isUnique": false
+        },
+        "VillageAlliance_villageIdB_idx": {
+          "name": "VillageAlliance_villageIdB_idx",
+          "columns": [
+            "villageIdB"
+          ],
+          "isUnique": false
+        },
+        "VillageAlliance_status_idx": {
+          "name": "VillageAlliance_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "VillageAlliance_id": {
+          "name": "VillageAlliance_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "VillageElderVote": {
+      "name": "VillageElderVote",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('WAR_DECLARATION','KAGE_REMOVAL')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initiatedByUserId": {
+          "name": "initiatedByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetId": {
+          "name": "targetId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warType": {
+          "name": "warType",
+          "type": "enum('VILLAGE_WAR','SECTOR_WAR','WAR_RAID')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "targetStructureRoute": {
+          "name": "targetStructureRoute",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('PENDING','APPROVED','REJECTED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING'"
+        },
+        "activeFlag": {
+          "name": "activeFlag",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "CASE WHEN `status` = 'PENDING' THEN 1 ELSE NULL END",
+            "type": "stored"
+          }
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "endsAt": {
+          "name": "endsAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "VillageElderVote_villageId_idx": {
+          "name": "VillageElderVote_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        },
+        "VillageElderVote_type_idx": {
+          "name": "VillageElderVote_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "VillageElderVote_status_idx": {
+          "name": "VillageElderVote_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "VillageElderVote_endsAt_idx": {
+          "name": "VillageElderVote_endsAt_idx",
+          "columns": [
+            "endsAt"
+          ],
+          "isUnique": false
+        },
+        "VillageElderVote_initiatedByUserId_idx": {
+          "name": "VillageElderVote_initiatedByUserId_idx",
+          "columns": [
+            "initiatedByUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "VillageElderVote_id": {
+          "name": "VillageElderVote_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "VillageElderVote_active_pending_unique": {
+          "name": "VillageElderVote_active_pending_unique",
+          "columns": [
+            "villageId",
+            "type",
+            "targetId",
+            "activeFlag"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "VillageElderVoteEntry": {
+      "name": "VillageElderVoteEntry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voteId": {
+          "name": "voteId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vote": {
+          "name": "vote",
+          "type": "enum('YES','NO')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "VillageElderVoteEntry_voteId_idx": {
+          "name": "VillageElderVoteEntry_voteId_idx",
+          "columns": [
+            "voteId"
+          ],
+          "isUnique": false
+        },
+        "VillageElderVoteEntry_userId_idx": {
+          "name": "VillageElderVoteEntry_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "VillageElderVoteEntry_id": {
+          "name": "VillageElderVoteEntry_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "VillageElderVoteEntry_voteId_userId_unique": {
+          "name": "VillageElderVoteEntry_voteId_userId_unique",
+          "columns": [
+            "voteId",
+            "userId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "VillageStructure": {
+      "name": "VillageStructure",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "route": {
+          "name": "route",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "hasPage": {
+          "name": "hasPage",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "curSp": {
+          "name": "curSp",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "maxSp": {
+          "name": "maxSp",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "allyAccess": {
+          "name": "allyAccess",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "showInVillagePage": {
+          "name": "showInVillagePage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "level": {
+          "name": "level",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "maxLevel": {
+          "name": "maxLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "lastUpgradedAt": {
+          "name": "lastUpgradedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anbuSquadsPerLvl": {
+          "name": "anbuSquadsPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "arenaRewardPerLvl": {
+          "name": "arenaRewardPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bankInterestPerLvl": {
+          "name": "bankInterestPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "blackDiscountPerLvl": {
+          "name": "blackDiscountPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "clansPerLvl": {
+          "name": "clansPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hospitalSpeedupPerLvl": {
+          "name": "hospitalSpeedupPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "itemDiscountPerLvl": {
+          "name": "itemDiscountPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionRewardPerLvl": {
+          "name": "missionRewardPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "patrolsPerLvl": {
+          "name": "patrolsPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "ramenDiscountPerLvl": {
+          "name": "ramenDiscountPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "regenIncreasePerLvl": {
+          "name": "regenIncreasePerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "sleepRegenPerLvl": {
+          "name": "sleepRegenPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "structureDiscountPerLvl": {
+          "name": "structureDiscountPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "trainBoostPerLvl": {
+          "name": "trainBoostPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "villageDefencePerLvl": {
+          "name": "villageDefencePerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "temporaryLevelBonus": {
+          "name": "temporaryLevelBonus",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "temporaryLevelBonusExpiresAt": {
+          "name": "temporaryLevelBonusExpiresAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "VillageStructure_name_villageId_key": {
+          "name": "VillageStructure_name_villageId_key",
+          "columns": [
+            "name",
+            "villageId"
+          ],
+          "isUnique": true
+        },
+        "VillageStructure_villageId_idx": {
+          "name": "VillageStructure_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "VillageStructure_id": {
+          "name": "VillageStructure_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "VisitorLog": {
+      "name": "VisitorLog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref": {
+          "name": "ref",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmSource": {
+          "name": "utmSource",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "VisitorLog_ip_key": {
+          "name": "VisitorLog_ip_key",
+          "columns": [
+            "ip"
+          ],
+          "isUnique": true
+        },
+        "VisitorLog_ref_idx": {
+          "name": "VisitorLog_ref_idx",
+          "columns": [
+            "ref"
+          ],
+          "isUnique": false
+        },
+        "VisitorLog_utmSource_idx": {
+          "name": "VisitorLog_utmSource_idx",
+          "columns": [
+            "utmSource"
+          ],
+          "isUnique": false
+        },
+        "VisitorLog_createdAt_idx": {
+          "name": "VisitorLog_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "VisitorLog_ip_utmSource_idx": {
+          "name": "VisitorLog_ip_utmSource_idx",
+          "columns": [
+            "ip",
+            "utmSource"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "VisitorLog_id": {
+          "name": "VisitorLog_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "War": {
+      "name": "War",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attackerVillageId": {
+          "name": "attackerVillageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "defenderVillageId": {
+          "name": "defenderVillageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('ACTIVE','ATTACKER_VICTORY','DEFENDER_VICTORY','DRAW')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('VILLAGE_WAR','SECTOR_WAR','WAR_RAID')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attackerShrineHp": {
+          "name": "attackerShrineHp",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 500
+        },
+        "attackerShrineMaxHp": {
+          "name": "attackerShrineMaxHp",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 500
+        },
+        "attackerShrineStatus": {
+          "name": "attackerShrineStatus",
+          "type": "enum('ACTIVE','CAPTURED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "defenderShrineHp": {
+          "name": "defenderShrineHp",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3000
+        },
+        "defenderShrineMaxHp": {
+          "name": "defenderShrineMaxHp",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3000
+        },
+        "defenderShrineStatus": {
+          "name": "defenderShrineStatus",
+          "type": "enum('ACTIVE','CAPTURED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "lastTokenReductionAt": {
+          "name": "lastTokenReductionAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "targetStructureRoute": {
+          "name": "targetStructureRoute",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'/townhall'"
+        },
+        "attackerWarHealth": {
+          "name": "attackerWarHealth",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10000
+        },
+        "defenderWarHealth": {
+          "name": "defenderWarHealth",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10000
+        },
+        "attackerWarHealthMax": {
+          "name": "attackerWarHealthMax",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10000
+        },
+        "defenderWarHealthMax": {
+          "name": "defenderWarHealthMax",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10000
+        }
+      },
+      "indexes": {
+        "War_attackerVillageId_idx": {
+          "name": "War_attackerVillageId_idx",
+          "columns": [
+            "attackerVillageId"
+          ],
+          "isUnique": false
+        },
+        "War_defenderVillageId_idx": {
+          "name": "War_defenderVillageId_idx",
+          "columns": [
+            "defenderVillageId"
+          ],
+          "isUnique": false
+        },
+        "War_sector_idx": {
+          "name": "War_sector_idx",
+          "columns": [
+            "sector"
+          ],
+          "isUnique": false
+        },
+        "War_status_idx": {
+          "name": "War_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "War_id": {
+          "name": "War_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "WarAlly": {
+      "name": "WarAlly",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warId": {
+          "name": "warId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supportVillageId": {
+          "name": "supportVillageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tokensPaid": {
+          "name": "tokensPaid",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "joinedAt": {
+          "name": "joinedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "WarAlly_warId_idx": {
+          "name": "WarAlly_warId_idx",
+          "columns": [
+            "warId"
+          ],
+          "isUnique": false
+        },
+        "WarAlly_villageId_idx": {
+          "name": "WarAlly_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "WarAlly_id": {
+          "name": "WarAlly_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "WarKill": {
+      "name": "WarKill",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warId": {
+          "name": "warId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "killerId": {
+          "name": "killerId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "victimId": {
+          "name": "victimId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "killerVillageId": {
+          "name": "killerVillageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "victimVillageId": {
+          "name": "victimVillageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1337
+        },
+        "shrineHpChange": {
+          "name": "shrineHpChange",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1337
+        },
+        "townhallHpChange": {
+          "name": "townhallHpChange",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1337
+        },
+        "killedAt": {
+          "name": "killedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "WarKill_warId_idx": {
+          "name": "WarKill_warId_idx",
+          "columns": [
+            "warId"
+          ],
+          "isUnique": false
+        },
+        "WarKill_killerId_idx": {
+          "name": "WarKill_killerId_idx",
+          "columns": [
+            "killerId"
+          ],
+          "isUnique": false
+        },
+        "WarKill_victimId_idx": {
+          "name": "WarKill_victimId_idx",
+          "columns": [
+            "victimId"
+          ],
+          "isUnique": false
+        },
+        "WarKill_killerVillageId_idx": {
+          "name": "WarKill_killerVillageId_idx",
+          "columns": [
+            "killerVillageId"
+          ],
+          "isUnique": false
+        },
+        "WarKill_victimVillageId_idx": {
+          "name": "WarKill_victimVillageId_idx",
+          "columns": [
+            "victimVillageId"
+          ],
+          "isUnique": false
+        },
+        "WarKill_killedAt_idx": {
+          "name": "WarKill_killedAt_idx",
+          "columns": [
+            "killedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "WarKill_id": {
+          "name": "WarKill_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/app/drizzle/migrations/meta/_journal.json
+++ b/app/drizzle/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1785879665755,
       "tag": "0025_hot_ken_ellis",
       "breakpoints": false
+    },
+    {
+      "idx": 26,
+      "version": "5",
+      "when": 1786785600765,
+      "tag": "0026_blushing_gauntlet",
+      "breakpoints": false
     }
   ]
 }

--- a/app/drizzle/schema.ts
+++ b/app/drizzle/schema.ts
@@ -2781,6 +2781,11 @@ export const userJutsu = mysqlTable(
       ),
       jutsuIdIdx: index("UserJutsu_jutsuId_idx").on(table.jutsuId),
       equippedIdx: index("Jutsu_equipped_idx").on(table.equipped),
+      // Composite index for equip-cap guards: WHERE userId = ? AND equipped = true
+      userIdEquippedIdx: index("UserJutsu_userId_equipped_idx").on(
+        table.userId,
+        table.equipped,
+      ),
       reskinIdIdx: index("UserJutsu_reskinId_idx").on(table.reskinId),
     };
   },

--- a/app/src/app/manual/pvp_rank/page.tsx
+++ b/app/src/app/manual/pvp_rank/page.tsx
@@ -11,6 +11,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   RANKED_LOADOUT_MAX_CONSUMABLES,
+  RANKED_LOADOUT_MAX_HEAL_JUTSUS,
   RANKED_LOADOUT_MAX_INCREASECOST_ITEMS,
   RANKED_LOADOUT_MAX_INCREASECOST_JUTSUS,
   RANKED_LOADOUT_MAX_JUTSUS,
@@ -113,6 +114,7 @@ export default function RankedManualPage() {
                     <li>
                       Maximum {RANKED_LOADOUT_MAX_INCREASECOST_ITEMS} increasecost item
                     </li>
+                    <li>Maximum {RANKED_LOADOUT_MAX_HEAL_JUTSUS} heal jutsu</li>
                   </ul>
                 </div>
               </CardContent>
@@ -210,6 +212,10 @@ export default function RankedManualPage() {
                     <li>
                       Increasecost items are limited to{" "}
                       {RANKED_LOADOUT_MAX_INCREASECOST_ITEMS} in ranked battles
+                    </li>
+                    <li>
+                      Heal jutsu are limited to {RANKED_LOADOUT_MAX_HEAL_JUTSUS} in
+                      ranked battles
                     </li>
                   </ul>
                 </div>

--- a/app/src/app/profile/edit/page.tsx
+++ b/app/src/app/profile/edit/page.tsx
@@ -2041,7 +2041,8 @@ const ManagementCommands: React.FC<ManagementCommandsProps> = ({ user }) => {
             unequipAllGear();
           }}
         >
-          This will unequip all currently equipped gear <b>FOR ALL USERS</b>. Are you
+          This will unequip all currently equipped gear <b>FOR ALL NON-AI USERS</b> and
+          clear all of their item loadouts (AI opponents are left unchanged). Are you
           sure you want to continue?
         </Confirm2>
       )}
@@ -2069,8 +2070,9 @@ const ManagementCommands: React.FC<ManagementCommandsProps> = ({ user }) => {
             unequipAllJutsus();
           }}
         >
-          This will unequip all currently equipped jutsus <b>FOR ALL USERS</b>. Are you
-          sure you want to continue?
+          This will unequip all currently equipped jutsus <b>FOR ALL NON-AI USERS</b>{" "}
+          and clear all of their jutsu loadouts (AI opponents are left unchanged). Are
+          you sure you want to continue?
         </Confirm2>
       )}
       {canUnequipAllUsers(user) && (

--- a/app/src/app/traininggrounds/page.tsx
+++ b/app/src/app/traininggrounds/page.tsx
@@ -85,6 +85,7 @@ import {
   checkJutsuBloodline,
   checkJutsuRank,
   checkJutsuVillage,
+  isJutsuTrainToLearnRestricted,
   trainEfficiency,
   trainingSpeedSeconds,
 } from "@/libs/train";
@@ -743,7 +744,7 @@ const JutsuTraining: React.FC<TrainingProps> = (props) => {
     .filter((j) => !evolvedAncestorIds.has(j.id))
     .filter((j) => {
       const userJutsu = userJutsus?.find((uj) => uj.jutsuId === j.id);
-      return userJutsu || !["EVENT", "LOYALTY", "SPECIAL"].includes(j.jutsuType);
+      return userJutsu || !isJutsuTrainToLearnRestricted(j.jutsuType);
     })
     .map((j) => {
       const uj = userJutsus?.find((uj) => uj.jutsuId === j.id);

--- a/app/src/layout/PvpRank.tsx
+++ b/app/src/layout/PvpRank.tsx
@@ -10,11 +10,8 @@ import {
   RANKED_ENTRY_COST,
   RANKED_LOADOUT_MAX_CONSUMABLES,
   RANKED_LOADOUT_MAX_INCREASECOST_ITEMS,
-  RANKED_LOADOUT_MAX_INCREASECOST_JUTSUS,
   RANKED_LOADOUT_MAX_JUTSUS,
   RANKED_LOADOUT_MAX_POISON_ITEMS,
-  RANKED_LOADOUT_MAX_POISON_JUTSUS,
-  RANKED_LOADOUT_MAX_RESIDUAL_JUTSUS,
   RANKED_LOADOUT_MAX_WEAPONS,
 } from "@/drizzle/constants";
 import type { Item, Jutsu } from "@/drizzle/schema";
@@ -26,6 +23,12 @@ import ItemWithEffects from "@/layout/ItemWithEffects";
 import JutsuFiltering, { getFilter, useFiltering } from "@/layout/JutsuFiltering";
 import Loader from "@/layout/Loader";
 import Modal2 from "@/layout/Modal2";
+import {
+  getJutsuCapFlags,
+  getJutsuCategoryDef,
+  RANKED_JUTSU_CAPS,
+  RANKED_JUTSU_SELECT_WARNINGS,
+} from "@/libs/jutsu";
 import { validateItemLoadout, validateJutsuLoadout } from "@/libs/ranked_pvp";
 import { showMutationToast } from "@/libs/toast";
 import { useRequireInVillage } from "@/utils/UserContext";
@@ -757,35 +760,21 @@ export const RankedLoadoutSelector: React.FC = () => {
               </Button>
             </div>
             {!loadoutJutsus.includes(selectedJutsu.id) &&
-              selectedJutsu.effects.some(
-                (e) => "residualModifier" in e && e.residualModifier,
-              ) && (
-                <div className="text-muted-foreground text-sm">
-                  <p>
-                    ⚠️ This is a residual jutsu. You can equip up to{" "}
-                    {RANKED_LOADOUT_MAX_RESIDUAL_JUTSUS} residual jutsu in ranked PvP.
-                  </p>
-                </div>
-              )}
-            {!loadoutJutsus.includes(selectedJutsu.id) &&
-              selectedJutsu.effects.some((e) => e.type === "poison") && (
-                <div className="text-muted-foreground text-sm">
-                  <p>
-                    ⚠️ This is a poison jutsu. You can equip up to{" "}
-                    {RANKED_LOADOUT_MAX_POISON_JUTSUS} poison jutsu in ranked PvP.
-                  </p>
-                </div>
-              )}
-            {!loadoutJutsus.includes(selectedJutsu.id) &&
-              selectedJutsu.effects.some((e) => e.type === "increasepoolcost") && (
-                <div className="text-muted-foreground text-sm">
-                  <p>
-                    ⚠️ This is an increasecost jutsu. You can equip up to{" "}
-                    {RANKED_LOADOUT_MAX_INCREASECOST_JUTSUS} increasecost jutsu in
-                    ranked PvP.
-                  </p>
-                </div>
-              )}
+              RANKED_JUTSU_SELECT_WARNINGS.map((key) => {
+                const flags = getJutsuCapFlags(selectedJutsu);
+                if (!flags[key]) return null;
+                const cap = RANKED_JUTSU_CAPS.find((c) => c.key === key);
+                if (!cap) return null;
+                const label = getJutsuCategoryDef(key).label;
+                return (
+                  <div key={key} className="text-muted-foreground text-sm">
+                    <p>
+                      ⚠️ This is a {label} jutsu. You can equip up to {cap.max} {label}{" "}
+                      jutsu in ranked PvP.
+                    </p>
+                  </div>
+                );
+              })}
           </div>
         </Modal2>
       )}

--- a/app/src/libs/jutsu.ts
+++ b/app/src/libs/jutsu.ts
@@ -2,6 +2,8 @@ import type { FederalStatus } from "@/drizzle/constants";
 import {
   JUTSU_MAX_BARRIER_EQUIPPED,
   JUTSU_MAX_EVENT_EQUIPPED,
+  JUTSU_MAX_FORBIDDEN_EQUIPPED,
+  JUTSU_MAX_HEAL_EQUIPPED,
   JUTSU_MAX_PIERCE_EQUIPPED,
   JUTSU_MAX_RESIDUAL_EQUIPPED,
   JUTSU_MAX_SHIELD_EQUIPPED,
@@ -10,6 +12,14 @@ import {
   JUTSU_TRANSFER_FREE_GOLD,
   JUTSU_TRANSFER_FREE_NORMAL,
   JUTSU_TRANSFER_FREE_SILVER,
+  RANKED_LOADOUT_MAX_BARRIER_JUTSUS,
+  RANKED_LOADOUT_MAX_HEAL_JUTSUS,
+  RANKED_LOADOUT_MAX_INCREASECOST_JUTSUS,
+  RANKED_LOADOUT_MAX_POISON_JUTSUS,
+  RANKED_LOADOUT_MAX_RESIDUAL_JUTSUS,
+  RANKED_LOADOUT_MAX_SHIELD_JUTSUS,
+  RANKED_LOADOUT_MAX_STUN_JUTSUS,
+  RANKED_LOADOUT_MAX_SUMMON_JUTSUS,
 } from "@/drizzle/constants";
 import type { Jutsu, UserJutsuWithRelations } from "@/drizzle/schema";
 import { calcJutsuEquipLimit, canUseJutsu } from "@/libs/train";
@@ -39,31 +49,225 @@ export interface ComputedJutsuLoadout {
   invalidJutsus: string[];
 }
 
-export interface JutsuCapFlags {
-  isResidual: boolean;
-  isPierce: boolean;
-  isEvent: boolean;
-  isBarrier: boolean;
-  isStun: boolean;
-  isShield: boolean;
-}
+type JutsuCapMatchInput = Pick<Jutsu, "effects" | "jutsuType">;
 
 /**
- * Which capped equip categories a jutsu counts against (residual / pierce /
- * event / barrier / stun / shield). Centralised so the loadout, toggle-equip and
- * auto-equip paths share one definition and a new capped category only needs
- * editing in one place.
+ * All jutsu category predicates (normal equip + ranked-only). Single definition of
+ * what counts as residual / heal / poison / etc. so equip and ranked caps stay aligned.
  */
-export const getJutsuCapFlags = (
-  jutsu: Pick<Jutsu, "effects" | "jutsuType">,
-): JutsuCapFlags => ({
-  isResidual: jutsu.effects.some((e) => "residualModifier" in e && e.residualModifier),
-  isPierce: jutsu.effects.some((e) => e.type === "pierce"),
-  isEvent: jutsu.jutsuType === "EVENT",
-  isBarrier: jutsu.effects.some((e) => e.type === "barrier"),
-  isStun: jutsu.effects.some((e) => e.type === "stun"),
-  isShield: jutsu.effects.some((e) => e.type === "shield"),
-});
+export const JUTSU_CATEGORY_DEFS = [
+  {
+    key: "isResidual",
+    label: "residual",
+    matches: (jutsu: JutsuCapMatchInput) =>
+      jutsu.effects.some((e) => "residualModifier" in e && e.residualModifier),
+  },
+  {
+    key: "isPierce",
+    label: "piercing",
+    matches: (jutsu: JutsuCapMatchInput) =>
+      jutsu.effects.some((e) => e.type === "pierce"),
+  },
+  {
+    key: "isEvent",
+    label: "event",
+    matches: (jutsu: JutsuCapMatchInput) => jutsu.jutsuType === "EVENT",
+  },
+  {
+    key: "isForbidden",
+    label: "forbidden",
+    matches: (jutsu: JutsuCapMatchInput) => jutsu.jutsuType === "FORBIDDEN",
+  },
+  {
+    key: "isBarrier",
+    label: "barrier",
+    matches: (jutsu: JutsuCapMatchInput) =>
+      jutsu.effects.some((e) => e.type === "barrier"),
+  },
+  {
+    key: "isStun",
+    label: "stun",
+    matches: (jutsu: JutsuCapMatchInput) =>
+      jutsu.effects.some((e) => e.type === "stun"),
+  },
+  {
+    key: "isShield",
+    label: "shield",
+    matches: (jutsu: JutsuCapMatchInput) =>
+      jutsu.effects.some((e) => e.type === "shield"),
+  },
+  {
+    key: "isHeal",
+    label: "heal",
+    matches: (jutsu: JutsuCapMatchInput) =>
+      jutsu.effects.some((e) => e.type === "heal"),
+  },
+  {
+    key: "isPoison",
+    label: "poison",
+    matches: (jutsu: JutsuCapMatchInput) =>
+      jutsu.effects.some((e) => e.type === "poison"),
+  },
+  {
+    key: "isIncreaseCost",
+    label: "increasecost",
+    matches: (jutsu: JutsuCapMatchInput) =>
+      jutsu.effects.some((e) => e.type === "increasepoolcost"),
+  },
+  {
+    key: "isSummon",
+    label: "summon",
+    matches: (jutsu: JutsuCapMatchInput) =>
+      jutsu.effects.some((e) => e.type === "summon"),
+  },
+] as const;
+
+export type JutsuCapFlagKey = (typeof JUTSU_CATEGORY_DEFS)[number]["key"];
+export type JutsuCapFlags = Record<JutsuCapFlagKey, boolean>;
+export type JutsuCategoryDef = (typeof JUTSU_CATEGORY_DEFS)[number];
+
+export const getJutsuCategoryDef = (key: JutsuCapFlagKey): JutsuCategoryDef => {
+  const def = JUTSU_CATEGORY_DEFS.find((d) => d.key === key);
+  if (!def) throw new Error(`Unknown jutsu category: ${key}`);
+  return def;
+};
+
+/** Which categories a jutsu counts against (equip + ranked). */
+export const getJutsuCapFlags = (jutsu: JutsuCapMatchInput): JutsuCapFlags =>
+  Object.fromEntries(
+    JUTSU_CATEGORY_DEFS.map((def) => [def.key, def.matches(jutsu)]),
+  ) as JutsuCapFlags;
+
+/**
+ * Normal equip caps. Subset of JUTSU_CATEGORY_DEFS enforced outside ranked.
+ * Loadout / toggleEquip / startTraining / SQL CAS all loop this table.
+ */
+export const JUTSU_EQUIP_CAPS = [
+  {
+    key: "isResidual",
+    max: JUTSU_MAX_RESIDUAL_EQUIPPED,
+    countAlias: "residual_cnt",
+    sql: { kind: "residual" as const },
+  },
+  {
+    key: "isPierce",
+    max: JUTSU_MAX_PIERCE_EQUIPPED,
+    countAlias: "pierce_cnt",
+    sql: { kind: "effect" as const, effectType: "pierce" },
+  },
+  {
+    key: "isEvent",
+    max: JUTSU_MAX_EVENT_EQUIPPED,
+    countAlias: "event_cnt",
+    sql: { kind: "jutsuType" as const, jutsuType: "EVENT" },
+  },
+  {
+    key: "isForbidden",
+    max: JUTSU_MAX_FORBIDDEN_EQUIPPED,
+    countAlias: "forbidden_cnt",
+    sql: { kind: "jutsuType" as const, jutsuType: "FORBIDDEN" },
+  },
+  {
+    key: "isBarrier",
+    max: JUTSU_MAX_BARRIER_EQUIPPED,
+    countAlias: "barrier_cnt",
+    sql: { kind: "effect" as const, effectType: "barrier" },
+  },
+  {
+    key: "isStun",
+    max: JUTSU_MAX_STUN_EQUIPPED,
+    countAlias: "stun_cnt",
+    sql: { kind: "effect" as const, effectType: "stun" },
+  },
+  {
+    key: "isShield",
+    max: JUTSU_MAX_SHIELD_EQUIPPED,
+    countAlias: "shield_cnt",
+    sql: { kind: "effect" as const, effectType: "shield" },
+  },
+  {
+    key: "isHeal",
+    max: JUTSU_MAX_HEAL_EQUIPPED,
+    countAlias: "heal_cnt",
+    sql: { kind: "effect" as const, effectType: "heal" },
+  },
+] as const satisfies readonly {
+  key: JutsuCapFlagKey;
+  max: number;
+  countAlias: string;
+  sql:
+    | { kind: "residual" }
+    | { kind: "effect"; effectType: string }
+    | { kind: "jutsuType"; jutsuType: string };
+}[];
+
+export type JutsuEquipCap = (typeof JUTSU_EQUIP_CAPS)[number];
+export type JutsuCapCounts = Record<JutsuEquipCap["key"], number>;
+
+/**
+ * Ranked loadout category caps. Predicates come from getJutsuCapFlags /
+ * JUTSU_CATEGORY_DEFS; only the max values differ (or match equip for event/forbidden).
+ */
+export const RANKED_JUTSU_CAPS = [
+  { key: "isResidual", max: RANKED_LOADOUT_MAX_RESIDUAL_JUTSUS },
+  { key: "isPoison", max: RANKED_LOADOUT_MAX_POISON_JUTSUS },
+  { key: "isIncreaseCost", max: RANKED_LOADOUT_MAX_INCREASECOST_JUTSUS },
+  { key: "isSummon", max: RANKED_LOADOUT_MAX_SUMMON_JUTSUS },
+  { key: "isBarrier", max: RANKED_LOADOUT_MAX_BARRIER_JUTSUS },
+  { key: "isStun", max: RANKED_LOADOUT_MAX_STUN_JUTSUS },
+  { key: "isShield", max: RANKED_LOADOUT_MAX_SHIELD_JUTSUS },
+  { key: "isHeal", max: RANKED_LOADOUT_MAX_HEAL_JUTSUS },
+  { key: "isEvent", max: JUTSU_MAX_EVENT_EQUIPPED },
+  { key: "isForbidden", max: JUTSU_MAX_FORBIDDEN_EQUIPPED },
+] as const satisfies readonly { key: JutsuCapFlagKey; max: number }[];
+
+/** Ranked select-UI warnings (subset of RANKED_JUTSU_CAPS shown when picking a jutsu). */
+export const RANKED_JUTSU_SELECT_WARNINGS = [
+  "isResidual",
+  "isPoison",
+  "isIncreaseCost",
+  "isHeal",
+] as const satisfies readonly JutsuCapFlagKey[];
+
+const emptyCapCounts = (): JutsuCapCounts =>
+  Object.fromEntries(JUTSU_EQUIP_CAPS.map((cap) => [cap.key, 0])) as JutsuCapCounts;
+
+/** True when any normal-equip capped category flag is set (e.g. force-unequip on evolution). */
+export const hasAnyJutsuEquipCap = (flags: JutsuCapFlags) =>
+  JUTSU_EQUIP_CAPS.some((cap) => flags[cap.key]);
+
+/** Equipped counts per normal-equip capped category. */
+export const countEquippedByCap = (
+  equippedJutsus: { jutsu: JutsuCapMatchInput }[],
+): JutsuCapCounts => {
+  const counts = emptyCapCounts();
+  for (const uj of equippedJutsus) {
+    const flags = getJutsuCapFlags(uj.jutsu);
+    for (const cap of JUTSU_EQUIP_CAPS) {
+      if (flags[cap.key]) counts[cap.key] += 1;
+    }
+  }
+  return counts;
+};
+
+/** Whether `flags` fit under `equippedCounts` for every normal-equip capped category. */
+export const canEquipUnderCaps = (
+  flags: JutsuCapFlags,
+  equippedCounts: JutsuCapCounts,
+) =>
+  JUTSU_EQUIP_CAPS.every((cap) => !flags[cap.key] || equippedCounts[cap.key] < cap.max);
+
+/** First exceeded normal-equip cap for error messaging, if any. */
+export const findExceededJutsuEquipCap = (
+  flags: JutsuCapFlags,
+  equippedCounts: JutsuCapCounts,
+): (JutsuEquipCap & { label: string }) | undefined => {
+  const cap = JUTSU_EQUIP_CAPS.find(
+    (c) => flags[c.key] && equippedCounts[c.key] >= c.max,
+  );
+  if (!cap) return undefined;
+  return { ...cap, label: getJutsuCategoryDef(cap.key).label };
+};
 
 /**
  * Pure decision logic for applying a jutsu loadout. Validates every saved
@@ -86,12 +290,7 @@ export const computeJutsuLoadoutAssignments = (args: {
   const invalidJutsus: string[] = [];
   const maxEquip = calcJutsuEquipLimit(user);
   let total = 0;
-  let pierce = 0;
-  let event = 0;
-  let barrier = 0;
-  let stun = 0;
-  let shield = 0;
-  let residual = 0;
+  const counts = emptyCapCounts();
 
   // A jutsu is equipped or not (no quantity), and the equip CASE matches by
   // jutsuId, so a duplicate id in a stale loadout equips the same row once.
@@ -99,7 +298,7 @@ export const computeJutsuLoadoutAssignments = (args: {
   // falsely reject a later jutsu.
   const uniqueJutsuIds = [...new Set(jutsuIds)];
 
-  for (const jutsuId of uniqueJutsuIds) {
+  jutsuLoop: for (const jutsuId of uniqueJutsuIds) {
     const uj = userjutsus.find((j) => j.jutsuId === jutsuId);
     if (!uj) {
       invalidJutsus.push("Jutsu not found");
@@ -114,44 +313,24 @@ export const computeJutsuLoadoutAssignments = (args: {
       invalidJutsus.push(`${jutsu.name}: missing requirements`);
       continue;
     }
-    const { isResidual, isPierce, isEvent, isBarrier, isStun, isShield } =
-      getJutsuCapFlags(jutsu);
+    const flags = getJutsuCapFlags(jutsu);
     if (total >= maxEquip) {
       invalidJutsus.push(`${jutsu.name}: equip limit reached`);
       continue;
     }
-    if (isResidual && residual >= JUTSU_MAX_RESIDUAL_EQUIPPED) {
-      invalidJutsus.push(`${jutsu.name}: residual jutsu limit reached`);
-      continue;
-    }
-    if (isPierce && pierce >= JUTSU_MAX_PIERCE_EQUIPPED) {
-      invalidJutsus.push(`${jutsu.name}: piercing jutsu limit reached`);
-      continue;
-    }
-    if (isEvent && event >= JUTSU_MAX_EVENT_EQUIPPED) {
-      invalidJutsus.push(`${jutsu.name}: event jutsu limit reached`);
-      continue;
-    }
-    if (isBarrier && barrier >= JUTSU_MAX_BARRIER_EQUIPPED) {
-      invalidJutsus.push(`${jutsu.name}: barrier jutsu limit reached`);
-      continue;
-    }
-    if (isStun && stun >= JUTSU_MAX_STUN_EQUIPPED) {
-      invalidJutsus.push(`${jutsu.name}: stun jutsu limit reached`);
-      continue;
-    }
-    if (isShield && shield >= JUTSU_MAX_SHIELD_EQUIPPED) {
-      invalidJutsus.push(`${jutsu.name}: shield jutsu limit reached`);
-      continue;
+    for (const cap of JUTSU_EQUIP_CAPS) {
+      if (flags[cap.key] && counts[cap.key] >= cap.max) {
+        invalidJutsus.push(
+          `${jutsu.name}: ${getJutsuCategoryDef(cap.key).label} jutsu limit reached`,
+        );
+        continue jutsuLoop;
+      }
     }
     equipIds.push(jutsuId);
     total += 1;
-    if (isResidual) residual += 1;
-    if (isPierce) pierce += 1;
-    if (isEvent) event += 1;
-    if (isBarrier) barrier += 1;
-    if (isStun) stun += 1;
-    if (isShield) shield += 1;
+    for (const cap of JUTSU_EQUIP_CAPS) {
+      if (flags[cap.key]) counts[cap.key] += 1;
+    }
   }
 
   return { equipIds, invalidJutsus };

--- a/app/src/libs/jutsu.ts
+++ b/app/src/libs/jutsu.ts
@@ -269,6 +269,65 @@ export const findExceededJutsuEquipCap = (
   return { ...cap, label: getJutsuCategoryDef(cap.key).label };
 };
 
+type JutsuLoadoutValidationInput = Pick<UserJutsuWithRelations, "jutsuId" | "jutsu">;
+
+/**
+ * Apply ownership, caller-specific eligibility, total-slot, and category-cap
+ * validation to an ordered list of saved jutsu IDs. Keeping the cap pass here
+ * ensures every loadout-selection surface, including the combat lobby, uses
+ * the same rules as manual equip.
+ */
+export const computeJutsuLoadoutCapAssignments = (args: {
+  jutsuIds: string[];
+  userjutsus: JutsuLoadoutValidationInput[];
+  maxEquip: number;
+  validateJutsu?: (userJutsu: JutsuLoadoutValidationInput) => string | undefined;
+}): ComputedJutsuLoadout => {
+  const { jutsuIds, userjutsus, maxEquip, validateJutsu } = args;
+  const equipIds: string[] = [];
+  const invalidJutsus: string[] = [];
+  const counts = emptyCapCounts();
+
+  // A jutsu is equipped or not (no quantity), and the equip CASE matches by
+  // jutsuId, so duplicates must not consume slots or category capacity.
+  const uniqueJutsuIds = [...new Set(jutsuIds)];
+
+  jutsuLoop: for (const jutsuId of uniqueJutsuIds) {
+    const userJutsu = userjutsus.find((entry) => entry.jutsuId === jutsuId);
+    if (!userJutsu) {
+      invalidJutsus.push("Jutsu not found");
+      continue;
+    }
+
+    const validationError = validateJutsu?.(userJutsu);
+    if (validationError) {
+      invalidJutsus.push(validationError);
+      continue;
+    }
+
+    const flags = getJutsuCapFlags(userJutsu.jutsu);
+    if (equipIds.length >= maxEquip) {
+      invalidJutsus.push(`${userJutsu.jutsu.name}: equip limit reached`);
+      continue;
+    }
+    for (const cap of JUTSU_EQUIP_CAPS) {
+      if (flags[cap.key] && counts[cap.key] >= cap.max) {
+        invalidJutsus.push(
+          `${userJutsu.jutsu.name}: ${getJutsuCategoryDef(cap.key).label} jutsu limit reached`,
+        );
+        continue jutsuLoop;
+      }
+    }
+
+    equipIds.push(jutsuId);
+    for (const cap of JUTSU_EQUIP_CAPS) {
+      if (flags[cap.key]) counts[cap.key] += 1;
+    }
+  }
+
+  return { equipIds, invalidJutsus };
+};
+
 /**
  * Pure decision logic for applying a jutsu loadout. Validates every saved
  * jutsuId against the user's ownership, the hidden-content gate, usability
@@ -286,54 +345,20 @@ export const computeJutsuLoadoutAssignments = (args: {
   user: NonNullable<UserWithRelations>;
 }): ComputedJutsuLoadout => {
   const { jutsuIds, userjutsus, user } = args;
-  const equipIds: string[] = [];
-  const invalidJutsus: string[] = [];
-  const maxEquip = calcJutsuEquipLimit(user);
-  let total = 0;
-  const counts = emptyCapCounts();
-
-  // A jutsu is equipped or not (no quantity), and the equip CASE matches by
-  // jutsuId, so a duplicate id in a stale loadout equips the same row once.
-  // Dedupe up front so duplicates cannot double-count toward the caps and
-  // falsely reject a later jutsu.
-  const uniqueJutsuIds = [...new Set(jutsuIds)];
-
-  jutsuLoop: for (const jutsuId of uniqueJutsuIds) {
-    const uj = userjutsus.find((j) => j.jutsuId === jutsuId);
-    if (!uj) {
-      invalidJutsus.push("Jutsu not found");
-      continue;
-    }
-    const jutsu = uj.jutsu;
-    if (jutsu.hidden && !canChangeContent(user.role)) {
-      invalidJutsus.push(`${jutsu.name} is hidden`);
-      continue;
-    }
-    if (!canUseJutsu(jutsu, user)) {
-      invalidJutsus.push(`${jutsu.name}: missing requirements`);
-      continue;
-    }
-    const flags = getJutsuCapFlags(jutsu);
-    if (total >= maxEquip) {
-      invalidJutsus.push(`${jutsu.name}: equip limit reached`);
-      continue;
-    }
-    for (const cap of JUTSU_EQUIP_CAPS) {
-      if (flags[cap.key] && counts[cap.key] >= cap.max) {
-        invalidJutsus.push(
-          `${jutsu.name}: ${getJutsuCategoryDef(cap.key).label} jutsu limit reached`,
-        );
-        continue jutsuLoop;
+  return computeJutsuLoadoutCapAssignments({
+    jutsuIds,
+    userjutsus,
+    maxEquip: calcJutsuEquipLimit(user),
+    validateJutsu: ({ jutsu }) => {
+      if (jutsu.hidden && !canChangeContent(user.role)) {
+        return `${jutsu.name} is hidden`;
       }
-    }
-    equipIds.push(jutsuId);
-    total += 1;
-    for (const cap of JUTSU_EQUIP_CAPS) {
-      if (flags[cap.key]) counts[cap.key] += 1;
-    }
-  }
-
-  return { equipIds, invalidJutsus };
+      if (!canUseJutsu(jutsu, user)) {
+        return `${jutsu.name}: missing requirements`;
+      }
+      return undefined;
+    },
+  });
 };
 
 /**

--- a/app/src/libs/ranked_pvp.ts
+++ b/app/src/libs/ranked_pvp.ts
@@ -1,19 +1,11 @@
 import type { RankedRank } from "@/drizzle/constants";
 import {
-  JUTSU_MAX_EVENT_EQUIPPED,
   RANKED_DIVISIONS,
   RANKED_LEGEND_LP_REQUIREMENT,
-  RANKED_LOADOUT_MAX_BARRIER_JUTSUS,
   RANKED_LOADOUT_MAX_CONSUMABLES,
   RANKED_LOADOUT_MAX_INCREASECOST_ITEMS,
-  RANKED_LOADOUT_MAX_INCREASECOST_JUTSUS,
   RANKED_LOADOUT_MAX_JUTSUS,
   RANKED_LOADOUT_MAX_POISON_ITEMS,
-  RANKED_LOADOUT_MAX_POISON_JUTSUS,
-  RANKED_LOADOUT_MAX_RESIDUAL_JUTSUS,
-  RANKED_LOADOUT_MAX_SHIELD_JUTSUS,
-  RANKED_LOADOUT_MAX_STUN_JUTSUS,
-  RANKED_LOADOUT_MAX_SUMMON_JUTSUS,
   RANKED_LOADOUT_MAX_WEAPONS,
   RANKED_MIN_LP_GAIN,
   RANKED_QUEUE_MAX_WAIT_SECS,
@@ -22,6 +14,7 @@ import {
   RANKED_STREAK_BONUS,
 } from "@/drizzle/constants";
 import type { Item, Jutsu, UserData } from "@/drizzle/schema";
+import { getJutsuCapFlags, getJutsuCategoryDef, RANKED_JUTSU_CAPS } from "@/libs/jutsu";
 
 /**
  * Determine player rank based on LP and top players
@@ -149,74 +142,14 @@ export const validateJutsuLoadout = (jutsus: Jutsu[]) => {
   let check = true;
   let message = "";
 
-  // Check residual jutsu limit
-  const residualJutsus = jutsus.filter((jutsu) =>
-    jutsu.effects.some((e) => "residualModifier" in e && e.residualModifier),
-  );
-  if (residualJutsus.length > RANKED_LOADOUT_MAX_RESIDUAL_JUTSUS) {
-    check = false;
-    message = `You can only equip up to ${RANKED_LOADOUT_MAX_RESIDUAL_JUTSUS} residual jutsu in ranked PvP`;
-  }
-
-  // Check poison jutsu limit
-  const poisonJutsus = jutsus.filter((jutsu) =>
-    jutsu.effects.some((e) => e.type === "poison"),
-  );
-  if (poisonJutsus.length > RANKED_LOADOUT_MAX_POISON_JUTSUS) {
-    check = false;
-    message = `You can only equip up to ${RANKED_LOADOUT_MAX_POISON_JUTSUS} poison jutsu in ranked PvP`;
-  }
-
-  // Check increasecost jutsu limit
-  const increasecostJutsus = jutsus.filter((jutsu) =>
-    jutsu.effects.some((e) => e.type === "increasepoolcost"),
-  );
-  if (increasecostJutsus.length > RANKED_LOADOUT_MAX_INCREASECOST_JUTSUS) {
-    check = false;
-    message = `You can only equip up to ${RANKED_LOADOUT_MAX_INCREASECOST_JUTSUS} increasecost jutsu in ranked PvP`;
-  }
-
-  // Check summon jutsu limit
-  const summonJutsus = jutsus.filter((jutsu) =>
-    jutsu.effects.some((e) => e.type === "summon"),
-  );
-  if (summonJutsus.length > RANKED_LOADOUT_MAX_SUMMON_JUTSUS) {
-    check = false;
-    message = `You can only equip up to ${RANKED_LOADOUT_MAX_SUMMON_JUTSUS} summon jutsu in ranked PvP`;
-  }
-
-  // Check barrier jutsu limit
-  const barrierJutsus = jutsus.filter((jutsu) =>
-    jutsu.effects.some((e) => e.type === "barrier"),
-  );
-  if (barrierJutsus.length > RANKED_LOADOUT_MAX_BARRIER_JUTSUS) {
-    check = false;
-    message = `You can only equip up to ${RANKED_LOADOUT_MAX_BARRIER_JUTSUS} barrier jutsu in ranked PvP`;
-  }
-
-  // Check stun jutsu limit
-  const stunJutsus = jutsus.filter((jutsu) =>
-    jutsu.effects.some((e) => e.type === "stun"),
-  );
-  if (stunJutsus.length > RANKED_LOADOUT_MAX_STUN_JUTSUS) {
-    check = false;
-    message = `You can only equip up to ${RANKED_LOADOUT_MAX_STUN_JUTSUS} stun jutsu in ranked PvP`;
-  }
-
-  // Check shield jutsu limit
-  const shieldJutsus = jutsus.filter((jutsu) =>
-    jutsu.effects.some((e) => e.type === "shield"),
-  );
-  if (shieldJutsus.length > RANKED_LOADOUT_MAX_SHIELD_JUTSUS) {
-    check = false;
-    message = `You can only equip up to ${RANKED_LOADOUT_MAX_SHIELD_JUTSUS} shield jutsu in ranked PvP`;
-  }
-
-  // Check event jutsu limit
-  const eventJutsus = jutsus.filter((jutsu) => jutsu.jutsuType === "EVENT");
-  if (eventJutsus.length > JUTSU_MAX_EVENT_EQUIPPED) {
-    check = false;
-    message = `You can only equip up to ${JUTSU_MAX_EVENT_EQUIPPED} event jutsu in ranked PvP`;
+  const flagged = jutsus.map((jutsu) => getJutsuCapFlags(jutsu));
+  for (const cap of RANKED_JUTSU_CAPS) {
+    const count = flagged.filter((flags) => flags[cap.key]).length;
+    if (count > cap.max) {
+      check = false;
+      const label = getJutsuCategoryDef(cap.key).label;
+      message = `You can only equip up to ${cap.max} ${label} jutsu in ranked PvP`;
+    }
   }
 
   if (jutsus.length > RANKED_LOADOUT_MAX_JUTSUS) {

--- a/app/src/libs/train.ts
+++ b/app/src/libs/train.ts
@@ -345,7 +345,12 @@ export const calcJutsuTrainCost = (
   return cost;
 };
 
-export const calcJutsuEquipLimit = (userdata: UserData) => {
+type JutsuEquipLimitUser = Pick<
+  UserData,
+  "rank" | "staffAccount" | "extraJutsuSlots" | "federalStatus"
+>;
+
+export const calcJutsuEquipLimit = (userdata: JutsuEquipLimitUser) => {
   const rankContrib = (rank: UserRank) => {
     switch (rank) {
       case "GENIN":
@@ -361,7 +366,7 @@ export const calcJutsuEquipLimit = (userdata: UserData) => {
     }
     return 4 + 2;
   };
-  const fedContrib = (userdata: UserData) => {
+  const fedContrib = (userdata: JutsuEquipLimitUser) => {
     const status = getUserFederalStatus(userdata);
     switch (status) {
       case "NORMAL":

--- a/app/src/libs/train.ts
+++ b/app/src/libs/train.ts
@@ -10,6 +10,7 @@ import {
   FED_GOLD_JUTSU_SLOTS,
   FED_NORMAL_JUTSU_SLOTS,
   FED_SILVER_JUTSU_SLOTS,
+  JUTSU_TRAIN_TO_LEARN_RESTRICTED_TYPES,
   LetterRanks,
   MAX_EXTRA_JUTSU_SLOTS,
   MAX_JUTSU_TRAIN_TIME_MS,
@@ -266,6 +267,12 @@ export const canTrainJutsu = (
   // the item only gates equipping and in-combat use, so skip that check here.
   return canUseJutsu(jutsu, userdata, true);
 };
+
+/** True for jutsu types that cannot be initially learned via training (owned ones can still be leveled). */
+export const isJutsuTrainToLearnRestricted = (jutsuType: Jutsu["jutsuType"]) =>
+  (JUTSU_TRAIN_TO_LEARN_RESTRICTED_TYPES as readonly Jutsu["jutsuType"][]).includes(
+    jutsuType,
+  );
 
 export const canUseJutsu = (
   jutsu: Jutsu,

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -146,6 +146,7 @@ import {
   rollInitiative,
 } from "@/libs/combat/util";
 import { fetchDmgConfig } from "@/libs/gamesettings";
+import { computeJutsuLoadoutCapAssignments } from "@/libs/jutsu";
 import {
   calcActiveUserRegen,
   calcCP,
@@ -167,7 +168,12 @@ import {
 import { toDefenceStat, toOffenceStat } from "@/libs/stats";
 import { rollStealthKeep } from "@/libs/stealth";
 import type { GlobalMapData } from "@/libs/threejs/types";
-import { canUseJutsu, checkJutsuBloodlineItem, checkJutsuItems } from "@/libs/train";
+import {
+  calcJutsuEquipLimit,
+  canUseJutsu,
+  checkJutsuBloodlineItem,
+  checkJutsuItems,
+} from "@/libs/train";
 import { calcIsInVillage, getBiomeFromGlobalTile } from "@/libs/travel";
 import {
   extendWarParticipantSql,
@@ -956,13 +962,16 @@ export const combatRouter = createTRPCRouter({
               jutsuLoadouts,
               userjutsus,
               user,
-              (jutsuIds) => {
-                const equipIds = jutsuIds.filter((jutsuId) => {
-                  const owned = userjutsus.find((uj) => uj.jutsuId === jutsuId);
-                  return owned ? checkJutsuBloodlineItem(owned.jutsu, useritems) : true;
-                });
-                return { equipIds, invalidJutsus: [] };
-              },
+              (jutsuIds) =>
+                computeJutsuLoadoutCapAssignments({
+                  jutsuIds,
+                  userjutsus,
+                  maxEquip: calcJutsuEquipLimit(user),
+                  validateJutsu: ({ jutsu }) =>
+                    checkJutsuBloodlineItem(jutsu, useritems)
+                      ? undefined
+                      : `${jutsu.name}: required bloodline item is not equipped`,
+                }),
             );
 
       // When only the item loadout changed, selectJutsuLoadout (and its

--- a/app/src/server/api/routers/jutsu.ts
+++ b/app/src/server/api/routers/jutsu.ts
@@ -1079,19 +1079,13 @@ export const jutsuRouter = createTRPCRouter({
         questDataFull = trackers;
       }
       const questDataForDb = filterQuestTrackersForDbPersist(questDataFull, user);
-      // Pre-mutation snapshot for refund if the new-jutsu insert fails after deduct.
-      const questDataBeforeTrain = filterQuestTrackersForDbPersist(
-        user.questData ?? [],
-        user,
-      );
 
-      // Deduct money
+      // Deduct money first, but persist new-jutsu quest progress only after the
+      // ownership insert is confirmed. A duplicate request can then refund its
+      // own money without restoring a stale questData snapshot over the winner.
       const moneyUpdate = await ctx.drizzle
         .update(userData)
-        .set({
-          money: sql`${userData.money} - ${trainCost}`,
-          questData: questDataForDb,
-        })
+        .set({ money: sql`${userData.money} - ${trainCost}` })
         .where(and(eq(userData.userId, ctx.userId), gte(userData.money, trainCost)));
       if (moneyUpdate.rowsAffected !== 1) {
         return errorResponse("You don't have enough money");
@@ -1123,17 +1117,15 @@ export const jutsuRouter = createTRPCRouter({
         const newUserJutsuId = nanoid();
         // onDuplicateKeyUpdate no-op (`id = id`) absorbs unique-index races. PlanetScale
         // reports changed rows, so a duplicate yields rowsAffected === 0 (not 2). Deduct
-        // already happened above — refund money + quest snapshot when this request did
-        // not insert (otherwise jutsus_mastered / train_specific_jutsu stay incremented).
+        // already happened above, so refund it when this request definitively did not
+        // insert. Quest progress has not been persisted yet and needs no compensation.
         const refundTrainCost = () =>
           ctx.drizzle
             .update(userData)
-            .set({
-              money: sql`${userData.money} + ${trainCost}`,
-              questData: questDataBeforeTrain,
-            })
+            .set({ money: sql`${userData.money} + ${trainCost}` })
             .where(eq(userData.userId, ctx.userId));
 
+        let insertedByThisRequest = false;
         try {
           const insertResult = await ctx.drizzle
             .insert(userJutsu)
@@ -1145,27 +1137,61 @@ export const jutsuRouter = createTRPCRouter({
               equipped: canAutoEquip,
             })
             .onDuplicateKeyUpdate({ set: { id: sql`id` } });
-
-          if (insertResult.rowsAffected !== 1) {
-            await refundTrainCost();
+          insertedByThisRequest = insertResult.rowsAffected === 1;
+        } catch {
+          // A transport error can arrive after MySQL committed the insert. Re-read
+          // the unique ownership row before compensating so a committed training
+          // session is never refunded and granted for free.
+          let persisted: { id: string } | undefined;
+          try {
+            [persisted] = await ctx.drizzle
+              .select({ id: userJutsu.id })
+              .from(userJutsu)
+              .where(
+                and(
+                  eq(userJutsu.userId, ctx.userId),
+                  eq(userJutsu.jutsuId, input.jutsuId),
+                ),
+              )
+              .limit(1);
+          } catch {
             return errorResponse(
-              "You already own this jutsu — please refresh and try again",
+              "Training status could not be confirmed — please refresh before retrying",
             );
           }
-        } catch {
-          await refundTrainCost();
-          return errorResponse("Failed to start training — please try again");
+          insertedByThisRequest = persisted?.id === newUserJutsuId;
+          if (!insertedByThisRequest) {
+            await refundTrainCost();
+            return errorResponse(
+              persisted
+                ? "You already own this jutsu — please refresh and try again"
+                : "Failed to start training — please try again",
+            );
+          }
         }
 
-        if (canAutoEquip) {
-          await rollbackEquipIfOverCap({
-            client: ctx.drizzle,
-            userId: ctx.userId,
-            userJutsuId: newUserJutsuId,
-            maxEquip,
-            flags: capFlags,
-          });
+        if (!insertedByThisRequest) {
+          await refundTrainCost();
+          return errorResponse(
+            "You already own this jutsu — please refresh and try again",
+          );
         }
+
+        await Promise.all([
+          ctx.drizzle
+            .update(userData)
+            .set({ questData: questDataForDb })
+            .where(eq(userData.userId, ctx.userId)),
+          canAutoEquip
+            ? rollbackEquipIfOverCap({
+                client: ctx.drizzle,
+                userId: ctx.userId,
+                userJutsuId: newUserJutsuId,
+                maxEquip,
+                flags: capFlags,
+              })
+            : undefined,
+        ]);
       }
 
       return {
@@ -1337,16 +1363,7 @@ export const jutsuRouter = createTRPCRouter({
                   eq(userJutsu.id, input.userJutsuId),
                   eq(userJutsu.userId, ctx.userId),
                   eq(userJutsu.equipped, true),
-                  sql`NOT EXISTS (
-                    SELECT 1 FROM (
-                      SELECT ${jutsuLoadout.jutsuIds} AS ids
-                      FROM ${userData}
-                      INNER JOIN ${jutsuLoadout} ON ${jutsuLoadout.id} = ${userData.jutsuLoadout}
-                      WHERE ${userData.userId} = ${ctx.userId}
-                        AND ${jutsuLoadout.userId} = ${ctx.userId}
-                    ) AS active_loadout
-                    WHERE JSON_CONTAINS(active_loadout.ids, JSON_QUOTE(${userjutsuObj.jutsuId}))
-                  )`,
+                  activeJutsuLoadoutLacksJutsuSql(ctx.userId, userjutsuObj.jutsuId),
                 ),
               );
             if (rolledBack.rowsAffected === 1) {
@@ -1386,7 +1403,7 @@ export const jutsuRouter = createTRPCRouter({
           }
         }
         try {
-          await ctx.drizzle
+          const unequipped = await ctx.drizzle
             .update(userJutsu)
             .set({ equipped: false })
             .where(
@@ -1394,8 +1411,38 @@ export const jutsuRouter = createTRPCRouter({
                 eq(userJutsu.id, input.userJutsuId),
                 eq(userJutsu.userId, ctx.userId),
                 eq(userJutsu.equipped, true),
+                // If a concurrent selectJutsuLoadout activated another loadout
+                // containing this jutsu after the removal above, leave the row
+                // equipped so the newly active loadout remains consistent.
+                activeJutsuLoadoutLacksJutsuSql(ctx.userId, userjutsuObj.jutsuId),
               ),
             );
+          if (unequipped.rowsAffected !== 1) {
+            const [row, activeIds] = await Promise.all([
+              ctx.drizzle
+                .select({ equipped: userJutsu.equipped })
+                .from(userJutsu)
+                .where(
+                  and(
+                    eq(userJutsu.id, input.userJutsuId),
+                    eq(userJutsu.userId, ctx.userId),
+                  ),
+                )
+                .limit(1)
+                .then((rows) => rows[0]),
+              fetchActiveLoadoutJutsuIds(ctx.drizzle, ctx.userId),
+            ]);
+            if (row && !row.equipped && !activeIds?.includes(userjutsuObj.jutsuId)) {
+              return {
+                success: true,
+                message: "Jutsu unequipped",
+                data: { equipped: false, jutsuId: userjutsuObj.jutsuId },
+              };
+            }
+            return errorResponse(
+              "Active loadout changed while unequipping — please refresh and retry",
+            );
+          }
         } catch {
           const [row] = await ctx.drizzle
             .select({ equipped: userJutsu.equipped })
@@ -2323,22 +2370,21 @@ export const selectJutsuLoadout = async (
     ? validateLoadout(loadout.jutsuIds)
     : { equipIds: loadout.jutsuIds, invalidJutsus: [] as string[] };
 
-  // Equip first, then advance the pointer (mirrors selectItemLoadout). The equip
-  // is one atomic statement, so serializing keeps the jutsuLoadout pointer from
-  // racing ahead and pointing at a loadout whose jutsus were not equipped.
-  await client
-    .update(userJutsu)
-    .set({
-      equipped:
-        equipIds.length > 0
-          ? sql`CASE WHEN ${inArray(userJutsu.jutsuId, equipIds)} THEN 1 ELSE 0 END`
-          : false,
-    })
-    .where(eq(userJutsu.userId, user.userId));
-  await client
-    .update(userData)
-    .set({ jutsuLoadout: loadout.id })
-    .where(eq(userData.userId, user.userId));
+  // Update the active pointer and every equipped row in one multi-table UPDATE.
+  // Keeping these writes in a single statement closes the window where
+  // toggleEquip could observe the old pointer after the new loadout's equipped
+  // rows were already applied (or vice versa).
+  const equippedAssignment =
+    equipIds.length > 0
+      ? sql`CASE WHEN ${inArray(userJutsu.jutsuId, equipIds)} THEN 1 ELSE 0 END`
+      : sql`0`;
+  await client.execute(sql`
+    UPDATE ${userData}
+    LEFT JOIN ${userJutsu} ON ${userJutsu.userId} = ${userData.userId}
+    SET ${userData.jutsuLoadout} = ${loadout.id},
+        ${userJutsu.equipped} = ${equippedAssignment}
+    WHERE ${userData.userId} = ${user.userId}
+  `);
 
   const message =
     invalidJutsus.length > 0
@@ -2555,6 +2601,19 @@ const isActiveJutsuLoadoutSql = (userId: string, loadoutId: string) => sql`EXIST
     AND ${userData.jutsuLoadout} = ${loadoutId}
 )`;
 
+/** True when the user's active loadout does not currently contain `jutsuId`. */
+const activeJutsuLoadoutLacksJutsuSql = (userId: string, jutsuId: string) =>
+  sql`NOT EXISTS (
+    SELECT 1 FROM (
+      SELECT ${jutsuLoadout.jutsuIds} AS ids
+      FROM ${userData}
+      INNER JOIN ${jutsuLoadout} ON ${jutsuLoadout.id} = ${userData.jutsuLoadout}
+      WHERE ${userData.userId} = ${userId}
+        AND ${jutsuLoadout.userId} = ${userId}
+    ) AS active_loadout
+    WHERE JSON_CONTAINS(active_loadout.ids, JSON_QUOTE(${jutsuId}))
+  )`;
+
 /** Active loadout's jutsuIds, or null when the user has no pointer / join miss. */
 const fetchActiveLoadoutJutsuIds = async (
   client: DrizzleClient,
@@ -2648,7 +2707,7 @@ const removeJutsuIdFromLoadoutAtomically = async (args: {
     if (result.rowsAffected === 1) return true;
     // Pointer moved or already absent — only the active loadout must lack this id.
     const ids = await fetchActiveLoadoutJutsuIds(client, userId);
-    return !ids || !ids.includes(jutsuId);
+    return !ids?.includes(jutsuId);
   } catch {
     return false;
   }

--- a/app/src/server/api/routers/jutsu.ts
+++ b/app/src/server/api/routers/jutsu.ts
@@ -2548,10 +2548,33 @@ export const tryEquipUserJutsuAtomically = async (args: {
   return kept ? "equipped" : "cap-reached";
 };
 
+/** True when this loadout is still the user's active `userData.jutsuLoadout`. */
+const isActiveJutsuLoadoutSql = (userId: string, loadoutId: string) => sql`EXISTS (
+  SELECT 1 FROM ${userData}
+  WHERE ${userData.userId} = ${userId}
+    AND ${userData.jutsuLoadout} = ${loadoutId}
+)`;
+
+/** Active loadout's jutsuIds, or null when the user has no pointer / join miss. */
+const fetchActiveLoadoutJutsuIds = async (
+  client: DrizzleClient,
+  userId: string,
+): Promise<string[] | null> => {
+  const [active] = await client
+    .select({ jutsuIds: jutsuLoadout.jutsuIds })
+    .from(userData)
+    .innerJoin(jutsuLoadout, eq(jutsuLoadout.id, userData.jutsuLoadout))
+    .where(and(eq(userData.userId, userId), eq(jutsuLoadout.userId, userId)))
+    .limit(1);
+  return active?.jutsuIds ?? null;
+};
+
 /**
  * Append a jutsuId to a loadout's JSON array without rewriting the whole array, so
  * concurrent equips cannot drop each other's IDs. Idempotent via NOT JSON_CONTAINS.
- * Returns true when the loadout ends up containing jutsuId (append or already present).
+ * Only mutates the loadout if it is still the user's active pointer — otherwise a
+ * concurrent selectJutsuLoadout would desynchronize the old loadout from equipped
+ * rows. Returns true when the *active* loadout contains jutsuId.
  */
 const appendJutsuIdToLoadoutAtomically = async (args: {
   client: DrizzleClient;
@@ -2570,16 +2593,14 @@ const appendJutsuIdToLoadoutAtomically = async (args: {
         and(
           eq(jutsuLoadout.id, loadoutId),
           eq(jutsuLoadout.userId, userId),
+          isActiveJutsuLoadoutSql(userId, loadoutId),
           sql`NOT JSON_CONTAINS(${jutsuLoadout.jutsuIds}, JSON_QUOTE(${jutsuId}))`,
         ),
       );
     if (result.rowsAffected === 1) return true;
-    // Already present (PlanetScale reports 0 changed rows) or missing loadout — verify.
-    const row = await client.query.jutsuLoadout.findFirst({
-      where: and(eq(jutsuLoadout.id, loadoutId), eq(jutsuLoadout.userId, userId)),
-      columns: { jutsuIds: true },
-    });
-    return !!row?.jutsuIds.includes(jutsuId);
+    // Already present, pointer moved, or missing loadout — check the active one.
+    const ids = await fetchActiveLoadoutJutsuIds(client, userId);
+    return !!ids?.includes(jutsuId);
   } catch {
     return false;
   }
@@ -2595,7 +2616,8 @@ const escapeJsonSearchPattern = (value: string) =>
 /**
  * Remove a jutsuId from a loadout's JSON array without rewriting the whole array, so
  * concurrent unequips cannot restore each other's IDs from stale snapshots.
- * Returns true when the loadout no longer contains jutsuId (removed or already absent).
+ * Only mutates the loadout if it is still the user's active pointer.
+ * Returns true when the *active* loadout no longer contains jutsuId.
  */
 const removeJutsuIdFromLoadoutAtomically = async (args: {
   client: DrizzleClient;
@@ -2618,17 +2640,15 @@ const removeJutsuIdFromLoadoutAtomically = async (args: {
         and(
           eq(jutsuLoadout.id, loadoutId),
           eq(jutsuLoadout.userId, userId),
+          isActiveJutsuLoadoutSql(userId, loadoutId),
           // Exact membership — do not use unescaped JSON_SEARCH (LIKE wildcards).
           sql`JSON_CONTAINS(${jutsuLoadout.jutsuIds}, JSON_QUOTE(${jutsuId}))`,
         ),
       );
     if (result.rowsAffected === 1) return true;
-    const row = await client.query.jutsuLoadout.findFirst({
-      where: and(eq(jutsuLoadout.id, loadoutId), eq(jutsuLoadout.userId, userId)),
-      columns: { jutsuIds: true },
-    });
-    // Missing loadout is fine (nothing to keep in sync); otherwise require absence.
-    return !row || !row.jutsuIds.includes(jutsuId);
+    // Pointer moved or already absent — only the active loadout must lack this id.
+    const ids = await fetchActiveLoadoutJutsuIds(client, userId);
+    return !ids || !ids.includes(jutsuId);
   } catch {
     return false;
   }

--- a/app/src/server/api/routers/jutsu.ts
+++ b/app/src/server/api/routers/jutsu.ts
@@ -20,12 +20,6 @@ import {
   COST_RESKIN_JUTSU,
   IMG_AVATAR_DEFAULT,
   JUTSU_LEVEL_CAP,
-  JUTSU_MAX_BARRIER_EQUIPPED,
-  JUTSU_MAX_EVENT_EQUIPPED,
-  JUTSU_MAX_PIERCE_EQUIPPED,
-  JUTSU_MAX_RESIDUAL_EQUIPPED,
-  JUTSU_MAX_SHIELD_EQUIPPED,
-  JUTSU_MAX_STUN_EQUIPPED,
   JUTSU_TRAIN_LEVEL_CAP,
   JUTSU_TRANSFER_COST,
   JUTSU_TRANSFER_DAYS,
@@ -47,12 +41,17 @@ import {
   userData,
   userJutsu,
 } from "@/drizzle/schema";
-import type { ComputedJutsuLoadout } from "@/libs/jutsu";
+import type { ComputedJutsuLoadout, JutsuCapFlags, JutsuEquipCap } from "@/libs/jutsu";
 import {
+  canEquipUnderCaps,
   computeJutsuLoadoutAssignments,
+  countEquippedByCap,
+  findExceededJutsuEquipCap,
   getFreeTransfers,
   getJutsuCapFlags,
   getReskinnedUserJutsu,
+  hasAnyJutsuEquipCap,
+  JUTSU_EQUIP_CAPS,
 } from "@/libs/jutsu";
 import {
   buildMissingLoadouts,
@@ -72,6 +71,7 @@ import {
   checkJutsuBloodlineItem,
   hasRequiredLevel,
   hasRequiredRank,
+  isJutsuTrainToLearnRestricted,
 } from "@/libs/train";
 import { fetchStudents } from "@/routers/sensei";
 import {
@@ -582,13 +582,7 @@ export const jutsuRouter = createTRPCRouter({
       ]);
       const questDataForDb = filterQuestTrackersForDbPersist(trackers, user);
       const evolutionCapFlags = getJutsuCapFlags(evolutionJutsu);
-      const isRestrictedEquipType =
-        evolutionCapFlags.isEvent ||
-        evolutionCapFlags.isPierce ||
-        evolutionCapFlags.isBarrier ||
-        evolutionCapFlags.isStun ||
-        evolutionCapFlags.isShield ||
-        evolutionCapFlags.isResidual;
+      const isRestrictedEquipType = hasAnyJutsuEquipCap(evolutionCapFlags);
       // Single compare-and-swap update that applies every userJutsu-row change at once:
       // - jutsuId/level/experience/finishTraining — the evolution itself
       // - equipped — force off for restricted types to avoid cap overflows
@@ -1036,28 +1030,14 @@ export const jutsuRouter = createTRPCRouter({
       const equippedJutsus = userjutsus.filter((uj) => uj.equipped);
       const curEquip = equippedJutsus.length;
       const maxEquip = calcJutsuEquipLimit(user);
-      const residualJutsus = equippedJutsus.filter(
-        (uj) => getJutsuCapFlags(uj.jutsu).isResidual,
-      );
-      const pierceJutsus = equippedJutsus.filter(
-        (uj) => getJutsuCapFlags(uj.jutsu).isPierce,
-      );
-      const eventJutsus = equippedJutsus.filter(
-        (uj) => getJutsuCapFlags(uj.jutsu).isEvent,
-      );
-      const barrierJutsus = equippedJutsus.filter(
-        (uj) => getJutsuCapFlags(uj.jutsu).isBarrier,
-      );
-      const stunJutsus = equippedJutsus.filter(
-        (uj) => getJutsuCapFlags(uj.jutsu).isStun,
-      );
-      const shieldJutsus = equippedJutsus.filter(
-        (uj) => getJutsuCapFlags(uj.jutsu).isShield,
-      );
+      const equippedCapCounts = countEquippedByCap(equippedJutsus);
 
       if (!info) return errorResponse("Jutsu not found");
       if (!canTrainJutsu(info, user) && !info.parentJutsuId)
         return errorResponse("Jutsu not for you");
+      if (!userjutsuObj && isJutsuTrainToLearnRestricted(info.jutsuType)) {
+        return errorResponse("This jutsu cannot be learned through training");
+      }
       if (info.parentJutsuId && !userjutsuObj)
         return errorResponse(
           "Evolution jutsus can only be obtained by evolving the parent jutsu",
@@ -1099,6 +1079,11 @@ export const jutsuRouter = createTRPCRouter({
         questDataFull = trackers;
       }
       const questDataForDb = filterQuestTrackersForDbPersist(questDataFull, user);
+      // Pre-mutation snapshot for refund if the new-jutsu insert fails after deduct.
+      const questDataBeforeTrain = filterQuestTrackersForDbPersist(
+        user.questData ?? [],
+        user,
+      );
 
       // Deduct money
       const moneyUpdate = await ctx.drizzle
@@ -1125,37 +1110,62 @@ export const jutsuRouter = createTRPCRouter({
             and(eq(userJutsu.id, userjutsuObj.id), eq(userJutsu.userId, ctx.userId)),
           );
       } else {
-        // Check if jutsu can be auto-equipped
-        const {
-          isResidual: jutsuHasResidual,
-          isPierce: jutsuHasPierce,
-          isEvent: jutsuIsEvent,
-          isBarrier: jutsuHasBarrier,
-          isStun: jutsuHasStun,
-          isShield: jutsuHasShield,
-        } = getJutsuCapFlags(info);
-
+        // Soft pre-check whether auto-equip is likely to succeed. Insert already
+        // equipped when the snapshot says yes; only the over-cap rollback CAS
+        // runs afterward to handle concurrent equips (under-cap re-check would
+        // duplicate what the rollback covers a moment later).
+        const capFlags = getJutsuCapFlags(info);
         const canAutoEquip =
           curEquip < maxEquip &&
           checkJutsuBloodlineItem(info, user.items) &&
-          (!jutsuHasResidual || residualJutsus.length < JUTSU_MAX_RESIDUAL_EQUIPPED) &&
-          (!jutsuHasPierce || pierceJutsus.length < JUTSU_MAX_PIERCE_EQUIPPED) &&
-          (!jutsuIsEvent || eventJutsus.length < JUTSU_MAX_EVENT_EQUIPPED) &&
-          (!jutsuHasBarrier || barrierJutsus.length < JUTSU_MAX_BARRIER_EQUIPPED) &&
-          (!jutsuHasStun || stunJutsus.length < JUTSU_MAX_STUN_EQUIPPED) &&
-          (!jutsuHasShield || shieldJutsus.length < JUTSU_MAX_SHIELD_EQUIPPED);
+          canEquipUnderCaps(capFlags, equippedCapCounts);
 
-        // Use onDuplicateKeyUpdate to handle race conditions
-        await ctx.drizzle
-          .insert(userJutsu)
-          .values({
-            id: nanoid(),
+        const newUserJutsuId = nanoid();
+        // onDuplicateKeyUpdate no-op (`id = id`) absorbs unique-index races. PlanetScale
+        // reports changed rows, so a duplicate yields rowsAffected === 0 (not 2). Deduct
+        // already happened above — refund money + quest snapshot when this request did
+        // not insert (otherwise jutsus_mastered / train_specific_jutsu stay incremented).
+        const refundTrainCost = () =>
+          ctx.drizzle
+            .update(userData)
+            .set({
+              money: sql`${userData.money} + ${trainCost}`,
+              questData: questDataBeforeTrain,
+            })
+            .where(eq(userData.userId, ctx.userId));
+
+        try {
+          const insertResult = await ctx.drizzle
+            .insert(userJutsu)
+            .values({
+              id: newUserJutsuId,
+              userId: ctx.userId,
+              jutsuId: input.jutsuId,
+              finishTraining: new Date(Date.now() + trainTime),
+              equipped: canAutoEquip,
+            })
+            .onDuplicateKeyUpdate({ set: { id: sql`id` } });
+
+          if (insertResult.rowsAffected !== 1) {
+            await refundTrainCost();
+            return errorResponse(
+              "You already own this jutsu — please refresh and try again",
+            );
+          }
+        } catch {
+          await refundTrainCost();
+          return errorResponse("Failed to start training — please try again");
+        }
+
+        if (canAutoEquip) {
+          await rollbackEquipIfOverCap({
+            client: ctx.drizzle,
             userId: ctx.userId,
-            jutsuId: input.jutsuId,
-            finishTraining: new Date(Date.now() + trainTime),
-            equipped: canAutoEquip,
-          })
-          .onDuplicateKeyUpdate({ set: { id: sql`id` } });
+            userJutsuId: newUserJutsuId,
+            maxEquip,
+            flags: capFlags,
+          });
+        }
       }
 
       return {
@@ -1253,39 +1263,11 @@ export const jutsuRouter = createTRPCRouter({
       const curJutsuFlags = userjutsuObj
         ? getJutsuCapFlags(userjutsuObj.jutsu)
         : undefined;
-      const pierceEquipped = equippedJutsus.filter(
-        (j) => getJutsuCapFlags(j.jutsu).isPierce,
-      ).length;
-      const curJutsuIsPierce = curJutsuFlags?.isPierce;
-      const eventEquipped = equippedJutsus.filter(
-        (j) => getJutsuCapFlags(j.jutsu).isEvent,
-      ).length;
-      const curJutsuIsEvent = curJutsuFlags?.isEvent ?? false;
-      const barrierEquipped = equippedJutsus.filter(
-        (j) => getJutsuCapFlags(j.jutsu).isBarrier,
-      ).length;
-      const curJutsuIsBarrier = curJutsuFlags?.isBarrier;
-      const stunEquipped = equippedJutsus.filter(
-        (j) => getJutsuCapFlags(j.jutsu).isStun,
-      ).length;
-      const curJutsuIsStun = curJutsuFlags?.isStun;
-      const shieldEquipped = equippedJutsus.filter(
-        (j) => getJutsuCapFlags(j.jutsu).isShield,
-      ).length;
-      const curJutsuIsShield = curJutsuFlags?.isShield;
+      const equippedCapCounts = countEquippedByCap(equippedJutsus);
       const newEquippedState = !isEquipped;
       const loadout = loadouts.find((l) => l.id === user.jutsuLoadout);
-      const isLoaded = userjutsuObj && loadout?.jutsuIds.includes(userjutsuObj.jutsuId);
-      const residualJutsus = userjutsus.filter(
-        (uj) => uj.equipped && getJutsuCapFlags(uj.jutsu).isResidual,
-      );
 
       // Guards
-      if (residualJutsus.length >= JUTSU_MAX_RESIDUAL_EQUIPPED && newEquippedState) {
-        return errorResponse(
-          `You cannot equip more than ${JUTSU_MAX_RESIDUAL_EQUIPPED} residual jutsu. Please unequip first.`,
-        );
-      }
       if (!userjutsuObj) return errorResponse("Jutsu not found");
       if (!isEquipped && userjutsuObj.jutsu.hidden && !canChangeContent(user.role))
         return errorResponse("Jutsu is hidden, cannot be equipped");
@@ -1304,63 +1286,131 @@ export const jutsuRouter = createTRPCRouter({
       if (!isEquipped && curEquip >= maxEquip) {
         return errorResponse("You cannot equip more jutsu");
       }
-      if (
-        !isEquipped &&
-        curJutsuIsPierce &&
-        pierceEquipped >= JUTSU_MAX_PIERCE_EQUIPPED
-      ) {
-        return errorResponse(
-          `You cannot equip more than ${JUTSU_MAX_PIERCE_EQUIPPED} piercing jutsu`,
-        );
-      }
-      if (!isEquipped && curJutsuIsEvent && eventEquipped >= JUTSU_MAX_EVENT_EQUIPPED) {
-        return errorResponse(
-          `You cannot equip more than ${JUTSU_MAX_EVENT_EQUIPPED} event jutsu`,
-        );
-      }
-      if (
-        !isEquipped &&
-        curJutsuIsBarrier &&
-        barrierEquipped >= JUTSU_MAX_BARRIER_EQUIPPED
-      ) {
-        return errorResponse(
-          `You cannot equip more than ${JUTSU_MAX_BARRIER_EQUIPPED} barrier jutsu`,
-        );
-      }
-      if (!isEquipped && curJutsuIsStun && stunEquipped >= JUTSU_MAX_STUN_EQUIPPED) {
-        return errorResponse(
-          `You cannot equip more than ${JUTSU_MAX_STUN_EQUIPPED} stun jutsu`,
-        );
-      }
-      if (
-        !isEquipped &&
-        curJutsuIsShield &&
-        shieldEquipped >= JUTSU_MAX_SHIELD_EQUIPPED
-      ) {
-        return errorResponse(
-          `You cannot equip more than ${JUTSU_MAX_SHIELD_EQUIPPED} shield jutsu`,
-        );
+      if (!isEquipped && curJutsuFlags) {
+        const exceeded = findExceededJutsuEquipCap(curJutsuFlags, equippedCapCounts);
+        if (exceeded) {
+          return errorResponse(
+            `You cannot equip more than ${exceeded.max} ${exceeded.label} jutsu`,
+          );
+        }
       }
 
-      // Calculate loadout
-      if (loadout && isLoaded && !newEquippedState) {
-        loadout.jutsuIds = loadout.jutsuIds.filter((id) => id !== userjutsuObj.jutsuId);
-      } else if (loadout && !isLoaded && newEquippedState) {
-        loadout.jutsuIds.push(userjutsuObj.jutsuId);
+      // Calculate loadout after a successful equip/unequip write
+      if (newEquippedState) {
+        // CAS equip with live cap counts so concurrent equips cannot both slip under a
+        // snapshot-based heal/pierce/… check (see tryEquipUserJutsuAtomically).
+        const equipResult = await tryEquipUserJutsuAtomically({
+          client: ctx.drizzle,
+          userId: ctx.userId,
+          userJutsuId: input.userJutsuId,
+          maxEquip,
+          flags: getJutsuCapFlags(userjutsuObj.jutsu),
+        });
+        if (equipResult === "already-equipped") {
+          return errorResponse(
+            "Could not equip jutsu — it may already be equipped. Please refresh and retry.",
+          );
+        }
+        if (equipResult === "cap-reached") {
+          return errorResponse(
+            "Could not equip jutsu — an equip limit was reached. Please retry.",
+          );
+        }
+        // Atomic JSON append — concurrent equips must not replace the whole array from
+        // stale snapshots (last writer would drop the other jutsuId). If sync fails,
+        // roll back the equip only when the active loadout still lacks this jutsu —
+        // membership is checked inside the UPDATE so a concurrent selectLoadout/equip
+        // that already made state consistent cannot be clobbered (check-then-act window).
+        if (loadout) {
+          const synced = await appendJutsuIdToLoadoutAtomically({
+            client: ctx.drizzle,
+            loadoutId: loadout.id,
+            userId: ctx.userId,
+            jutsuId: userjutsuObj.jutsuId,
+          });
+          if (!synced) {
+            const rolledBack = await ctx.drizzle
+              .update(userJutsu)
+              .set({ equipped: false })
+              .where(
+                and(
+                  eq(userJutsu.id, input.userJutsuId),
+                  eq(userJutsu.userId, ctx.userId),
+                  eq(userJutsu.equipped, true),
+                  sql`NOT EXISTS (
+                    SELECT 1 FROM (
+                      SELECT ${jutsuLoadout.jutsuIds} AS ids
+                      FROM ${userData}
+                      INNER JOIN ${jutsuLoadout} ON ${jutsuLoadout.id} = ${userData.jutsuLoadout}
+                      WHERE ${userData.userId} = ${ctx.userId}
+                        AND ${jutsuLoadout.userId} = ${ctx.userId}
+                    ) AS active_loadout
+                    WHERE JSON_CONTAINS(active_loadout.ids, JSON_QUOTE(${userjutsuObj.jutsuId}))
+                  )`,
+                ),
+              );
+            if (rolledBack.rowsAffected === 1) {
+              return errorResponse("Failed to update loadout — please retry");
+            }
+          }
+        }
+      } else {
+        // Remove from loadout first, then unequip. On unequip failure, re-append only
+        // when the row is still equipped — if the UPDATE committed but the response
+        // was lost, re-appending would leave the loadout listing an unequipped jutsu.
+        if (loadout) {
+          const synced = await removeJutsuIdFromLoadoutAtomically({
+            client: ctx.drizzle,
+            loadoutId: loadout.id,
+            userId: ctx.userId,
+            jutsuId: userjutsuObj.jutsuId,
+          });
+          if (!synced) {
+            return errorResponse("Failed to update loadout — please retry");
+          }
+        }
+        try {
+          await ctx.drizzle
+            .update(userJutsu)
+            .set({ equipped: false })
+            .where(
+              and(
+                eq(userJutsu.id, input.userJutsuId),
+                eq(userJutsu.userId, ctx.userId),
+                eq(userJutsu.equipped, true),
+              ),
+            );
+        } catch {
+          const [row] = await ctx.drizzle
+            .select({ equipped: userJutsu.equipped })
+            .from(userJutsu)
+            .where(
+              and(
+                eq(userJutsu.id, input.userJutsuId),
+                eq(userJutsu.userId, ctx.userId),
+              ),
+            )
+            .limit(1);
+          if (row && !row.equipped) {
+            // Unequip committed despite the lost/failed response — loadout already
+            // removed; treat as success rather than restoring a stale id.
+            return {
+              success: true,
+              message: "Jutsu unequipped",
+              data: { equipped: false, jutsuId: userjutsuObj.jutsuId },
+            };
+          }
+          if (loadout && row?.equipped) {
+            await appendJutsuIdToLoadoutAtomically({
+              client: ctx.drizzle,
+              loadoutId: loadout.id,
+              userId: ctx.userId,
+              jutsuId: userjutsuObj.jutsuId,
+            });
+          }
+          return errorResponse("Failed to unequip jutsu — please retry");
+        }
       }
-
-      await Promise.all([
-        ctx.drizzle
-          .update(userJutsu)
-          .set({ equipped: newEquippedState })
-          .where(eq(userJutsu.id, input.userJutsuId)),
-        loadout
-          ? ctx.drizzle
-              .update(jutsuLoadout)
-              .set({ jutsuIds: loadout.jutsuIds })
-              .where(eq(jutsuLoadout.id, loadout.id))
-          : null,
-      ]);
 
       return {
         success: true,
@@ -2284,4 +2334,286 @@ export const selectJutsuLoadout = async (
     message,
     jutsus: userjutsus.filter((u) => equipIds.includes(u.jutsuId)),
   };
+};
+
+/**
+ * Materialized equip-cap counts for MySQL UPDATE guards. Wrapping in a derived
+ * table avoids ERROR 1093 (can't select from the table being updated).
+ *
+ * All counters share one UserJutsu ⨝ Jutsu pass driven by JUTSU_EQUIP_CAPS.
+ * jutsuType != 'AI' mirrors fetchUserJutsus so CAS guards agree with JS pre-checks.
+ *
+ * residualModifier is numeric JSON, so JSON_SEARCH (string-only) cannot detect it,
+ * and PlanetScale has no JSON_TABLE. One `$[*].residualModifier` extract returns
+ * every match; REGEXP `[1-9]` then tests for any non-zero value in that array
+ * (matches getJutsuCapFlags truthiness; combat schema is 0..2).
+ */
+const residualModifierOnAliasSql = (alias: string) =>
+  sql.raw(
+    `CAST(JSON_EXTRACT(${alias}.effects, '$[*].residualModifier') AS CHAR) REGEXP '[1-9]'`,
+  );
+
+const equipCapCategorySql = (cap: JutsuEquipCap, alias: string) => {
+  const kind = cap.sql;
+  if (kind.kind === "residual") return residualModifierOnAliasSql(alias);
+  if (kind.kind === "jutsuType") {
+    return sql.raw(`${alias}.jutsuType = '${kind.jutsuType}'`);
+  }
+  return sql`JSON_SEARCH(${sql.raw(`${alias}.effects`)}, 'one', ${kind.effectType}, NULL, '$[*].type') IS NOT NULL`;
+};
+
+const equippedCapCountsDerivedSql = (userId: string) => {
+  const sumCols = JUTSU_EQUIP_CAPS.map(
+    (cap) =>
+      sql`COALESCE(SUM(CASE WHEN ${equipCapCategorySql(cap, "j_cap")} THEN 1 ELSE 0 END), 0) AS ${sql.raw(cap.countAlias)}`,
+  );
+  return sql`(
+    SELECT
+      COUNT(*) AS total,
+      ${sql.join(
+        sumCols,
+        sql`,
+      `,
+      )}
+    FROM ${userJutsu} AS uj_cap
+    INNER JOIN ${jutsu} AS j_cap ON j_cap.id = uj_cap.jutsuId
+    WHERE uj_cap.userId = ${userId}
+      AND uj_cap.equipped = true
+      AND j_cap.jutsuType != 'AI'
+  )`;
+};
+
+/** Under-cap predicate: all applicable counts must still have room (AND). */
+const equipCapUnderGuardSql = (
+  userId: string,
+  maxEquip: number,
+  flags: JutsuCapFlags,
+) => {
+  const parts = [sql`c.total < ${maxEquip}`];
+  for (const cap of JUTSU_EQUIP_CAPS) {
+    if (flags[cap.key]) {
+      parts.push(sql`${sql.raw(`c.${cap.countAlias}`)} < ${cap.max}`);
+    }
+  }
+  return sql`(
+    SELECT ${sql.join(parts, sql` AND `)}
+    FROM ${equippedCapCountsDerivedSql(userId)} AS c
+  )`;
+};
+
+/**
+ * True when this updated row's rank among equipped peers (updatedAt ASC, id ASC)
+ * exceeds `cap`. Optional `categorySql` restricts the peer set (heal/event/…).
+ * Derived-table wrapper avoids ERROR 1093 on the table being updated.
+ */
+const equippedRankExceedsCapSql = (
+  userId: string,
+  cap: number,
+  categorySql?: ReturnType<typeof sql>,
+) => sql`(
+  SELECT cnt FROM (
+    SELECT COUNT(*) AS cnt
+    FROM ${userJutsu} AS uj_rank
+    INNER JOIN ${jutsu} AS j_rank ON j_rank.id = uj_rank.jutsuId
+    WHERE uj_rank.userId = ${userId}
+      AND uj_rank.equipped = true
+      AND j_rank.jutsuType != 'AI'
+      ${categorySql ? sql`AND ${categorySql}` : sql``}
+      AND (
+        uj_rank.updatedAt < ${userJutsu.updatedAt}
+        OR (
+          uj_rank.updatedAt = ${userJutsu.updatedAt}
+          AND uj_rank.id <= ${userJutsu.id}
+        )
+      )
+  ) AS equip_rank_cnt
+) > ${cap}`;
+
+/**
+ * Rollback predicate: unequip this row only when it sits outside the first N
+ * kept slots for an exceeded cap. Concurrent racers that both passed under-cap
+ * then both equip no longer both lose — earlier (updatedAt, id) keeps the slot.
+ */
+const equipCapRollbackGuardSql = (
+  userId: string,
+  maxEquip: number,
+  flags: JutsuCapFlags,
+) => {
+  const parts = [equippedRankExceedsCapSql(userId, maxEquip)];
+  for (const cap of JUTSU_EQUIP_CAPS) {
+    if (flags[cap.key]) {
+      parts.push(
+        equippedRankExceedsCapSql(userId, cap.max, equipCapCategorySql(cap, "j_rank")),
+      );
+    }
+  }
+  return sql`(${sql.join(parts, sql` OR `)})`;
+};
+
+/**
+ * Unequip a row if it falls outside the first-N kept slots for any exceeded cap.
+ * Used after inserting already-equipped (startTraining) and after a successful
+ * under-cap equip CAS (toggleEquip) to close concurrent-equip races without
+ * making both racers lose.
+ *
+ * Returns true when the row remains equipped (no rollback).
+ */
+export const rollbackEquipIfOverCap = async (args: {
+  client: DrizzleClient;
+  userId: string;
+  userJutsuId: string;
+  maxEquip: number;
+  flags: JutsuCapFlags;
+}): Promise<boolean> => {
+  const { client, userId, userJutsuId, maxEquip, flags } = args;
+  const rollback = await client
+    .update(userJutsu)
+    .set({ equipped: false })
+    .where(
+      and(
+        eq(userJutsu.id, userJutsuId),
+        eq(userJutsu.userId, userId),
+        eq(userJutsu.equipped, true),
+        equipCapRollbackGuardSql(userId, maxEquip, flags),
+      ),
+    );
+  return rollback.rowsAffected === 0;
+};
+
+/**
+ * Equip a single userJutsu row under live equip-cap guards.
+ *
+ * Pre-check counts in the UPDATE WHERE reject the common already-at-cap case.
+ * Those counts alone are not race-safe across distinct rows: two concurrent
+ * equips can each lock a different PK, both observe "under cap", and both
+ * persist. After a successful equip we therefore re-rank and roll this row
+ * back only when it sits outside the first-N kept slots for an exceeded cap
+ * (so one concurrent racer keeps the slot).
+ */
+export type TryEquipUserJutsuResult = "equipped" | "already-equipped" | "cap-reached";
+
+export const tryEquipUserJutsuAtomically = async (args: {
+  client: DrizzleClient;
+  userId: string;
+  userJutsuId: string;
+  maxEquip: number;
+  flags: JutsuCapFlags;
+}): Promise<TryEquipUserJutsuResult> => {
+  const { client, userId, userJutsuId, maxEquip, flags } = args;
+
+  const result = await client
+    .update(userJutsu)
+    .set({ equipped: true, updatedAt: new Date() })
+    .where(
+      and(
+        eq(userJutsu.id, userJutsuId),
+        eq(userJutsu.userId, userId),
+        eq(userJutsu.equipped, false),
+        equipCapUnderGuardSql(userId, maxEquip, flags),
+      ),
+    );
+  if (result.rowsAffected !== 1) {
+    // Distinguish double-click / concurrent equip from a genuine cap rejection.
+    const [row] = await client
+      .select({ equipped: userJutsu.equipped })
+      .from(userJutsu)
+      .where(and(eq(userJutsu.id, userJutsuId), eq(userJutsu.userId, userId)))
+      .limit(1);
+    return row?.equipped ? "already-equipped" : "cap-reached";
+  }
+
+  const kept = await rollbackEquipIfOverCap({
+    client,
+    userId,
+    userJutsuId,
+    maxEquip,
+    flags,
+  });
+  return kept ? "equipped" : "cap-reached";
+};
+
+/**
+ * Append a jutsuId to a loadout's JSON array without rewriting the whole array, so
+ * concurrent equips cannot drop each other's IDs. Idempotent via NOT JSON_CONTAINS.
+ * Returns true when the loadout ends up containing jutsuId (append or already present).
+ */
+const appendJutsuIdToLoadoutAtomically = async (args: {
+  client: DrizzleClient;
+  loadoutId: string;
+  userId: string;
+  jutsuId: string;
+}): Promise<boolean> => {
+  const { client, loadoutId, userId, jutsuId } = args;
+  try {
+    const result = await client
+      .update(jutsuLoadout)
+      .set({
+        jutsuIds: sql`JSON_ARRAY_APPEND(${jutsuLoadout.jutsuIds}, '$', ${jutsuId})`,
+      })
+      .where(
+        and(
+          eq(jutsuLoadout.id, loadoutId),
+          eq(jutsuLoadout.userId, userId),
+          sql`NOT JSON_CONTAINS(${jutsuLoadout.jutsuIds}, JSON_QUOTE(${jutsuId}))`,
+        ),
+      );
+    if (result.rowsAffected === 1) return true;
+    // Already present (PlanetScale reports 0 changed rows) or missing loadout — verify.
+    const row = await client.query.jutsuLoadout.findFirst({
+      where: and(eq(jutsuLoadout.id, loadoutId), eq(jutsuLoadout.userId, userId)),
+      columns: { jutsuIds: true },
+    });
+    return !!row?.jutsuIds.includes(jutsuId);
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Escape `%`, `_`, and `\` so MySQL JSON_SEARCH treats the needle as a literal
+ * (JSON_SEARCH uses LIKE matching). nanoid IDs commonly contain `_`.
+ */
+const escapeJsonSearchPattern = (value: string) =>
+  value.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
+
+/**
+ * Remove a jutsuId from a loadout's JSON array without rewriting the whole array, so
+ * concurrent unequips cannot restore each other's IDs from stale snapshots.
+ * Returns true when the loadout no longer contains jutsuId (removed or already absent).
+ */
+const removeJutsuIdFromLoadoutAtomically = async (args: {
+  client: DrizzleClient;
+  loadoutId: string;
+  userId: string;
+  jutsuId: string;
+}): Promise<boolean> => {
+  const { client, loadoutId, userId, jutsuId } = args;
+  const searchPattern = escapeJsonSearchPattern(jutsuId);
+  try {
+    const result = await client
+      .update(jutsuLoadout)
+      .set({
+        jutsuIds: sql`JSON_REMOVE(
+          ${jutsuLoadout.jutsuIds},
+          JSON_UNQUOTE(JSON_SEARCH(${jutsuLoadout.jutsuIds}, 'one', ${searchPattern}, ${"\\"}))
+        )`,
+      })
+      .where(
+        and(
+          eq(jutsuLoadout.id, loadoutId),
+          eq(jutsuLoadout.userId, userId),
+          // Exact membership — do not use unescaped JSON_SEARCH (LIKE wildcards).
+          sql`JSON_CONTAINS(${jutsuLoadout.jutsuIds}, JSON_QUOTE(${jutsuId}))`,
+        ),
+      );
+    if (result.rowsAffected === 1) return true;
+    const row = await client.query.jutsuLoadout.findFirst({
+      where: and(eq(jutsuLoadout.id, loadoutId), eq(jutsuLoadout.userId, userId)),
+      columns: { jutsuIds: true },
+    });
+    // Missing loadout is fine (nothing to keep in sync); otherwise require absence.
+    return !row || !row.jutsuIds.includes(jutsuId);
+  } catch {
+    return false;
+  }
 };

--- a/app/src/server/api/routers/jutsu.ts
+++ b/app/src/server/api/routers/jutsu.ts
@@ -1352,6 +1352,22 @@ export const jutsuRouter = createTRPCRouter({
             if (rolledBack.rowsAffected === 1) {
               return errorResponse("Failed to update loadout — please retry");
             }
+            // 0 rows: either a concurrent writer already put this id in the
+            // active loadout (leave equipped), or a concurrent unequip already
+            // flipped the row. Only report success when the row is still on.
+            const [row] = await ctx.drizzle
+              .select({ equipped: userJutsu.equipped })
+              .from(userJutsu)
+              .where(
+                and(
+                  eq(userJutsu.id, input.userJutsuId),
+                  eq(userJutsu.userId, ctx.userId),
+                ),
+              )
+              .limit(1);
+            if (!row?.equipped) {
+              return errorResponse("Failed to update loadout — please retry");
+            }
           }
         }
       } else {

--- a/app/src/server/api/routers/staff.ts
+++ b/app/src/server/api/routers/staff.ts
@@ -24,6 +24,7 @@ import {
   forumThread,
   historicalAvatar,
   historicalIp,
+  itemLoadout,
   jutsuLoadout,
   kageDefendedChallenges,
   linkPromotion,
@@ -273,17 +274,36 @@ export const staffRouter = createTRPCRouter({
       if (!canUnequipAllUsers(user)) {
         return errorResponse("You do not have permission to unequip all jutsus");
       }
-      // Update all equipped jutsus to set equipped = 0 for all users and clear loadouts
+      // Non-AI only — AI opponents keep their equipped loadouts for combat.
+      // Non-AI only — AI opponents keep equipped jutsu for combat.
+      // Prefer NOT IN (isAi = true): AI accounts are few, so the subquery stays small;
+      // IN (isAi = false) would materialize essentially every human userId.
+      // Orphan userJutsu/loadout rows (userId missing from UserData) are included —
+      // harmless for unequip-all.
       await Promise.all([
         ctx.drizzle
           .update(userJutsu)
           .set({ equipped: false })
-          .where(ne(userJutsu.equipped, false)),
-        ctx.drizzle.update(jutsuLoadout).set({ jutsuIds: [] }),
+          .where(
+            and(
+              ne(userJutsu.equipped, false),
+              sql`${userJutsu.userId} NOT IN (
+                SELECT ${userData.userId} FROM ${userData} WHERE ${userData.isAi} = true
+              )`,
+            ),
+          ),
+        ctx.drizzle
+          .update(jutsuLoadout)
+          .set({ jutsuIds: [] })
+          .where(
+            sql`${jutsuLoadout.userId} NOT IN (
+              SELECT ${userData.userId} FROM ${userData} WHERE ${userData.isAi} = true
+            )`,
+          ),
       ]);
       return {
         success: true,
-        message: `All jutsu has been unequipped for all users.`,
+        message: `All jutsu has been unequipped for all non-AI users.`,
       };
     }),
   unequipAllGear: protectedProcedure
@@ -295,14 +315,33 @@ export const staffRouter = createTRPCRouter({
       if (!canUnequipAllUsers(user)) {
         return errorResponse("You do not have permission to unequip all gear");
       }
-      // Update all equipped items to set equipped = 'NONE' for all users
-      await ctx.drizzle
-        .update(userItem)
-        .set({ equipped: "NONE" })
-        .where(ne(userItem.equipped, "NONE"));
+      // Non-AI only — AI opponents keep their equipped gear for combat.
+      // Clear every item loadout (not only the active pointer), matching unequipAllJutsus.
+      // Same NOT IN (isAi = true) pattern as unequipAllJutsus (small AI set vs all humans).
+      await Promise.all([
+        ctx.drizzle
+          .update(userItem)
+          .set({ equipped: "NONE" })
+          .where(
+            and(
+              ne(userItem.equipped, "NONE"),
+              sql`${userItem.userId} NOT IN (
+                SELECT ${userData.userId} FROM ${userData} WHERE ${userData.isAi} = true
+              )`,
+            ),
+          ),
+        ctx.drizzle
+          .update(itemLoadout)
+          .set({ itemData: [] })
+          .where(
+            sql`${itemLoadout.userId} NOT IN (
+              SELECT ${userData.userId} FROM ${userData} WHERE ${userData.isAi} = true
+            )`,
+          ),
+      ]);
       return {
         success: true,
-        message: `All gear has been unequipped for all users.`,
+        message: `All gear has been unequipped for all non-AI users.`,
       };
     }),
   forceAwake: protectedProcedure

--- a/app/tests/libs/jutsu.test.ts
+++ b/app/tests/libs/jutsu.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   JUTSU_MAX_BARRIER_EQUIPPED,
   JUTSU_MAX_EVENT_EQUIPPED,
+  JUTSU_MAX_FORBIDDEN_EQUIPPED,
+  JUTSU_MAX_HEAL_EQUIPPED,
   JUTSU_MAX_SHIELD_EQUIPPED,
 } from "@/drizzle/constants";
 import type { UserJutsuWithRelations } from "@/drizzle/schema";
@@ -146,6 +148,20 @@ describe("computeJutsuLoadoutAssignments", () => {
     expect(out.invalidJutsus[0]).toMatch(/event/);
   });
 
+  it("enforces the forbidden-jutsu cap", () => {
+    const count = JUTSU_MAX_FORBIDDEN_EQUIPPED + 1;
+    const userjutsus = Array.from({ length: count }, (_, i) =>
+      uj({ jutsuId: `f${i}`, name: `Forbidden ${i}`, jutsuType: "FORBIDDEN" }),
+    );
+    const out = computeJutsuLoadoutAssignments({
+      jutsuIds: userjutsus.map((j) => j.jutsuId),
+      userjutsus,
+      user: USER,
+    });
+    expect(out.equipIds).toHaveLength(JUTSU_MAX_FORBIDDEN_EQUIPPED);
+    expect(out.invalidJutsus[0]).toMatch(/forbidden/);
+  });
+
   it("deduplicates repeated jutsuIds so they do not double-count toward caps", () => {
     calcJutsuEquipLimitMock.mockReturnValueOnce(2);
     const userjutsus = [uj({ jutsuId: "a" }), uj({ jutsuId: "b" })];
@@ -186,5 +202,19 @@ describe("computeJutsuLoadoutAssignments", () => {
     });
     expect(out.equipIds).toHaveLength(JUTSU_MAX_SHIELD_EQUIPPED);
     expect(out.invalidJutsus[0]).toMatch(/shield/);
+  });
+
+  it("enforces the heal-jutsu cap", () => {
+    const count = JUTSU_MAX_HEAL_EQUIPPED + 1;
+    const userjutsus = Array.from({ length: count }, (_, i) =>
+      uj({ jutsuId: `h${i}`, name: `Heal ${i}`, effectTypes: ["heal"] }),
+    );
+    const out = computeJutsuLoadoutAssignments({
+      jutsuIds: userjutsus.map((j) => j.jutsuId),
+      userjutsus,
+      user: USER,
+    });
+    expect(out.equipIds).toHaveLength(JUTSU_MAX_HEAL_EQUIPPED);
+    expect(out.invalidJutsus[0]).toMatch(/heal/);
   });
 });

--- a/app/tests/libs/jutsu.test.ts
+++ b/app/tests/libs/jutsu.test.ts
@@ -18,7 +18,10 @@ vi.mock("@/libs/train", () => ({
   calcJutsuEquipLimit: vi.fn(() => 100),
 }));
 
-import { computeJutsuLoadoutAssignments } from "@/libs/jutsu";
+import {
+  computeJutsuLoadoutAssignments,
+  computeJutsuLoadoutCapAssignments,
+} from "@/libs/jutsu";
 import type { UserWithRelations } from "@/routers/profile";
 import { calcJutsuEquipLimit } from "@/libs/train";
 
@@ -216,5 +219,39 @@ describe("computeJutsuLoadoutAssignments", () => {
     });
     expect(out.equipIds).toHaveLength(JUTSU_MAX_HEAL_EQUIPPED);
     expect(out.invalidJutsus[0]).toMatch(/heal/);
+  });
+});
+
+describe("computeJutsuLoadoutCapAssignments", () => {
+  it("enforces heal caps for callers without a full profile user", () => {
+    const count = JUTSU_MAX_HEAL_EQUIPPED + 1;
+    const userjutsus = Array.from({ length: count }, (_, i) =>
+      uj({ jutsuId: `combat-heal-${i}`, effectTypes: ["heal"] }),
+    );
+
+    const out = computeJutsuLoadoutCapAssignments({
+      jutsuIds: userjutsus.map((entry) => entry.jutsuId),
+      userjutsus,
+      maxEquip: 100,
+    });
+
+    expect(out.equipIds).toHaveLength(JUTSU_MAX_HEAL_EQUIPPED);
+    expect(out.invalidJutsus).toHaveLength(1);
+    expect(out.invalidJutsus[0]).toMatch(/heal/);
+  });
+
+  it("applies caller eligibility before consuming equip capacity", () => {
+    const userjutsus = [uj({ jutsuId: "blocked" }), uj({ jutsuId: "allowed" })];
+
+    const out = computeJutsuLoadoutCapAssignments({
+      jutsuIds: userjutsus.map((entry) => entry.jutsuId),
+      userjutsus,
+      maxEquip: 1,
+      validateJutsu: (entry) =>
+        entry.jutsuId === "blocked" ? "required item missing" : undefined,
+    });
+
+    expect(out.equipIds).toEqual(["allowed"]);
+    expect(out.invalidJutsus).toEqual(["required item missing"]);
   });
 });


### PR DESCRIPTION
# Pull Request

Applies a limit on the number of equipped heal jutsu.

Mass unequip jutsu/items now unequips all inactive loadouts as well.
Mass unequip jutsu/items no longer unequip them from AI

Require forbidden jutsu to be learned by scrolls instead of through training

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added limits for equipping healing jutsu in ranked PvP loadouts.
  * Ranked loadout screens now display healing jutsu restrictions and warnings.
  * Jutsu management prevents equipping or automatically selecting healing jutsu beyond the allowed limit.
  * Staff bulk unequipping now clears affected non-AI players’ gear, jutsu, and loadouts while leaving AI opponents unchanged.

* **Bug Fixes**
  * Improved reliability of jutsu equip and loadout updates during simultaneous actions.

* **Documentation**
  * Updated the Ranked PvP manual with healing jutsu limits.

* **Tests**
  * Added coverage verifying healing jutsu equip limits are enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->