### PR TITLE
fix: sync light layout chrome and settings

### DIFF
--- a/app/src/components/layout/shared/GameLayoutController.tsx
+++ b/app/src/components/layout/shared/GameLayoutController.tsx
@@ -203,7 +203,7 @@ const GameLayoutController: React.FC<GameLayoutControllerProps> = ({
     rightSideBar,
     leftSideBarMainMenu,
     handleRightSidebarClick,
-    lightLayout,
+    lightLayout: isMounted ? lightLayout : false,
     toggleLightLayout,
     imageset,
     variantClasses,

--- a/app/src/components/layout/shared/GameLayoutController.tsx
+++ b/app/src/components/layout/shared/GameLayoutController.tsx
@@ -55,7 +55,7 @@ const GameLayoutController: React.FC<GameLayoutControllerProps> = ({
   const [rightSideBarOpen, setRightSideBarOpen] = useState(false);
   const rightSideBarRef = React.useRef<HTMLDivElement | null>(null);
   const [theme, setTheme] = useState<"light" | "dark">("light");
-  const [lightLayout, setLightLayout] = useState<boolean>(false);
+  const [lightLayout, setLightLayout] = useLocalStorage<boolean>("lightLayout", false);
   const [isMounted, setIsMounted] = useState(false);
 
   useEffect(() => {
@@ -65,11 +65,6 @@ const GameLayoutController: React.FC<GameLayoutControllerProps> = ({
       const savedTheme = safeLocalStorageGetItem("theme");
       if (savedTheme === "dark" || savedTheme === "light") {
         setTheme(savedTheme);
-      }
-
-      const savedLayout = safeLocalStorageGetItem("lightLayout");
-      if (savedLayout !== null) {
-        setLightLayout(JSON.parse(savedLayout) as boolean);
       }
     }
 
@@ -101,11 +96,7 @@ const GameLayoutController: React.FC<GameLayoutControllerProps> = ({
   }, [theme, isMounted, variant]);
 
   const toggleLightLayout = () => {
-    setLightLayout((prev) => {
-      const newState = !prev;
-      safeLocalStorageSetItem("lightLayout", JSON.stringify(newState));
-      return newState;
-    });
+    setLightLayout(!lightLayout);
   };
 
   const toggleTheme = () => {


### PR DESCRIPTION
## Summary
- `GameLayoutController` now reads and writes `lightLayout` through the shared `useLocalStorage` hook instead of a mount-only `useState` + raw `setItem`.
- The classic-layout eye button therefore dispatches `localStorageSync`, so Game Settings (and other same-page stores) flip immediately.
- Combat/map 3D still needs a refresh to redraw; that path is unchanged. Settings already show “Refresh to apply” for 3D.

## Test plan
- [ ] On classic layout, hide chrome with the eye button and confirm the Game Settings “Lighter Layout” switch flips on the same page (and vice versa).
- [ ] Confirm combat/map 3D still requires a refresh after toggling light layout.
- [ ] Confirm pixel layout is unchanged (no light-layout switch / eye button).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persistence of the light layout preference so it remains consistent across sessions.
  * Reduced potential issues when initializing or toggling the light layout setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->