### PR TITLE
Point @codex workflow at gpt-5.6-sol

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -204,7 +204,7 @@ jobs:
           openai-api-key: ${{ secrets.AZURE_API_KEY }}
           responses-api-endpoint: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
           # Azure Responses API expects the deployment name here.
-          model: "gpt-5.4-2026-03-05"
+          model: "gpt-5.6-sol"
           # Needed for branch/commit/push/PR operations (.git writes).
           sandbox: "danger-full-access"
           # Blacksmith runners currently fail both drop-sudo and sudo-based user switching checks.


### PR DESCRIPTION
## Summary
- Switch the `@codex` GitHub Action model from `gpt-5.4-2026-03-05` to `gpt-5.6-sol`.

## Test plan
- [ ] After merge, comment `@codex` on a test issue/PR and confirm the job starts and the Azure Responses call uses `gpt-5.6-sol`.
- [ ] Confirm the workflow still posts/updates the GitHub comment as before.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Codex workflow to use the newer Azure model deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->