### PR TITLE
Fix Sentry issues from the last 14 days

### DIFF
--- a/app/sentry.server.config.ts
+++ b/app/sentry.server.config.ts
@@ -14,7 +14,16 @@ Sentry.init({
   sampleRate: 1.0,
 
   // Which errors to ignore from frontend
-  ignoreErrors: ["Unauthorized for tRPC endpoint", "You are acting too fast"],
+  ignoreErrors: [
+    "Unauthorized for tRPC endpoint",
+    "You are acting too fast",
+    // Stale client after a deployment: the router state tree's last element used
+    // to be a boolean and is now a number, so a browser still running the
+    // previous build fails Next's schema check on every RSC request. UX: the
+    // failed RSC fetch makes Next fall back to a full page load, and the client
+    // picks up the new build in the process, so it self-heals on that navigation.
+    "The router state header was sent but could not be parsed.",
+  ],
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/app/src/app/api/daily-emails-sync/route.ts
+++ b/app/src/app/api/daily-emails-sync/route.ts
@@ -120,39 +120,43 @@ export async function GET() {
     }
 
     // Insert the clerk users & their emails into the database
-    await drizzleDB.insert(emailReminder).values(
-      allClerkUsers
-        .map((user) => {
-          // Data to fill in
-          const mail = user.email_addresses.find(
-            (e) => e.id === user.primary_email_address_id,
-          );
-          const callName = user.username || `${user.first_name} ${user.last_name}`;
-          const lastActivity = new Date(user.last_active_at);
-          if (mail) {
-            return {
-              userId: user.id,
-              callName: callName,
-              email: mail.email_address,
-              secret: nanoid(21),
-              lastActivity: lastActivity,
-            };
-          } else {
-            return null;
-          }
-        })
-        .filter(
-          (
-            v,
-          ): v is {
-            userId: string;
-            callName: string;
-            email: string;
-            secret: string;
-            lastActivity: Date;
-          } => v !== null,
-        ),
-    );
+    const newReminders = allClerkUsers
+      .map((user) => {
+        // Data to fill in
+        const mail = user.email_addresses.find(
+          (e) => e.id === user.primary_email_address_id,
+        );
+        const callName = user.username || `${user.first_name} ${user.last_name}`;
+        const lastActivity = new Date(user.last_active_at);
+        if (mail) {
+          return {
+            userId: user.id,
+            callName: callName,
+            email: mail.email_address,
+            secret: nanoid(21),
+            lastActivity: lastActivity,
+          };
+        } else {
+          return null;
+        }
+      })
+      .filter(
+        (
+          v,
+        ): v is {
+          userId: string;
+          callName: string;
+          email: string;
+          secret: string;
+          lastActivity: Date;
+        } => v !== null,
+      );
+
+    // Every Clerk user may already be known, or none may have a primary email, in
+    // which case there is nothing to insert - drizzle rejects an empty values() list.
+    if (newReminders.length > 0) {
+      await drizzleDB.insert(emailReminder).values(newReminders);
+    }
 
     // Update emailReminder's lastActivity with userData's updatedAt for matching userIds
     await drizzleDB.execute(sql`

--- a/app/src/proxy.ts
+++ b/app/src/proxy.ts
@@ -98,6 +98,15 @@ export const config = {
      * layout, so missing assets and scanner probes remain cheap 404 responses.
      */
     "/((?!api(?:/|$)|trpc(?:/|$)|_next(?:/|$)|static(?:/|$)|[^?]*\\.[^/?]+).*)",
+    /*
+     * Optional catch-all routes are the exception to the file-like skip above:
+     * they render the Clerk-dependent root layout for paths such as
+     * /signup/administration/index.php, which scanners probe for. Without the
+     * proxy those requests reach auth() with no Clerk context and throw.
+     */
+    "/login(.*)",
+    "/signup(.*)",
+    "/manual/damage_calcs(.*)",
     // Only route handlers that call Clerk's server helpers need its context.
     "/api/trpc/(.*)",
     "/api/chat/:path*",

--- a/app/src/server/api/routers/badge.ts
+++ b/app/src/server/api/routers/badge.ts
@@ -61,7 +61,7 @@ export const badgeRouter = createTRPCRouter({
     .input(z.object({ id: z.string(), data: BadgeValidator }))
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
-      setEmptyStringsToNulls(input.data);
+      setEmptyStringsToNulls(input.data, badge);
       const [user, entry, badgeWithName] = await Promise.all([
         fetchUser(ctx.drizzle, ctx.userId),
         fetchBadge(ctx.drizzle, input.id),

--- a/app/src/server/api/routers/bloodline.ts
+++ b/app/src/server/api/routers/bloodline.ts
@@ -149,6 +149,7 @@ export const bloodlineRouter = createTRPCRouter({
         description: "New bloodline description",
         effects: [],
         rank: "D",
+        statClassification: "Highest",
         hidden: true,
       });
       return { success: true, message: id };
@@ -646,7 +647,10 @@ export const bloodlineRouter = createTRPCRouter({
         return errorResponse("Bloodline name already exists");
       if (canChangeContent(user.role)) {
         // Prepare data: convert empty strings to null for optional fields
-        setEmptyStringsToNulls(input.data as unknown as Record<string, unknown>);
+        setEmptyStringsToNulls(
+          input.data as unknown as Record<string, unknown>,
+          bloodline,
+        );
         // Calculate diff
         const newData = {
           ...input.data,

--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -328,7 +328,7 @@ export const itemRouter = createTRPCRouter({
     .input(z.object({ id: z.string(), data: ItemValidator }))
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
-      setEmptyStringsToNulls(input.data);
+      setEmptyStringsToNulls(input.data, item);
       // Query
       const [user, entry, itemWithName] = await Promise.all([
         fetchUser(ctx.drizzle, ctx.userId),

--- a/app/src/server/api/routers/jutsu.ts
+++ b/app/src/server/api/routers/jutsu.ts
@@ -405,6 +405,7 @@ export const jutsuRouter = createTRPCRouter({
         requiredLevel: 1,
         target: "OTHER_USER",
         jutsuType: "AI",
+        statClassification: "Highest",
         image: IMG_AVATAR_DEFAULT,
       });
       return { success: true, message: id };

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -1310,7 +1310,7 @@ export const profileRouter = createTRPCRouter({
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
       // Set empty strings to null
-      setEmptyStringsToNulls(input.data);
+      setEmptyStringsToNulls(input.data, userData);
       input.data.customTitle = input.data.customTitle ?? "";
 
       // Queries

--- a/app/src/server/api/routers/quests.ts
+++ b/app/src/server/api/routers/quests.ts
@@ -883,7 +883,7 @@ export const questsRouter = createTRPCRouter({
     .input(z.object({ id: z.string(), data: QuestValidator }))
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
-      setEmptyStringsToNulls(input.data);
+      setEmptyStringsToNulls(input.data, quest);
       // Query
       const [user, entry, tierQuests] = await Promise.all([
         fetchUser(ctx.drizzle, ctx.userId),

--- a/app/src/server/api/routers/war.ts
+++ b/app/src/server/api/routers/war.ts
@@ -67,7 +67,6 @@ import {
   createTRPCRouter,
   errorResponse,
   protectedProcedure,
-  serverError,
 } from "../trpc";
 
 export const warRouter = createTRPCRouter({
@@ -1186,14 +1185,20 @@ export const warRouter = createTRPCRouter({
     })
     .input(z.object({ villageId: z.string() }))
     .query(async ({ ctx, input }) => {
+      // Optimistically fetch for the requested village; it is the user's own in
+      // every normal case, so this stays a single round-trip.
       const [user, votes] = await Promise.all([
         fetchUser(ctx.drizzle, ctx.userId),
         fetchElderVotes(ctx.drizzle, input.villageId),
       ]);
-      if (user.villageId !== input.villageId && !canSeeSecretData(user.role)) {
-        throw serverError("FORBIDDEN", "You can only view votes for your own village");
+      // Staff may inspect any village. Everyone else only ever sees their own, so
+      // a villageId the client cached before switching village re-reads the
+      // current one instead of failing the townhall page with an error toast.
+      if (canSeeSecretData(user.role) || user.villageId === input.villageId) {
+        return votes;
       }
-      return votes;
+      if (!user.villageId) return [];
+      return await fetchElderVotes(ctx.drizzle, user.villageId);
     }),
 
   // Kage cancels a pending war declaration before elders vote

--- a/app/src/utils/typeutils.ts
+++ b/app/src/utils/typeutils.ts
@@ -1,5 +1,5 @@
 import type { ExecutedQuery } from "@planetscale/database";
-import type { SQL } from "drizzle-orm";
+import { getTableColumns, type SQL, type Table } from "drizzle-orm";
 
 export type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
 
@@ -47,16 +47,24 @@ export const setNullsToEmptyStrings = (
 };
 
 /**
- * Reset all fields on an object that are null to empty strings. Convenient
- * for forms, where null does not exist, but needs to be empty strings instead
+ * Reset all empty-string fields on an object back to null, undoing what
+ * `setNullsToEmptyStrings` does for forms before the data is written back.
+ *
+ * Pass the drizzle table the object is written to so that NOT NULL columns are
+ * left alone: those reject SQL NULL, and an empty string is the intended
+ * "no value" for them (e.g. `Item.battleDescription`, which defaults to '').
  */
 export const setEmptyStringsToNulls = (
   object: Record<string, unknown> | undefined | null,
+  table?: Table,
 ) => {
   if (object) {
+    const columns = table ? getTableColumns(table) : undefined;
     let propertyKey: keyof typeof object;
     for (propertyKey in object) {
-      if (object[propertyKey] === "") setValueOnObj(object, propertyKey, null);
+      if (object[propertyKey] !== "") continue;
+      if (columns?.[propertyKey]?.notNull) continue;
+      setValueOnObj(object, propertyKey, null);
     }
   }
 };

--- a/app/src/validators/combat.ts
+++ b/app/src/validators/combat.ts
@@ -1215,7 +1215,13 @@ export const JutsuValidatorRawSchema = z.object({
   method: z.enum(AttackMethods),
   target: z.enum(AttackTargets),
   range: z.coerce.number().int().min(0).max(5),
-  statClassification: z.enum(StatTypes),
+  // The column is nullable and predates this field, so content saved before it
+  // existed - and anything freshly created - arrives as null. Fall back to the
+  // catch-all classification rather than blocking the save.
+  statClassification: z
+    .enum(StatTypes)
+    .nullish()
+    .transform((v) => v ?? "Highest"),
   hidden: z.coerce.boolean().optional(),
   injectableInBattle: z.coerce.boolean().prefault(false),
   healthCost: z.coerce.number().min(0).max(10000),
@@ -1268,7 +1274,11 @@ export const BloodlineValidator = z.object({
   description: z.string(),
   rank: z.enum(LetterRanks),
   regenIncrease: z.coerce.number().int().min(0).max(100),
-  statClassification: z.enum(StatTypes),
+  // Nullable in the schema for the same reason as on jutsu - see JutsuValidatorRawSchema.
+  statClassification: z
+    .enum(StatTypes)
+    .nullish()
+    .transform((v) => v ?? "Highest"),
   villageId: z.string().nullable(),
   hidden: z.coerce.boolean().optional(),
   difficulty: z.enum(BloodlineDifficultyRatings).nullable().optional(),

--- a/app/src/validators/combat.ts
+++ b/app/src/validators/combat.ts
@@ -1215,9 +1215,9 @@ export const JutsuValidatorRawSchema = z.object({
   method: z.enum(AttackMethods),
   target: z.enum(AttackTargets),
   range: z.coerce.number().int().min(0).max(5),
-  // The column is nullable and predates this field, so content saved before it
-  // existed - and anything freshly created - arrives as null. Fall back to the
-  // catch-all classification rather than blocking the save.
+  // The column is nullable, so rows stored before this field existed - and any
+  // write that leaves it out - arrive as null. Fall back to the catch-all
+  // classification rather than blocking the save.
   statClassification: z
     .enum(StatTypes)
     .nullish()

--- a/app/tests/utils/typeutils.test.ts
+++ b/app/tests/utils/typeutils.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { item, jutsu } from "@/drizzle/schema";
+import { setEmptyStringsToNulls, setNullsToEmptyStrings } from "@/utils/typeutils";
+
+describe("setEmptyStringsToNulls", () => {
+  it("nulls empty strings when no table is given", () => {
+    const data: Record<string, unknown> = { a: "", b: "keep", c: 0 };
+    setEmptyStringsToNulls(data);
+    expect(data).toEqual({ a: null, b: "keep", c: 0 });
+  });
+
+  it("leaves NOT NULL columns as empty strings", () => {
+    // THENINJARPG-2P0: Item.battleDescription is NOT NULL with a '' default, so
+    // nulling a blank one made every item.update fail with errno 1048.
+    const data: Record<string, unknown> = { battleDescription: "", description: "" };
+    setEmptyStringsToNulls(data, item);
+    expect(data.battleDescription).toBe("");
+  });
+
+  it("still nulls nullable columns when a table is given", () => {
+    const data: Record<string, unknown> = { bloodlineId: "", statClassification: "" };
+    setEmptyStringsToNulls(data, jutsu);
+    expect(data.bloodlineId).toBeNull();
+    expect(data.statClassification).toBeNull();
+  });
+
+  it("ignores keys that are not columns on the table", () => {
+    const data: Record<string, unknown> = { notAColumn: "" };
+    setEmptyStringsToNulls(data, item);
+    expect(data.notAColumn).toBeNull();
+  });
+
+  it("round-trips with setNullsToEmptyStrings for nullable columns", () => {
+    const data: Record<string, unknown> = { bloodlineId: null };
+    setNullsToEmptyStrings(data);
+    expect(data.bloodlineId).toBe("");
+    setEmptyStringsToNulls(data, jutsu);
+    expect(data.bloodlineId).toBeNull();
+  });
+
+  it("tolerates null and undefined objects", () => {
+    expect(() => setEmptyStringsToNulls(null)).not.toThrow();
+    expect(() => setEmptyStringsToNulls(undefined, item)).not.toThrow();
+  });
+});

--- a/app/tests/utils/typeutils.test.ts
+++ b/app/tests/utils/typeutils.test.ts
@@ -10,8 +10,8 @@ describe("setEmptyStringsToNulls", () => {
   });
 
   it("leaves NOT NULL columns as empty strings", () => {
-    // THENINJARPG-2P0: Item.battleDescription is NOT NULL with a '' default, so
-    // nulling a blank one made every item.update fail with errno 1048.
+    // Item.battleDescription is NOT NULL with a '' default, so nulling a blank
+    // one makes the whole update fail on the database rather than the column.
     const data: Record<string, unknown> = { battleDescription: "", description: "" };
     setEmptyStringsToNulls(data, item);
     expect(data.battleDescription).toBe("");

--- a/app/tests/validators/stat_classification.test.ts
+++ b/app/tests/validators/stat_classification.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { BloodlineValidator, JutsuValidatorRawSchema } from "@/validators/combat";
 
-// THENINJARPG-2P1: statClassification is nullable in the schema, so freshly
-// created content - and anything saved before the field existed - reaches
-// jutsu.update as null and used to fail input validation outright.
+// statClassification is nullable in the schema, so freshly created content -
+// and anything saved before the field existed - reaches the update endpoints as
+// null, which must not block the save.
 describe("statClassification", () => {
   const jutsuField = JutsuValidatorRawSchema.shape.statClassification;
   const bloodlineField = BloodlineValidator.shape.statClassification;

--- a/app/tests/validators/stat_classification.test.ts
+++ b/app/tests/validators/stat_classification.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { BloodlineValidator, JutsuValidatorRawSchema } from "@/validators/combat";
+
+// THENINJARPG-2P1: statClassification is nullable in the schema, so freshly
+// created content - and anything saved before the field existed - reaches
+// jutsu.update as null and used to fail input validation outright.
+describe("statClassification", () => {
+  const jutsuField = JutsuValidatorRawSchema.shape.statClassification;
+  const bloodlineField = BloodlineValidator.shape.statClassification;
+
+  it.each([
+    ["jutsu", jutsuField],
+    ["bloodline", bloodlineField],
+  ])("%s falls back to Highest for null and undefined", (_name, field) => {
+    expect(field.parse(null)).toBe("Highest");
+    expect(field.parse(undefined)).toBe("Highest");
+  });
+
+  it.each([
+    ["jutsu", jutsuField],
+    ["bloodline", bloodlineField],
+  ])("%s keeps an explicit classification", (_name, field) => {
+    expect(field.parse("Ninjutsu")).toBe("Ninjutsu");
+  });
+
+  it.each([
+    ["jutsu", jutsuField],
+    ["bloodline", bloodlineField],
+  ])("%s still rejects values outside the enum", (_name, field) => {
+    expect(() => field.parse("Speed")).toThrow();
+    expect(() => field.parse("")).toThrow();
+  });
+});


### PR DESCRIPTION
Works through the twelve most recent unresolved issues on the `theninjarpg` Sentry project. Each was traced to a root cause before being changed; two groups are deliberately not code changes and are explained below.

## Fixed

| Issue | Root cause | Fix |
|---|---|---|
| [THENINJARPG-2P0](https://studie-tech-aps.sentry.io/issues/137938583/) | `setEmptyStringsToNulls` blanket-converted every `""` to `null`, including NOT NULL text columns like `Item.battleDescription` (NOT NULL, defaults to `''`). Every `item.update` with a blank battle description died with errno 1048. | The helper now takes the target drizzle table and skips NOT NULL columns. Applied at all five call sites — they share the same latent failure. |
| [THENINJARPG-2P1](https://studie-tech-aps.sentry.io/issues/137974190/) | `jutsu.create`/`bloodline.create` never set `statClassification`, so a freshly created jutsu held NULL and then failed input validation on save. Confirmed against prod: 3 jutsu + 1 bloodline currently NULL, two of them still named `New Jutsu - <id>`. | Both creates seed `"Highest"`; the validators accept null so the rows that already exist can be saved. |
| [THENINJARPG-2P3](https://studie-tech-aps.sentry.io/issues/137996693/) | A sync run where every Clerk user was already known produced `.values([])`, which drizzle rejects. | Skip the insert when there is nothing to insert. |
| [THENINJARPG-2P5](https://studie-tech-aps.sentry.io/issues/137999394/) | The townhall page sends the `villageId` it has cached; after a village switch that is stale, and the guard threw FORBIDDEN. | Non-staff callers now always read their own village. Also tightens the boundary — there is no longer any way to probe another village. |
| [THENINJARPG-2P6](https://studie-tech-aps.sentry.io/issues/138037456/) | The proxy matcher skips file-like paths on the assumption they never render the root layout — but optional catch-all routes match them anyway. Scanners probing `/signup/administration/index.php` reached `auth()` with no Clerk context. | The three catch-all prefixes (`/login`, `/signup`, `/manual/damage_calcs`) are matched explicitly. |

## Filtered

[THENINJARPG-2NY](https://studie-tech-aps.sentry.io/issues/137901214/) — `The router state header was sent but could not be parsed.` Replayed the exact header from the event through Next's own validator: it fails because the router state tree's last element used to be a boolean and is now a number, so a browser still running a pre-deploy build fails the schema check on every RSC request. Next falls back to a full page load, which also picks up the new build, so it self-heals on that navigation and is not user-visible. Filtered by exact message string only, alongside the existing "new deployment" entries.

## Not changed

**Transient PlanetScale faults** — [2D1](https://studie-tech-aps.sentry.io/issues/87965821/), [2P2](https://studie-tech-aps.sentry.io/issues/137982374/), [2NZ](https://studie-tech-aps.sentry.io/issues/137927261/). The read-path retry added in 3665a84c2 already took 2D1 from a ~400/day peak to **zero over the last 24h**. The remaining two are writes (a CAS position update and a multi-row `UserItem` insert that deadlocked), which `dbRetry` deliberately does not re-issue because rewards are granted through non-idempotent increments. Left alone rather than weakened.

**Stale `theninja-ai` database** — [2NW](https://studie-tech-aps.sentry.io/issues/137882903/), [2NX](https://studie-tech-aps.sentry.io/issues/137883965/), [2P4](https://studie-tech-aps.sentry.io/issues/137996816/), 288 of ~310 total events. The `the-ninja-ai` Vercel project deploys this same repo, so it inherits every cron in `app/vercel.json`, but its `DATABASE_URL` points at a full-but-outdated clone of the game schema. Resolved by migrating that database rather than in code (owner's call). Measured drift: 7 missing tables (`ItemVariant`, `MapAsset`, `MapTerrain`, `SectorMap`, `UserItemVariant`, `VillageElderVote`, `VillageElderVoteEntry`), 1 extra (`ShrineBoostSchedule`), and 13 tables with column drift.

## Verification

- `make typecheck` clean, `make lint` clean on changed files, **523 tests pass** (12 new).
- 2P6 verified live against a dev server: `/signup/administration/index.php?route=common/login` returns **500 without** the matcher entries and **200 with** them; `/nonexistent/thing.php` still 404s cheaply.
- 2NY reproduced locally by replaying the captured header through `parseAndValidateFlightRouterState`.
- 2P1 confirmed against the production database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when daily reminder synchronization has no eligible reminders.
  * Improved empty-field handling while preserving required values.
  * Fixed village vote retrieval for users with outdated village selections.
  * Improved login, signup, and damage calculator route handling.
  * Reduced noisy error reporting for stale clients after deployments.

* **Improvements**
  * New and legacy jutsu and bloodline records now default missing classifications to “Highest.”

* **Tests**
  * Added coverage for field normalization and stat classification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->