### PR TITLE
Fix Sentry issues from the last 14 days

### DIFF
--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -859,8 +859,12 @@ const isClerkSessionTouchNetworkError = (event: Sentry.ErrorEvent): boolean => {
   let isSessionTouchEndpoint = false;
   try {
     const url = new URL(quotedUrl);
+    // Anchored so a lookalike host (clerk.attacker.com) cannot suppress reports.
+    // Covers our Clerk custom domains - the CSP in next.config.mjs allows the
+    // clerk.www.* forms, and production currently reports clerk.theninja-rpg.com
+    // - plus Clerk's own domains used by preview deployments.
     const isClerkHost =
-      url.hostname.startsWith("clerk.") ||
+      /^clerk\.(www\.)?theninja-rpg\.(com|ai)$/.test(url.hostname) ||
       url.hostname.endsWith(".clerk.com") ||
       url.hostname.endsWith(".clerk.accounts.dev");
     isSessionTouchEndpoint =

--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -203,6 +203,12 @@ Sentry.init({
     if (isClerkSignOutError(event)) {
       return null; // Drop Clerk sign-out race condition errors
     }
+    if (isClerkSessionTouchNetworkError(event)) {
+      return null; // Drop failed Clerk session heartbeats (no user-visible impact)
+    }
+    if (isNavigationAbortError(event)) {
+      return null; // Drop requests the browser aborted when the user navigated away
+    }
     if (isOutOfMemoryError(event)) {
       return null; // Drop scoped out of memory errors from /travel 3D rendering
     }
@@ -788,6 +794,96 @@ const isClerkSyntaxError = (event: Sentry.ErrorEvent): boolean => {
 };
 
 /**
+ * Check if an error is a request aborted by the browser during navigation.
+ *
+ * When a user navigates (or closes a tab) while requests are still in flight,
+ * the browser rejects them. Firefox words this "AbortError: The operation was
+ * aborted."; Chrome and Safari produce "Failed to fetch" / "Load failed", which
+ * are already filtered above. This is the Firefox equivalent of those entries.
+ *
+ * UX note: no user-visible impact. The requests belong to a page the user has
+ * left; react-query refetches whatever the destination page needs.
+ *
+ * Deliberately narrow - only filters when there is NO stack trace at all, which
+ * is the signature of a browser-level DOMException. Every place this codebase
+ * aborts on purpose (fetchWithTimeout) surfaces the error to its caller with a
+ * real stack, so those keep reporting.
+ */
+const isNavigationAbortError = (event: Sentry.ErrorEvent): boolean => {
+  const exception = event.exception?.values?.[0];
+  const message = exception?.value ?? "";
+  const errorType = exception?.type ?? "";
+  const stackFrames = exception?.stacktrace?.frames ?? [];
+  const mechanism = exception?.mechanism?.type ?? "";
+
+  if (errorType !== "AbortError") return false;
+  if (!message.trim().startsWith("The operation was aborted")) return false;
+
+  // A browser-level abort carries no frames; anything with a stack is ours to fix
+  if (stackFrames.length > 0) return false;
+
+  return mechanism.includes("onunhandledrejection");
+};
+
+/**
+ * Check if an error is a failed Clerk session "touch" request.
+ *
+ * Clerk periodically POSTs to /v1/client/sessions/<id>/touch to refresh the
+ * session's last-active timestamp. On flaky mobile networks (device sleep, WiFi
+ * to cellular handoff, tunnels) this background request fails and Clerk rejects
+ * the promise, which our global handler reports.
+ *
+ * UX note: no user-visible impact. Touch is a heartbeat that only updates
+ * "last active at"; it does not mint or refresh the session token, so a failed
+ * touch never signs the user out or blocks a request. Clerk simply retries on
+ * its next poll. This is deliberately scoped to the touch endpoint - failures on
+ * token or sign-in endpoints DO affect the user and must keep reporting.
+ *
+ * Detection pattern:
+ * - Message begins with "ClerkJS: Network error at"
+ * - The quoted URL is a Clerk host and a /v1/client/sessions/<id>/touch path
+ * - The underlying cause is a network-level TypeError, whose wording differs per
+ *   browser ("Load failed" on Safari, "NetworkError when attempting to fetch
+ *   resource." on Firefox, "Failed to fetch" on Chrome)
+ */
+const isClerkSessionTouchNetworkError = (event: Sentry.ErrorEvent): boolean => {
+  const message = event.exception?.values?.[0]?.value ?? "";
+
+  if (!message.startsWith("ClerkJS: Network error at")) return false;
+
+  // Extract the quoted request URL so the host and path can be validated
+  // properly rather than substring-matched (a spoofed path could otherwise pass)
+  const quotedUrl = /^ClerkJS: Network error at "([^"]+)"/.exec(message)?.[1];
+  if (!quotedUrl) return false;
+
+  let isSessionTouchEndpoint = false;
+  try {
+    const url = new URL(quotedUrl);
+    const isClerkHost =
+      url.hostname.startsWith("clerk.") ||
+      url.hostname.endsWith(".clerk.com") ||
+      url.hostname.endsWith(".clerk.accounts.dev");
+    isSessionTouchEndpoint =
+      isClerkHost && /^\/v1\/client\/sessions\/[^/]+\/touch$/.test(url.pathname);
+  } catch {
+    // Not a parseable URL - do not filter
+    return false;
+  }
+
+  if (!isSessionTouchEndpoint) return false;
+
+  // Only transient network failures; anything else from this endpoint is worth seeing
+  const networkCauses = [
+    "Load failed",
+    "Failed to fetch",
+    "NetworkError when attempting to fetch resource.",
+    "network error",
+    "The network connection was lost.",
+  ];
+  return networkCauses.some((cause) => message.includes(cause));
+};
+
+/**
  * Check if an error is a Clerk sign-out race condition error that should be filtered.
  * These occur when Clerk attempts to sign out a user whose session has already been
  * invalidated server-side. This is a transient race condition in Clerk's sign-out flow:
@@ -1233,6 +1329,14 @@ const isThirdPartyStackOverflowError = (event: Sentry.ErrorEvent): boolean => {
 
     // Anonymous script markers
     if (filename === "<anonymous>" || absPath === "<anonymous>") return true;
+
+    // Cross-origin scripts whose source URL could not be resolved are reported
+    // with the literal strings "undefined"/"null" as the path. Such a frame can
+    // never point at our own code, so it carries no diagnostic value.
+    const isUnresolvedPath = (path: string) => path === "undefined" || path === "null";
+    if (isUnresolvedPath(filename) && (!absPath || isUnresolvedPath(absPath))) {
+      return true;
+    }
 
     // Check for the "undefined:? in ?" pattern (function is "?" with no filename)
     if (func === "?" && !filename && !absPath) return true;
@@ -1919,11 +2023,21 @@ const hasUserscriptStackSignal = (
     return (
       filename.includes("app:///userscripts/") ||
       absPath.includes("app:///userscripts/") ||
-      filename.endsWith(".user.js") ||
-      absPath.endsWith(".user.js") ||
+      isUserscriptFilename(filename) ||
+      isUserscriptFilename(absPath) ||
       hasUserscriptFunctionName(func)
     );
   });
+};
+
+/**
+ * Match a Tampermonkey/Greasemonkey script path. Tampermonkey appends an
+ * injection index to the source URL (e.g. "app:///%20TNR%20Builder.user.js#26"),
+ * so the extension must be matched allowing a trailing fragment or query rather
+ * than only at the very end of the string.
+ */
+const isUserscriptFilename = (path: string): boolean => {
+  return /\.user\.js(?:[#?]|$)/.test(path);
 };
 
 const hasMeaningfulAppCodeFrame = (

--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -64,6 +64,18 @@ const config = {
       },
     ],
   },
+  async redirects() {
+    return [
+      // Referral links from the original PHP game are still in circulation and
+      // land on /index.php?ref=<username>. Next forwards the query string, so
+      // the referral is preserved instead of dead-ending on the 404 page.
+      {
+        source: "/index.php",
+        destination: "/",
+        permanent: true,
+      },
+    ];
+  },
   async headers() {
     return [
       {

--- a/app/src/layout/Sector.tsx
+++ b/app/src/layout/Sector.tsx
@@ -2508,18 +2508,29 @@ const Sector: React.FC<SectorProps> = (props) => {
 
 export default Sector;
 
+/**
+ * Identity of the synthetic shrine, which is created once for the sector state
+ * and again for the rendered scene. Both copies must share an id so a raycast
+ * hit on the shrine sprite resolves back to a structure, the same way it does
+ * for database-backed buildings.
+ */
+const SECTOR_SHRINE_ID = "sector-shrine";
+
 const createShrineStructure = (map: NormalizedSectorMap, globalTileType: number) => {
   const shrineAnchor = map.anchors.find((anchor) => anchor.key === "shrine.default");
-  return createGenericStructure({
-    name: "Sector Shrine",
-    route: "/shrine",
-    image:
-      WAR_SHRINE_IMAGE_BY_BIOME[
-        getBiomeAtSectorAnchor(map, "shrine.default", globalTileType)
-      ],
-    longitude: shrineAnchor?.x ?? 10,
-    latitude: shrineAnchor?.y ?? 5,
-  });
+  return {
+    ...createGenericStructure({
+      name: "Sector Shrine",
+      route: "/shrine",
+      image:
+        WAR_SHRINE_IMAGE_BY_BIOME[
+          getBiomeAtSectorAnchor(map, "shrine.default", globalTileType)
+        ],
+      longitude: shrineAnchor?.x ?? 10,
+      latitude: shrineAnchor?.y ?? 5,
+    }),
+    id: SECTOR_SHRINE_ID,
+  };
 };
 
 interface SorroundingUsersProps {

--- a/app/src/server/db.ts
+++ b/app/src/server/db.ts
@@ -4,6 +4,7 @@ import {
   type PlanetScaleDatabase,
 } from "drizzle-orm/planetscale-serverless";
 import { env } from "@/env/server.mjs";
+import { createRetryingFetch } from "@/server/dbRetry";
 import * as schema from "../../drizzle/schema";
 
 export type DrizzleClient = PlanetScaleDatabase<typeof schema>;
@@ -22,7 +23,12 @@ export const drizzleDB =
   global.drizzleClient && global.drizzleSchemaKeys === schemaKeys
     ? global.drizzleClient
     : createDrizzle(
-        new Client({ url: process.env.DATABASE_URL }),
+        new Client({
+          url: process.env.DATABASE_URL,
+          // Vitess drops pooled connections under load; re-issue reads rather than
+          // surfacing "vttablet: rpc error: code = Unavailable" to the player.
+          fetch: createRetryingFetch(),
+        }),
         { schema }, // ,  logger: true
       );
 

--- a/app/src/server/dbRetry.ts
+++ b/app/src/server/dbRetry.ts
@@ -1,0 +1,143 @@
+import { type RetryOptions, withRetry } from "@/utils/retry";
+
+/**
+ * Vitess/PlanetScale occasionally drops a pooled connection mid-query and returns
+ * an `Unavailable` rpc error. The query never reaches the tablet in that case, so
+ * re-issuing it is safe - but only for statements that do not mutate data, since a
+ * write could equally well have been applied before the connection died.
+ *
+ * Markers are taken verbatim from the errors PlanetScale returns, e.g.
+ * "target: tnr.-.primary: vttablet: rpc error: code = Unavailable desc = error
+ * reading from server: read tcp ...: read: connection reset by peer".
+ */
+const TRANSIENT_MARKERS = [
+  "code = Unavailable",
+  "connection reset by peer",
+  "broken pipe",
+  "unexpected EOF",
+] as const;
+
+/** Statements that cannot change data, and are therefore safe to re-issue. */
+const READ_ONLY_STATEMENTS = /^(select|show|describe|desc|explain)\b/i;
+
+/** Thrown internally to signal `withRetry` that another attempt is worthwhile. */
+class TransientDatabaseError extends Error {}
+
+/**
+ * Strip leading comments and whitespace so the leading keyword can be inspected.
+ * Drizzle emits plain statements, but the PlanetScale driver may prepend hints.
+ */
+const stripLeadingComments = (query: string): string => {
+  let remaining = query.trimStart();
+  let previous = "";
+  while (remaining !== previous) {
+    previous = remaining;
+    if (remaining.startsWith("--")) {
+      remaining = remaining.slice(remaining.indexOf("\n") + 1).trimStart();
+    } else if (remaining.startsWith("/*")) {
+      const end = remaining.indexOf("*/");
+      if (end === -1) return "";
+      remaining = remaining.slice(end + 2).trimStart();
+    }
+  }
+  return remaining;
+};
+
+/**
+ * A statement is retryable only when it is unambiguously a read. `WITH` is
+ * deliberately excluded: MySQL 8 allows a CTE to precede UPDATE/DELETE, so the
+ * leading keyword alone does not prove the statement is side-effect free.
+ */
+export const isReadOnlyQuery = (query: string): boolean => {
+  return READ_ONLY_STATEMENTS.test(stripLeadingComments(query));
+};
+
+/** Detect a dropped-connection error in a PlanetScale HTTP response body. */
+export const isTransientDatabaseResponse = (status: number, body: string): boolean => {
+  if (status === 502 || status === 503 || status === 504) return true;
+  return TRANSIENT_MARKERS.some((marker) => body.includes(marker));
+};
+
+/** Pull the SQL text out of the JSON body the PlanetScale driver posts. */
+const extractQuery = (body: BodyInit | null | undefined): string | null => {
+  if (typeof body !== "string") return null;
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (parsed && typeof parsed === "object" && "query" in parsed) {
+      const { query } = parsed as { query?: unknown };
+      return typeof query === "string" ? query : null;
+    }
+  } catch {
+    // Not a JSON body (e.g. session creation) - never retried.
+  }
+  return null;
+};
+
+/**
+ * Wrap `fetch` so that read-only PlanetScale queries survive a dropped
+ * connection instead of surfacing as a user-visible tRPC error.
+ *
+ * Writes are passed straight through: a mutation may have been applied before
+ * the connection reset, and this codebase grants money/XP through non-idempotent
+ * increments, so a blind retry could double-apply a reward.
+ *
+ * When every attempt fails the final response is returned unchanged, so the
+ * driver still raises its normal `DatabaseError` and callers behave as before.
+ */
+export const createRetryingFetch = (
+  baseFetch: typeof fetch = fetch,
+  options: RetryOptions = {},
+): typeof fetch => {
+  return async (input, init) => {
+    const query = extractQuery(init?.body);
+    if (!query || !isReadOnlyQuery(query)) {
+      return baseFetch(input, init);
+    }
+
+    let lastResponse: { body: string; status: number; headers: Headers } | null = null;
+
+    const rebuild = (response: {
+      body: string;
+      status: number;
+      headers: Headers;
+    }): Response => {
+      const hasBody = response.status !== 204 && response.status !== 304;
+      return new Response(hasBody ? response.body : null, {
+        status: response.status,
+        headers: response.headers,
+      });
+    };
+
+    try {
+      return await withRetry(
+        async () => {
+          const response = await baseFetch(input, init);
+          const snapshot = {
+            body: await response.text(),
+            status: response.status,
+            headers: response.headers,
+          };
+          lastResponse = snapshot;
+          if (isTransientDatabaseResponse(snapshot.status, snapshot.body)) {
+            throw new TransientDatabaseError("Transient PlanetScale error");
+          }
+          return rebuild(snapshot);
+        },
+        {
+          maxRetries: 2,
+          // Connection resets clear in milliseconds; a request is waiting on this.
+          baseDelayMs: 50,
+          deadlineMs: 3000,
+          isTransient: (error) =>
+            error instanceof TransientDatabaseError || error instanceof TypeError,
+          ...options,
+        },
+      );
+    } catch (error) {
+      if (error instanceof TransientDatabaseError && lastResponse) {
+        return rebuild(lastResponse);
+      }
+      throw error;
+    }
+  };
+};

--- a/app/src/server/dbRetry.ts
+++ b/app/src/server/dbRetry.ts
@@ -58,15 +58,33 @@ export const isTransientDatabaseResponse = (status: number, body: string): boole
   return TRANSIENT_MARKERS.some((marker) => body.includes(marker));
 };
 
-/** Pull the SQL text out of the JSON body the PlanetScale driver posts. */
-const extractQuery = (body: BodyInit | null | undefined): string | null => {
+interface DriverRequest {
+  query: string;
+  /**
+   * True while the statement runs between BEGIN and COMMIT. The driver echoes
+   * the vitess session on every request, and it carries `inTransaction` only
+   * for statements inside a transaction - plain autocommit connections omit it.
+   */
+  inTransaction: boolean;
+}
+
+/** Pull the SQL text and transaction state out of the driver's JSON body. */
+const parseDriverRequest = (
+  body: BodyInit | null | undefined,
+): DriverRequest | null => {
   if (typeof body !== "string") return null;
   try {
     const parsed: unknown = JSON.parse(body);
-    if (parsed && typeof parsed === "object" && "query" in parsed) {
-      const { query } = parsed as { query?: unknown };
-      return typeof query === "string" ? query : null;
-    }
+    if (!parsed || typeof parsed !== "object" || !("query" in parsed)) return null;
+    const { query, session } = parsed as {
+      query?: unknown;
+      session?: { vitessSession?: { inTransaction?: unknown } } | null;
+    };
+    if (typeof query !== "string") return null;
+    return {
+      query,
+      inTransaction: session?.vitessSession?.inTransaction === true,
+    };
   } catch {
     // Not a JSON body (e.g. session creation) - never retried.
   }
@@ -81,6 +99,10 @@ const extractQuery = (body: BodyInit | null | undefined): string | null => {
  * the connection reset, and this codebase grants money/XP through non-idempotent
  * increments, so a blind retry could double-apply a reward.
  *
+ * Statements inside a transaction are also passed through. A reset aborts the
+ * transaction server-side, so re-issuing the read would run it outside the
+ * transaction's snapshot - `paypal.ts` depends on that isolation.
+ *
  * When every attempt fails the final response is returned unchanged, so the
  * driver still raises its normal `DatabaseError` and callers behave as before.
  */
@@ -89,8 +111,8 @@ export const createRetryingFetch = (
   options: RetryOptions = {},
 ): typeof fetch => {
   return async (input, init) => {
-    const query = extractQuery(init?.body);
-    if (!query || !isReadOnlyQuery(query)) {
+    const request = parseDriverRequest(init?.body);
+    if (!request || request.inTransaction || !isReadOnlyQuery(request.query)) {
       return baseFetch(input, init);
     }
 

--- a/app/tests/server/dbRetry.test.ts
+++ b/app/tests/server/dbRetry.test.ts
@@ -19,6 +19,24 @@ const RESET_BODY = JSON.stringify({
 
 const post = (query: string) => ({ method: "POST", body: JSON.stringify({ query }) });
 
+// Shape the driver actually posts once a connection has a session. `inTransaction`
+// is present only between BEGIN and COMMIT; plain autocommit sessions omit it.
+const postInTransaction = (query: string) => ({
+  method: "POST",
+  body: JSON.stringify({
+    query,
+    session: { signature: "sig", vitessSession: { inTransaction: true, autocommit: true } },
+  }),
+});
+
+const postWithSession = (query: string) => ({
+  method: "POST",
+  body: JSON.stringify({
+    query,
+    session: { signature: "sig", vitessSession: { autocommit: true } },
+  }),
+});
+
 describe("isReadOnlyQuery", () => {
   it("accepts read statements", () => {
     expect(isReadOnlyQuery("select `id` from `UserData`")).toBe(true);
@@ -109,6 +127,33 @@ describe("createRetryingFetch", () => {
 
     expect(baseFetch).toHaveBeenCalledTimes(1);
     expect(await response.text()).toContain("Unknown column");
+  });
+
+  it("never retries a read inside a transaction", async () => {
+    const baseFetch = vi.fn(async () => new Response(RESET_BODY, { status: 200 }));
+    const retrying = createRetryingFetch(baseFetch as unknown as typeof fetch, FAST);
+
+    // A reset aborts the transaction server-side; re-issuing would read outside it
+    const response = await retrying("https://db.test", postInTransaction("select 1"));
+
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+    expect(await response.text()).toContain("connection reset by peer");
+  });
+
+  it("still retries a read on an ordinary session outside a transaction", async () => {
+    let calls = 0;
+    const baseFetch = vi.fn(async () => {
+      calls += 1;
+      return calls < 2
+        ? new Response(RESET_BODY, { status: 200 })
+        : new Response('{"result":{"rows":[]}}', { status: 200 });
+    });
+    const retrying = createRetryingFetch(baseFetch as unknown as typeof fetch, FAST);
+
+    const response = await retrying("https://db.test", postWithSession("select 1"));
+
+    expect(calls).toBe(2);
+    expect(await response.json()).toEqual({ result: { rows: [] } });
   });
 
   it("passes through non-query requests untouched", async () => {

--- a/app/tests/server/dbRetry.test.ts
+++ b/app/tests/server/dbRetry.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createRetryingFetch,
+  isReadOnlyQuery,
+  isTransientDatabaseResponse,
+} from "@/server/dbRetry";
+
+// Tiny backoff so retry tests run in milliseconds with real timers
+const FAST = { maxRetries: 2, baseDelayMs: 1, deadlineMs: 5_000 };
+
+// Verbatim body PlanetScale returned in THENINJARPG-2D1
+const RESET_BODY = JSON.stringify({
+  error: {
+    message:
+      "target: tnr.-.primary: vttablet: rpc error: code = Unavailable desc = error reading from server: read tcp 10.199.58.69:41408->10.199.169.104:15999: read: connection reset by peer",
+    code: "UNKNOWN",
+  },
+});
+
+const post = (query: string) => ({ method: "POST", body: JSON.stringify({ query }) });
+
+describe("isReadOnlyQuery", () => {
+  it("accepts read statements", () => {
+    expect(isReadOnlyQuery("select `id` from `UserData`")).toBe(true);
+    expect(isReadOnlyQuery("  SELECT 1")).toBe(true);
+    expect(isReadOnlyQuery("SHOW TABLES")).toBe(true);
+    expect(isReadOnlyQuery("/* hint */ select 1")).toBe(true);
+    expect(isReadOnlyQuery("-- comment\nselect 1")).toBe(true);
+  });
+
+  it("rejects anything that can mutate data", () => {
+    expect(isReadOnlyQuery("update `UserData` set `money` = `money` + 100")).toBe(false);
+    expect(isReadOnlyQuery("insert into `UserData` (id) values (1)")).toBe(false);
+    expect(isReadOnlyQuery("delete from `UserData`")).toBe(false);
+    // A CTE may precede UPDATE/DELETE in MySQL 8, so WITH is never retried
+    expect(isReadOnlyQuery("with x as (select 1) update `UserData` set `a` = 1")).toBe(
+      false,
+    );
+    expect(isReadOnlyQuery("selection_is_not_a_keyword")).toBe(false);
+  });
+});
+
+describe("isTransientDatabaseResponse", () => {
+  it("detects dropped Vitess connections", () => {
+    expect(isTransientDatabaseResponse(200, RESET_BODY)).toBe(true);
+    expect(isTransientDatabaseResponse(503, "{}")).toBe(true);
+  });
+
+  it("ignores ordinary query errors", () => {
+    expect(
+      isTransientDatabaseResponse(
+        200,
+        JSON.stringify({ error: { message: "Duplicate entry 'x' for key 'PRIMARY'" } }),
+      ),
+    ).toBe(false);
+    expect(isTransientDatabaseResponse(200, '{"result":{}}')).toBe(false);
+  });
+});
+
+describe("createRetryingFetch", () => {
+  it("retries a read that hits a dropped connection and returns a readable body", async () => {
+    let calls = 0;
+    const baseFetch = vi.fn(async () => {
+      calls += 1;
+      return calls < 2
+        ? new Response(RESET_BODY, { status: 200 })
+        : new Response('{"result":{"rows":[]}}', { status: 200 });
+    });
+    const retrying = createRetryingFetch(baseFetch as unknown as typeof fetch, FAST);
+
+    const response = await retrying("https://db.test", post("select 1"));
+
+    expect(calls).toBe(2);
+    // Body must still be unconsumed for the PlanetScale driver
+    expect(await response.json()).toEqual({ result: { rows: [] } });
+  });
+
+  it("never retries a write, even on a transient error", async () => {
+    const baseFetch = vi.fn(async () => new Response(RESET_BODY, { status: 200 }));
+    const retrying = createRetryingFetch(baseFetch as unknown as typeof fetch, FAST);
+
+    const response = await retrying(
+      "https://db.test",
+      post("update `UserData` set `money` = `money` + 100"),
+    );
+
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+    expect(await response.text()).toContain("connection reset by peer");
+  });
+
+  it("returns the final response when every retry fails", async () => {
+    const baseFetch = vi.fn(async () => new Response(RESET_BODY, { status: 200 }));
+    const retrying = createRetryingFetch(baseFetch as unknown as typeof fetch, FAST);
+
+    const response = await retrying("https://db.test", post("select 1"));
+
+    // maxRetries: 2 => 3 attempts total, then the driver raises its own error
+    expect(baseFetch).toHaveBeenCalledTimes(3);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("code = Unavailable");
+  });
+
+  it("does not retry a genuine query error", async () => {
+    const body = JSON.stringify({ error: { message: "Unknown column 'nope'" } });
+    const baseFetch = vi.fn(async () => new Response(body, { status: 200 }));
+    const retrying = createRetryingFetch(baseFetch as unknown as typeof fetch, FAST);
+
+    const response = await retrying("https://db.test", post("select nope"));
+
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+    expect(await response.text()).toContain("Unknown column");
+  });
+
+  it("passes through non-query requests untouched", async () => {
+    const baseFetch = vi.fn(async () => new Response("{}", { status: 200 }));
+    const retrying = createRetryingFetch(baseFetch as unknown as typeof fetch, FAST);
+
+    await retrying("https://db.test", { method: "POST", body: "{}" });
+
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Works through all 12 unresolved Sentry issues from the last 14 days. Every filter here was verified by replaying the **real captured production payload** through the live `beforeSend` in a browser, rather than by reasoning about the message text.

## Real fixes

**PlanetScale dropped connections — [THENINJARPG-2D1](https://studie-tech-aps.sentry.io/issues/87965821/) (3763 events / 262 users)**

Vitess resets pooled connections under load and returns `vttablet: rpc error: code = Unavailable ... read: connection reset by peer`, which reached players as a failed request on `/bank` and elsewhere. `createRetryingFetch` re-issues the query.

Safety: only `SELECT`/`SHOW`/`DESCRIBE`/`EXPLAIN` are retried. A write may have been applied *before* the connection died, and this codebase grants money/XP through non-idempotent increments, so replaying one could double-apply a reward. `WITH` is excluded too, since MySQL 8 allows a CTE to precede `UPDATE`/`DELETE`. When the retry budget is exhausted the original response is returned untouched, so the driver still raises its normal `DatabaseError` and no caller changes behaviour.

**Legacy PHP referral links — [THENINJARPG-17A](https://studie-tech-aps.sentry.io/issues/38057642/) (804 events / 9 users)**

Referral links from the original PHP game (`/index.php?ref=<user>`) are still in circulation and dead-ended on the 404 page. Now a permanent redirect to `/` with the query preserved.

Note: the RSC digest is stripped in production builds and was not recoverable from the client event, so this fixes the *known trigger* rather than being a proven root-cause fix. The error itself is deliberately **not** filtered — a Server Components render error should keep reporting.

## Sentry noise

Each is scoped to a signature that cannot mask a real defect:

| Issue | Events | Why it is safe to drop |
|---|---|---|
| [2CQ](https://studie-tech-aps.sentry.io/issues/87319081/) / [2M8](https://studie-tech-aps.sentry.io/issues/119421392/) / [2M7](https://studie-tech-aps.sentry.io/issues/119376906/) | ~6000 | Scoped to `/v1/client/sessions/<id>/touch` on a **hostname-validated** Clerk host with a network-level cause. Touch only updates "last active at" — it does not mint or refresh the session token, so a failure cannot sign anyone out. Token and sign-in endpoints keep reporting. |
| [2N4](https://studie-tech-aps.sentry.io/issues/130941114/) | 92 | `hasUserscriptStackSignal` matched `.user.js` only at end-of-string, but Tampermonkey appends an injection index (`app:///%20TNR%20Builder.user.js#26`). Third-party userscript, not our code. |
| [1XW](https://studie-tech-aps.sentry.io/issues/64755854/) | 71 | Unresolvable cross-origin scripts report the **literal path `"undefined"`**, which the existing "no meaningful stack" check did not recognise. Such a frame can never point at our code. |
| [2MN](https://studie-tech-aps.sentry.io/issues/121829572/) | 40 | Firefox's wording of the already-filtered "Failed to fetch"/"Load failed". Only filtered when there is **no stack trace at all** — every deliberate abort (`fetchWithTimeout`) surfaces with a real stack and keeps reporting. |

## Investigated, no code change

- **[2KH](https://studie-tech-aps.sentry.io/issues/111193709/) (Safari JSON) and [2NN](https://studie-tech-aps.sentry.io/issues/135224553/) (WebGL context loss)** — the existing filters already drop these payloads; confirmed against the live `beforeSend`. No edit needed.
- **[2NP](https://studie-tech-aps.sentry.io/issues/136434828/) Rage Click** — `issueType: replay_click_rage`, a Sentry **backend-generated occurrence** with no exception payload. It never passes through client `beforeSend`, so the existing `isRageClickEvent` filter is dead code for it. This has to be turned off in Sentry's project issue-detection settings; worth doing given Session Replay is sampled at 0.
- **[2NQ](https://studie-tech-aps.sentry.io/issues/137378114/) NotSupportedError (1 event)** — every `play()` call in `audio.ts`, `useAudio.ts` and `Welcome.tsx` is already guarded, and the event carries no stack. Left reporting rather than adding a broad media filter that could hide a genuinely broken asset.

## Verification

- Replayed all 12 production payloads through the live `beforeSend`: 1XW, 2CQ, 2M7, 2M8, 2MN, 2N4 flipped from `SENT` to `DROPPED`; 17A, 2D1, 2NQ still report as intended.
- `/index.php?ref=koh222` → `308` → `/?ref=koh222` on the dev server; unrelated 404s unaffected.
- 9 new unit tests for the DB retry path; `509/509` tests pass, typecheck clean.
- Confirmed live tRPC reads still return real rows through the new retrying fetch, with no console errors.

Also includes the `Sector` shrine raycast id fix carried over from the previous PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a permanent redirect from `/index.php` to the homepage while preserving referral parameters.

- **Bug Fixes**
  - Improved interaction with procedurally created shrine structures.
  - Reduced false error reports from expected browser navigation cancellations and temporary session-related network failures.
  - Improved detection of third-party stack traces and userscripts with URL parameters.

- **Reliability**
  - Added automatic retries for transient, read-only database requests while avoiding retries for write operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->