### PR TITLE
Restore kage challengers to KAGE_QUEUED on battle-start rollback

### DIFF
--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -196,6 +196,7 @@ import {
 } from "@/server/api/routers/jutsu";
 import { fetchUserSkills } from "@/server/api/routers/skillTree";
 import type { DrizzleClient } from "@/server/db";
+import { battleClaimRollbackStatus } from "@/server/utils/concurrency";
 import { findRelationship } from "@/utils/alliance";
 import { getRandomElement } from "@/utils/array";
 import { randomInt } from "@/utils/math";
@@ -2382,15 +2383,7 @@ export const initiateBattle = async (
       client
         .update(userData)
         .set({
-          status:
-            battleType === "RANKED_PVP"
-              ? sql`CASE WHEN ${exists(
-                  client
-                    .select({ one: sql`1` })
-                    .from(rankedPvpQueue)
-                    .where(eq(rankedPvpQueue.userId, userData.userId)),
-                )} THEN "QUEUED" ELSE "AWAKE" END`
-              : "AWAKE",
+          status: battleClaimRollbackStatus(client, battleType, userIds),
           battleId: null,
         })
         .where(eq(userData.battleId, battleId)),

--- a/app/src/server/utils/concurrency.ts
+++ b/app/src/server/utils/concurrency.ts
@@ -11,7 +11,13 @@
  */
 import { and, eq, exists, gte, inArray, ne, sql } from "drizzle-orm";
 import type { BattleType } from "@/drizzle/constants";
-import { bloodlineRolls, rankedPvpQueue, userData, userItem } from "@/drizzle/schema";
+import {
+  bloodlineRolls,
+  rankedPvpQueue,
+  userData,
+  userItem,
+  userRequest,
+} from "@/drizzle/schema";
 import type { DrizzleClient } from "@/server/db";
 import type { QueryCondition } from "@/utils/typeutils";
 
@@ -205,11 +211,15 @@ export const removeBloodlineFromPoolAtomically = async ({
  * usable:
  * - RANKED_PVP rows were claimed from QUEUED and only return to QUEUED while
  *   their `rankedPvpQueue` row still exists (the user may have left the queue).
- * - KAGE_PVP challengers were claimed from KAGE_QUEUED; restoring it keeps the
- *   still-PENDING challenge request acceptable on a retry, since accepting
- *   requires the challenger to be KAGE_QUEUED. The kage target was claimed from
- *   AWAKE and returns there.
- * - Every other battle type claims AWAKE rows.
+ * - KAGE_PVP challengers were claimed from KAGE_QUEUED and only return to it
+ *   while their kage challenge request is still PENDING, keeping the request
+ *   acceptable on a retry (accepting requires a KAGE_QUEUED challenger). A
+ *   concurrent cancel/reject ends the request but cannot reset a challenger row
+ *   that is mid-claim, so an unconditional restore would strand the challenger
+ *   in KAGE_QUEUED. The kage target was claimed from AWAKE and returns there.
+ * - Every other battle type falls back to AWAKE (pre-existing behavior: e.g.
+ *   CLAN_BATTLE and RAID claim QUEUED rows, but their queue entries are managed
+ *   by their own flows).
  */
 export const battleClaimRollbackStatus = (
   client: DrizzleClient,
@@ -225,7 +235,18 @@ export const battleClaimRollbackStatus = (
     )} THEN "QUEUED" ELSE "AWAKE" END`;
   }
   if (battleType === "KAGE_PVP") {
-    return sql`CASE WHEN ${inArray(userData.userId, challengerIds)} THEN "KAGE_QUEUED" ELSE "AWAKE" END`;
+    return sql`CASE WHEN ${inArray(userData.userId, challengerIds)} AND ${exists(
+      client
+        .select({ one: sql`1` })
+        .from(userRequest)
+        .where(
+          and(
+            eq(userRequest.senderId, userData.userId),
+            eq(userRequest.type, "KAGE"),
+            eq(userRequest.status, "PENDING"),
+          ),
+        ),
+    )} THEN "KAGE_QUEUED" ELSE "AWAKE" END`;
   }
   return "AWAKE" as const;
 };

--- a/app/src/server/utils/concurrency.ts
+++ b/app/src/server/utils/concurrency.ts
@@ -9,8 +9,9 @@
  * Failed CAS (`success: false` / `false`) means another request mutated the row first — return a
  * safe client error and retry-friendly message.
  */
-import { and, eq, gte, ne, sql } from "drizzle-orm";
-import { bloodlineRolls, userData, userItem } from "@/drizzle/schema";
+import { and, eq, exists, gte, inArray, ne, sql } from "drizzle-orm";
+import type { BattleType } from "@/drizzle/constants";
+import { bloodlineRolls, rankedPvpQueue, userData, userItem } from "@/drizzle/schema";
 import type { DrizzleClient } from "@/server/db";
 import type { QueryCondition } from "@/utils/typeutils";
 
@@ -195,4 +196,36 @@ export const removeBloodlineFromPoolAtomically = async ({
       ),
   ]);
   return deleteResult.rowsAffected + updateResult.rowsAffected > 0;
+};
+
+/**
+ * Status to restore on player rows caught by a failed battle-start claim (the
+ * `initiateBattle` CAS rollback). Rows claimed out of a queue must return to
+ * their queue status rather than AWAKE, so the queue entry they came from stays
+ * usable:
+ * - RANKED_PVP rows were claimed from QUEUED and only return to QUEUED while
+ *   their `rankedPvpQueue` row still exists (the user may have left the queue).
+ * - KAGE_PVP challengers were claimed from KAGE_QUEUED; restoring it keeps the
+ *   still-PENDING challenge request acceptable on a retry, since accepting
+ *   requires the challenger to be KAGE_QUEUED. The kage target was claimed from
+ *   AWAKE and returns there.
+ * - Every other battle type claims AWAKE rows.
+ */
+export const battleClaimRollbackStatus = (
+  client: DrizzleClient,
+  battleType: BattleType,
+  challengerIds: string[],
+) => {
+  if (battleType === "RANKED_PVP") {
+    return sql`CASE WHEN ${exists(
+      client
+        .select({ one: sql`1` })
+        .from(rankedPvpQueue)
+        .where(eq(rankedPvpQueue.userId, userData.userId)),
+    )} THEN "QUEUED" ELSE "AWAKE" END`;
+  }
+  if (battleType === "KAGE_PVP") {
+    return sql`CASE WHEN ${inArray(userData.userId, challengerIds)} THEN "KAGE_QUEUED" ELSE "AWAKE" END`;
+  }
+  return "AWAKE" as const;
 };

--- a/app/tests/server/utils/concurrency.test.ts
+++ b/app/tests/server/utils/concurrency.test.ts
@@ -121,7 +121,14 @@ describe("battleClaimRollbackStatus", () => {
     const { sql: rendered, params } = render(expr);
     expect(rendered).toContain('THEN "KAGE_QUEUED" ELSE "AWAKE" END');
     expect(rendered).toMatch(/in \(\?,\s*\?\)/i);
-    expect(params).toEqual(["challenger-1", "challenger-2"]);
+    expect(params).toEqual(["challenger-1", "challenger-2", "KAGE", "PENDING"]);
+  });
+
+  it("only restores KAGE_QUEUED while the kage challenge request is still pending", () => {
+    const expr = battleClaimRollbackStatus(qb as never, "KAGE_PVP", ["challenger-1"]);
+    const { sql: rendered } = render(expr);
+    expect(rendered).toMatch(/exists/i);
+    expect(rendered).toContain("UserRequest");
   });
 
   it("restores RANKED_PVP rows to QUEUED only while their queue row exists", () => {

--- a/app/tests/server/utils/concurrency.test.ts
+++ b/app/tests/server/utils/concurrency.test.ts
@@ -1,8 +1,11 @@
 // @vitest-environment node
 
+import type { SQL } from "drizzle-orm";
+import { QueryBuilder } from "drizzle-orm/mysql-core";
 import { describe, expect, it, vi } from "vitest";
 import { userData, userItem } from "@/drizzle/schema";
 import {
+  battleClaimRollbackStatus,
   claimUserSnapshot,
   consumeUserItemAtomically,
   updateUserItemQuantityAtomically,
@@ -98,5 +101,43 @@ describe("concurrency helpers", () => {
     });
     expect(result).toBe(false);
     expect(client.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("battleClaimRollbackStatus", () => {
+  // A session-less builder is enough: the helper only constructs SQL, and the
+  // RANKED_PVP branch uses the client solely for its exists-subquery select.
+  const qb = new QueryBuilder();
+  const render = (expr: ReturnType<typeof battleClaimRollbackStatus>) => {
+    if (typeof expr === "string") throw new Error("expected a SQL expression");
+    return qb.select({ status: expr as SQL }).from(userData).toSQL();
+  };
+
+  it("restores KAGE_PVP challengers to KAGE_QUEUED with one binding per id", () => {
+    const expr = battleClaimRollbackStatus(qb as never, "KAGE_PVP", [
+      "challenger-1",
+      "challenger-2",
+    ]);
+    const { sql: rendered, params } = render(expr);
+    expect(rendered).toContain('THEN "KAGE_QUEUED" ELSE "AWAKE" END');
+    expect(rendered).toMatch(/in \(\?,\s*\?\)/i);
+    expect(params).toEqual(["challenger-1", "challenger-2"]);
+  });
+
+  it("restores RANKED_PVP rows to QUEUED only while their queue row exists", () => {
+    const expr = battleClaimRollbackStatus(qb as never, "RANKED_PVP", ["challenger-1"]);
+    const { sql: rendered } = render(expr);
+    expect(rendered).toMatch(/exists/i);
+    expect(rendered).toContain("RankedPvpQueue");
+    expect(rendered).toContain('THEN "QUEUED" ELSE "AWAKE" END');
+  });
+
+  it("restores plain AWAKE for battle types claimed from AWAKE", () => {
+    expect(battleClaimRollbackStatus(qb as never, "COMBAT", ["challenger-1"])).toBe(
+      "AWAKE",
+    );
+    expect(battleClaimRollbackStatus(qb as never, "KAGE_AI", ["challenger-1"])).toBe(
+      "AWAKE",
+    );
   });
 });


### PR DESCRIPTION
## Summary

The `initiateBattle` CAS rollback (the "Attack failed, did the target move?" path) reset every claimed row's status to `AWAKE` for all battle types except `RANKED_PVP`. For `KAGE_PVP`, the challenger is claimed from status `KAGE_QUEUED` (set by `challengeKage`), and `acceptChallenge` only marks the kage challenge request `ACCEPTED` when the battle actually starts. So when the CAS guard failed (e.g. the kage entered another battle between fetch and update), the challenger was rolled back to `AWAKE` while the challenge request stayed `PENDING` — and any retried accept then failed the pre-check "Challenger X is not in kage queue", stranding the pending challenge.

## Changes

- Extracted the rollback status expression into `battleClaimRollbackStatus` in `app/src/server/utils/concurrency.ts` (the existing home for CAS helpers), keeping the `RANKED_PVP` exists-check behavior unchanged.
- Added a `KAGE_PVP` branch that restores challengers (the `userIds` side of the claim) to `KAGE_QUEUED`; the kage target still returns to `AWAKE`. The rollback's `WHERE battleId = ...` already restricts the update to rows actually claimed.
- `KAGE_AI` intentionally stays on the `AWAKE` path: the expired-challenge flow marks the request `EXPIRED` and resets the challenger regardless of battle outcome, so no queue status needs restoring there.
- Added unit tests for the helper covering all three branches, including that the generated SQL binds one parameter per challenger id (guarding against the joined-string `sql` interpolation regression).

Found during the PR #1423 review, but this is pre-existing behavior unrelated to that PR's AI-row deadlock fix, hence a separate change.

## Testing

- `make test` (625 pass)
- `make typecheck`
- `make lint` (no diagnostics on changed files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when battle participant claims fail.
  * Preserved the correct player and queue status across ranked PvP, Kage PvP, and standard battles.
  * Prevented ranked players from being restored to the queue when their queue entry no longer exists.
  * Prevented Kage PvP challengers from returning to the queue after their pending challenge request is no longer active.

* **Tests**
  * Added coverage for battle rollback behavior across supported battle types and status conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->