### PR TITLE
Block the same offensive-word list on first posts and names

### DIFF
--- a/app/src/server/api/routers/anbu.ts
+++ b/app/src/server/api/routers/anbu.ts
@@ -152,7 +152,7 @@ export const anbuRouter = createTRPCRouter({
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
       // Fetch
-      const [user, leader, village, anbuCount] = await Promise.all([
+      const [user, leader, village, anbuCount, moderationResult] = await Promise.all([
         fetchAnbuActor({
           client: ctx.drizzle,
           userId: ctx.userId,
@@ -160,6 +160,7 @@ export const anbuRouter = createTRPCRouter({
         fetchAnbuMember(ctx.drizzle, input.leaderId),
         fetchVillage(ctx.drizzle, input.villageId),
         countAnbuSquads(ctx.drizzle, input.villageId),
+        checkForBadWords(input.name),
       ]);
       // Derived
       const villageId = village?.id;
@@ -182,7 +183,6 @@ export const anbuRouter = createTRPCRouter({
       if (!hasRequiredRank(leader.rank, ANBU_LEADER_RANK_REQUIREMENT)) {
         return errorResponse("Leader rank too low");
       }
-      const moderationResult = await checkForBadWords(input.name);
       if (!moderationResult.success) return moderationResult;
       // Mutate
       const anbuId = nanoid();
@@ -267,7 +267,7 @@ export const anbuRouter = createTRPCRouter({
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
       // Fetch
-      const [user, squad, image, squadWithName] = await Promise.all([
+      const [user, squad, image, squadWithName, moderationResult] = await Promise.all([
         fetchAnbuMember(ctx.drizzle, ctx.userId),
         fetchSquadSummary(ctx.drizzle, input.squadId),
         ctx.drizzle.query.historicalAvatar.findFirst({
@@ -277,6 +277,7 @@ export const anbuRouter = createTRPCRouter({
           columns: { name: true, id: true },
           where: eq(anbuSquad.name, input.name),
         }),
+        checkForBadWords(input.name),
       ]);
       // Guards
       if (!squad) return errorResponse("Squad not found");
@@ -296,7 +297,6 @@ export const anbuRouter = createTRPCRouter({
             validated.error.issues[0]?.message ?? "Invalid squad name",
           );
         }
-        const moderationResult = await checkForBadWords(input.name);
         if (!moderationResult.success) return moderationResult;
       }
       // Short-circuit no-op submits so PlanetScale's rowsAffected=0 on

--- a/app/src/server/api/routers/anbu.ts
+++ b/app/src/server/api/routers/anbu.ts
@@ -42,6 +42,7 @@ import {
 import type { DrizzleClient } from "@/server/db";
 import { isMysqlDuplicateKeyError } from "@/server/utils/mysqlErrors";
 import { canEditClans } from "@/utils/permissions";
+import { checkForBadWords } from "@/utils/profanity";
 import { secondsFromDate, secondsFromNow } from "@/utils/time";
 import { getEffectiveStructureLevel } from "@/utils/village";
 import {
@@ -181,6 +182,8 @@ export const anbuRouter = createTRPCRouter({
       if (!hasRequiredRank(leader.rank, ANBU_LEADER_RANK_REQUIREMENT)) {
         return errorResponse("Leader rank too low");
       }
+      const moderationResult = await checkForBadWords(input.name);
+      if (!moderationResult.success) return moderationResult;
       // Mutate
       const anbuId = nanoid();
       const leaderClaim = await ctx.drizzle
@@ -293,6 +296,8 @@ export const anbuRouter = createTRPCRouter({
             validated.error.issues[0]?.message ?? "Invalid squad name",
           );
         }
+        const moderationResult = await checkForBadWords(input.name);
+        if (!moderationResult.success) return moderationResult;
       }
       // Short-circuit no-op submits so PlanetScale's rowsAffected=0 on
       // unchanged UPDATE isn't misread as a concurrent-rename conflict.

--- a/app/src/server/api/routers/clan.ts
+++ b/app/src/server/api/routers/clan.ts
@@ -573,7 +573,7 @@ export const clanRouter = createTRPCRouter({
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
       // Fetch
-      const [user, villageData, clans, clanWithName, villageWithName] =
+      const [user, villageData, clans, clanWithName, villageWithName, moderationResult] =
         await Promise.all([
           fetchUser(ctx.drizzle, ctx.userId),
           fetchVillage(ctx.drizzle, input.villageId),
@@ -582,6 +582,7 @@ export const clanRouter = createTRPCRouter({
           ctx.drizzle.query.village.findFirst({
             where: eq(village.name, input.name),
           }),
+          checkForBadWords(input.name),
         ]);
       // Derived
       const villageId = villageData?.id;
@@ -615,7 +616,6 @@ export const clanRouter = createTRPCRouter({
       if (!hasRequiredRank(user.rank, CLAN_RANK_REQUIREMENT)) {
         return errorResponse("Rank too low");
       }
-      const moderationResult = await checkForBadWords(input.name);
       if (!moderationResult.success) return moderationResult;
       // Reduce money
       const clanId = nanoid();
@@ -646,14 +646,16 @@ export const clanRouter = createTRPCRouter({
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
       // Fetch
-      const [user, fetchedClan, clanWithName, image] = await Promise.all([
-        fetchUser(ctx.drizzle, ctx.userId),
-        fetchClan(ctx.drizzle, input.clanId),
-        fetchClanByName(ctx.drizzle, input.name),
-        ctx.drizzle.query.historicalAvatar.findFirst({
-          where: eq(historicalAvatar.avatar, input.image),
-        }),
-      ]);
+      const [user, fetchedClan, clanWithName, image, moderationResult] =
+        await Promise.all([
+          fetchUser(ctx.drizzle, ctx.userId),
+          fetchClan(ctx.drizzle, input.clanId),
+          fetchClanByName(ctx.drizzle, input.name),
+          ctx.drizzle.query.historicalAvatar.findFirst({
+            where: eq(historicalAvatar.avatar, input.image),
+          }),
+          checkForBadWords(input.name),
+        ]);
       const groupLabel = user?.isOutlaw ? "faction" : "clan";
       const locationLabel = user?.isOutlaw ? "syndicate" : "village";
       // Guards
@@ -676,7 +678,6 @@ export const clanRouter = createTRPCRouter({
             validated.error.issues[0]?.message ?? "Invalid clan name",
           );
         }
-        const moderationResult = await checkForBadWords(input.name);
         if (!moderationResult.success) return moderationResult;
       }
       // Short-circuit no-op submits so PlanetScale's rowsAffected=0 on

--- a/app/src/server/api/routers/clan.ts
+++ b/app/src/server/api/routers/clan.ts
@@ -75,6 +75,7 @@ import {
 } from "@/server/api/trpc";
 import type { DrizzleClient } from "@/server/db";
 import { canEditClans } from "@/utils/permissions";
+import { checkForBadWords } from "@/utils/profanity";
 import { secondsFromDate } from "@/utils/time";
 import { getEffectiveStructureLevel } from "@/utils/village";
 import {
@@ -614,6 +615,8 @@ export const clanRouter = createTRPCRouter({
       if (!hasRequiredRank(user.rank, CLAN_RANK_REQUIREMENT)) {
         return errorResponse("Rank too low");
       }
+      const moderationResult = await checkForBadWords(input.name);
+      if (!moderationResult.success) return moderationResult;
       // Reduce money
       const clanId = nanoid();
       const result = await ctx.drizzle
@@ -673,6 +676,8 @@ export const clanRouter = createTRPCRouter({
             validated.error.issues[0]?.message ?? "Invalid clan name",
           );
         }
+        const moderationResult = await checkForBadWords(input.name);
+        if (!moderationResult.success) return moderationResult;
       }
       // Short-circuit no-op submits so PlanetScale's rowsAffected=0 on
       // unchanged UPDATE isn't misread as a concurrent-rename conflict.

--- a/app/src/server/api/routers/comments.ts
+++ b/app/src/server/api/routers/comments.ts
@@ -208,10 +208,11 @@ export const commentsRouter = createTRPCRouter({
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
       // Query
-      const [user, thread, sender] = await Promise.all([
+      const [user, thread, sender, moderated] = await Promise.all([
         fetchUser(ctx.drizzle, ctx.userId),
         fetchThread(ctx.drizzle, input.object_id),
         input.senderId ? fetchUser(ctx.drizzle, input.senderId) : null,
+        moderateUserText(input.comment),
       ]);
       // Resolve effective poster (allow staff to post as AI)
       const effectiveUserId = resolveSenderId(user, sender);
@@ -224,7 +225,6 @@ export const commentsRouter = createTRPCRouter({
       if (!thread) {
         return errorResponse("Thread not found");
       }
-      const moderated = await moderateUserText(input.comment);
       if (!moderated.success) return moderated;
       // Mutate
       const sanitized = moderated.sanitized;
@@ -257,7 +257,7 @@ export const commentsRouter = createTRPCRouter({
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
       // Query
-      const [user, comment] = await Promise.all([
+      const [user, comment, moderated] = await Promise.all([
         fetchUser(ctx.drizzle, ctx.userId),
         ctx.drizzle.query.forumPost.findFirst({
           where: and(
@@ -265,12 +265,12 @@ export const commentsRouter = createTRPCRouter({
             eq(forumPost.userId, ctx.userId),
           ),
         }),
+        moderateUserText(input.comment),
       ]);
       // Guard
       if (user.isBanned) return errorResponse("You are banned");
       if (user.isSilenced) return errorResponse("You are silenced");
       if (!comment) return errorResponse("Comment not found");
-      const moderated = await moderateUserText(input.comment);
       if (!moderated.success) return moderated;
       // Mutate
       const postId = input.object_id;
@@ -384,17 +384,17 @@ export const commentsRouter = createTRPCRouter({
     .output(baseServerResponse.extend({ conversationId: z.string().optional() }))
     .mutation(async ({ ctx, input }) => {
       // Query
-      const [user, sender] = await Promise.all([
+      const [user, sender, titleCheck, moderationResult] = await Promise.all([
         fetchUser(ctx.drizzle, ctx.userId),
         input.senderId ? fetchUser(ctx.drizzle, input.senderId) : null,
+        checkForBadWords(input.title),
+        checkForBadWords(input.comment),
       ]);
       // Guard
       const messagingRestriction = getMessagingRestriction(user);
       if (messagingRestriction) return errorResponse(messagingRestriction);
       const effectiveUserId = resolveSenderId(user, sender);
-      const titleCheck = await checkForBadWords(input.title);
       if (!titleCheck.success) return titleCheck;
-      const moderationResult = await checkForBadWords(input.comment);
       if (!moderationResult.success) return moderationResult;
       const { processedContent } = processMentions(input.comment);
       // Mutate
@@ -679,7 +679,7 @@ export const commentsRouter = createTRPCRouter({
     .output(baseServerResponse.extend({ commentId: z.string().optional() }))
     .mutation(async ({ ctx, input }) => {
       // Fetch data
-      const [convo, user, quotes, sender] = await Promise.all([
+      const [convo, user, quotes, sender, moderationResult] = await Promise.all([
         fetchConversation({
           client: ctx.drizzle,
           id: input.object_id,
@@ -688,6 +688,7 @@ export const commentsRouter = createTRPCRouter({
         fetchUser(ctx.drizzle, ctx.userId),
         fetchComments(ctx.drizzle, input.quoteIds || []),
         input.senderId ? fetchUser(ctx.drizzle, input.senderId) : null,
+        checkForBadWords(input.comment),
       ]);
 
       // Resolve effective poster (allow staff to post as AI)
@@ -739,7 +740,6 @@ export const commentsRouter = createTRPCRouter({
       const pusher = getServerPusher();
 
       // For staff accounts, verify the language is appropriate
-      const moderationResult = await checkForBadWords(input.comment);
       if (!moderationResult.success) return moderationResult;
 
       // Create the content, santizied & with added quotes
@@ -912,7 +912,7 @@ export const commentsRouter = createTRPCRouter({
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
       // Query
-      const [user, comment] = await Promise.all([
+      const [user, comment, moderated] = await Promise.all([
         fetchUser(ctx.drizzle, ctx.userId),
         ctx.drizzle.query.conversationComment.findFirst({
           where: and(
@@ -920,12 +920,12 @@ export const commentsRouter = createTRPCRouter({
             eq(conversationComment.userId, ctx.userId),
           ),
         }),
+        moderateUserText(input.comment),
       ]);
       // Guard
       if (user.isBanned) return errorResponse("You are banned");
       if (user.isSilenced) return errorResponse("You are silenced");
       if (!comment) return errorResponse("Comment not found");
-      const moderated = await moderateUserText(input.comment);
       if (!moderated.success) return moderated;
       // Mutate
       const commentId = input.object_id;

--- a/app/src/server/api/routers/comments.ts
+++ b/app/src/server/api/routers/comments.ts
@@ -51,7 +51,7 @@ import {
   RESTRICTED_STAFF_CONVERSATION_MESSAGE,
   RESTRICTED_SUPPORT_TICKET_REPLY_MESSAGE,
 } from "@/utils/permissions";
-import { checkForBadWords } from "@/utils/profanity";
+import { checkForBadWords, moderateUserText } from "@/utils/profanity";
 import sanitize, { stripBlockquotes } from "@/utils/sanitize";
 import {
   createConversationSchema,
@@ -224,10 +224,10 @@ export const commentsRouter = createTRPCRouter({
       if (!thread) {
         return errorResponse("Thread not found");
       }
-      const moderationResult = await checkForBadWords(input.comment);
-      if (!moderationResult.success) return moderationResult;
+      const moderated = await moderateUserText(input.comment);
+      if (!moderated.success) return moderated;
       // Mutate
-      const sanitized = sanitize(input.comment);
+      const sanitized = moderated.sanitized;
       const createdId = nanoid();
       await Promise.all([
         moderateContent(ctx.drizzle, {
@@ -270,11 +270,11 @@ export const commentsRouter = createTRPCRouter({
       if (user.isBanned) return errorResponse("You are banned");
       if (user.isSilenced) return errorResponse("You are silenced");
       if (!comment) return errorResponse("Comment not found");
-      const moderationResult = await checkForBadWords(input.comment);
-      if (!moderationResult.success) return moderationResult;
+      const moderated = await moderateUserText(input.comment);
+      if (!moderated.success) return moderated;
       // Mutate
       const postId = input.object_id;
-      const sanitized = sanitize(input.comment);
+      const sanitized = moderated.sanitized;
       await Promise.all([
         moderateContent(ctx.drizzle, {
           content: sanitized,
@@ -392,6 +392,11 @@ export const commentsRouter = createTRPCRouter({
       const messagingRestriction = getMessagingRestriction(user);
       if (messagingRestriction) return errorResponse(messagingRestriction);
       const effectiveUserId = resolveSenderId(user, sender);
+      const titleCheck = await checkForBadWords(input.title);
+      if (!titleCheck.success) return titleCheck;
+      const moderationResult = await checkForBadWords(input.comment);
+      if (!moderationResult.success) return moderationResult;
+      const { processedContent } = processMentions(input.comment);
       // Mutate
       const convoId = await createConvo({
         client: ctx.drizzle,
@@ -399,7 +404,7 @@ export const commentsRouter = createTRPCRouter({
         senderUserId: effectiveUserId,
         receiverUserIds: input.users,
         title: input.title,
-        content: input.comment,
+        content: processedContent,
       });
       return { success: true, message: "Message sent.", conversationId: convoId };
     }),
@@ -920,11 +925,11 @@ export const commentsRouter = createTRPCRouter({
       if (user.isBanned) return errorResponse("You are banned");
       if (user.isSilenced) return errorResponse("You are silenced");
       if (!comment) return errorResponse("Comment not found");
-      const moderationResult = await checkForBadWords(input.comment);
-      if (!moderationResult.success) return moderationResult;
+      const moderated = await moderateUserText(input.comment);
+      if (!moderated.success) return moderated;
       // Mutate
       const commentId = input.object_id;
-      const sanitized = sanitize(input.comment);
+      const sanitized = moderated.sanitized;
       await Promise.all([
         moderateContent(ctx.drizzle, {
           content: sanitized,

--- a/app/src/server/api/routers/comments.ts
+++ b/app/src/server/api/routers/comments.ts
@@ -771,16 +771,13 @@ export const commentsRouter = createTRPCRouter({
         .map((q) => q.user?.userId)
         .filter((id): id is string => !!id);
 
-      // Fetch users to notify about mentions and quotes
-      const notifiedUserIds = await fetchUsersToNotify(
-        ctx.drizzle,
-        ctx.userId,
-        mentionedUserNames,
-        quotedUserIds,
-      );
-
-      // Database mutations first (must complete before Pusher notifications)
-      await Promise.all([
+      const [notifiedUserIds] = await Promise.all([
+        fetchUsersToNotify(
+          ctx.drizzle,
+          ctx.userId,
+          mentionedUserNames,
+          quotedUserIds,
+        ),
         // Insert into DB
         ctx.drizzle.insert(conversationComment).values({
           id: commentId,

--- a/app/src/server/api/routers/forum.ts
+++ b/app/src/server/api/routers/forum.ts
@@ -71,10 +71,12 @@ export const forumRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       // Query
       const threadId = nanoid();
-      const [board, user, sender] = await Promise.all([
+      const [board, user, sender, titleCheck, moderated] = await Promise.all([
         fetchBoard(ctx.drizzle, input.board_id),
         fetchUser(ctx.drizzle, ctx.userId),
         input.senderId ? fetchUser(ctx.drizzle, input.senderId) : null,
+        checkForBadWords(input.title),
+        moderateUserText(input.content),
       ]);
       // Guard
       if (!board) {
@@ -91,9 +93,7 @@ export const forumRouter = createTRPCRouter({
       if (user.level < FORUM_MIN_LEVEL) {
         return errorResponse(forumLevelMessage);
       }
-      const titleCheck = await checkForBadWords(input.title);
       if (!titleCheck.success) return titleCheck;
-      const moderated = await moderateUserText(input.content);
       if (!moderated.success) return moderated;
       // Mutate
       const sanitized = moderated.sanitized;

--- a/app/src/server/api/routers/forum.ts
+++ b/app/src/server/api/routers/forum.ts
@@ -140,7 +140,7 @@ export const forumRouter = createTRPCRouter({
         void Promise.allSettled(
           publishNewsToSocialMedia(
             input.title,
-            input.content,
+            sanitized,
             user.avatar,
             input.image,
           ),

--- a/app/src/server/api/routers/forum.ts
+++ b/app/src/server/api/routers/forum.ts
@@ -22,7 +22,7 @@ import {
   publicProcedure,
 } from "@/server/api/trpc";
 import { canCreateNews, canModerate } from "@/utils/permissions";
-import sanitize from "@/utils/sanitize";
+import { checkForBadWords, moderateUserText } from "@/utils/profanity";
 import { forumBoardSchema } from "@/validators/forum";
 import type { DrizzleClient } from "../../db";
 
@@ -91,8 +91,12 @@ export const forumRouter = createTRPCRouter({
       if (user.level < FORUM_MIN_LEVEL) {
         return errorResponse(forumLevelMessage);
       }
+      const titleCheck = await checkForBadWords(input.title);
+      if (!titleCheck.success) return titleCheck;
+      const moderated = await moderateUserText(input.content);
+      if (!moderated.success) return moderated;
       // Mutate
-      const sanitized = sanitize(input.content);
+      const sanitized = moderated.sanitized;
       const postId = nanoid();
       const [, , , boardUpdateResult] = await Promise.all([
         moderateContent(ctx.drizzle, {

--- a/app/src/server/api/routers/forum.ts
+++ b/app/src/server/api/routers/forum.ts
@@ -123,6 +123,14 @@ export const forumRouter = createTRPCRouter({
           .update(forumBoard)
           .set({ nThreads: sql`nThreads + 1`, updatedAt: new Date() })
           .where(eq(forumBoard.id, input.board_id)),
+        ...(isNews
+          ? [
+              ctx.drizzle
+                .update(userData)
+                .set({ unreadNews: sql`LEAST(unreadNews + 1, 1000)` })
+                .where(ne(userData.userId, ctx.userId)),
+            ]
+          : []),
       ]);
 
       // Note: In edge case where board is deleted during mutation, thread/post still exist
@@ -133,10 +141,6 @@ export const forumRouter = createTRPCRouter({
         );
       }
       if (isNews) {
-        await ctx.drizzle
-          .update(userData)
-          .set({ unreadNews: sql`LEAST(unreadNews + 1, 1000)` })
-          .where(ne(userData.userId, ctx.userId));
         void Promise.allSettled(
           publishNewsToSocialMedia(
             input.title,

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -148,6 +148,7 @@ import {
   canSeeSecretData,
   getApprovalGroup,
 } from "@/utils/permissions";
+import { checkForBadWords } from "@/utils/profanity";
 import sanitize from "@/utils/sanitize";
 import {
   getTimeOfLastReset,
@@ -1418,6 +1419,8 @@ export const profileRouter = createTRPCRouter({
       if (user.username === input.username) {
         return errorResponse("Username is the same");
       }
+      const moderationResult = await checkForBadWords(input.username);
+      if (!moderationResult.success) return moderationResult;
       if (user.reputationPoints < COST_CHANGE_USERNAME) {
         return errorResponse("Not enough reputation points");
       }

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -1408,18 +1408,18 @@ export const profileRouter = createTRPCRouter({
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
       // Fetch
-      const [user, target] = await Promise.all([
+      const [user, target, moderationResult] = await Promise.all([
         fetchUser(ctx.drizzle, ctx.userId),
         ctx.drizzle.query.userData.findFirst({
           columns: { username: true },
           where: eq(userData.username, input.username),
         }),
+        checkForBadWords(input.username),
       ]);
       // Guard
       if (user.username === input.username) {
         return errorResponse("Username is the same");
       }
-      const moderationResult = await checkForBadWords(input.username);
       if (!moderationResult.success) return moderationResult;
       if (user.reputationPoints < COST_CHANGE_USERNAME) {
         return errorResponse("Not enough reputation points");

--- a/app/src/server/api/routers/register.ts
+++ b/app/src/server/api/routers/register.ts
@@ -83,9 +83,6 @@ export const registerRouter = createTRPCRouter({
     .input(registrationSchema)
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
-      // Check for bad words
-      const moderationResult = await checkForBadWords(input.username);
-      if (!moderationResult.success) return moderationResult;
       // Query
       const [
         villageData,
@@ -94,6 +91,7 @@ export const registerRouter = createTRPCRouter({
         reminder,
         selectedBloodline,
         currentIp,
+        moderationResult,
       ] = await Promise.all([
         ctx.drizzle.query.village.findFirst({
           where: eq(village.name, "Horizon"),
@@ -116,9 +114,11 @@ export const registerRouter = createTRPCRouter({
             eq(historicalIp.userId, ctx.userId),
           ),
         }),
+        checkForBadWords(input.username),
       ]);
 
       // Guard
+      if (!moderationResult.success) return moderationResult;
       if (existingUser)
         return errorResponse("Character already created for this account");
       if (usernameTaken) return errorResponse("Username already taken");

--- a/app/src/utils/profanity.ts
+++ b/app/src/utils/profanity.ts
@@ -1,4 +1,4 @@
-import sanitize, { htmlToPlainText } from "@/utils/sanitize";
+import sanitize, { htmlToModerationText } from "@/utils/sanitize";
 
 type BadWordsResult =
   | { success: false; message: string }
@@ -13,7 +13,7 @@ type ModeratedUserText =
  * HTML is reduced to visible text first so markup and entities cannot hide a match.
  */
 export const checkForBadWords = async (content: string): Promise<BadWordsResult> => {
-  const visibleText = htmlToPlainText(content);
+  const visibleText = htmlToModerationText(content);
   // Only horizontal whitespace and hyphens may connect phrase tokens. Sentence,
   // clause, and line boundaries start a new run so phrases cannot match across them.
   const tokenRuns =

--- a/app/src/utils/profanity.ts
+++ b/app/src/utils/profanity.ts
@@ -1,3 +1,5 @@
+import sanitize from "@/utils/sanitize";
+
 /**
  * Moderates the content of a comment
  * @param content - The content of the comment
@@ -32,6 +34,21 @@ export const checkForBadWords = async (content: string) => {
     }
   }
   return { success: true, message: "Comment passed moderation" };
+};
+
+/**
+ * Block offensive language, then HTML-sanitize. Use on player-authored
+ * bodies that are stored as HTML. Names and titles should call
+ * checkForBadWords only.
+ */
+export const moderateUserText = async (content: string) => {
+  const moderationResult = await checkForBadWords(content);
+  if (!moderationResult.success) return moderationResult;
+  return {
+    success: true as const,
+    message: moderationResult.message,
+    sanitized: sanitize(content),
+  };
 };
 
 /**

--- a/app/src/utils/profanity.ts
+++ b/app/src/utils/profanity.ts
@@ -1,11 +1,19 @@
 import sanitize from "@/utils/sanitize";
 
+type BadWordsResult =
+  | { success: false; message: string }
+  | { success: true; message: string };
+
+type ModeratedUserText =
+  | { success: false; message: string }
+  | { success: true; message: string; sanitized: string };
+
 /**
  * Moderates the content of a comment
  * @param content - The content of the comment
  * @returns An error response if the content is flagged, otherwise undefined
  */
-export const checkForBadWords = async (content: string) => {
+export const checkForBadWords = async (content: string): Promise<BadWordsResult> => {
   // Only horizontal whitespace and hyphens may connect phrase tokens. Sentence,
   // clause, and line boundaries start a new run so phrases cannot match across them.
   const tokenRuns =
@@ -41,11 +49,13 @@ export const checkForBadWords = async (content: string) => {
  * bodies that are stored as HTML. Names and titles should call
  * checkForBadWords only.
  */
-export const moderateUserText = async (content: string) => {
+export const moderateUserText = async (
+  content: string,
+): Promise<ModeratedUserText> => {
   const moderationResult = await checkForBadWords(content);
   if (!moderationResult.success) return moderationResult;
   return {
-    success: true as const,
+    success: true,
     message: moderationResult.message,
     sanitized: sanitize(content),
   };

--- a/app/src/utils/profanity.ts
+++ b/app/src/utils/profanity.ts
@@ -1,4 +1,4 @@
-import sanitize from "@/utils/sanitize";
+import sanitize, { htmlToPlainText } from "@/utils/sanitize";
 
 type BadWordsResult =
   | { success: false; message: string }
@@ -9,15 +9,15 @@ type ModeratedUserText =
   | { success: true; message: string; sanitized: string };
 
 /**
- * Moderates the content of a comment
- * @param content - The content of the comment
- * @returns An error response if the content is flagged, otherwise undefined
+ * Block player-authored text that matches the offensive-word list.
+ * HTML is reduced to visible text first so markup and entities cannot hide a match.
  */
 export const checkForBadWords = async (content: string): Promise<BadWordsResult> => {
+  const visibleText = htmlToPlainText(content);
   // Only horizontal whitespace and hyphens may connect phrase tokens. Sentence,
   // clause, and line boundaries start a new run so phrases cannot match across them.
   const tokenRuns =
-    content
+    visibleText
       .toLowerCase()
       .match(/\w+(?:(?:[ \t]+|-+)\w+)*/g)
       ?.map((run) => run.match(/\w+/g) ?? []) ?? [];
@@ -26,7 +26,7 @@ export const checkForBadWords = async (content: string): Promise<BadWordsResult>
   if (foundWord) {
     return {
       success: false,
-      message: `Your comment was flagged for inappropriate language and will not be shown to others. Details: ${foundWord}`,
+      message: `Your text was flagged for inappropriate language and will not be shown to others. Details: ${foundWord}`,
     };
   }
   for (const run of tokenRuns) {
@@ -35,13 +35,13 @@ export const checkForBadWords = async (content: string): Promise<BadWordsResult>
         if (phrase.every((token, j) => run[i + j] === token)) {
           return {
             success: false,
-            message: `Your comment was flagged for inappropriate language and will not be shown to others. Details: ${phrase.join(" ")}`,
+            message: `Your text was flagged for inappropriate language and will not be shown to others. Details: ${phrase.join(" ")}`,
           };
         }
       }
     }
   }
-  return { success: true, message: "Comment passed moderation" };
+  return { success: true, message: "Text passed moderation" };
 };
 
 /**

--- a/app/src/utils/sanitize.ts
+++ b/app/src/utils/sanitize.ts
@@ -81,27 +81,33 @@ const PLAIN_TEXT_SEPARATOR_TAGS = new Set([
   "ul",
 ]);
 
-/** Converts stored HTML to normalized text without retaining script/style contents. */
-export const htmlToPlainText = (html: string) => {
-  let needsSpace = false;
-  const plainText = sanitizeHtml(html, {
+const htmlToText = (html: string, breakText: string, collapse: RegExp) => {
+  let needsBreak = false;
+  const text = sanitizeHtml(html, {
     allowedTags: [],
     allowedAttributes: {},
     onOpenTag: (tagName) => {
-      if (PLAIN_TEXT_SEPARATOR_TAGS.has(tagName)) needsSpace = true;
+      if (PLAIN_TEXT_SEPARATOR_TAGS.has(tagName)) needsBreak = true;
     },
     onCloseTag: (tagName) => {
-      if (PLAIN_TEXT_SEPARATOR_TAGS.has(tagName)) needsSpace = true;
+      if (PLAIN_TEXT_SEPARATOR_TAGS.has(tagName)) needsBreak = true;
     },
-    textFilter: (text) => {
-      if (!needsSpace) return text;
-      needsSpace = false;
-      return ` ${text}`;
+    textFilter: (chunk) => {
+      if (!needsBreak) return chunk;
+      needsBreak = false;
+      return `${breakText}${chunk}`;
     },
   });
 
-  return decodeHTML(plainText).replace(/\s+/g, " ").trim();
+  return decodeHTML(text).replace(collapse, " ").trim();
 };
+
+/** Converts stored HTML to normalized text without retaining script/style contents. */
+export const htmlToPlainText = (html: string) => htmlToText(html, " ", /\s+/g);
+
+/** Visible text for moderation: inline tags vanish, block/br stay as line breaks. */
+export const htmlToModerationText = (html: string) =>
+  htmlToText(html, "\n", /[ \t]+/g);
 
 /**
  * Strict sanitizer for variant description/battleDescription fields.

--- a/app/src/utils/sanitize.ts
+++ b/app/src/utils/sanitize.ts
@@ -99,7 +99,10 @@ const htmlToText = (html: string, breakText: string, collapse: RegExp) => {
     },
   });
 
-  return decodeHTML(text).replace(collapse, " ").trim();
+  return decodeHTML(text)
+    .replace(/\r\n?/g, "\n")
+    .replace(collapse, " ")
+    .trim();
 };
 
 /** Converts stored HTML to normalized text without retaining script/style contents. */
@@ -107,7 +110,7 @@ export const htmlToPlainText = (html: string) => htmlToText(html, " ", /\s+/g);
 
 /** Visible text for moderation: inline tags vanish, block/br stay as line breaks. */
 export const htmlToModerationText = (html: string) =>
-  htmlToText(html, "\n", /[ \t]+/g);
+  htmlToText(html, "\n", /[^\S\n]+/g);
 
 /**
  * Strict sanitizer for variant description/battleDescription fields.

--- a/app/tests/utils/profanity.test.ts
+++ b/app/tests/utils/profanity.test.ts
@@ -24,8 +24,8 @@ describe("checkForBadWords", () => {
     await expectFlagged("faggoty", "faggoty");
   });
 
-  it.each(["alligator bait", "alligator-bait"])(
-    "flags offensive phrases joined by spaces or hyphens: %s",
+  it.each(["alligator bait", "alligator-bait", "alligator&nbsp;bait"])(
+    "flags offensive phrases joined by spaces, hyphens, or entity spaces: %s",
     async (content) => {
       await expectFlagged(content, "alligator bait");
     },

--- a/app/tests/utils/profanity.test.ts
+++ b/app/tests/utils/profanity.test.ts
@@ -11,7 +11,7 @@ const expectFlagged = async (content: string, detail: string) => {
 const expectAllowed = async (content: string) => {
   await expect(checkForBadWords(content)).resolves.toEqual({
     success: true,
-    message: "Comment passed moderation",
+    message: "Text passed moderation",
   });
 };
 
@@ -44,6 +44,13 @@ describe("checkForBadWords", () => {
     "allows removed low-signal phrases: %s",
     async (content) => {
       await expectAllowed(content);
+    },
+  );
+
+  it.each(["fu<b>cked</b>", "f&#x75;cked"])(
+    "flags words hidden by HTML markup or entities: %s",
+    async (content) => {
+      await expectFlagged(content, "fucked");
     },
   );
 });

--- a/app/tests/utils/profanity.test.ts
+++ b/app/tests/utils/profanity.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { checkForBadWords } from "@/utils/profanity";
+import { checkForBadWords, moderateUserText } from "@/utils/profanity";
 
 const expectFlagged = async (content: string, detail: string) => {
   await expect(checkForBadWords(content)).resolves.toEqual({
@@ -46,4 +46,23 @@ describe("checkForBadWords", () => {
       await expectAllowed(content);
     },
   );
+});
+
+describe("moderateUserText", () => {
+  it("returns sanitized HTML when the text is clean", async () => {
+    const result = await moderateUserText("<script>alert(1)</script><p>Hello</p>");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.sanitized).toContain("Hello");
+      expect(result.sanitized).not.toContain("script");
+    }
+  });
+
+  it("blocks the same offensive words as checkForBadWords", async () => {
+    const result = await moderateUserText("That was FuCkEd.");
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.message).toContain("Details: fucked");
+    }
+  });
 });

--- a/app/tests/utils/profanity.test.ts
+++ b/app/tests/utils/profanity.test.ts
@@ -36,6 +36,7 @@ describe("checkForBadWords", () => {
     "alligator? bait",
     "alligator, bait",
     "alligator\nbait",
+    "alligator<br>bait",
   ])("does not flag phrase tokens across unrelated text or boundaries: %s", async (content) => {
     await expectAllowed(content);
   });


### PR DESCRIPTION
## Summary
- Forum replies, tavern/PM replies, and character creation already call `checkForBadWords`. New threads, first PMs, username changes, and clan/ANBU names did not, so a slur could go public while a reply on the same thread would be rejected.
- Add `moderateUserText` (check, then HTML-sanitize) and use it on player-authored HTML bodies. Names and titles call `checkForBadWords` only.
- Username, clan, and ANBU name checks run before ryo/reputation debits. First PMs now run `processMentions` like replies. Staff report comments are unchanged.

## Test plan
- [ ] New forum thread with a blocked word in the title or first post is rejected; a clean thread still posts
- [ ] First PM with a blocked word is rejected; a clean first PM still sends and `@name` becomes a link
- [ ] Username change to a blocked word fails before reputation is spent
- [ ] Clan/ANBU create or rename to a blocked word fails before money/claim writes
- [ ] Forum/PM replies still reject the same list as before
- [ ] Staff report comments still post without this gate


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added profanity moderation for squad, clan, faction, and username creation or renaming.
  * Added moderation and sanitization for forum posts, conversation titles, and comments.
  * Clean HTML content is preserved while unsafe scripts are removed.

* **Bug Fixes**
  * Offensive content is rejected before changes are saved, with clear moderation feedback.
  * Conversation titles and comments are moderated consistently, while mentions continue to be processed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->