### PR TITLE
Use the live staff-role helper for support tickets

### DIFF
--- a/app/src/layout/SupportTicketFiltering.tsx
+++ b/app/src/layout/SupportTicketFiltering.tsx
@@ -13,6 +13,7 @@ import {
   toOptions,
   useContentFiltering,
 } from "@/layout/ContentFiltering";
+import { canViewStaffOnlyComments } from "@/utils/permissions";
 import { useUserData } from "@/utils/UserContext";
 
 interface SupportTicketFilteringProps {
@@ -90,9 +91,7 @@ const makeSupportSchema = (
 
 const SupportTicketFiltering: React.FC<SupportTicketFilteringProps> = (props) => {
   const { data: userData } = useUserData();
-  const isStaff = Boolean(
-    userData?.role && ["ADMIN", "MODERATOR", "SUPPORTER"].includes(userData.role),
-  );
+  const isStaff = Boolean(userData?.role && canViewStaffOnlyComments(userData.role));
   const { data } = api.profile.getPublicUsers.useQuery(
     { orderBy: "Staff", isAi: false, limit: 50 },
     { enabled: isStaff },
@@ -157,9 +156,7 @@ export const getFilter = (state: SupportTicketFilteringState): SupportTicketFilt
 
 export const useFiltering = () => {
   const { data: userData } = useUserData();
-  const isStaff = Boolean(
-    userData?.role && ["ADMIN", "MODERATOR", "SUPPORTER"].includes(userData.role),
-  );
+  const isStaff = Boolean(userData?.role && canViewStaffOnlyComments(userData.role));
   const { data } = api.profile.getPublicUsers.useQuery(
     { orderBy: "Staff", isAi: false, limit: 50 },
     { enabled: isStaff },

--- a/app/src/server/api/routers/support.ts
+++ b/app/src/server/api/routers/support.ts
@@ -94,7 +94,7 @@ export const supportRouter = createTRPCRouter({
       }
 
       // Sanitize ticket for public view if user is not staff
-      if (!user.role || !["ADMIN", "MODERATOR", "SUPPORTER"].includes(user.role)) {
+      if (!canViewStaffOnlyComments(user.role)) {
         return sanitizeSupportTicketForPublic(ticket, user);
       }
 


### PR DESCRIPTION
## Summary
- Ticket detail and the support filter UI still treated staff as `ADMIN` / `MODERATOR` / `SUPPORTER`. Those first and last roles do not exist on `UserRoles`, so only bare `MODERATOR` skipped sanitization and saw staff filters.
- OWNER, `*-ADMIN`, JR_MODERATOR, CONTENT, and the rest already use `canViewStaffOnlyComments` (`role !== "USER"`) for staff-only comments and assign controls. Route the three leftover checks through that helper.

## Test plan
- [ ] As a normal USER: ticket detail stays sanitized; staff-only filters stay hidden
- [ ] As MODERATOR: still sees unsanitized ticket detail and staff filters (unchanged)
- [ ] As OWNER / CONTENT-ADMIN / JR_MODERATOR / CONTENT: ticket detail is no longer sanitized; staff filters (assignee, etc.) appear
- [ ] Staff-only activity rows (ASSIGNED / TAGGED) remain hidden from USER viewers


Made with [Cursor](https://cursor.com)