### PR TITLE
Fix: Delete Conversations

### DIFF
--- a/app/src/app/inbox/page.tsx
+++ b/app/src/app/inbox/page.tsx
@@ -38,6 +38,7 @@ import Confirm2 from "@/layout/Confirm2";
 import ContentBox from "@/layout/ContentBox";
 import Conversation from "@/layout/Conversation";
 import Loader from "@/layout/Loader";
+import Modal2 from "@/layout/Modal2";
 import RichInput from "@/layout/RichInput";
 import UserBlacklistControl from "@/layout/UserBlacklistControl";
 import UserSearchSelect from "@/layout/UserSearchSelect";
@@ -119,6 +120,8 @@ const ShowConversations: React.FC<ShowConversationsProps> = (props) => {
   // Get user data & destructure
   const { data: userData } = useRequiredUserData();
   const { selectedConvo, setSelectedConvo } = props;
+  const [pendingConvoId, setPendingConvoId] = useState<string | null>(null);
+  const [isExitConfirmOpen, setIsExitConfirmOpen] = useState(false);
 
   // Fetch conversations. Note we pass the selected convo to automatically re-fetch when it changes
   const {
@@ -131,11 +134,15 @@ const ShowConversations: React.FC<ShowConversationsProps> = (props) => {
   );
 
   // Mutations
-  const { mutate: exitConversation } = api.comments.exitConversation.useMutation({
-    onSuccess: async (data) => {
+  const {
+    mutate: exitConversation,
+    isPending: isExitingConversation,
+    variables: exitConversationVariables,
+  } = api.comments.exitConversation.useMutation({
+    onSuccess: (data) => {
       showMutationToast(data);
       if (data.success) {
-        await refetch();
+        void refetch();
       }
     },
   });
@@ -146,6 +153,11 @@ const ShowConversations: React.FC<ShowConversationsProps> = (props) => {
     const hasNewMessages = !user?.lastReadAt || user.lastReadAt < c.updatedAt;
     return { ...c, hasNewMessages };
   });
+  const pendingConversation = filteredConversations?.find(
+    (convo) => convo.id === pendingConvoId,
+  );
+  const exitingConvoId = exitConversationVariables?.convo_id;
+  const isExitingPending = isExitingConversation && exitingConvoId === pendingConvoId;
 
   // Render
   return (
@@ -170,61 +182,106 @@ const ShowConversations: React.FC<ShowConversationsProps> = (props) => {
             </li>
 
             <hr />
-            {filteredConversations?.map((convo) => (
-              <li
-                className={`relative mx-3 my-3 flex h-12 flex-row items-center rounded-lg hover:bg-popover ${selectedConvo && selectedConvo === convo.id ? "bg-popover" : ""}`}
-                key={convo.id}
-              >
-                <button
-                  type="button"
-                  className="absolute inset-0 h-full w-full"
-                  onClick={() => setSelectedConvo(convo.id)}
-                  aria-label={`Select conversation with ${convo.users.map((u) => u.userData.username).join(", ")}`}
-                />
-                {convo.users.length > 0 &&
-                  convo.users.map((relation, i) => {
-                    const user = relation.userData;
-                    return (
-                      <div
-                        key={user.userId}
-                        className={`absolute w-14`}
-                        style={{ left: `${i * 2}rem` }}
-                      >
-                        <AvatarImage
-                          href={user.avatar}
-                          userId={user.userId}
-                          alt={user.username}
-                          size={50}
-                          priority
-                        />
-                      </div>
-                    );
-                  })}
-                <span
-                  className="... grow truncate text-sm"
-                  style={{
-                    marginLeft: `${(convo.users.length * 2 + 1.5).toString()}rem`,
-                  }}
+            {filteredConversations?.map((convo) => {
+              const isExiting = isExitingConversation && exitingConvoId === convo.id;
+              return (
+                <li
+                  className={`relative mx-3 my-3 flex h-12 flex-row items-center rounded-lg hover:bg-popover ${selectedConvo && selectedConvo === convo.id ? "bg-popover" : ""}`}
+                  key={convo.id}
                 >
-                  {convo.title}
-                  <br />
-                  {convo.createdAt.toDateString()}
-                </span>
-                <div className="grow"></div>
-                {convo.hasNewMessages && (
-                  <BellRing className="h-6 w-6 animate-[wiggle_1s_ease-in-out_infinite] text-red-500 hover:cursor-pointer hover:text-orange-500" />
-                )}
-                <Trash2
-                  className="mx-2 h-6 w-6 rounded-full hover:cursor-pointer hover:text-orange-500"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    exitConversation({ convo_id: convo.id });
-                  }}
-                />
-              </li>
-            ))}
+                  <button
+                    type="button"
+                    className="absolute inset-0 h-full w-full"
+                    onClick={() => setSelectedConvo(convo.id)}
+                    aria-label={`Select conversation with ${convo.users.map((u) => u.userData.username).join(", ")}`}
+                  />
+                  {convo.users.length > 0 &&
+                    convo.users.map((relation, i) => {
+                      const user = relation.userData;
+                      return (
+                        <div
+                          key={user.userId}
+                          className={`absolute w-14`}
+                          style={{ left: `${i * 2}rem` }}
+                        >
+                          <AvatarImage
+                            href={user.avatar}
+                            userId={user.userId}
+                            alt={user.username}
+                            size={50}
+                            priority
+                          />
+                        </div>
+                      );
+                    })}
+                  <span
+                    className="... grow truncate text-sm"
+                    style={{
+                      marginLeft: `${(convo.users.length * 2 + 1.5).toString()}rem`,
+                    }}
+                  >
+                    {convo.title}
+                    <br />
+                    {convo.createdAt.toDateString()}
+                  </span>
+                  <div className="grow"></div>
+                  {convo.hasNewMessages && (
+                    <BellRing className="h-6 w-6 animate-[wiggle_1s_ease-in-out_infinite] text-red-500 hover:cursor-pointer hover:text-orange-500" />
+                  )}
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="relative z-10 mx-2 rounded-full"
+                    aria-label={`Exit conversation ${convo.title}`}
+                    disabled={isExiting}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      setPendingConvoId(convo.id);
+                      setIsExitConfirmOpen(true);
+                    }}
+                  >
+                    <Trash2 className="h-6 w-6 hover:text-orange-500" />
+                  </Button>
+                </li>
+              );
+            })}
           </ul>
+          <Modal2
+            title="Confirm exiting conversation"
+            isOpen={isExitConfirmOpen}
+            setIsOpen={setIsExitConfirmOpen}
+            isLoading={isExitingPending}
+            proceed_loading_label="Exiting..."
+            proceed_label="Proceed"
+            proceedDisabled={!pendingConvoId || isExitingPending}
+            onAccept={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              if (!pendingConvoId) return;
+              const requestedConvoId = pendingConvoId;
+              exitConversation(
+                { convo_id: requestedConvoId },
+                {
+                  onSettled: () => {
+                    setPendingConvoId((currentConvoId) =>
+                      currentConvoId === requestedConvoId ? null : currentConvoId,
+                    );
+                  },
+                },
+              );
+            }}
+            onClose={() => {
+              if (!isExitingPending) {
+                setPendingConvoId(null);
+              }
+            }}
+          >
+            {pendingConversation
+              ? `You are about to exit "${pendingConversation.title}". Are you sure?`
+              : "You are about to exit this conversation. Are you sure?"}
+          </Modal2>
           <div className="m-3 italic">- Messages deleted after 14 days</div>
         </div>
       )}

--- a/app/src/app/inbox/page.tsx
+++ b/app/src/app/inbox/page.tsx
@@ -42,6 +42,7 @@ import Modal2 from "@/layout/Modal2";
 import RichInput from "@/layout/RichInput";
 import UserBlacklistControl from "@/layout/UserBlacklistControl";
 import UserSearchSelect from "@/layout/UserSearchSelect";
+import { isRaidChatConversationId } from "@/libs/raids";
 import { showMutationToast } from "@/libs/toast";
 import { canPostAsAi, getMessagingRestriction } from "@/utils/permissions";
 import { useRequiredUserData } from "@/utils/UserContext";
@@ -184,6 +185,9 @@ const ShowConversations: React.FC<ShowConversationsProps> = (props) => {
             <hr />
             {filteredConversations?.map((convo) => {
               const isExiting = isExitingConversation && exitingConvoId === convo.id;
+              // Raid chat membership follows the raid queue, so the server always
+              // rejects a manual exit; don't offer the control for those rows.
+              const canExit = !isRaidChatConversationId(convo.id);
               return (
                 <li
                   className={`relative mx-3 my-3 flex h-12 flex-row items-center rounded-lg hover:bg-popover ${selectedConvo && selectedConvo === convo.id ? "bg-popover" : ""}`}
@@ -228,22 +232,24 @@ const ShowConversations: React.FC<ShowConversationsProps> = (props) => {
                   {convo.hasNewMessages && (
                     <BellRing className="h-6 w-6 animate-[wiggle_1s_ease-in-out_infinite] text-red-500 hover:cursor-pointer hover:text-orange-500" />
                   )}
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="relative z-10 mx-2 rounded-full"
-                    aria-label={`Exit conversation ${convo.title}`}
-                    disabled={isExiting}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      setPendingConvoId(convo.id);
-                      setIsExitConfirmOpen(true);
-                    }}
-                  >
-                    <Trash2 className="h-6 w-6 hover:text-orange-500" />
-                  </Button>
+                  {canExit && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="relative z-10 mx-2 rounded-full"
+                      aria-label={`Exit conversation ${convo.title}`}
+                      disabled={isExiting}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        setPendingConvoId(convo.id);
+                        setIsExitConfirmOpen(true);
+                      }}
+                    >
+                      <Trash2 className="h-6 w-6 hover:text-orange-500" />
+                    </Button>
+                  )}
                 </li>
               );
             })}
@@ -252,6 +258,10 @@ const ShowConversations: React.FC<ShowConversationsProps> = (props) => {
             title="Confirm exiting conversation"
             isOpen={isExitConfirmOpen}
             setIsOpen={setIsExitConfirmOpen}
+            // Keep Modal2 from self-closing on accept, so this destructive action
+            // stays visible in its disabled "Exiting..." state until the request
+            // settles and onSettled closes the dialog.
+            isValid={false}
             isLoading={isExitingPending}
             proceed_loading_label="Exiting..."
             proceed_label="Proceed"
@@ -268,6 +278,7 @@ const ShowConversations: React.FC<ShowConversationsProps> = (props) => {
                     setPendingConvoId((currentConvoId) =>
                       currentConvoId === requestedConvoId ? null : currentConvoId,
                     );
+                    setIsExitConfirmOpen(false);
                   },
                 },
               );

--- a/app/src/layout/Modal2.tsx
+++ b/app/src/layout/Modal2.tsx
@@ -3,7 +3,7 @@
  * This is a modal that is used to display a modal.
  */
 import type React from "react";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -48,23 +48,44 @@ const Modal2: React.FC<Modal2Props> = (props) => {
 
   const isProceedDisabled = props.isLoading || props.proceedDisabled;
 
+  const handleAccept = useCallback(
+    (
+      e:
+        | React.MouseEvent<HTMLButtonElement, MouseEvent>
+        | React.KeyboardEvent<KeyboardEvent>,
+    ) => {
+      if (!props.onAccept) return;
+      props.onAccept(e);
+      if (props.isValid === undefined || props.isValid) {
+        props.setIsOpen(false);
+      }
+    },
+    [props.onAccept, props.isValid, props.setIsOpen],
+  );
+
   // Handle key-presses for Enter key only when this modal is open
   useEffect(() => {
+    if (!props.isOpen) return;
+
     const onDocumentKeyDown = (event: KeyboardEvent) => {
-      if (!props.isOpen) return;
       // Don't trigger if the active element is a button (it will handle Enter itself)
       const activeElement = document.activeElement;
       const isButton = activeElement?.tagName === "BUTTON";
 
-      if (event.key === "Enter" && props.onAccept && !isButton && !isProceedDisabled) {
-        props.onAccept(event as unknown as React.KeyboardEvent<KeyboardEvent>);
+      if (
+        event.key === "Enter" &&
+        props.proceed_label &&
+        !isButton &&
+        !isProceedDisabled
+      ) {
+        handleAccept(event as unknown as React.KeyboardEvent<KeyboardEvent>);
       }
     };
     document.addEventListener("keydown", onDocumentKeyDown);
     return () => {
       document.removeEventListener("keydown", onDocumentKeyDown);
     };
-  }, [props.isOpen, props.onAccept, isProceedDisabled]);
+  }, [props.isOpen, props.proceed_label, isProceedDisabled, handleAccept]);
 
   const handleDialogClose = () => {
     if (props.onClose) props.onClose();
@@ -112,10 +133,7 @@ const Modal2: React.FC<Modal2Props> = (props) => {
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
-                  if (props.onAccept) props.onAccept(e);
-                  if (props.isValid === undefined || props.isValid) {
-                    props.setIsOpen(false);
-                  }
+                  handleAccept(e);
                 }}
                 className={`z-30 rounded-lg ${confirmBtnClassName}`}
               >

--- a/app/src/layout/Modal2.tsx
+++ b/app/src/layout/Modal2.tsx
@@ -54,8 +54,9 @@ const Modal2: React.FC<Modal2Props> = (props) => {
         | React.MouseEvent<HTMLButtonElement, MouseEvent>
         | React.KeyboardEvent<KeyboardEvent>,
     ) => {
-      if (!props.onAccept) return;
-      props.onAccept(e);
+      // The close side-effect is independent of onAccept: dialogs that render a
+      // Proceed button without an accept handler still use it to dismiss.
+      props.onAccept?.(e);
       if (props.isValid === undefined || props.isValid) {
         props.setIsOpen(false);
       }
@@ -72,9 +73,12 @@ const Modal2: React.FC<Modal2Props> = (props) => {
       const activeElement = document.activeElement;
       const isButton = activeElement?.tagName === "BUTTON";
 
+      // Enter only mirrors a Proceed button that is visible, enabled, and backed
+      // by an accept handler, so it never dismisses a plain info/edit dialog.
       if (
         event.key === "Enter" &&
         props.proceed_label &&
+        props.onAccept &&
         !isButton &&
         !isProceedDisabled
       ) {
@@ -85,7 +89,13 @@ const Modal2: React.FC<Modal2Props> = (props) => {
     return () => {
       document.removeEventListener("keydown", onDocumentKeyDown);
     };
-  }, [props.isOpen, props.proceed_label, isProceedDisabled, handleAccept]);
+  }, [
+    props.isOpen,
+    props.proceed_label,
+    props.onAccept,
+    isProceedDisabled,
+    handleAccept,
+  ]);
 
   const handleDialogClose = () => {
     if (props.onClose) props.onClose();

--- a/app/src/server/api/routers/comments.ts
+++ b/app/src/server/api/routers/comments.ts
@@ -435,20 +435,21 @@ export const commentsRouter = createTRPCRouter({
         );
 
       if (membershipDeleteResult.rowsAffected === 1) {
-        const conversationDeleteResult = await ctx.drizzle
-          .delete(conversation)
-          .where(
-            and(
-              eq(conversation.id, convo.id),
-              sql`NOT EXISTS (SELECT 1 FROM ${user2conversation} WHERE ${user2conversation.conversationId} = ${convo.id})`,
-            ),
-          );
-
-        if (conversationDeleteResult.rowsAffected === 1) {
-          await ctx.drizzle
+        // Both cleanup deletes only need to know that no membership rows remain,
+        // which the awaited membership delete above already settled. Guarding
+        // each one on that condition keeps a concurrent exit from wiping a
+        // conversation someone still belongs to, without serializing them.
+        const noMembersLeft = sql`NOT EXISTS (SELECT 1 FROM ${user2conversation} WHERE ${user2conversation.conversationId} = ${convo.id})`;
+        await Promise.all([
+          ctx.drizzle
+            .delete(conversation)
+            .where(and(eq(conversation.id, convo.id), noMembersLeft)),
+          ctx.drizzle
             .delete(conversationComment)
-            .where(eq(conversationComment.conversationId, convo.id));
-        }
+            .where(
+              and(eq(conversationComment.conversationId, convo.id), noMembersLeft),
+            ),
+        ]);
       }
       return { success: true, message: "Conversation exited" };
     }),

--- a/app/src/server/api/routers/comments.ts
+++ b/app/src/server/api/routers/comments.ts
@@ -408,6 +408,9 @@ export const commentsRouter = createTRPCRouter({
     .input(z.object({ convo_id: z.string() }))
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
+      if (isRaidChatConversationId(input.convo_id)) {
+        return errorResponse("Raid chat membership is managed by the raid queue");
+      }
       const [user, convo] = await Promise.all([
         fetchUser(ctx.drizzle, ctx.userId),
         fetchConversation({
@@ -421,30 +424,27 @@ export const commentsRouter = createTRPCRouter({
       if (!canViewConversation(convo, ctx.userId, user.role)) {
         return errorResponse("You are not allowed to view this conversation");
       }
-      // Raid-chat membership is managed by joinRaidQueue / leaveRaidQueue /
-      // updateBattle purges, not from the inbox UI. Allowing a manual exit
-      // would silently revoke the user's mid-raid chat access and, if they are
-      // the last member, hard-delete the deterministic conversation row and
-      // all comments — wiping chat history for future raid runs of the same
-      // questId since the conversation ID is stable across raid resets.
-      if (isRaidChatConversationId(convo.id)) {
-        return errorResponse("Raid chat membership is managed by the raid queue");
-      }
+      const isLastMember =
+        convo.users.length === 1 && convo.users[0]?.userId === ctx.userId;
       // Mutate
-      await ctx.drizzle
-        .delete(user2conversation)
-        .where(
-          and(
-            eq(user2conversation.conversationId, convo.id),
-            eq(user2conversation.userId, ctx.userId),
+      await Promise.all([
+        ctx.drizzle
+          .delete(user2conversation)
+          .where(
+            and(
+              eq(user2conversation.conversationId, convo.id),
+              eq(user2conversation.userId, ctx.userId),
+            ),
           ),
-        );
-      if (convo.users.length === 1) {
-        await ctx.drizzle.delete(conversation).where(eq(conversation.id, convo.id));
-        await ctx.drizzle
-          .delete(conversationComment)
-          .where(eq(conversationComment.conversationId, convo.id));
-      }
+        ...(isLastMember
+          ? [
+              ctx.drizzle.delete(conversation).where(eq(conversation.id, convo.id)),
+              ctx.drizzle
+                .delete(conversationComment)
+                .where(eq(conversationComment.conversationId, convo.id)),
+            ]
+          : []),
+      ]);
       return { success: true, message: "Conversation exited" };
     }),
   fetchConversationComment: protectedProcedure

--- a/app/src/server/api/routers/comments.ts
+++ b/app/src/server/api/routers/comments.ts
@@ -424,27 +424,32 @@ export const commentsRouter = createTRPCRouter({
       if (!canViewConversation(convo, ctx.userId, user.role)) {
         return errorResponse("You are not allowed to view this conversation");
       }
-      const isLastMember =
-        convo.users.length === 1 && convo.users[0]?.userId === ctx.userId;
       // Mutate
-      await Promise.all([
-        ctx.drizzle
-          .delete(user2conversation)
+      const membershipDeleteResult = await ctx.drizzle
+        .delete(user2conversation)
+        .where(
+          and(
+            eq(user2conversation.conversationId, convo.id),
+            eq(user2conversation.userId, ctx.userId),
+          ),
+        );
+
+      if (membershipDeleteResult.rowsAffected === 1) {
+        const conversationDeleteResult = await ctx.drizzle
+          .delete(conversation)
           .where(
             and(
-              eq(user2conversation.conversationId, convo.id),
-              eq(user2conversation.userId, ctx.userId),
+              eq(conversation.id, convo.id),
+              sql`NOT EXISTS (SELECT 1 FROM ${user2conversation} WHERE ${user2conversation.conversationId} = ${convo.id})`,
             ),
-          ),
-        ...(isLastMember
-          ? [
-              ctx.drizzle.delete(conversation).where(eq(conversation.id, convo.id)),
-              ctx.drizzle
-                .delete(conversationComment)
-                .where(eq(conversationComment.conversationId, convo.id)),
-            ]
-          : []),
-      ]);
+          );
+
+        if (conversationDeleteResult.rowsAffected === 1) {
+          await ctx.drizzle
+            .delete(conversationComment)
+            .where(eq(conversationComment.conversationId, convo.id));
+        }
+      }
       return { success: true, message: "Conversation exited" };
     }),
   fetchConversationComment: protectedProcedure


### PR DESCRIPTION
# Pull Request

**Please fill: what was implemented, why, possibly include screenshots, are any of the changes breaking, etc.**

- Added a confirmation modal for conversation exit and fixed row-vs-trash interaction in app/src/app/inbox/page.tsx.
- Hardened modal keyboard behavior (Enter handling, shared accept path, visible-action gating) in app/src/layout/Modal2.tsx.
- Improved exit mutation UX by scoping pending state per target conversation and avoiding awaited refetch in app/src/app/inbox/page.tsx.
- Strengthened server-side exit safety in app/src/server/api/routers/comments.ts: early raid-chat guard and concurrency-safe cleanup (membership-first, guarded conversation delete, conditional comment cleanup).

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Added a confirmation dialog displaying the conversation title before exiting.
  * Exit and confirmation controls are disabled while the request is processing.
  * Pending confirmation state clears when the dialog closes or the request completes.

* **Accessibility**
  * Improved keyboard support and interaction handling for confirmation dialogs.
  * Prevented keyboard actions from triggering unavailable or disabled controls.

* **Bug Fixes**
  * Improved conversation exit handling and refresh behavior after a successful exit.
  * Prevented unsupported chat types from being exited.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->