### PR TITLE
Use correct loadout item copy

### DIFF
--- a/app/drizzle/schema.ts
+++ b/app/drizzle/schema.ts
@@ -1780,7 +1780,7 @@ export const itemLoadout = mysqlTable(
     id: varchar("id", { length: 191 }).primaryKey().notNull(),
     userId: varchar("userId", { length: 191 }).notNull(),
     itemData: json("itemData")
-      .$type<Array<{ itemId: string; slot: ItemSlot }>>()
+      .$type<Array<{ userItemId?: string; itemId: string; slot: ItemSlot }>>()
       .notNull(),
     name: varchar("name", { length: consts.LOADOUT_NAME_MAX_LENGTH })
       .default("")

--- a/app/src/libs/item.ts
+++ b/app/src/libs/item.ts
@@ -335,13 +335,25 @@ export interface ComputedLoadout {
 }
 
 /**
+ * Captures the equipped inventory rows for a loadout. `itemId` remains alongside
+ * the unique row id so legacy entries and entries whose row was removed can
+ * still fall back to another owned copy of the same item.
+ */
+export const buildItemLoadoutData = (
+  useritems: Array<{ id: string; itemId: string; equipped: ItemSlot }>,
+): Array<{ userItemId: string; itemId: string; slot: ItemSlot }> =>
+  useritems
+    .filter((ui) => ui.equipped !== "NONE")
+    .map((ui) => ({ userItemId: ui.id, itemId: ui.itemId, slot: ui.equipped }));
+
+/**
  * Pure decision logic for applying an item loadout. Validates every saved
  * entry against the user's current inventory and equip limits, assigning each
  * to a unique slot and a unique owned row. Skipped entries are reported in
  * `invalidItems`. No database access — fully unit-testable.
  */
 export const computeLoadoutAssignments = (
-  itemData: Array<{ itemId: string; slot: ItemSlot }>,
+  itemData: Array<{ userItemId?: string; itemId: string; slot: ItemSlot }>,
   useritems: UserItemWithRelations[],
   user: { level: number; bloodlineId: string | null },
   now: Date = new Date(),
@@ -353,13 +365,17 @@ export const computeLoadoutAssignments = (
   const current: EquippedAssignment[] = [];
 
   for (const entry of itemData) {
-    // Prefer an unconsumed unit that is actually equippable (carried, not
-    // auction/crafting/imbuing); fall back to any unconsumed unit so a
-    // duplicated itemId still reports a precise reason instead of being
-    // dropped silently.
-    const owned = useritems.filter(
-      (it) => it.itemId === entry.itemId && !consumedRowIds.has(it.id),
-    );
+    const unconsumed = useritems.filter((it) => !consumedRowIds.has(it.id));
+    const savedUserItem = entry.userItemId
+      ? unconsumed.find((it) => it.id === entry.userItemId)
+      : undefined;
+    // Prefer the exact saved inventory row, then try other copies of the same
+    // catalog item if it was removed or is currently unavailable. Entries saved
+    // before userItemId was introduced use only the catalog-id path.
+    const catalogMatches = unconsumed.filter((it) => it.itemId === entry.itemId);
+    const owned = savedUserItem
+      ? [savedUserItem, ...catalogMatches.filter((it) => it.id !== savedUserItem.id)]
+      : catalogMatches;
     const useritem =
       owned.find(
         (it) => getEquipBlockReason(it, now) === null && !isImbuing(it, now),

--- a/app/src/libs/item.ts
+++ b/app/src/libs/item.ts
@@ -18,6 +18,7 @@ import {
 } from "@/drizzle/constants";
 import type {
   Item,
+  ItemLoadout,
   UserData,
   UserItemWithItem,
   UserItemWithRelations,
@@ -353,7 +354,7 @@ export const buildItemLoadoutData = (
  * `invalidItems`. No database access — fully unit-testable.
  */
 export const computeLoadoutAssignments = (
-  itemData: Array<{ userItemId?: string; itemId: string; slot: ItemSlot }>,
+  itemData: ItemLoadout["itemData"],
   useritems: UserItemWithRelations[],
   user: { level: number; bloodlineId: string | null },
   now: Date = new Date(),
@@ -363,19 +364,21 @@ export const computeLoadoutAssignments = (
   const usedSlots = new Set<ItemSlot>();
   const consumedRowIds = new Set<string>();
   const current: EquippedAssignment[] = [];
+  const isFree = (it: UserItemWithRelations) => !consumedRowIds.has(it.id);
 
   for (const entry of itemData) {
-    const unconsumed = useritems.filter((it) => !consumedRowIds.has(it.id));
+    // Prefer the exact saved inventory row, then fall back to other copies of
+    // the same catalog item if it was removed or is currently unavailable.
+    // Entries saved before userItemId was introduced use only the catalog-id path.
     const savedUserItem = entry.userItemId
-      ? unconsumed.find((it) => it.id === entry.userItemId)
+      ? useritems.find((it) => it.id === entry.userItemId && isFree(it))
       : undefined;
-    // Prefer the exact saved inventory row, then try other copies of the same
-    // catalog item if it was removed or is currently unavailable. Entries saved
-    // before userItemId was introduced use only the catalog-id path.
-    const catalogMatches = unconsumed.filter((it) => it.itemId === entry.itemId);
-    const owned = savedUserItem
-      ? [savedUserItem, ...catalogMatches.filter((it) => it.id !== savedUserItem.id)]
-      : catalogMatches;
+    const owned = [
+      ...(savedUserItem ? [savedUserItem] : []),
+      ...useritems.filter(
+        (it) => it.itemId === entry.itemId && isFree(it) && it.id !== savedUserItem?.id,
+      ),
+    ];
     const useritem =
       owned.find(
         (it) => getEquipBlockReason(it, now) === null && !isImbuing(it, now),

--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -765,23 +765,29 @@ export const itemRouter = createTRPCRouter({
         );
       }
 
-      // Copy-specific entries can be updated directly. Legacy entries only have
-      // itemId, so they can be remapped or stripped when no other parent copy exists.
+      // Copy-specific entries can be updated directly. Legacy entries — and
+      // entries whose saved inventory row no longer exists — only identify the
+      // parent by itemId, so they may be remapped or stripped only when no other
+      // parent copy remains to which they could still belong.
       const ownsOtherParentCopy = userItems.some(
         (ui) =>
           ui.id !== input.userItemId && ui.itemId === parentItemId && ui.quantity > 0,
       );
+      const ownsSavedRow = (id?: string) =>
+        !!id && userItems.some((ui) => ui.id === id);
       const referencesEvolvedCopy = (entry: ItemLoadout["itemData"][number]) =>
-        entry.userItemId
+        ownsSavedRow(entry.userItemId)
           ? entry.userItemId === input.userItemId
           : !ownsOtherParentCopy && entry.itemId === parentItemId;
       loadouts
         .filter((loadout) => loadout.itemData.some(referencesEvolvedCopy))
         .forEach((loadout) => {
+          // Remapped entries also adopt the evolved row's id, upgrading legacy
+          // and dangling references to copy-specific ones.
           const itemData = canKeepEquipped
             ? loadout.itemData.map((entry) =>
                 referencesEvolvedCopy(entry)
-                  ? { ...entry, itemId: evolutionItem.id }
+                  ? { ...entry, userItemId: input.userItemId, itemId: evolutionItem.id }
                   : entry,
               )
             : loadout.itemData.filter((entry) => !referencesEvolvedCopy(entry));

--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -74,6 +74,7 @@ import {
   validateEvolutionGraph,
 } from "@/libs/evolution";
 import {
+  buildItemLoadoutData,
   calcItemRepairCost,
   calcItemSellingPrice,
   calcMaxEventItems,
@@ -764,39 +765,35 @@ export const itemRouter = createTRPCRouter({
         );
       }
 
-      // Loadouts are keyed by itemId, so parent references may only be remapped or
-      // stripped once the user owns no other copy of the parent item; otherwise the
-      // entries still belong to those remaining copies.
+      // Copy-specific entries can be updated directly. Legacy entries only have
+      // itemId, so they can be remapped or stripped when no other parent copy exists.
       const ownsOtherParentCopy = userItems.some(
         (ui) =>
           ui.id !== input.userItemId && ui.itemId === parentItemId && ui.quantity > 0,
       );
-      if (!ownsOtherParentCopy) {
-        loadouts
-          .filter((loadout) =>
-            loadout.itemData.some((entry) => entry.itemId === parentItemId),
-          )
-          .forEach((loadout) => {
-            const itemData = canKeepEquipped
-              ? loadout.itemData.map((entry) =>
-                  entry.itemId === parentItemId
-                    ? { ...entry, itemId: evolutionItem.id }
-                    : entry,
-                )
-              : loadout.itemData.filter((entry) => entry.itemId !== parentItemId);
-            cleanupWrites.push(
-              ctx.drizzle
-                .update(itemLoadout)
-                .set({ itemData })
-                .where(
-                  and(
-                    eq(itemLoadout.id, loadout.id),
-                    eq(itemLoadout.userId, ctx.userId),
-                  ),
-                ),
-            );
-          });
-      }
+      const referencesEvolvedCopy = (entry: ItemLoadout["itemData"][number]) =>
+        entry.userItemId
+          ? entry.userItemId === input.userItemId
+          : !ownsOtherParentCopy && entry.itemId === parentItemId;
+      loadouts
+        .filter((loadout) => loadout.itemData.some(referencesEvolvedCopy))
+        .forEach((loadout) => {
+          const itemData = canKeepEquipped
+            ? loadout.itemData.map((entry) =>
+                referencesEvolvedCopy(entry)
+                  ? { ...entry, itemId: evolutionItem.id }
+                  : entry,
+              )
+            : loadout.itemData.filter((entry) => !referencesEvolvedCopy(entry));
+          cleanupWrites.push(
+            ctx.drizzle
+              .update(itemLoadout)
+              .set({ itemData })
+              .where(
+                and(eq(itemLoadout.id, loadout.id), eq(itemLoadout.userId, ctx.userId)),
+              ),
+          );
+        });
 
       await Promise.all([
         ...cleanupWrites,
@@ -1590,9 +1587,7 @@ export const itemRouter = createTRPCRouter({
         if (user.itemLoadout) {
           const currentLoadout = loadouts.find((l) => l.id === user.itemLoadout);
           if (currentLoadout) {
-            const newItemData = result.newUserItems
-              .filter((ui) => ui.equipped !== "NONE")
-              .map((ui) => ({ itemId: ui.itemId, slot: ui.equipped }));
+            const newItemData = buildItemLoadoutData(result.newUserItems);
             result.promises.push(
               ctx.drizzle
                 .update(itemLoadout)

--- a/app/tests/libs/item.test.ts
+++ b/app/tests/libs/item.test.ts
@@ -193,8 +193,8 @@ const ui = (over: {
 
 const USER = { level: 50, bloodlineId: "bl1" };
 
-describe("computeLoadoutAssignments", () => {
-  it("serializes the unique inventory row id into new loadouts", () => {
+describe("buildItemLoadoutData", () => {
+  it("serializes the unique inventory row id for equipped rows only", () => {
     expect(
       buildItemLoadoutData([
         { id: "r1", itemId: "i1", equipped: "HEAD" },
@@ -202,7 +202,9 @@ describe("computeLoadoutAssignments", () => {
       ]),
     ).toEqual([{ userItemId: "r1", itemId: "i1", slot: "HEAD" }]);
   });
+});
 
+describe("computeLoadoutAssignments", () => {
   it("assigns a simple valid loadout", () => {
     const items = [ui({ id: "r1", itemId: "i1", slotType: "HEAD" })];
     const out = computeLoadoutAssignments(
@@ -250,6 +252,26 @@ describe("computeLoadoutAssignments", () => {
       USER,
     );
     expect(out.assignments).toEqual([{ userItemId: "r2", slot: "HEAD" }]);
+    expect(out.invalidItems).toEqual([]);
+  });
+
+  it("falls back to another copy when an earlier entry consumed the saved row", () => {
+    const items = [
+      ui({ id: "r1", itemId: "i1", slotType: "ITEM", maxEquips: 2 }),
+      ui({ id: "r2", itemId: "i1", slotType: "ITEM", maxEquips: 2 }),
+    ];
+    const out = computeLoadoutAssignments(
+      [
+        { userItemId: "r1", itemId: "i1", slot: "ITEM_1" },
+        { userItemId: "r1", itemId: "i1", slot: "ITEM_2" },
+      ],
+      items,
+      USER,
+    );
+    expect(out.assignments).toEqual([
+      { userItemId: "r1", slot: "ITEM_1" },
+      { userItemId: "r2", slot: "ITEM_2" },
+    ]);
     expect(out.invalidItems).toEqual([]);
   });
 

--- a/app/tests/libs/item.test.ts
+++ b/app/tests/libs/item.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  buildItemLoadoutData,
   canEquipAdditional,
   checkEquipConstraints,
   computeLoadoutAssignments,
@@ -193,6 +194,15 @@ const ui = (over: {
 const USER = { level: 50, bloodlineId: "bl1" };
 
 describe("computeLoadoutAssignments", () => {
+  it("serializes the unique inventory row id into new loadouts", () => {
+    expect(
+      buildItemLoadoutData([
+        { id: "r1", itemId: "i1", equipped: "HEAD" },
+        { id: "r2", itemId: "i1", equipped: "NONE" },
+      ]),
+    ).toEqual([{ userItemId: "r1", itemId: "i1", slot: "HEAD" }]);
+  });
+
   it("assigns a simple valid loadout", () => {
     const items = [ui({ id: "r1", itemId: "i1", slotType: "HEAD" })];
     const out = computeLoadoutAssignments(
@@ -201,6 +211,45 @@ describe("computeLoadoutAssignments", () => {
       USER,
     );
     expect(out.assignments).toEqual([{ userItemId: "r1", slot: "HEAD" }]);
+    expect(out.invalidItems).toEqual([]);
+  });
+
+  it("selects the exact saved inventory copy when duplicates exist", () => {
+    const items = [
+      ui({ id: "r2", itemId: "i1", slotType: "HEAD" }),
+      ui({ id: "r1", itemId: "i1", slotType: "HEAD" }),
+    ];
+    const out = computeLoadoutAssignments(
+      [{ userItemId: "r1", itemId: "i1", slot: "HEAD" }],
+      items,
+      USER,
+    );
+    expect(out.assignments).toEqual([{ userItemId: "r1", slot: "HEAD" }]);
+    expect(out.invalidItems).toEqual([]);
+  });
+
+  it("substitutes a duplicate when the saved copy is unavailable", () => {
+    const items = [
+      ui({ id: "r2", itemId: "i1", slotType: "HEAD" }),
+      ui({ id: "r1", itemId: "i1", slotType: "HEAD", storedAtHome: true }),
+    ];
+    const out = computeLoadoutAssignments(
+      [{ userItemId: "r1", itemId: "i1", slot: "HEAD" }],
+      items,
+      USER,
+    );
+    expect(out.assignments).toEqual([{ userItemId: "r2", slot: "HEAD" }]);
+    expect(out.invalidItems).toEqual([]);
+  });
+
+  it("falls back by item id when the saved inventory row no longer exists", () => {
+    const items = [ui({ id: "r2", itemId: "i1", slotType: "HEAD" })];
+    const out = computeLoadoutAssignments(
+      [{ userItemId: "deleted", itemId: "i1", slot: "HEAD" }],
+      items,
+      USER,
+    );
+    expect(out.assignments).toEqual([{ userItemId: "r2", slot: "HEAD" }]);
     expect(out.invalidItems).toEqual([]);
   });
 


### PR DESCRIPTION
# Pull Request

When using loadout swap, it sometimes pulls in the wrong copy of an item.  So if you have two loadouts, each with the same weapon but different imbuement, it'll sometimes pull the wrong weapon when you swap.

This change will prioritize useritemID, then fall back to itemID if it can't be reached.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Loadouts now preserve the specific inventory item assigned to each slot.
  - Equipped items synchronize more reliably when loadouts change.

- **Bug Fixes**
  - Improved loadout behavior for duplicate items and removed inventory items.
  - Evolution updates now retain compatible assignments and remove invalid ones.

- **Tests**
  - Added coverage for exact item matching, fallback selection, deleted items, and consumed duplicates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->