### PR TITLE
fix: prevent scouting menu from clicking sector tiles on mobile

### DIFF
--- a/app/src/layout/Sector.tsx
+++ b/app/src/layout/Sector.tsx
@@ -249,6 +249,8 @@ const Sector: React.FC<SectorProps> = (props) => {
   const gridRef = useRef<Grid<TerrainHex> | null>(null);
   const usersRef = useRef<SectorUser[]>([]);
   const showUsersRef = useRef<boolean>(showActive);
+  const showSorroundingRef = useRef<boolean>(props.showSorrounding);
+  const ignoreMapClicksUntilRef = useRef<number>(0);
   const minBracketDrawRef = useRef<number>(storedBracket);
   const hoveredStructureIdRef = useRef<string | null>(null);
   const structuresRef = useRef<VillageStructure[]>([]);
@@ -1647,6 +1649,32 @@ const Sector: React.FC<SectorProps> = (props) => {
     showUsersRef.current = showActive;
   }, [showActive]);
 
+  // The canvas click listener lives in the long-lived scene effect, so it
+  // reads this from a ref. After the menu closes, keep ignoring clicks long
+  // enough to swallow the mobile ghost-click on the map.
+  useEffect(() => {
+    const wasOpen = showSorroundingRef.current;
+    showSorroundingRef.current = props.showSorrounding;
+    const mount = mountRef.current;
+    if (props.showSorrounding) {
+      if (mount) mount.style.pointerEvents = "none";
+      if (controlsRef.current) controlsRef.current.enabled = false;
+      return;
+    }
+    if (wasOpen) {
+      ignoreMapClicksUntilRef.current =
+        performance.now() + MAP_CLICK_BLOCK_AFTER_MODAL_MS;
+    }
+    const timeout = window.setTimeout(
+      () => {
+        if (mount) mount.style.pointerEvents = "";
+        if (controlsRef.current) controlsRef.current.enabled = true;
+      },
+      wasOpen ? MAP_CLICK_BLOCK_AFTER_MODAL_MS : 0,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [props.showSorrounding]);
+
   useEffect(() => {
     isAttackingRef.current = isAttacking;
   }, [isAttacking]);
@@ -2109,6 +2137,7 @@ const Sector: React.FC<SectorProps> = (props) => {
       controls.zoomSpeed = 1.0;
       controls.minZoom = 0.8;
       controls.maxZoom = 3;
+      controls.enabled = !showSorroundingRef.current;
       controlsRef.current = controls;
 
       // Save zoom level to localStorage when it changes (debounced to avoid excessive updates)
@@ -2155,6 +2184,12 @@ const Sector: React.FC<SectorProps> = (props) => {
 
       // Capture clicks to update move direction
       const onClick = (e: MouseEvent) => {
+        if (
+          showSorroundingRef.current ||
+          performance.now() < ignoreMapClicksUntilRef.current
+        ) {
+          return;
+        }
         // Find intersects with the scene
         setRaycasterFromMouse(raycaster, sceneRef, e, camera);
         // Sticky-select a structure under the pointer so touch / click can
@@ -2856,6 +2891,13 @@ export default Sector;
  * for database-backed buildings.
  */
 const SECTOR_SHRINE_ID = "sector-shrine";
+
+/**
+ * Mobile browsers synthesize a click on whatever sits under a dialog after the
+ * overlay unmounts from the same tap. Keep the sector canvas deaf for that
+ * window so closing scouting cannot also walk to a tile.
+ */
+const MAP_CLICK_BLOCK_AFTER_MODAL_MS = 400;
 
 const createShrineStructure = (map: NormalizedSectorMap, globalTileType: number) => {
   const shrineAnchor = map.anchors.find((anchor) => anchor.key === "shrine.default");


### PR DESCRIPTION
## Summary
- The scouting dialog overlay unmounts under the same mobile tap, so the browser synthesizes a click on the Three.js sector canvas and the player walks to a tile.
- While scouting is open, map pointer events and orbit controls are disabled; after close, canvas clicks are ignored briefly so the ghost-click cannot start a move.

## Test plan
- [ ] On mobile (or DevTools device mode), open the scouting menu on the sector map
- [ ] Tap the dimmed map / overlay: menu closes and the character does **not** walk
- [ ] Tap tiles, the slider, and the checkbox while the menu is open: no tile walk
- [ ] After closing, immediately tap a tile: movement works again
- [ ] Desktop: scouting still opens/closes normally and map clicks work when the menu is closed


Made with [Cursor](https://cursor.com)