### PR TITLE
Increase max stack/craft material count

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -14,6 +14,9 @@ export const VARIANT_COST_TYPES = [
 export type VariantCostType = (typeof VARIANT_COST_TYPES)[number];
 
 export const MAX_ITEM_VARIANTS = 7;
+export const MAX_ITEM_STACK_SIZE = 9_999;
+export const MAX_ITEM_CRAFTING_REQUIREMENT_QUANTITY = MAX_ITEM_STACK_SIZE;
+export const MAX_ITEM_SHOP_PURCHASE_QUANTITY = 50;
 
 export const ActivityStreakTypes = ["RECURRING", "EVENT_PASS"] as const;
 export type ActivityStreakType = (typeof ActivityStreakTypes)[number];

--- a/app/src/layout/Shop.tsx
+++ b/app/src/layout/Shop.tsx
@@ -41,6 +41,7 @@ import Loader from "@/layout/Loader";
 import Modal2 from "@/layout/Modal2";
 import { UncontrolledSliderField } from "@/layout/SliderField";
 import { cn } from "@/libs/shadui";
+import { getMaxItemShopPurchaseQuantity } from "@/libs/shop";
 import { showMutationToast } from "@/libs/toast";
 import type { UserWithRelations } from "@/routers/profile";
 import { useAwake } from "@/utils/routing";
@@ -448,7 +449,7 @@ const Shop: React.FC<ShopProps> = (props) => {
               label={`How many to buy: ${stacksize}`}
               value={stacksize}
               min={1}
-              max={item.stackSize}
+              max={getMaxItemShopPurchaseQuantity(item.stackSize)}
               setValue={setStacksize}
             />
           ) : undefined}

--- a/app/src/libs/shop.ts
+++ b/app/src/libs/shop.ts
@@ -1,0 +1,4 @@
+import { MAX_ITEM_SHOP_PURCHASE_QUANTITY } from "@/drizzle/constants";
+
+export const getMaxItemShopPurchaseQuantity = (stackSize: number) =>
+  Math.min(stackSize, MAX_ITEM_SHOP_PURCHASE_QUANTITY);

--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -32,6 +32,7 @@ import {
   ItemSlots,
   ItemTypes,
   MAX_EXTRA_RESKIN_SLOTS,
+  MAX_ITEM_SHOP_PURCHASE_QUANTITY,
   MAX_ITEM_VARIANTS,
   MAX_MARRIAGE_SLOTS,
   MEDNIN_HEAL_ITEM_DISCOUNT_PERC,
@@ -1909,7 +1910,7 @@ export const itemRouter = createTRPCRouter({
     .input(
       z.object({
         itemId: z.string(),
-        stack: z.number().min(1).max(50),
+        stack: z.number().min(1).max(MAX_ITEM_SHOP_PURCHASE_QUANTITY),
         villageId: z.string().nullish(),
       }),
     )

--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -32,7 +32,6 @@ import {
   ItemSlots,
   ItemTypes,
   MAX_EXTRA_RESKIN_SLOTS,
-  MAX_ITEM_SHOP_PURCHASE_QUANTITY,
   MAX_ITEM_VARIANTS,
   MAX_MARRIAGE_SLOTS,
   MEDNIN_HEAL_ITEM_DISCOUNT_PERC,
@@ -108,6 +107,7 @@ import type { ItemFilteringSchema } from "@/validators/item";
 import {
   ItemVariantResponseSchema,
   ItemVariantValidator,
+  itemBuySchema,
   itemFilteringSchema,
   UserUnlockedVariantResponseSchema,
 } from "@/validators/item";
@@ -1907,13 +1907,7 @@ export const itemRouter = createTRPCRouter({
   // Buy user item
   buy: protectedProcedure
     .meta({ mcp: { enabled: true, description: "Buy an item from shop" } })
-    .input(
-      z.object({
-        itemId: z.string(),
-        stack: z.number().min(1).max(MAX_ITEM_SHOP_PURCHASE_QUANTITY),
-        villageId: z.string().nullish(),
-      }),
-    )
+    .input(itemBuySchema)
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
       // Query

--- a/app/src/validators/combat.ts
+++ b/app/src/validators/combat.ts
@@ -14,6 +14,8 @@ import {
   JutsuTypes,
   LetterRanks,
   MAX_GENS_CAP,
+  MAX_ITEM_CRAFTING_REQUIREMENT_QUANTITY,
+  MAX_ITEM_STACK_SIZE,
   MAX_STATS_CAP,
   PoolTypes,
   SkillTreeEntryTypes,
@@ -1315,7 +1317,7 @@ export const ItemValidatorRawSchema = z.object({
   image: z.string(),
   description: z.string(),
   battleDescription: z.string(),
-  stackSize: z.coerce.number().int().min(1).max(9999),
+  stackSize: z.coerce.number().int().min(1).max(MAX_ITEM_STACK_SIZE),
   destroyOnUse: z.coerce.boolean().prefault(false),
   chakraCost: z.coerce.number().int().min(0).max(10000),
   healthCost: z.coerce.number().int().min(0).max(10000),
@@ -1362,7 +1364,11 @@ export const ItemValidatorRawSchema = z.object({
     .array(
       z.object({
         ids: z.array(z.string()),
-        number: z.coerce.number().int().min(1).max(9999),
+        number: z.coerce
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_ITEM_CRAFTING_REQUIREMENT_QUANTITY),
       }),
     )
     .prefault([])

--- a/app/src/validators/combat.ts
+++ b/app/src/validators/combat.ts
@@ -1315,7 +1315,7 @@ export const ItemValidatorRawSchema = z.object({
   image: z.string(),
   description: z.string(),
   battleDescription: z.string(),
-  stackSize: z.coerce.number().int().min(1).max(999),
+  stackSize: z.coerce.number().int().min(1).max(9999),
   destroyOnUse: z.coerce.boolean().prefault(false),
   chakraCost: z.coerce.number().int().min(0).max(10000),
   healthCost: z.coerce.number().int().min(0).max(10000),
@@ -1362,7 +1362,7 @@ export const ItemValidatorRawSchema = z.object({
     .array(
       z.object({
         ids: z.array(z.string()),
-        number: z.coerce.number().int().min(1).max(100),
+        number: z.coerce.number().int().min(1).max(9999),
       }),
     )
     .prefault([])

--- a/app/src/validators/item.ts
+++ b/app/src/validators/item.ts
@@ -6,10 +6,17 @@ import {
   ItemRarities,
   ItemSlotTypes,
   ItemTypes,
+  MAX_ITEM_SHOP_PURCHASE_QUANTITY,
   MAX_ITEM_VARIANTS,
   VARIANT_COST_TYPES,
 } from "@/drizzle/constants";
 import { statFilters } from "@/libs/train";
+
+export const itemBuySchema = z.object({
+  itemId: z.string(),
+  stack: z.number().int().min(1).max(MAX_ITEM_SHOP_PURCHASE_QUANTITY),
+  villageId: z.string().nullish(),
+});
 
 export const itemFilteringSchema = z.object({
   limit: z.number().min(1).max(500),

--- a/app/tests/libs/shop.test.ts
+++ b/app/tests/libs/shop.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { getMaxItemShopPurchaseQuantity } from "@/libs/shop";
+
+describe("getMaxItemShopPurchaseQuantity", () => {
+  it("uses the item's smaller stack size", () => {
+    expect(getMaxItemShopPurchaseQuantity(20)).toBe(20);
+  });
+
+  it("caps large item stacks at the server purchase limit", () => {
+    expect(getMaxItemShopPurchaseQuantity(9_999)).toBe(50);
+  });
+});

--- a/app/tests/validators/item_limits.test.ts
+++ b/app/tests/validators/item_limits.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_ITEM_CRAFTING_REQUIREMENT_QUANTITY,
+  MAX_ITEM_STACK_SIZE,
+} from "@/drizzle/constants";
+import { ItemValidatorRawSchema } from "@/validators/combat";
+
+describe("item quantity limits", () => {
+  const stackSizeSchema = ItemValidatorRawSchema.shape.stackSize;
+  const craftingRequirementsSchema =
+    ItemValidatorRawSchema.shape.craftingRequirements;
+
+  it("accepts the maximum item stack size and rejects larger stacks", () => {
+    expect(stackSizeSchema.safeParse(MAX_ITEM_STACK_SIZE).success).toBe(true);
+    expect(stackSizeSchema.safeParse(MAX_ITEM_STACK_SIZE + 1).success).toBe(false);
+  });
+
+  it("accepts the maximum crafting requirement and rejects larger quantities", () => {
+    expect(
+      craftingRequirementsSchema.safeParse([
+        { ids: ["material-id"], number: MAX_ITEM_CRAFTING_REQUIREMENT_QUANTITY },
+      ]).success,
+    ).toBe(true);
+    expect(
+      craftingRequirementsSchema.safeParse([
+        {
+          ids: ["material-id"],
+          number: MAX_ITEM_CRAFTING_REQUIREMENT_QUANTITY + 1,
+        },
+      ]).success,
+    ).toBe(false);
+  });
+});

--- a/app/tests/validators/item_purchase.test.ts
+++ b/app/tests/validators/item_purchase.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { MAX_ITEM_SHOP_PURCHASE_QUANTITY } from "@/drizzle/constants";
+import { itemBuySchema } from "@/validators/item";
+
+describe("itemBuySchema", () => {
+  const validInput = {
+    itemId: "item-id",
+    stack: 1,
+    villageId: "village-id",
+  };
+
+  it("accepts integer purchase quantities through the configured maximum", () => {
+    expect(itemBuySchema.safeParse(validInput).success).toBe(true);
+    expect(
+      itemBuySchema.safeParse({
+        ...validInput,
+        stack: MAX_ITEM_SHOP_PURCHASE_QUANTITY,
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects fractional purchase quantities", () => {
+    expect(itemBuySchema.safeParse({ ...validInput, stack: 1.5 }).success).toBe(false);
+  });
+});


### PR DESCRIPTION
# Pull Request

Increased max stack size from 999 -> 9999
Increase max allowed crafting mats from 100 -> 9999

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized item quantity limits, supporting stacks and crafting requirements up to 9,999.
  * Limited individual shop purchases to a maximum of 50 items.
  * Updated purchase controls and validation to consistently enforce the applicable quantity limits.
  * Improved handling of item stacks smaller than the shop purchase maximum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->