### PR TITLE
Stop battle start from claiming shared AI rows

### DIFF
--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -2851,10 +2851,11 @@ export const getPreventTypeName = (preventType: string): string => {
  * The returned length is the expected rowsAffected for the compare-and-swap
  * guard, so it has to stay in step with that update's WHERE clause.
  *
- * @param battleType - The type of battle being started
- * @param userIds - The attacking user ids
- * @param targetIds - The defending user ids
- * @param participants - Fetched rows for the battle, used to identify AI
+ * @param info - Battle claim inputs
+ * @param info.battleType - The type of battle being started
+ * @param info.userIds - The attacking user ids
+ * @param info.targetIds - The defending user ids
+ * @param info.participants - Fetched rows for the battle, used to identify AI
  * @returns Deduplicated ids of the non-AI rows the update should claim
  */
 export const getBattleClaimIds = (info: {

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -10,6 +10,7 @@ import {
 } from "honeycomb-grid";
 import type { BattleType, PoolType } from "@/drizzle/constants";
 import {
+  AutoBattleTypes,
   CLAN_BATTLE_REWARD_POINTS,
   FRIENDLY_PRESTIGE_COST,
   getUserCaps,
@@ -2837,4 +2838,35 @@ export const getDistanceToClosestEnemy = (
  */
 export const getPreventTypeName = (preventType: string): string => {
   return preventType.replace(/prevent$/, "");
+};
+
+/**
+ * Determines which participant rows the battle-start update should claim.
+ *
+ * AI opponents are left out. One row backs every fight against a given AI, so
+ * claiming it makes concurrent battles contend on a single shared row, and the
+ * battle state clones AI under a fresh id anyway. Auto battles only ever claim
+ * the attackers.
+ *
+ * The returned length is the expected rowsAffected for the compare-and-swap
+ * guard, so it has to stay in step with that update's WHERE clause.
+ *
+ * @param battleType - The type of battle being started
+ * @param userIds - The attacking user ids
+ * @param targetIds - The defending user ids
+ * @param participants - Fetched rows for the battle, used to identify AI
+ * @returns Deduplicated ids of the non-AI rows the update should claim
+ */
+export const getBattleClaimIds = (info: {
+  battleType: BattleType;
+  userIds: string[];
+  targetIds: string[];
+  participants: { userId: string; isAi: boolean }[];
+}): string[] => {
+  const { battleType, userIds, targetIds, participants } = info;
+  const aiIds = new Set(participants.filter((u) => u.isAi).map((u) => u.userId));
+  const claimed = AutoBattleTypes.includes(battleType)
+    ? userIds
+    : [...userIds, ...targetIds];
+  return [...new Set(claimed)].filter((id) => !aiIds.has(id));
 };

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -2289,11 +2289,11 @@ export const initiateBattle = async (
         // Attackers roll to keep stealth based on their stealth stat
         stealthActive:
           stealthBreakUserIds.length > 0
-            ? sql`CASE WHEN userId IN (${stealthBreakUserIds.map((id) => `"${id}"`).join(", ")}) THEN false ELSE stealthActive END`
+            ? sql`CASE WHEN ${inArray(userData.userId, stealthBreakUserIds)} THEN false ELSE ${userData.stealthActive} END`
             : sql`stealthActive`,
         stealthActivatedAt:
           stealthBreakUserIds.length > 0
-            ? sql`CASE WHEN userId IN (${stealthBreakUserIds.map((id) => `"${id}"`).join(", ")}) THEN NULL ELSE stealthActivatedAt END`
+            ? sql`CASE WHEN ${inArray(userData.userId, stealthBreakUserIds)} THEN NULL ELSE ${userData.stealthActivatedAt} END`
             : sql`stealthActivatedAt`,
         // Stamp war aggressors AND bracket-immunity aggressors in the same update so the WHERE guard
         // (status/sector match) gates both the battle entry and these timers atomically. GREATEST never

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -138,6 +138,7 @@ import {
   alignBattle,
   applyPoolAdjustmentsToBase,
   calcBattleResult,
+  getBattleClaimIds,
   getBattleGrid,
   getDefaultBattleSizes,
   isEffectActive,
@@ -2137,15 +2138,13 @@ export const initiateBattle = async (
       ID_SFX_CLEAR,
     ]);
 
-  // Calculate expected rows for user status update
-  // For auto battles (KAGE_AI, CLAN_CHALLENGE), only the attacker userIds are updated
-  // For other battles, all participants (userIds + targetIds) should be updated
-  // Use Set to deduplicate - the database UPDATE affects unique rows by userId
-  const allParticipantIds = [
-    ...new Set(
-      AutoBattleTypes.includes(battleType) ? userIds : [...userIds, ...targetIds],
-    ),
-  ];
+  // Rows the status update below is expected to claim, used as the CAS guard
+  const allParticipantIds = getBattleClaimIds({
+    battleType,
+    userIds,
+    targetIds,
+    participants: users,
+  });
   const expectedRows = allParticipantIds.length;
 
   // Handle stealth breaking for combat
@@ -2253,8 +2252,8 @@ export const initiateBattle = async (
     client
       .update(userData)
       .set({
-        status: sql`CASE WHEN isAi = false THEN "BATTLE" ELSE "AWAKE" END`,
-        battleId: sql`CASE WHEN isAi = false THEN ${battleId} ELSE NULL END`,
+        status: "BATTLE",
+        battleId: battleId,
         pvpActivity: ["COMBAT"].includes(battleType)
           ? sql`${userData.pvpActivity} + 1`
           : sql`${userData.pvpActivity}`,
@@ -2301,6 +2300,9 @@ export const initiateBattle = async (
               ? [inArray(userData.userId, targetIds)]
               : []),
           ),
+          // Never move an AI into a battle: its row is shared by everyone
+          // fighting it, and the battle state clones it under a fresh id anyway.
+          eq(userData.isAi, false),
           // Ranked participants are claimed straight from the queue, so require
           // QUEUED specifically: a player who just left the queue (now AWAKE)
           // must not be pulled into a ranked battle by a poll whose snapshot

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -1791,6 +1791,24 @@ export const initiateBattle = async (
   const now = new Date();
   const nonAiTargets = users.filter((u) => targetIds.includes(u.userId) && !u.isAi);
 
+  // AI rows are excluded from the battle-start claim below (one shared row backs
+  // every fight against a given AI), so the update's location predicate no longer
+  // verifies an AI target's position. Enforce the COMBAT proximity rule against
+  // the fetched snapshot instead, mirroring the SQL predicate applied to players.
+  if (battleType === "COMBAT") {
+    const movedAiTarget = users.find(
+      (u) =>
+        u.isAi &&
+        targetIds.includes(u.userId) &&
+        ((sector !== undefined && u.sector !== sector) ||
+          (longitude !== undefined && u.longitude !== longitude) ||
+          (latitude !== undefined && u.latitude !== latitude)),
+    );
+    if (movedAiTarget) {
+      return { success: false, message: "Attack failed, did the target move?" };
+    }
+  }
+
   // Loop through each user
   for (const i of users.keys()) {
     // Get the user

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -2294,14 +2294,16 @@ export const initiateBattle = async (
       })
       .where(
         and(
-          or(
-            inArray(userData.userId, userIds),
-            ...(!AutoBattleTypes.includes(battleType)
-              ? [inArray(userData.userId, targetIds)]
-              : []),
-          ),
+          // Exactly the rows the CAS guard counts (expectedRows), so the
+          // predicate and the expected count derive from one source and cannot
+          // drift apart. The list already excludes AI rows, so the shared AI
+          // row is never even examined (or locked) by this update. Drizzle
+          // compiles an empty list to FALSE, matching expectedRows === 0.
+          inArray(userData.userId, allParticipantIds),
           // Never move an AI into a battle: its row is shared by everyone
           // fighting it, and the battle state clones it under a fresh id anyway.
+          // Redundant with the claim list above, but kept so a drifting AI
+          // classification fails the CAS guard instead of claiming a shared row.
           eq(userData.isAi, false),
           // Ranked participants are claimed straight from the queue, so require
           // QUEUED specifically: a player who just left the queue (now AWAKE)

--- a/app/src/server/api/routers/shrine.ts
+++ b/app/src/server/api/routers/shrine.ts
@@ -1203,9 +1203,9 @@ export const shrineRouter = createTRPCRouter({
           .set({ battleId: result.battleId })
           .where(eq(mpvpBattleQueue.id, input.shrineBattleId));
 
-        // Note: initiateBattle() already sets user statuses appropriately:
-        // - Human players: status="BATTLE"
-        // - AI defenders: status="AWAKE"
+        // Note: initiateBattle() sets human participants to status="BATTLE".
+        // AI defender rows are never claimed or modified — the shared AI row
+        // is cloned into the battle state instead, so it stays untouched.
 
         // Notify participants
         allUserIds.forEach((userId) => {

--- a/app/tests/libs/combat/battle_claim_ids.test.ts
+++ b/app/tests/libs/combat/battle_claim_ids.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { getBattleClaimIds } from "@/libs/combat/util";
+
+// A single AI row backs every fight against that opponent, so the battle-start
+// update must leave it alone - claiming it made concurrent arena fights contend
+// on one shared row and deadlock. The returned length doubles as the expected
+// rowsAffected for the compare-and-swap guard, so an AI slipping back in would
+// also start failing battles with a spurious rollback.
+describe("getBattleClaimIds", () => {
+  const human = { userId: "human-1", isAi: false };
+  const ai = { userId: "arena-ai", isAi: true };
+
+  it("claims the player but not the AI opponent in an arena fight", () => {
+    const ids = getBattleClaimIds({
+      battleType: "ARENA",
+      userIds: ["human-1"],
+      targetIds: ["arena-ai"],
+      participants: [human, ai],
+    });
+    expect(ids).toEqual(["human-1"]);
+  });
+
+  it("claims both sides of a player-versus-player fight", () => {
+    const other = { userId: "human-2", isAi: false };
+    const ids = getBattleClaimIds({
+      battleType: "COMBAT",
+      userIds: ["human-1"],
+      targetIds: ["human-2"],
+      participants: [human, other],
+    });
+    expect(ids.sort()).toEqual(["human-1", "human-2"]);
+  });
+
+  it("claims only the attackers for auto battles", () => {
+    const ids = getBattleClaimIds({
+      battleType: "KAGE_AI",
+      userIds: ["human-1"],
+      targetIds: ["arena-ai"],
+      participants: [human, ai],
+    });
+    expect(ids).toEqual(["human-1"]);
+  });
+
+  it("skips an AI attacker as well as an AI defender", () => {
+    const ids = getBattleClaimIds({
+      battleType: "COMBAT",
+      userIds: ["arena-ai"],
+      targetIds: ["human-1"],
+      participants: [ai, human],
+    });
+    expect(ids).toEqual(["human-1"]);
+  });
+
+  it("returns nothing when every participant is an AI", () => {
+    const otherAi = { userId: "arena-ai-2", isAi: true };
+    const ids = getBattleClaimIds({
+      battleType: "COMBAT",
+      userIds: ["arena-ai"],
+      targetIds: ["arena-ai-2"],
+      participants: [ai, otherAi],
+    });
+    expect(ids).toEqual([]);
+  });
+
+  it("deduplicates a player listed on both sides", () => {
+    const ids = getBattleClaimIds({
+      battleType: "COMBAT",
+      userIds: ["human-1"],
+      targetIds: ["human-1"],
+      participants: [human],
+    });
+    expect(ids).toEqual(["human-1"]);
+  });
+});

--- a/app/tests/libs/combat/battle_claim_ids.test.ts
+++ b/app/tests/libs/combat/battle_claim_ids.test.ts
@@ -41,6 +41,31 @@ describe("getBattleClaimIds", () => {
     expect(ids).toEqual(["human-1"]);
   });
 
+  it("claims only the attacker in a clan challenge against a human leader", () => {
+    const leader = { userId: "human-2", isAi: false };
+    const ids = getBattleClaimIds({
+      battleType: "CLAN_CHALLENGE",
+      userIds: ["human-1"],
+      targetIds: ["human-2"],
+      participants: [human, leader],
+    });
+    expect(ids).toEqual(["human-1"]);
+  });
+
+  it("counts an id with no fetched participant row so the CAS guard fails safe", () => {
+    // The database update's own predicates are the authority on what actually
+    // gets claimed; counting an unknown id here keeps the expected row count
+    // high, so the rowsAffected check rolls the battle back instead of starting
+    // it with a missing participant.
+    const ids = getBattleClaimIds({
+      battleType: "COMBAT",
+      userIds: ["human-1"],
+      targetIds: ["ghost-id"],
+      participants: [human],
+    });
+    expect(ids.sort()).toEqual(["ghost-id", "human-1"]);
+  });
+
   it("skips an AI attacker as well as an AI defender", () => {
     const ids = getBattleClaimIds({
       battleType: "COMBAT",


### PR DESCRIPTION
Follow-up to #1422, covering the Sentry issues raised since it merged.

## THENINJARPG-2P7 — deadlock on `combat.startArenaBattle`

```
DatabaseError: Deadlock found when trying to get lock; try restarting
transaction (errno 1213) (sqlstate 40001)
  Sql: "update UserData set `status` = case when isAi = false then ... "
```

`initiateBattle` claimed **every** participant row, including the AI opponent's.
But one `UserData` row backs every fight against a given AI — the arena picks an
opponent by id from a fixed roster — so each concurrent arena battle updated
that same shared row alongside the player's own. Two fights in flight against
the same opponent locked overlapping row sets and deadlocked.

The AI row was never actually part of this state transition, only contention
for it:

- the update already refused to move AI into battle
  (`CASE WHEN isAi = false THEN "BATTLE" ELSE "AWAKE" END`, `battleId` `NULL`),
- the battle state clones AI under a fresh id (`processUsersForBattle`), and
- the rollback path only matches `battleId = <id>`, which never matches an AI
  row — so the counter bump it did apply was never rolled back anyway.

So the update now skips AI rows outright: `isAi = false` in the WHERE, and the
expected-rows CAS guard counts only non-AI participants. With the guard in
place the two `CASE` expressions can no longer take their AI branch, so they
collapse to plain values.

The participant calculation moved to `getBattleClaimIds` in `libs/combat/util`,
because its length is the CAS guard — if it ever drifts from that WHERE clause,
battles start failing with a spurious "did the target move?" rollback. Six tests
pin that down, including the AI-attacker and all-AI-participant edges.

## Verified

- Arena fight driven end to end on a provisioned test user against
  "Academy Dummy": `startArenaBattle` returns 200, status goes
  `AWAKE` -> `BATTLE`, and the client lands in `/combat` at ROUND 1. That path
  is the CAS guard — had `expectedRows` disagreed with the new WHERE, it would
  have rolled back instead.
- Re-ran after extracting the helper to confirm the refactor holds.
- `make test` 529 pass (6 new), `make typecheck`, `make lint` clean.

The deadlock itself needs production-level concurrency, so it was not
reproduced locally — the fix removes the shared row the cycle formed on.

## Not in this PR

**THENINJARPG-2NW / 2NX** are the `theninja-ai` schema drift from #1422
(`Unknown column 'bidderMinLevel'`, missing `VillageElderVote`), still firing
from that deployment's crons. They need DDL on that database, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved battle participant tracking to prevent AI-controlled participants from being incorrectly claimed.
  * Ensured battle status updates apply only to eligible player participants.
  * Prevented duplicate participant claims during battle creation.
  * Added validation for AI battle target locations before battles begin.
  * Improved stealth battle updates for more reliable processing.
* **Tests**
  * Added coverage for player battles, auto battles, AI-only battles, duplicate IDs, and mixed AI/player participation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->