### PR TITLE
fix: align mission reduced-reward previews with claim

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -1350,6 +1350,8 @@ export type OverworldLocationType = (typeof OverworldLocationTypes)[number];
 
 export const MEDICAL_MISSIONS_PER_DAY = 9;
 export const PVP_MISSIONS_PER_DAY = 12;
+/** Last daily mission that still pays full rewards. The 10th+ pay the reduced multiplier. */
+export const MISSIONS_FULL_REWARD_COUNT = 9;
 export const ADDITIONAL_MISSION_REWARD_MULTIPLIER = 0.4;
 
 // War config

--- a/app/src/layout/Logbook.tsx
+++ b/app/src/layout/Logbook.tsx
@@ -9,7 +9,6 @@ import {
   IMG_SCENE_BACKGROUND,
   IMG_URL_ASSISTANT,
   IMG_URL_ASSISTANT_2,
-  MISSIONS_PER_DAY,
   TERMINAL_DIALOG_PREFIX,
 } from "@/drizzle/constants";
 import type { UserQuest } from "@/drizzle/schema";
@@ -29,6 +28,7 @@ import {
   isQuestObjectiveAvailable,
 } from "@/libs/objectives";
 import { useInfinitePagination } from "@/libs/pagination";
+import { isReducedMissionReward } from "@/libs/quest";
 import { cn } from "@/libs/shadui";
 import { showMutationToast, showRewardToast } from "@/libs/toast";
 import { parseHtml } from "@/utils/parse";
@@ -348,7 +348,9 @@ export const LogbookEntry: React.FC<LogbookEntryProps> = (props) => {
   const missionOrCrime = ["mission", "crime"].includes(quest.questType);
   const isStarterQuest = quest.questType === "starter";
   const rewardMultiplier =
-    userData && missionOrCrime && userData.dailyMissions > MISSIONS_PER_DAY
+    userData &&
+    missionOrCrime &&
+    isReducedMissionReward(userData.dailyMissions, { phase: "in-progress" })
       ? ADDITIONAL_MISSION_REWARD_MULTIPLIER
       : 1;
   const allDone = isQuestComplete(quest, tracker);

--- a/app/src/layout/MissionHall.tsx
+++ b/app/src/layout/MissionHall.tsx
@@ -14,10 +14,12 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import {
+  ADDITIONAL_MISSION_REWARD_MULTIPLIER,
   ERRANDS_PER_DAY,
   IMG_BUILDING_MISSIONHALL,
   IMG_MISSION_WAR,
   MEDICAL_MISSIONS_PER_DAY,
+  MISSIONS_FULL_REWARD_COUNT,
   MISSIONS_PER_DAY,
   PVP_MISSIONS_PER_DAY,
   VILLAGE_SYNDICATE_ID,
@@ -27,7 +29,11 @@ import Image from "@/layout/Image";
 import Loader from "@/layout/Loader";
 import { LogbookEntry } from "@/layout/Logbook";
 import MissionPicker from "@/layout/MissionPicker";
-import { fallbackQuestsFilter, getMissionHallSettings } from "@/libs/quest";
+import {
+  fallbackQuestsFilter,
+  getMissionHallSettings,
+  isReducedMissionReward,
+} from "@/libs/quest";
 import { cn } from "@/libs/shadui";
 import { showMutationToast } from "@/libs/toast";
 import { availableQuestLetterRanks } from "@/libs/train";
@@ -224,7 +230,9 @@ export default function MissionHall({ userData }: MissionHallProps) {
                 !isErrand &&
                 !isMedical &&
                 !isPvp &&
-                userData.dailyMissions >= 9 &&
+                isReducedMissionReward(userData.dailyMissions, {
+                  phase: "pre-start",
+                }) &&
                 userData.dailyMissions < MISSIONS_PER_DAY;
 
               const keyPrefix = isPvp ? "pvp" : isMedical ? "medical" : "mission";
@@ -258,8 +266,11 @@ export default function MissionHall({ userData }: MissionHallProps) {
                             <br />
                             <br />
                             <span className="text-yellow-500">
-                              Note: You have completed more than 9 missions today. This
-                              mission will only give 40% of its normal rewards.
+                              Note: You have completed more than{" "}
+                              {MISSIONS_FULL_REWARD_COUNT} missions today. This mission
+                              will only give{" "}
+                              {ADDITIONAL_MISSION_REWARD_MULTIPLIER * 100}% of its
+                              normal rewards.
                             </span>
                           </>
                         )}
@@ -273,7 +284,9 @@ export default function MissionHall({ userData }: MissionHallProps) {
                   additionalContent={() => (
                     <>
                       {isReducedRewards && (
-                        <p className="text-sm text-yellow-500">40% Rewards</p>
+                        <p className="text-sm text-yellow-500">
+                          {ADDITIONAL_MISSION_REWARD_MULTIPLIER * 100}% Rewards
+                        </p>
                       )}
                       {isDailyLimitReached && (
                         <p className="text-red-500 text-sm">Daily Limit Reached</p>
@@ -283,6 +296,13 @@ export default function MissionHall({ userData }: MissionHallProps) {
                 />
               );
             } else {
+              const isReducedRewards =
+                !isErrand &&
+                !isMedical &&
+                !isPvp &&
+                isReducedMissionReward(userData.dailyMissions, {
+                  phase: "pre-start",
+                });
               return (
                 <Fragment key={setting.name}>
                   <AlertDialog>
@@ -307,12 +327,11 @@ export default function MissionHall({ userData }: MissionHallProps) {
                             <span className="text-yellow-500"> {rankInfo}</span>
                           )}
                         </p>
-                        {!isErrand &&
-                          !isMedical &&
-                          !isPvp &&
-                          userData.dailyMissions >= 9 &&
+                        {isReducedRewards &&
                           userData.dailyMissions < MISSIONS_PER_DAY && (
-                            <p className="text-sm text-yellow-500">40% Rewards</p>
+                            <p className="text-sm text-yellow-500">
+                              {ADDITIONAL_MISSION_REWARD_MULTIPLIER * 100}% Rewards
+                            </p>
                           )}
                         {!isErrand &&
                           !isPvp &&
@@ -357,20 +376,19 @@ export default function MissionHall({ userData }: MissionHallProps) {
                                   ? "PvP mission"
                                   : `${setting.rank}-rank ${setting.type}`}
                               ? You can only have one active {classifier} at a time.
-                              {!isErrand &&
-                                !isMedical &&
-                                !isPvp &&
-                                userData.dailyMissions >= 9 && (
-                                  <>
-                                    <br />
-                                    <br />
-                                    <span className="text-yellow-500">
-                                      Note: You have already completed 9 missions today.
-                                      This mission will only give 40% of its normal
-                                      rewards.
-                                    </span>
-                                  </>
-                                )}
+                              {isReducedRewards && (
+                                <>
+                                  <br />
+                                  <br />
+                                  <span className="text-yellow-500">
+                                    Note: You have already completed{" "}
+                                    {MISSIONS_FULL_REWARD_COUNT} missions today. This
+                                    mission will only give{" "}
+                                    {ADDITIONAL_MISSION_REWARD_MULTIPLIER * 100}% of its
+                                    normal rewards.
+                                  </span>
+                                </>
+                              )}
                             </>
                           )}
                         </AlertDialogDescription>

--- a/app/src/libs/quest.ts
+++ b/app/src/libs/quest.ts
@@ -17,6 +17,7 @@ import {
   MAP_SECTOR_ID_MIN,
   type MEDNIN_RANK,
   MEDNIN_RANKS,
+  MISSIONS_FULL_REWARD_COUNT,
   type QuestType,
   QuestTypesWithMaxAttempts,
   type RetryQuestDelay,
@@ -223,6 +224,19 @@ export const isObjectiveLocationSatisfied = (
 };
 
 /**
+ * Whether the current daily-mission count pays the reduced reward multiplier.
+ * `pre-start` is the Mission Hall picker (counter not yet incremented).
+ * `in-progress` is claim / Logbook (counter already incremented at start).
+ */
+export const isReducedMissionReward = (
+  dailyMissions: number,
+  { phase }: { phase: "pre-start" | "in-progress" },
+) =>
+  phase === "pre-start"
+    ? dailyMissions >= MISSIONS_FULL_REWARD_COUNT
+    : dailyMissions > MISSIONS_FULL_REWARD_COUNT;
+
+/**
  * Go through current user quests, and return updated list of questData &
  * list of rewards to award the user
  * @param user - User with questData
@@ -361,8 +375,11 @@ export const getReward = (
     const missionLike = ["mission", "crime"].includes(userQuest.quest.questType);
     let factor = boostFactor; // Start with shrine boost factor
 
-    // Apply daily mission limit penalty if applicable (after 9 missions), but keep shrine boost
-    if (missionLike && user.dailyMissions > 9) {
+    // Apply daily mission limit penalty if applicable, but keep shrine boost
+    if (
+      missionLike &&
+      isReducedMissionReward(user.dailyMissions, { phase: "in-progress" })
+    ) {
       factor = ADDITIONAL_MISSION_REWARD_MULTIPLIER * boostFactor;
     }
 

--- a/app/tests/libs/quest.reduced_reward.test.ts
+++ b/app/tests/libs/quest.reduced_reward.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { MISSIONS_FULL_REWARD_COUNT } from "@/drizzle/constants";
+import { isReducedMissionReward } from "@/libs/quest";
+
+describe("isReducedMissionReward", () => {
+  it("pre-start warns once the last full-reward mission is already done", () => {
+    expect(
+      isReducedMissionReward(MISSIONS_FULL_REWARD_COUNT - 1, { phase: "pre-start" }),
+    ).toBe(false);
+    expect(
+      isReducedMissionReward(MISSIONS_FULL_REWARD_COUNT, { phase: "pre-start" }),
+    ).toBe(true);
+    expect(
+      isReducedMissionReward(MISSIONS_FULL_REWARD_COUNT + 1, { phase: "pre-start" }),
+    ).toBe(true);
+  });
+
+  it("in-progress matches claim after the counter has been incremented at start", () => {
+    expect(
+      isReducedMissionReward(MISSIONS_FULL_REWARD_COUNT, { phase: "in-progress" }),
+    ).toBe(false);
+    expect(
+      isReducedMissionReward(MISSIONS_FULL_REWARD_COUNT + 1, { phase: "in-progress" }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Unify the “after N daily missions, pay 40%” threshold across Mission Hall, Logbook, and `getReward` via `MISSIONS_FULL_REWARD_COUNT` and `isReducedMissionReward`.
- Picker uses the pre-start rule (`>= 9`); claim and Logbook use the in-progress rule (`> 9`) so Active previews match what claim already pays.
- Render `ADDITIONAL_MISSION_REWARD_MULTIPLIER` instead of a hardcoded `40%`. The paid backend cutoff is unchanged.

## Test plan
- [ ] Start a 9th daily mission: Mission Hall should not warn; Logbook Active should show full rewards; claim pays 100%.
- [ ] Start a 10th daily mission: Mission Hall should warn at 40% before accept; Logbook Active should preview 40%; claim pays 40%.
- [ ] Confirm missions 10–20 still show the reduced preview in Logbook (previously they showed full rewards).
- [ ] Confirm medical / PvP / errand / war pickers are unaffected.


Made with [Cursor](https://cursor.com)