### PR TITLE
Persist sanitized HTML for nindo and public support tickets

### DIFF
--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -2171,12 +2171,12 @@ export const updateNindo = async (
     nindo
       ? client
           .update(userNindo)
-          .set({ content: content })
+          .set({ content: sanitized })
           .where(eq(userNindo.userId, userId))
       : client.insert(userNindo).values({
           id: nanoid(),
           userId: userId,
-          content: content,
+          content: sanitized,
         }),
   ]);
   return { success: true, message: "Content updated" };

--- a/app/src/server/api/routers/support.ts
+++ b/app/src/server/api/routers/support.ts
@@ -26,6 +26,7 @@ import {
 } from "@/server/api/trpc";
 import type { DrizzleClient } from "@/server/db";
 import { reduceByKey } from "@/utils/grouping";
+import sanitize from "@/utils/sanitize";
 import {
   canAssignSupportTicket,
   canDeleteSupportTicket,
@@ -123,11 +124,12 @@ export const supportRouter = createTRPCRouter({
       // Mutate
       const ticketId = nanoid(10);
       const convoId = nanoid();
+      const sanitizedDescription = sanitize(input.description);
       await Promise.all([
         ctx.drizzle.insert(supportTicket).values({
           id: ticketId,
           title: input.title,
-          description: input.description,
+          description: sanitizedDescription,
           category: input.category,
           priority: input.priority,
           isPublic: input.isPublic,
@@ -141,7 +143,7 @@ export const supportRouter = createTRPCRouter({
           senderUserId: ctx.userId,
           receiverUserIds: [],
           title: input.title,
-          content: input.description,
+          content: sanitizedDescription,
           isStaffAvailable: true,
           convoId,
           isPublic: input.isPublic,
@@ -230,11 +232,15 @@ export const supportRouter = createTRPCRouter({
         });
       }
       // Update ticket
+      const { description: nextDescription, ...ticketUpdate } = updateData;
       await Promise.all([
         ctx.drizzle
           .update(supportTicket)
           .set({
-            ...updateData,
+            ...ticketUpdate,
+            ...(nextDescription !== undefined
+              ? { description: sanitize(nextDescription) }
+              : {}),
             updatedAt: new Date(),
             closedAt: updateData.status === "RESOLVED" ? new Date() : ticket.closedAt,
           })

--- a/app/src/validators/support.ts
+++ b/app/src/validators/support.ts
@@ -29,6 +29,11 @@ export const updateSupportTicketSchema = z.object({
   isPublic: z.boolean().optional(),
   tags: z.array(z.string()).optional(),
   assignedToUserId: z.string().optional(),
+  description: z
+    .string()
+    .min(50, "Description must be at least 50 characters")
+    .max(5000, "Description cannot exceed 5000 characters")
+    .optional(),
 });
 
 // Escalate to GitHub Schema


### PR DESCRIPTION
## Summary
- Persist the already-sanitized nindo/notice/order string in `updateNindo` instead of the raw input, matching how forum posts already store `sanitize()`.
- Persist `sanitize(input.description)` on support ticket create/update so public ticket HTML cannot keep event-handler attributes or `javascript:` hrefs that `parseHtml` does not strip.
- Leave staff-only notification and poll descriptions unchanged. Existing rows are not backfilled.

## Test plan
- [ ] Save a nindo, village notice, clan order, or ANBU order that includes a disallowed tag (e.g. `<script>` or an `onclick` / `javascript:` href) and confirm the stored/rendered HTML drops those attributes while still allowing default `sanitize` tags such as `img`/`iframe`.
- [ ] Create a public support ticket with the same HTML and confirm both the ticket description on `/support` and the linked conversation copy are sanitized.
- [ ] Confirm staff-only notification and poll description writes are unchanged.
- [ ] Confirm existing nindo/ticket rows are not rewritten until they are saved again.


Made with [Cursor](https://cursor.com)