### PR TITLE
DEBUG: diagnose missing backend Sentry errors on Vercel

### DIFF
--- a/app/instrumentation.ts
+++ b/app/instrumentation.ts
@@ -1,12 +1,26 @@
 import * as Sentry from "@sentry/nextjs";
 
 export async function register() {
-  if (process.env.NEXT_RUNTIME === "nodejs") {
-    await import("./sentry.server.config");
+  const marker: Record<string, unknown> = {
+    called: true,
+    nextRuntime: process.env.NEXT_RUNTIME ?? null,
+    at: new Date().toISOString(),
+  };
+  (globalThis as Record<string, unknown>).__TNR_SENTRY_REGISTER__ = marker;
+  try {
+    if (process.env.NEXT_RUNTIME === "nodejs") {
+      await import("./sentry.server.config");
+      marker.imported = "nodejs";
+    }
+    if (process.env.NEXT_RUNTIME === "edge") {
+      await import("./sentry.edge.config");
+      marker.imported = "edge";
+    }
+    marker.clientAfterInit = !!Sentry.getClient();
+  } catch (error) {
+    marker.error = error instanceof Error ? error.message : String(error);
   }
-  if (process.env.NEXT_RUNTIME === "edge") {
-    await import("./sentry.edge.config");
-  }
+  console.log("[sentry-probe] register()", JSON.stringify(marker));
 }
 
 export const onRequestError = Sentry.captureRequestError;

--- a/app/src/app/api/sentry-probe/route.ts
+++ b/app/src/app/api/sentry-probe/route.ts
@@ -1,0 +1,155 @@
+import * as SentryNext from "@sentry/nextjs";
+import * as SentryNode from "@sentry/node";
+import type { NextRequest } from "next/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const DSN =
+  "https://c35c54f99b73b4a3b8a7e60936bc2967@o4507797256601600.ingest.de.sentry.io/4507797262958672";
+
+type ClientInfo = {
+  initialized: boolean;
+  dsn: string | null;
+  environment: string | null;
+  release: string | null;
+  sampleRate: number | null;
+  enabled: boolean | null;
+  integrations: string[] | null;
+};
+
+const describeClient = (
+  client: ReturnType<typeof SentryNext.getClient>,
+): ClientInfo => {
+  if (!client) {
+    return {
+      initialized: false,
+      dsn: null,
+      environment: null,
+      release: null,
+      sampleRate: null,
+      enabled: null,
+      integrations: null,
+    };
+  }
+  const options = client.getOptions();
+  return {
+    initialized: true,
+    dsn: options.dsn ? String(options.dsn).slice(-24) : null,
+    environment: options.environment ?? null,
+    release: options.release ?? null,
+    sampleRate: options.sampleRate ?? null,
+    enabled: options.enabled ?? null,
+    integrations: Object.keys(
+      (client as unknown as { _integrations?: Record<string, unknown> })
+        ._integrations ?? {},
+    ),
+  };
+};
+
+export async function GET(req: NextRequest) {
+  const mode = new URL(req.url).searchParams.get("mode") ?? "info";
+  const marker = `SENTRY_PROBE_${mode.toUpperCase()}_${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) ?? "local"}_${Date.now()}`;
+
+  const nextClient = SentryNext.getClient();
+  const nodeClient = SentryNode.getClient();
+  const carrier = (globalThis as Record<string, unknown>).__SENTRY__ as
+    | Record<string, unknown>
+    | undefined;
+
+  const diagnostics: Record<string, unknown> = {
+    marker,
+    env: {
+      NODE_ENV: process.env.NODE_ENV,
+      NEXT_RUNTIME: process.env.NEXT_RUNTIME,
+      VERCEL: process.env.VERCEL ?? null,
+      VERCEL_ENV: process.env.VERCEL_ENV ?? null,
+      VERCEL_REGION: process.env.VERCEL_REGION ?? null,
+      SENTRY_DSN_set: !!process.env.SENTRY_DSN,
+      NEXT_PUBLIC_SENTRY_DSN_set: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
+      SENTRY_AUTH_TOKEN_set: !!process.env.SENTRY_AUTH_TOKEN,
+    },
+    sdkVersions: {
+      nextjs: SentryNext.SDK_VERSION,
+      node: SentryNode.SDK_VERSION,
+    },
+    registerMarker:
+      (globalThis as Record<string, unknown>).__TNR_SENTRY_REGISTER__ ?? null,
+    carrierKeys: carrier ? Object.keys(carrier) : null,
+    sameClientInstance: !!nextClient && nextClient === nodeClient,
+    nextjsClient: describeClient(nextClient),
+    nodeClient: describeClient(nodeClient),
+  };
+
+  if (mode === "info") {
+    return Response.json(diagnostics);
+  }
+
+  if (mode === "throw") {
+    throw new Error(marker);
+  }
+
+  if (mode === "raw") {
+    // Bypass the SDK entirely: does this lambda have egress to Sentry ingest?
+    const { host, publicKey, projectId } = parseDsn(DSN);
+    const envelope = buildEnvelope(marker, publicKey);
+    try {
+      const res = await fetch(`https://${host}/api/${projectId}/envelope/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-sentry-envelope" },
+        body: envelope,
+      });
+      diagnostics.raw = { status: res.status, body: (await res.text()).slice(0, 300) };
+    } catch (error) {
+      diagnostics.raw = {
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+    return Response.json(diagnostics);
+  }
+
+  // mode=capture (via @sentry/nextjs) or mode=capturenode (via @sentry/node)
+  const sdk = mode === "capturenode" ? SentryNode : SentryNext;
+  const eventId = sdk.captureException(new Error(marker));
+  let flushed: boolean | string;
+  try {
+    flushed = await sdk.flush(8000);
+  } catch (error) {
+    flushed = `flush threw: ${error instanceof Error ? error.message : String(error)}`;
+  }
+  diagnostics.capture = { via: mode, eventId, flushed };
+  return Response.json(diagnostics);
+}
+
+const parseDsn = (dsn: string) => {
+  const url = new URL(dsn);
+  return {
+    host: url.host,
+    publicKey: url.username,
+    projectId: url.pathname.replace("/", ""),
+  };
+};
+
+const buildEnvelope = (marker: string, publicKey: string) => {
+  const eventId = crypto.randomUUID().replace(/-/g, "");
+  const sentAt = new Date().toISOString();
+  const header = JSON.stringify({
+    event_id: eventId,
+    sent_at: sentAt,
+    dsn: DSN,
+    sdk: { name: "tnr.probe", version: "0.0.0" },
+  });
+  const itemHeader = JSON.stringify({ type: "event" });
+  const payload = JSON.stringify({
+    event_id: eventId,
+    timestamp: Date.now() / 1000,
+    platform: "node",
+    level: "error",
+    environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+    exception: {
+      values: [{ type: "SentryProbeRawEnvelope", value: marker }],
+    },
+    tags: { probe: "raw-envelope", public_key: publicKey.slice(0, 6) },
+  });
+  return `${header}\n${itemHeader}\n${payload}\n`;
+};

--- a/app/src/instrumentation.ts
+++ b/app/src/instrumentation.ts
@@ -9,11 +9,11 @@ export async function register() {
   (globalThis as Record<string, unknown>).__TNR_SENTRY_REGISTER__ = marker;
   try {
     if (process.env.NEXT_RUNTIME === "nodejs") {
-      await import("./sentry.server.config");
+      await import("../sentry.server.config");
       marker.imported = "nodejs";
     }
     if (process.env.NEXT_RUNTIME === "edge") {
-      await import("./sentry.edge.config");
+      await import("../sentry.edge.config");
       marker.imported = "edge";
     }
     marker.clientAfterInit = !!Sentry.getClient();

--- a/app/src/server/api/root.ts
+++ b/app/src/server/api/root.ts
@@ -16,6 +16,7 @@ import { combatRouter } from "./routers/combat";
 import { commentsRouter } from "./routers/comments";
 import { conceptartRouter } from "./routers/conceptart";
 import { dataRouter } from "./routers/data";
+import { debugSentryRouter } from "./routers/debugSentry";
 import { forumRouter } from "./routers/forum";
 import { homeRouter } from "./routers/home";
 import { hospitalRouter } from "./routers/hospital";
@@ -75,6 +76,7 @@ export const appRouter = createTRPCRouter({
   conceptart: conceptartRouter,
   clan: clanRouter,
   data: dataRouter,
+  debugSentry: debugSentryRouter,
   forum: forumRouter,
   gameAsset: gameAssetRouter,
   home: homeRouter,

--- a/app/src/server/api/routers/debugSentry.ts
+++ b/app/src/server/api/routers/debugSentry.ts
@@ -1,0 +1,30 @@
+import * as SentryNext from "@sentry/nextjs";
+import * as SentryNode from "@sentry/node";
+import { TRPCError } from "@trpc/server";
+import { createTRPCRouter, publicProcedure } from "@/api/trpc";
+
+/**
+ * Temporary router used to verify whether backend errors raised inside tRPC
+ * procedures reach Sentry when running on Vercel. Not part of the game.
+ */
+export const debugSentryRouter = createTRPCRouter({
+  info: publicProcedure.query(() => {
+    const nextClient = SentryNext.getClient();
+    const nodeClient = SentryNode.getClient();
+    return {
+      vercelEnv: process.env.VERCEL_ENV ?? null,
+      nodeEnv: process.env.NODE_ENV,
+      nextRuntime: process.env.NEXT_RUNTIME ?? null,
+      registerMarker:
+        (globalThis as Record<string, unknown>).__TNR_SENTRY_REGISTER__ ?? null,
+      nextjsClientInitialized: !!nextClient,
+      nodeClientInitialized: !!nodeClient,
+      sameClientInstance: !!nextClient && nextClient === nodeClient,
+      environmentOption: nextClient?.getOptions().environment ?? null,
+    };
+  }),
+  throw: publicProcedure.query(() => {
+    const marker = `SENTRY_PROBE_TRPC_${process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) ?? "local"}_${Date.now()}`;
+    throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: marker });
+  }),
+});


### PR DESCRIPTION
Temporary debug branch. Adds `/api/sentry-probe` and `debugSentry.*` tRPC procedures to determine why server-side errors do not reach Sentry from Vercel deployments while they do locally.

Not for merge — findings will be moved into a clean PR.