### PR TITLE
Allow clearing trade bans

### DIFF
--- a/app/src/server/api/routers/reports.ts
+++ b/app/src/server/api/routers/reports.ts
@@ -756,36 +756,59 @@ export const reportsRouter = createTRPCRouter({
       if (!canClearReport(user, report)) return errorResponse("No permission");
       // If someone was reported
       if (report.reportedUserId) {
-        // Remove ban if no other active bans
-        const bans = await ctx.drizzle.query.userReport.findMany({
-          where: and(
-            eq(userReport.reportedUserId, report.reportedUserId ?? ""),
-            eq(userReport.status, "BAN_ACTIVATED"),
-            gte(userReport.banEnd, new Date()),
-            ne(userReport.id, report.id),
-          ),
-        });
-        if (bans.length === 0) {
-          await ctx.drizzle
-            .update(userData)
-            .set({ isBanned: false })
-            .where(eq(userData.userId, report.reportedUserId));
-        }
-        // Remove silence if no other active silence or timeout reports
-        const activeSilenceOrTimeout = await ctx.drizzle.query.userReport.findMany({
-          where: and(
-            eq(userReport.reportedUserId, report.reportedUserId ?? ""),
-            inArray(userReport.status, ["SILENCE_ACTIVATED", "TIMEOUT_ACTIVATED"]),
-            gte(userReport.banEnd, new Date()),
-            ne(userReport.id, report.id),
-          ),
-        });
-        if (activeSilenceOrTimeout.length === 0) {
-          await ctx.drizzle
-            .update(userData)
-            .set({ isSilenced: false })
-            .where(eq(userData.userId, report.reportedUserId));
-        }
+        const reportedUserId = report.reportedUserId;
+        const [bans, activeSilenceOrTimeout, activeTradeBans] = await Promise.all([
+          ctx.drizzle.query.userReport.findMany({
+            where: and(
+              eq(userReport.reportedUserId, reportedUserId),
+              eq(userReport.status, "BAN_ACTIVATED"),
+              gte(userReport.banEnd, new Date()),
+              ne(userReport.id, report.id),
+            ),
+          }),
+          ctx.drizzle.query.userReport.findMany({
+            where: and(
+              eq(userReport.reportedUserId, reportedUserId),
+              inArray(userReport.status, ["SILENCE_ACTIVATED", "TIMEOUT_ACTIVATED"]),
+              gte(userReport.banEnd, new Date()),
+              ne(userReport.id, report.id),
+            ),
+          }),
+          ctx.drizzle.query.userReport.findMany({
+            where: and(
+              eq(userReport.reportedUserId, reportedUserId),
+              eq(userReport.status, "TRADE_BAN_ACTIVATED"),
+              gte(userReport.banEnd, new Date()),
+              ne(userReport.id, report.id),
+            ),
+          }),
+        ]);
+        await Promise.all([
+          ...(bans.length === 0
+            ? [
+                ctx.drizzle
+                  .update(userData)
+                  .set({ isBanned: false })
+                  .where(eq(userData.userId, reportedUserId)),
+              ]
+            : []),
+          ...(activeSilenceOrTimeout.length === 0
+            ? [
+                ctx.drizzle
+                  .update(userData)
+                  .set({ isSilenced: false })
+                  .where(eq(userData.userId, reportedUserId)),
+              ]
+            : []),
+          ...(activeTradeBans.length === 0
+            ? [
+                ctx.drizzle
+                  .update(userData)
+                  .set({ isTradeBanned: false })
+                  .where(eq(userData.userId, reportedUserId)),
+              ]
+            : []),
+        ]);
       }
       // Update report
       await Promise.all([

--- a/app/src/utils/permissions.ts
+++ b/app/src/utils/permissions.ts
@@ -320,16 +320,19 @@ export const canModerateReports = (user: UserData, report: UserReport) => {
       (user.role === "JR_MODERATOR" && report.status === "UNVIEWED") ||
       (user.role === "MODERATOR-ADMIN" && report.status === "OFFICIAL_WARNING") ||
       (user.role === "MODERATOR-ADMIN" && report.status === "BAN_ACTIVATED") ||
+      (user.role === "MODERATOR-ADMIN" && report.status === "TRADE_BAN_ACTIVATED") ||
       (user.role === "MODERATOR-ADMIN" && report.status === "BAN_ESCALATED") ||
       (user.role === "MODERATOR-ADMIN" && report.status === "SILENCE_ACTIVATED") ||
       (user.role === "MODERATOR-ADMIN" && report.status === "SILENCE_ESCALATED") ||
       (user.role === "OWNER" && report.status === "OFFICIAL_WARNING") ||
       (user.role === "OWNER" && report.status === "BAN_ACTIVATED") ||
+      (user.role === "OWNER" && report.status === "TRADE_BAN_ACTIVATED") ||
       (user.role === "OWNER" && report.status === "BAN_ESCALATED") ||
       (user.role === "OWNER" && report.status === "SILENCE_ACTIVATED") ||
       (user.role === "OWNER" && report.status === "SILENCE_ESCALATED") ||
       (user.role === "CODING-ADMIN" && report.status === "OFFICIAL_WARNING") ||
       (user.role === "CODING-ADMIN" && report.status === "BAN_ACTIVATED") ||
+      (user.role === "CODING-ADMIN" && report.status === "TRADE_BAN_ACTIVATED") ||
       (user.role === "CODING-ADMIN" && report.status === "BAN_ESCALATED") ||
       (user.role === "CODING-ADMIN" && report.status === "SILENCE_ACTIVATED") ||
       (user.role === "CODING-ADMIN" && report.status === "SILENCE_ESCALATED") ||
@@ -341,6 +344,7 @@ export const canModerateReports = (user: UserData, report: UserReport) => {
       (user.role === "HEAD_MODERATOR" && report.status === "TIMEOUT_ACTIVATED") ||
       (user.role === "MODERATOR" && report.status === "TIMEOUT_ACTIVATED") ||
       (user.role === "HEAD_MODERATOR" && report.status === "BAN_ACTIVATED") ||
+      (user.role === "HEAD_MODERATOR" && report.status === "TRADE_BAN_ACTIVATED") ||
       (user.role === "HEAD_MODERATOR" && report.status === "BAN_ESCALATED") ||
       (user.role === "HEAD_MODERATOR" && report.status === "SILENCE_ACTIVATED") ||
       (user.role === "HEAD_MODERATOR" && report.status === "SILENCE_ESCALATED") ||

--- a/app/src/utils/reports.ts
+++ b/app/src/utils/reports.ts
@@ -7,6 +7,7 @@ export const reportCommentColor = (status: ReportAction | null) => {
     case "REPORT_CLEARED":
       return "green";
     case "BAN_ACTIVATED":
+    case "TRADE_BAN_ACTIVATED":
       return "red";
     case "BAN_ESCALATED":
       return "blue";
@@ -23,6 +24,8 @@ export const reportCommentExplain = (status: ReportAction | null) => {
       return "Infraction Cleared";
     case "BAN_ACTIVATED":
       return "User Banned";
+    case "TRADE_BAN_ACTIVATED":
+      return "User Trade Banned";
     case "BAN_ESCALATED":
       return "Ban Escalated to Admin";
     case "SILENCE_ACTIVATED":


### PR DESCRIPTION
# Pull Request

Adds the report controls to trade bans.  The controls to be able to clear these reports were not available to moderators.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reviewing and managing trade-ban reports.
  * Authorized moderators can now moderate reports with an active trade ban.
  * Trade-ban report updates display clear red status messages.

* **Bug Fixes**
  * User trade-ban status is now cleared only when no other active trade-ban report remains.
  * Existing ban and timeout cleanup behavior remains consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->