### PR TITLE
Use one Legend top-10 LP set for Sannin rank

### DIFF
--- a/app/src/app/profile/page.tsx
+++ b/app/src/app/profile/page.tsx
@@ -125,10 +125,7 @@ export default function Profile() {
                 <div className="flex flex-row items-center gap-1">
                   <p>
                     PvP Rank:{" "}
-                    {getRankedRank(
-                      userData.rankedLp,
-                      topPlayers.map((x) => x.rankedLp),
-                    )}
+                    {getRankedRank(userData.rankedLp, topPlayers)}
                   </p>
                   <Tooltip>
                     <TooltipTrigger asChild>

--- a/app/src/app/profile/page.tsx
+++ b/app/src/app/profile/page.tsx
@@ -260,10 +260,7 @@ export default function Profile() {
           <div className="space-y-1 text-sm">
             <p>
               <span className="text-muted-foreground">Rank:</span>{" "}
-              {getRankedRank(
-                userData.rankedLp,
-                topPlayers.map((x) => x.rankedLp),
-              )}
+              {getRankedRank(userData.rankedLp, topPlayers)}
             </p>
             <p>
               <span className="text-muted-foreground">LP:</span> {userData.rankedLp}

--- a/app/src/app/users/page.tsx
+++ b/app/src/app/users/page.tsx
@@ -12,7 +12,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { RANKED_SANNIN_TOP_PLAYERS } from "@/drizzle/constants";
 import ContentBox from "@/layout/ContentBox";
 import Loader from "@/layout/Loader";
 import Table, { type ColumnDefinitionType } from "@/layout/Table";
@@ -74,12 +73,14 @@ export default function Users() {
   const { data: onlineStats } = api.profile.countOnlineUsers.useQuery(undefined, {
     enabled: isClerkLoaded,
   });
+  const { data: topPlayersLP } = api.pvpRank.getCurrentTopPlayers.useQuery(undefined, {
+    enabled: isClerkLoaded,
+    staleTime: 1000 * 60 * 5,
+  });
   const userCountNow = onlineStats?.onlineNow || 0;
   const userCountDay = onlineStats?.onlineDay || 0;
   const maxOnline = onlineStats?.maxOnline || 0;
   const flatUsers = users?.pages.flatMap((page) => page.data);
-  const topPlayersLP =
-    flatUsers?.slice(0, RANKED_SANNIN_TOP_PLAYERS).map((u) => u.rankedLp) || [];
   const allUsers = flatUsers?.map((user) => ({
     ...user,
     info: (
@@ -91,7 +92,7 @@ export default function Users() {
         <p>{user.village?.name || "Syndicate"}</p>
       </div>
     ),
-    pvpRank: getRankedRank(user.rankedLp, topPlayersLP),
+    pvpRank: getRankedRank(user.rankedLp, topPlayersLP ?? []),
   }));
   type User = ArrayElement<typeof allUsers>;
 

--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -355,6 +355,8 @@ export type ExtraState = {
   raidStartBattleCount?: Record<string, number>; // userId -> battleCount at battle start
   // Exclusive raids for SHRINE_WAR battles (pre-loaded at initiation)
   sectorExclusiveRaids?: Quest[];
+  // Ranked PvP: top Legend LP values for Sannin determination (loaded at initiation)
+  topPlayersLP?: number[];
 };
 
 // Create type for battle, which contains information on user current state

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -1552,7 +1552,12 @@ export const calcBattleResult = (
           // Both players gain 10 LP for draws
           lpDiff = 10;
         } else {
-          lpDiff = calculateLpEloChange(user, targets[0], didWin, []);
+          lpDiff = calculateLpEloChange(
+            user,
+            targets[0],
+            didWin,
+            battle.extraState.topPlayersLP ?? [],
+          );
         }
       }
 

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -197,6 +197,7 @@ import {
 import { fetchUserSkills } from "@/server/api/routers/skillTree";
 import type { DrizzleClient } from "@/server/db";
 import { battleClaimRollbackStatus } from "@/server/utils/concurrency";
+import { fetchSanninRankedPlayers } from "@/server/utils/ranked";
 import { findRelationship } from "@/utils/alliance";
 import { getRandomElement } from "@/utils/array";
 import { randomInt } from "@/utils/math";
@@ -1511,6 +1512,7 @@ export const initiateBattle = async (
     biome?: CombatBiome;
     forceKeepPools?: boolean;
     raidQuestId?: string;
+    topPlayersLP?: number[];
   },
   battleType: BattleType,
   scaleGains = 1,
@@ -1541,6 +1543,7 @@ export const initiateBattle = async (
     raidQuest,
     sectorExclusiveRaids,
     raidParticipations,
+    rankedTopPlayersLP,
   ] = await Promise.all([
     // Essentials
     fetchBattleEssentials(client),
@@ -1662,6 +1665,9 @@ export const initiateBattle = async (
           where: eq(raidParticipation.questId, info.raidQuestId),
           columns: { userId: true, battleCount: true },
         })
+      : [],
+    battleType === "RANKED_PVP"
+      ? (info.topPlayersLP ?? fetchSanninRankedPlayers(client))
       : [],
   ]);
 
@@ -2249,6 +2255,7 @@ export const initiateBattle = async (
           raidParticipations.map((p) => [p.userId, p.battleCount]),
         ),
         sectorExclusiveRaids: sectorExclusiveRaids,
+        topPlayersLP: rankedTopPlayersLP,
       },
       rewardScaling: rewardScaling,
       createdAt: startTime,

--- a/app/src/server/api/routers/data.ts
+++ b/app/src/server/api/routers/data.ts
@@ -55,7 +55,7 @@ import {
 } from "@/drizzle/schema";
 import { getRankedRank } from "@/libs/ranked_pvp";
 import { fetchPublicUsers } from "@/routers/profile";
-import { fetchSanninRankedPlayers } from "@/server/api/routers/pvprank";
+import { fetchSanninRankedPlayers } from "@/server/utils/ranked";
 import { type DeviceType, getDeviceType } from "@/utils/hardware";
 import {
   canChangeContent,

--- a/app/src/server/api/routers/pvprank.ts
+++ b/app/src/server/api/routers/pvprank.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from "@trpc/server";
-import { and, asc, desc, eq, gt, gte, inArray, lte, sql } from "drizzle-orm";
+import { and, asc, eq, gt, gte, inArray, lte, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import {
@@ -38,6 +38,7 @@ import { initiateBattle } from "@/routers/combat";
 import { fetchUser } from "@/routers/profile";
 import { updateRewards } from "@/server/api/routers/quests";
 import type { DrizzleClient } from "@/server/db";
+import { fetchSanninRankedPlayers } from "@/server/utils/ranked";
 import { canAwardReputation, canChangeContent } from "@/utils/permissions";
 import { capitalizeFirstLetter } from "@/utils/sanitize";
 import { secondsPassed } from "@/utils/time";
@@ -137,18 +138,14 @@ export const pvpRankRouter = createTRPCRouter({
 
   // Get the current season
   getCurrentTopPlayers: protectedProcedure
-    .meta({ mcp: { enabled: true, description: "Get top ranked players" } })
+    .meta({
+      mcp: {
+        enabled: true,
+        description: "Get LP values of the top Legend players used for Sannin rank",
+      },
+    })
     .query(async ({ ctx }) => {
-      const topPlayers = await ctx.drizzle.query.userData.findMany({
-        columns: {
-          userId: true,
-          rankedLp: true,
-        },
-        where: gt(userData.rankedLp, 0),
-        orderBy: [desc(userData.rankedLp)],
-        limit: RANKED_SANNIN_TOP_PLAYERS,
-      });
-      return topPlayers;
+      return await fetchSanninRankedPlayers(ctx.drizzle);
     }),
 
   // Create a new season
@@ -631,6 +628,7 @@ export const pvpRankRouter = createTRPCRouter({
             userEntry.user.rankedLoadout,
             opponentEntry.user.rankedLoadout,
           ],
+          topPlayersLP,
         },
         "RANKED_PVP",
       );
@@ -858,23 +856,4 @@ export const endRankedSeason = async (client: DrizzleClient, seasonId: string) =
     // Insert rewards rows if any
     rewardRows.length > 0 ? client.insert(rankedUserRewards).values(rewardRows) : null,
   ]);
-};
-
-/**
- * Fetch the top players for Sannin rank
- * @param client - The Drizzle client
- * @returns The top players for Sannin rank
- */
-export const fetchSanninRankedPlayers = async (client: DrizzleClient) => {
-  // Sannin is only the top 10 players who have reached Legend rank (900+ LP)
-  const users = await client.query.userData.findMany({
-    columns: {
-      userId: true,
-      rankedLp: true,
-    },
-    orderBy: (userData, { desc }) => [desc(userData.rankedLp)],
-    where: gte(userData.rankedLp, RANKED_LEGEND_LP_REQUIREMENT),
-    limit: RANKED_SANNIN_TOP_PLAYERS,
-  });
-  return users.map((u) => u.rankedLp);
 };

--- a/app/src/server/utils/ranked.ts
+++ b/app/src/server/utils/ranked.ts
@@ -1,0 +1,24 @@
+import { gte } from "drizzle-orm";
+import {
+  RANKED_LEGEND_LP_REQUIREMENT,
+  RANKED_SANNIN_TOP_PLAYERS,
+} from "@/drizzle/constants";
+import { userData } from "@/drizzle/schema";
+import type { DrizzleClient } from "@/server/db";
+
+/**
+ * LP values of the top Legend players. Sannin is the top
+ * RANKED_SANNIN_TOP_PLAYERS players who have reached Legend (900+ LP).
+ */
+export const fetchSanninRankedPlayers = async (client: DrizzleClient) => {
+  const users = await client.query.userData.findMany({
+    columns: {
+      userId: true,
+      rankedLp: true,
+    },
+    orderBy: (userData, { desc }) => [desc(userData.rankedLp)],
+    where: gte(userData.rankedLp, RANKED_LEGEND_LP_REQUIREMENT),
+    limit: RANKED_SANNIN_TOP_PLAYERS,
+  });
+  return users.map((u) => u.rankedLp);
+};

--- a/app/tests/libs/ranked_pvp.test.ts
+++ b/app/tests/libs/ranked_pvp.test.ts
@@ -79,7 +79,8 @@ describe("calculateLpEloChange", () => {
       true,
       sanninTopPlayersLP,
     );
-    expect(withSanninContext).toBe(withoutSanninContext + 10);
+    expect(withoutSanninContext).toBe(RANKED_MIN_LP_GAIN);
+    expect(withSanninContext).toBeGreaterThan(withoutSanninContext);
   });
 });
 

--- a/app/tests/libs/ranked_pvp.test.ts
+++ b/app/tests/libs/ranked_pvp.test.ts
@@ -1,6 +1,37 @@
 import { describe, it, expect } from "vitest";
-import { calculateLpEloChange, getRankedRadius } from "@/libs/ranked_pvp";
-import { RANKED_MIN_LP_GAIN, RANKED_QUEUE_MAX_WAIT_SECS } from "@/drizzle/constants";
+import {
+  calculateLpEloChange,
+  getRankedRadius,
+  getRankedRank,
+} from "@/libs/ranked_pvp";
+import {
+  RANKED_LEGEND_LP_REQUIREMENT,
+  RANKED_MIN_LP_GAIN,
+  RANKED_QUEUE_MAX_WAIT_SECS,
+  RANKED_SANNIN_TOP_PLAYERS,
+} from "@/drizzle/constants";
+
+const sanninThreshold = 950;
+const sanninTopPlayersLP = [
+  2000, 1800, 1600, 1400, 1300, 1200, 1100, 1050, 1000, sanninThreshold,
+];
+
+describe("getRankedRank", () => {
+  it("requires a full Legend top-10 set before awarding Sannin", () => {
+    expect(getRankedRank(2000, [])).toBe("Legend");
+    expect(
+      getRankedRank(2000, sanninTopPlayersLP.slice(0, RANKED_SANNIN_TOP_PLAYERS - 1)),
+    ).toBe("Legend");
+  });
+
+  it("awards Sannin only to Legends at or above the 10th Legend LP", () => {
+    expect(getRankedRank(sanninThreshold, sanninTopPlayersLP)).toBe("Sannin");
+    expect(getRankedRank(sanninThreshold - 1, sanninTopPlayersLP)).toBe("Legend");
+    expect(getRankedRank(RANKED_LEGEND_LP_REQUIREMENT - 1, sanninTopPlayersLP)).toBe(
+      "Master",
+    );
+  });
+});
 
 describe("calculateLpEloChange", () => {
   it("floors a win to RANKED_MIN_LP_GAIN when the raw Elo gain is below it", () => {
@@ -33,6 +64,22 @@ describe("calculateLpEloChange", () => {
       [],
     );
     expect(lp).toBeLessThan(0);
+  });
+
+  it("applies rank-diff LP when a Legend beats a Sannin", () => {
+    const withoutSanninContext = calculateLpEloChange(
+      { rankedLp: RANKED_LEGEND_LP_REQUIREMENT, rankedStreak: 0 },
+      { rankedLp: 2000 },
+      true,
+      [],
+    );
+    const withSanninContext = calculateLpEloChange(
+      { rankedLp: RANKED_LEGEND_LP_REQUIREMENT, rankedStreak: 0 },
+      { rankedLp: 2000 },
+      true,
+      sanninTopPlayersLP,
+    );
+    expect(withSanninContext).toBe(withoutSanninContext + 10);
   });
 });
 


### PR DESCRIPTION
## Summary
- Sannin is the top 10 Legends (900+ LP). Profile, the users list, and ranked battle-end LP each built a different `topPlayersLP` set, so badges and rank-diff LP could not agree.
- Route profile, the users list, matchmaking, and `initiateBattle` through `fetchSanninRankedPlayers`. Ranked battles store that set on `extraState` at start so `performAction` does not fetch mid-fight.
- Empty context no longer silently blocks Sannin, which previously skipped rank-diff LP for Sannin vs Legend matchups.

## Test plan
- [ ] Profile PvP rank: a Legend outside the current top 10 is Legend, not Sannin; a top-10 Legend is Sannin
- [ ] Users → Ranked tab: ranks match the same Legend top-10 set (not the first 10 rows of the current page)
- [ ] Finish a ranked match between a Sannin and a Legend and confirm the winner/loser LP includes the one-rank bonus/protection that was previously skipped
- [ ] Confirm a non-ranked battle still starts (no extra Sannin query required on that path)
- [ ] Unit tests in `app/tests/libs/ranked_pvp.test.ts` cover Sannin eligibility and the Legend-beats-Sannin rank-diff bonus


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ranked PvP calculations now use current top-player rankings.
  * Battle results account for top-ranked players when determining Sannin eligibility and LP changes.
  * Profile and user views display more accurate PvP ranks.

* **Bug Fixes**
  * Corrected Sannin eligibility requirements and rank-difference LP adjustments in ranked matches.

* **Tests**
  * Added coverage for top-player requirements, Legend thresholds, and ranked LP adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->