### PR TITLE
fix(map): make every sector clickable and stop the globe crawling on mobile

### DIFF
--- a/app/src/app/api/chat/support/route.ts
+++ b/app/src/app/api/chat/support/route.ts
@@ -164,7 +164,7 @@ This document outlines various screens, menus, and gameplay systems available in
     - Provides access to the world map.
 - **Global Map:**  
   - Click and drag to rotate.  
-  - Double-click a sector to initiate travel (492 sectors available).
+  - Click a sector to initiate travel, then confirm in the dialog.
 - **Errand Completion:**  
   - Travel to the designated location, complete the errand, and claim your reward (2500 ryo).
 

--- a/app/src/app/manual/world/page.tsx
+++ b/app/src/app/manual/world/page.tsx
@@ -71,7 +71,7 @@ export default function ManualWorld() {
             intersection={canEditMaps}
             hexasphere={globe}
             highlights={villages}
-            actionExplanation="Double click a sector to edit its map"
+            actionExplanation="Click a sector to edit its map"
             onTileClick={
               canEditMaps
                 ? (sector) => {

--- a/app/src/app/manual/world/page.tsx
+++ b/app/src/app/manual/world/page.tsx
@@ -17,8 +17,8 @@ const GlobalMap = dynamic(() => import("@/layout/Map"), { ssr: false });
 
 /**
  * Manual page explaining world travel, rendered around the interactive globe.
- * For content staff it doubles as the map-editing entry point: double-clicking
- * a globe sector routes to /manual/world/sector-maps?sector=N.
+ * For content staff it doubles as the map-editing entry point: clicking a globe
+ * sector routes to /manual/world/sector-maps?sector=N.
  */
 export default function ManualWorld() {
   const router = useRouter();
@@ -59,8 +59,7 @@ export default function ManualWorld() {
       a hexagonal map where your character can explore and interact with other players.
       {canEditMaps && (
         <p className="mt-2 font-bold text-orange-500">
-          As a content editor: double-click any sector on the globe to open its map
-          editor.
+          As a content editor: click any sector on the globe to open its map editor.
         </p>
       )}
       <div className="mt-4">

--- a/app/src/app/travel/page.tsx
+++ b/app/src/app/travel/page.tsx
@@ -342,6 +342,27 @@ export default function Travel() {
     ];
   }, [villages]);
 
+  // Names for the sectors the player can already see marked on the globe, so
+  // the travel dialog can say where it is sending them rather than only which
+  // number. A hideout is named only for the faction that owns it, matching how
+  // the globe decides which hideout labels to draw.
+  const sectorNames = useMemo(() => {
+    const names = new Map<number, string>();
+    names.set(MAP_WAR_TORN_BATTLEGROUND_SECTOR, "War-Torn Battleground");
+    villages?.forEach((village) => {
+      if (village.type === "HIDEOUT" && userData?.clan?.villageId !== village.id)
+        return;
+      names.set(village.sector, village.mapName || village.name);
+    });
+    return names;
+  }, [villages, userData?.clan?.villageId]);
+
+  /** "sector 222 (Wake Island)", or just the number for empty wilderness. */
+  const describeSector = (sector: number) => {
+    const name = sectorNames.get(sector);
+    return name ? `sector ${sector} (${name})` : `sector ${sector}`;
+  };
+
   // Fetch tracked bounties for map display
   const { data: trackedBounties } = api.bounty.getTrackedBounties.useQuery(undefined, {
     enabled: !!userData,
@@ -1073,7 +1094,8 @@ export default function Travel() {
             {isStartingTravel && <Loader explanation="Preparing to Travel" />}
             {!isStartingTravel && (
               <div>
-                You are about to move from sector {userData.sector} to {targetSector}.{" "}
+                You are about to move from {describeSector(userData.sector)} to{" "}
+                {describeSector(targetSector)}.{" "}
                 <p className="py-2">
                   The travel time is estimated to be{" "}
                   {calcGlobalTravelTime(userData.sector, targetSector, globe)} seconds.

--- a/app/src/app/travel/page.tsx
+++ b/app/src/app/travel/page.tsx
@@ -667,7 +667,6 @@ export default function Travel() {
           userLocation={true}
           showOwnership={showOwnership && !userData?.tutorialOn}
           autoRotate={false}
-          markerOnlyInteraction={true}
           focusSector={focusSector}
           focusSectorLabel="Target"
           onTileClick={(sector) => {

--- a/app/src/layout/Map.tsx
+++ b/app/src/layout/Map.tsx
@@ -928,25 +928,31 @@ const GlobalMap: React.FC<MapProps> = (props) => {
         // Update all TWEEN animations (color pulsing, etc.)
         TWEEN.update();
 
+        // Nothing below reaches the GPU while the context is lost, and queueing
+        // buffer update ranges that never get uploaded would grow unbounded.
+        const canRender = !contextHandlers.isContextLost();
+
         // Tint each highlighted sector's slice of the merged surface's colors
-        for (const pulse of pulses) {
-          const color =
-            pulse.type === "war"
-              ? warTweenColor
-              : pulse.type === "focus"
-                ? focusTweenColor
-                : questTweenColor;
-          for (let i = 0; i < pulse.terrain.length; i += 3) {
-            surfaceColorValues[pulse.offset + i] = (pulse.terrain[i] ?? 0) * color.r;
-            surfaceColorValues[pulse.offset + i + 1] =
-              (pulse.terrain[i + 1] ?? 0) * color.g;
-            surfaceColorValues[pulse.offset + i + 2] =
-              (pulse.terrain[i + 2] ?? 0) * color.b;
+        if (canRender && pulses.length > 0) {
+          for (const pulse of pulses) {
+            const color =
+              pulse.type === "war"
+                ? warTweenColor
+                : pulse.type === "focus"
+                  ? focusTweenColor
+                  : questTweenColor;
+            for (let i = 0; i < pulse.terrain.length; i += 3) {
+              surfaceColorValues[pulse.offset + i] = (pulse.terrain[i] ?? 0) * color.r;
+              surfaceColorValues[pulse.offset + i + 1] =
+                (pulse.terrain[i + 1] ?? 0) * color.g;
+              surfaceColorValues[pulse.offset + i + 2] =
+                (pulse.terrain[i + 2] ?? 0) * color.b;
+            }
+            // Upload only the pulsed vertices, not the whole 400k-vertex buffer
+            surfaceColors.addUpdateRange(pulse.offset, pulse.terrain.length);
           }
-          // Upload only the pulsed vertices, not the whole 400k-vertex buffer
-          surfaceColors.addUpdateRange(pulse.offset, pulse.terrain.length);
+          surfaceColors.needsUpdate = true;
         }
-        if (pulses.length > 0) surfaceColors.needsUpdate = true;
         // Intersections with mouse: https://threejs.org/docs/index.html#api/en/core/Raycaster
         const cameraOrPointerMoved =
           camera.position.x !== lastRaycastCamX ||
@@ -979,7 +985,7 @@ const GlobalMap: React.FC<MapProps> = (props) => {
 
         // Render the scene (skip if WebGL context is lost or invalid)
         animationId = requestAnimationFrame(render);
-        if (!contextHandlers.isContextLost() && renderer) {
+        if (canRender && renderer) {
           renderer.render(scene, camera);
         }
 

--- a/app/src/layout/Map.tsx
+++ b/app/src/layout/Map.tsx
@@ -192,10 +192,18 @@ const GlobalMap: React.FC<MapProps> = (props) => {
         );
       };
 
-      // Latest pointer position, consumed by the hover pick in the render loop
+      // Latest pointer position, consumed by the hover pick in the render loop.
+      // It stays unset until a real pointer lands: an unset Vector2 is the
+      // canvas centre in NDC, which would otherwise highlight whatever sector
+      // happens to sit there before anyone pointed at it.
       const mouse = new Vector2();
+      let hasPointerPosition = false;
+      const trackPointer = (point: Vector2) => {
+        mouse.copy(point);
+        hasPointerPosition = true;
+      };
       const onDocumentMouseMove = (event: MouseEvent) => {
-        mouse.copy(toPointerNdc(event.clientX, event.clientY));
+        trackPointer(toPointerNdc(event.clientX, event.clientY));
       };
       if (props.intersection) {
         hoverCanvas.addEventListener("mousemove", onDocumentMouseMove, false);
@@ -472,11 +480,17 @@ const GlobalMap: React.FC<MapProps> = (props) => {
           tapGesture.active = false;
           const moved = Math.hypot(e.clientX - tapGesture.x, e.clientY - tapGesture.y);
           if (tapGesture.navigated || moved > TAP_SLOP_PX) return;
-          const sector = pickSector(toPointerNdc(e.clientX, e.clientY));
+          const point = toPointerNdc(e.clientX, e.clientY);
+          const sector = pickSector(point);
           const tile = sector !== null ? hexasphere?.tiles[sector] : undefined;
           if (sector !== null && tile) {
-            // Keep the picked sector outlined while the caller decides what to
-            // do with it - on touch there is no hover to show what was hit.
+            // Outline the picked sector while the caller decides what to do
+            // with it - on touch there is no hover to show what was hit. A
+            // mouse goes on hovering afterwards, so its position stays live; a
+            // finger leaves no pointer behind, so the outline stays where the
+            // tap put it rather than being replaced by a pick at a phantom
+            // position the moment the globe turns.
+            if (e.pointerType === "mouse") trackPointer(point);
             highlightSector(sector);
             onTileClickRef.current?.(sector, tile);
           }
@@ -967,7 +981,7 @@ const GlobalMap: React.FC<MapProps> = (props) => {
           camera.position.z !== lastRaycastCamZ ||
           mouse.x !== lastRaycastMouseX ||
           mouse.y !== lastRaycastMouseY;
-        if (props.intersection && cameraOrPointerMoved) {
+        if (props.intersection && hasPointerPosition && cameraOrPointerMoved) {
           lastRaycastCamX = camera.position.x;
           lastRaycastCamY = camera.position.y;
           lastRaycastCamZ = camera.position.z;

--- a/app/src/layout/Map.tsx
+++ b/app/src/layout/Map.tsx
@@ -452,6 +452,11 @@ const GlobalMap: React.FC<MapProps> = (props) => {
         const tapGesture = { x: 0, y: 0, active: false, navigated: false };
         onLabelPointerDown = (e: PointerEvent) => {
           if (e.isPrimary) {
+            // A finger or pen taking over means the mouse has stopped pointing
+            // at anything, so its last position must stop driving the hover
+            // pick - on a hybrid device it would otherwise reclaim the outline
+            // from the tap as soon as the globe turned.
+            if (e.pointerType !== "mouse") hasPointerPosition = false;
             // Only a touch/pen contact or the left mouse button can start a
             // tap; right/middle clicks are trackball input, never travel
             if (e.pointerType === "mouse" && e.button !== 0) {

--- a/app/src/layout/Map.tsx
+++ b/app/src/layout/Map.tsx
@@ -13,6 +13,7 @@ import {
   Mesh,
   MeshBasicMaterial,
   PerspectiveCamera,
+  Sphere,
   SphereGeometry,
   Sprite,
   SpriteMaterial,
@@ -33,10 +34,10 @@ import type { Village } from "@/drizzle/schema";
 import { safeLocalStorageGetItem, safeLocalStorageSetItem } from "@/hooks/localstorage";
 import { useTutorialStep } from "@/hooks/tutorial";
 import WebGlError from "@/layout/WebGLError";
-import type { HexagonalFaceMesh } from "@/libs/hexgrid";
 import {
-  buildGlobeTileGeometry,
+  buildGlobeSurface,
   createUserAvatarSprite,
+  pickGlobeSector,
   samplePolarCapColor,
 } from "@/libs/threejs/globe";
 import { TrackballControls } from "@/libs/threejs/TrackBallControls";
@@ -70,8 +71,6 @@ interface MapProps {
   actionExplanation?: string;
   focusSector?: number | null;
   focusSectorLabel?: string;
-  /** Restrict clicks/taps to visible labels and pins instead of bare sectors. */
-  markerOnlyInteraction?: boolean;
   onTileClick?: (sector: number | null, tile: GlobalTile | null) => void;
   onTileHover?: (sector: number | null, tile: GlobalTile | null) => void;
 }
@@ -106,14 +105,9 @@ const GlobalMap: React.FC<MapProps> = (props) => {
   // without rebuilding the three.js scene when travel state changes.
   const onTileClickRef = useRef(props.onTileClick);
   onTileClickRef.current = props.onTileClick;
-  const mouse = new Vector2();
   const { hexasphere, showOwnership } = props;
   const autoRotate = props.autoRotate ?? true;
-  const actionExplanation =
-    props.actionExplanation ||
-    (props.markerOnlyInteraction
-      ? "Click a village label to travel"
-      : "Double click tile to move there");
+  const actionExplanation = props.actionExplanation || "Click tile to move there";
 
   // Get sector ownerships if needed
   const { data: ownershipData } = api.village.getSectorOwnerships.useQuery(
@@ -131,20 +125,6 @@ const GlobalMap: React.FC<MapProps> = (props) => {
     }
   }, [ownershipData]);
 
-  const onDocumentMouseMove = (event: MouseEvent) => {
-    if (mountRef.current) {
-      const bounding_box = mountRef.current.getBoundingClientRect();
-      mouse.x = (event.offsetX / bounding_box.width) * 2 - 1;
-      mouse.y = -((event.offsetY / bounding_box.height) * 2 - 1);
-    }
-  };
-
-  // Track touch state for double-tap detection on mobile
-  const lastTapRef = useRef<{ time: number; sector: number | null }>({
-    time: 0,
-    sector: null,
-  });
-
   // Tutorial step
   const { currentStep } = useTutorialStep();
   const isTravelStep = currentStep?.title === "Travel";
@@ -156,12 +136,6 @@ const GlobalMap: React.FC<MapProps> = (props) => {
       // Performance stats
       // const stats = new Stats();
       // document.body.appendChild(stats.dom);
-
-      // Interacivity with mouse
-      if (props.intersection) {
-        sceneRef.addEventListener("mousemove", onDocumentMouseMove, false);
-      }
-      let intersected: HexagonalFaceMesh | undefined;
 
       const WIDTH = sceneRef.getBoundingClientRect().width;
       const HEIGHT = WIDTH;
@@ -179,7 +153,7 @@ const GlobalMap: React.FC<MapProps> = (props) => {
       // scene-graph order and ignores renderOrder entirely, and since
       // group_highlights is traversed before group_tiles the translucent sector
       // grid painted OVER every marker. Sorting makes the marker/label/pin
-      // renderOrder tiers effective (~500 objects, negligible sort cost).
+      // renderOrder tiers effective (a few dozen objects, negligible sort cost).
       const { scene, renderer, raycaster, handleResize } = setupScene({
         mountRef: mountRef,
         width: WIDTH,
@@ -201,6 +175,28 @@ const GlobalMap: React.FC<MapProps> = (props) => {
       // Canvas element (renderer is non-null past the guard above) - used to
       // toggle the pointer cursor while hovering sectors on the globe
       const hoverCanvas = renderer.domElement;
+
+      /**
+       * Viewport coordinates to normalized device coordinates, measured against
+       * the canvas itself rather than the event target, so a pointer event that
+       * originated on an overlay still maps to the right point on the globe.
+       */
+      const toPointerNdc = (clientX: number, clientY: number) => {
+        const bounds = hoverCanvas.getBoundingClientRect();
+        return new Vector2(
+          ((clientX - bounds.left) / bounds.width) * 2 - 1,
+          -((clientY - bounds.top) / bounds.height) * 2 + 1,
+        );
+      };
+
+      // Latest pointer position, consumed by the hover pick in the render loop
+      const mouse = new Vector2();
+      const onDocumentMouseMove = (event: MouseEvent) => {
+        mouse.copy(toPointerNdc(event.clientX, event.clientY));
+      };
+      if (props.intersection) {
+        hoverCanvas.addEventListener("mousemove", onDocumentMouseMove, false);
+      }
 
       // Track WebGL context loss to prevent shader errors on iOS mobile browsers
       // Clear texture caches when context is lost to free memory
@@ -382,95 +378,65 @@ const GlobalMap: React.FC<MapProps> = (props) => {
 
       /**
        * Sector of the closest label/pin under the given NDC point, or null.
-       * Sprites still raycast when the globe occludes them, so a label hit
-       * only counts when no tile sits in front of it along the same ray.
+       * Sprites still raycast when the globe occludes them, so a label hit only
+       * counts when the globe surface does not sit in front of it.
        */
+      const globeSphere = new Sphere(new Vector3(0, 0, 0), hexasphere.radius / 3);
+      const globeHit = new Vector3();
       const pickLabelTarget = (point: Vector2): number | null => {
         if (labelTargets.length === 0) return null;
         raycaster.setFromCamera(point, camera);
         const labelHit = raycaster.intersectObjects(labelTargets, false)[0];
         if (!labelHit) return null;
-        const tileHit = raycaster.intersectObjects(group_tiles.children)[0];
-        if (tileHit && tileHit.distance < labelHit.distance) return null;
+        if (
+          raycaster.ray.intersectSphere(globeSphere, globeHit) &&
+          globeHit.distanceTo(raycaster.ray.origin) < labelHit.distance
+        ) {
+          return null;
+        }
         const sector = labelHit.object.userData.sector as number;
         return typeof sector === "number" ? sector : null;
       };
 
-      // Add map interaction handlers. Travel can opt into marker-only mode,
-      // while map editing and war declaration retain direct sector selection.
-      let onDblClick: (() => void) | null = null;
-      let onTouchEnd: ((e: TouchEvent) => void) | null = null;
+      /**
+       * Sector under an NDC point: labels and pins win over the bare terrain
+       * beneath them, matching what hovering highlights.
+       */
+      const pickSector = (point: Vector2): number | null => {
+        const labelSector = pickLabelTarget(point);
+        if (labelSector !== null) return labelSector;
+        raycaster.setFromCamera(point, camera);
+        return pickGlobeSector(raycaster, hexasphere);
+      };
+
+      // Currently highlighted sector, shared by the hover pick and the tap
+      // handler so a tap-set outline is not immediately treated as stale.
+      let highlightedSector: number | null = null;
+      const highlightSector = (sector: number | null) => {
+        if (sector === highlightedSector) return;
+        highlightedSector = sector;
+        setHoverOutline(sector);
+        hoverCanvas.style.cursor = sector === null ? "default" : "pointer";
+        const tile = sector !== null ? hexasphere?.tiles[sector] : undefined;
+        if (props.onTileHover && sector !== null && tile) {
+          props.onTileHover(sector, tile);
+        }
+        setHoverSector(sector);
+      };
+
+      // Single click/tap selects the sector under the pointer, whether that is
+      // a village label, a map pin or bare terrain. Pointer events cover mouse
+      // and touch alike, so desktop and mobile share one code path. A gesture
+      // only counts as a tap when it was single-pointer for its whole lifetime
+      // and the pointer never strayed from the start point - peak displacement,
+      // not start-to-end, so a rotate drag that circles back and a pinch whose
+      // primary finger barely moves both stay navigation.
       let onLabelPointerDown: ((e: PointerEvent) => void) | null = null;
       let onLabelPointerMove: ((e: PointerEvent) => void) | null = null;
       let onLabelPointerUp: ((e: PointerEvent) => void) | null = null;
       let onLabelPointerCancel: (() => void) | null = null;
 
       if (props.intersection && props.onTileClick) {
-        // Desktop: double-click handler
-        onDblClick = () => {
-          if (props.markerOnlyInteraction) return;
-          const intersects = raycaster.intersectObjects(group_tiles.children);
-          if (intersects.length > 0) {
-            const sector = intersects?.[0]?.object?.userData?.id as number;
-            const tile = hexasphere?.tiles[sector];
-            if (tile !== undefined) {
-              onTileClickRef.current?.(sector, tile);
-            }
-          }
-        };
-        renderer.domElement.addEventListener("dblclick", onDblClick, true);
-
-        // Mobile: double-tap detection via touchend
-        // We detect double-tap by checking if two taps happen within 300ms on the same sector
-        onTouchEnd = (e: TouchEvent) => {
-          if (props.markerOnlyInteraction || e.changedTouches.length === 0) return;
-          const touch = e.changedTouches[0];
-          if (!touch) return;
-
-          // Get which sector was tapped
-          const bounding_box = sceneRef.getBoundingClientRect();
-          const mouseX =
-            ((touch.clientX - bounding_box.left) / bounding_box.width) * 2 - 1;
-          const mouseY =
-            -((touch.clientY - bounding_box.top) / bounding_box.height) * 2 + 1;
-          raycaster.setFromCamera(new Vector2(mouseX, mouseY), camera);
-
-          const intersects = raycaster.intersectObjects(group_tiles.children);
-          if (intersects.length === 0) {
-            lastTapRef.current = { time: 0, sector: null };
-            return;
-          }
-
-          const sector = intersects?.[0]?.object?.userData?.id as number;
-          const now = Date.now();
-          const timeSinceLastTap = now - lastTapRef.current.time;
-          const DOUBLE_TAP_DELAY = 300; // ms
-
-          // Check if this is a double-tap on the same sector
-          if (
-            timeSinceLastTap < DOUBLE_TAP_DELAY &&
-            lastTapRef.current.sector === sector
-          ) {
-            // Double-tap detected!
-            const tile = hexasphere?.tiles[sector];
-            if (tile !== undefined) {
-              onTileClickRef.current?.(sector, tile);
-            }
-            // Reset to prevent triple-tap
-            lastTapRef.current = { time: 0, sector: null };
-          } else {
-            // First tap - record it
-            lastTapRef.current = { time: now, sector };
-          }
-        };
-        renderer.domElement.addEventListener("touchend", onTouchEnd, { passive: true });
-
-        // Single click/tap on a village label or map pin starts travel to the
-        // sector it points at. Pointer events cover mouse and touch alike. A
-        // gesture only counts as a tap when it was single-pointer for its whole
-        // lifetime and the pointer never strayed from the start point - peak
-        // displacement, not start-to-end, so a rotate drag that circles back
-        // and a pinch whose primary finger barely moves both stay navigation.
         const TAP_SLOP_PX = 10;
         const tapGesture = { x: 0, y: 0, active: false, navigated: false };
         onLabelPointerDown = (e: PointerEvent) => {
@@ -503,14 +469,12 @@ const GlobalMap: React.FC<MapProps> = (props) => {
           tapGesture.active = false;
           const moved = Math.hypot(e.clientX - tapGesture.x, e.clientY - tapGesture.y);
           if (tapGesture.navigated || moved > TAP_SLOP_PX) return;
-          const bounding_box = sceneRef.getBoundingClientRect();
-          const point = new Vector2(
-            ((e.clientX - bounding_box.left) / bounding_box.width) * 2 - 1,
-            -((e.clientY - bounding_box.top) / bounding_box.height) * 2 + 1,
-          );
-          const sector = pickLabelTarget(point);
+          const sector = pickSector(toPointerNdc(e.clientX, e.clientY));
           const tile = sector !== null ? hexasphere?.tiles[sector] : undefined;
           if (sector !== null && tile) {
+            // Keep the picked sector outlined while the caller decides what to
+            // do with it - on touch there is no hover to show what was hit.
+            highlightSector(sector);
             onTileClickRef.current?.(sector, tile);
           }
         };
@@ -520,59 +484,49 @@ const GlobalMap: React.FC<MapProps> = (props) => {
         renderer.domElement.addEventListener("pointercancel", onLabelPointerCancel);
       }
 
-      // Textured globe: each logical sector is rendered from a finer visual
-      // terrain field, while its outer quad remains the interaction boundary.
-      // The sector grid stops with the navigable tiles; the separate polar-cap
-      // sphere never contributes edges and therefore remains a solid surface.
+      // Textured globe: every logical sector is rendered from a finer visual
+      // terrain field, merged into a single indexed mesh so the whole world is
+      // one draw call. The sector grid stops with the navigable tiles; the
+      // separate polar-cap sphere never contributes edges and therefore remains
+      // a solid surface.
+      const surface = buildGlobeSurface(hexasphere, (sector) => {
+        // Ownership view tints the tile texture by owning village
+        if (!showOwnership || !ownershipData?.sectors || !ownershipData?.colors) {
+          return null;
+        }
+        const ownerVillageId = ownershipVillageBySector.get(sector);
+        const villageColor = ownerVillageId
+          ? ownershipColorByVillageId.get(ownerVillageId)
+          : undefined;
+        if (villageColor) return new Color(villageColor);
+        return MAP_RESERVED_SECTORS.includes(sector) ? new Color("#b3afae") : null;
+      });
+      const globeMesh = new Mesh(
+        surface.geometry,
+        new MeshBasicMaterial({ vertexColors: true, side: DoubleSide }),
+      );
+      globeMesh.matrixAutoUpdate = false;
+      // Picking is arithmetic (pickGlobeSector), so the terrain never needs to
+      // be a raycast target - and a 400k-vertex mesh would be a costly one.
+      globeMesh.raycast = () => {};
+      group_tiles.add(globeMesh);
+
       const edgePositions: number[] = [];
       const EDGE_LIFT = 1.0015; // sit the outline just above the tile faces
-      for (let i = 0; i < hexasphere.tiles.length; i++) {
-        const t = hexasphere.tiles[i];
-        const built = t && buildGlobeTileGeometry(hexasphere, t);
-        if (t && built) {
-          const geometry = new BufferGeometry();
-          geometry.setAttribute("position", new BufferAttribute(built.positions, 3));
-          geometry.setAttribute("color", new BufferAttribute(built.colors, 3));
-
-          // Ownership view tints the tile texture by owning village
-          let color: string | number = 0xffffff;
-          if (showOwnership && ownershipData?.sectors && ownershipData?.colors) {
-            const ownerVillageId = ownershipVillageBySector.get(i);
-            const villageColor = ownerVillageId
-              ? ownershipColorByVillageId.get(ownerVillageId)
-              : undefined;
-            if (MAP_RESERVED_SECTORS.includes(i)) {
-              color = "#b3afae";
-            }
-            if (villageColor) {
-              color = villageColor;
-            }
-          }
-          const material = new MeshBasicMaterial({
-            color,
-            vertexColors: true,
-            side: DoubleSide,
-          });
-
-          const mesh = new Mesh(geometry, material);
-          mesh.matrixAutoUpdate = false;
-          mesh.userData.id = i;
-          mesh.name = `${i}`;
-          group_tiles.add(mesh);
-
-          // Quad boundary (corners NW,NE,SE,SW), lifted just above the surface,
-          // for the sector-separation wireframe
-          const corner = t.b.map((p) => ({
-            x: (Number(p.x) / 3) * EDGE_LIFT,
-            y: (Number(p.y) / 3) * EDGE_LIFT,
-            z: (Number(p.z) / 3) * EDGE_LIFT,
-          }));
-          for (let k = 0; k < 4; k++) {
-            const a = corner[k];
-            const b = corner[(k + 1) % 4];
-            if (!a || !b) continue;
-            edgePositions.push(a.x, a.y, a.z, b.x, b.y, b.z);
-          }
+      for (const tile of hexasphere.tiles) {
+        if (tile.b.length !== 4) continue;
+        // Quad boundary (corners NW,NE,SE,SW), lifted just above the surface,
+        // for the sector-separation wireframe
+        const corner = tile.b.map((p) => ({
+          x: (Number(p.x) / 3) * EDGE_LIFT,
+          y: (Number(p.y) / 3) * EDGE_LIFT,
+          z: (Number(p.z) / 3) * EDGE_LIFT,
+        }));
+        for (let k = 0; k < 4; k++) {
+          const a = corner[k];
+          const b = corner[(k + 1) % 4];
+          if (!a || !b) continue;
+          edgePositions.push(a.x, a.y, a.z, b.x, b.y, b.z);
         }
       }
 
@@ -718,10 +672,6 @@ const GlobalMap: React.FC<MapProps> = (props) => {
         sector: number;
         color: typeof questTweenColor;
         type: "quest" | "war" | "focus";
-        // Resolved lazily on the first frame and cached, so the render loop does
-        // not re-scan group_tiles' ~486 children by name every frame. undefined =
-        // not yet resolved, null = resolved but no matching mesh (do not retry).
-        mesh?: HexagonalFaceMesh | null;
       }[] = [];
 
       // Add war-torn battleground sector to highlight
@@ -843,6 +793,26 @@ const GlobalMap: React.FC<MapProps> = (props) => {
         }
       });
 
+      // Pulsing a sector means rewriting its slice of the merged surface's
+      // shared color buffer every frame. Snapshot each one's terrain colors up
+      // front - taken lazily they would capture an already-pulsed slice
+      // whenever two highlights land on the same sector, and the tile would
+      // then darken a little more each frame.
+      const surfaceColors = surface.geometry.getAttribute("color") as BufferAttribute;
+      const surfaceColorValues = surfaceColors.array as Float32Array;
+      const pulses = sectorsToHighlight.flatMap((highlight) => {
+        const start = surface.vertexRanges[highlight.sector * 2] ?? -1;
+        const count = surface.vertexRanges[highlight.sector * 2 + 1] ?? 0;
+        if (start < 0) return [];
+        return [
+          {
+            type: highlight.type,
+            offset: start * 3,
+            terrain: surfaceColorValues.slice(start * 3, (start + count) * 3),
+          },
+        ];
+      });
+
       // Compensate camera distance for the narrower lens using the globe's
       // projected angular radius. This keeps the established zoom range while
       // making the globe read flatter.
@@ -946,41 +916,37 @@ const GlobalMap: React.FC<MapProps> = (props) => {
 
       // Render the image
       let animationId = 0;
-      // Gate the ~486-mesh hover raycast: only re-run it when the pointer or the
-      // camera pose actually changed since the last raycast (the globe auto-
-      // rotates, so the camera moving is itself a reason to re-test). Skips the
-      // full raycast on truly idle frames.
+      // Gate the hover pick: only re-run it when the pointer or the camera pose
+      // actually changed since the last one (the globe auto-rotates, so the
+      // camera moving is itself a reason to re-test).
       let lastRaycastCamX = Number.NaN;
       let lastRaycastCamY = Number.NaN;
       let lastRaycastCamZ = Number.NaN;
       let lastRaycastMouseX = Number.NaN;
       let lastRaycastMouseY = Number.NaN;
-      let hoveredLabelSector: number | null = null;
       function render() {
         // Update all TWEEN animations (color pulsing, etc.)
         TWEEN.update();
 
-        // Apply highlight colors to sectors (mesh resolved once, then cached)
-        if (sectorsToHighlight.length > 0) {
-          sectorsToHighlight.forEach((highlight) => {
-            if (highlight.mesh === undefined) {
-              highlight.mesh =
-                (group_tiles.getObjectByName(
-                  `${highlight.sector}`,
-                ) as HexagonalFaceMesh | null) ?? null;
-            }
-            const mesh = highlight.mesh;
-            if (mesh) {
-              const color =
-                highlight.type === "war"
-                  ? warTweenColor
-                  : highlight.type === "focus"
-                    ? focusTweenColor
-                    : questTweenColor;
-              mesh.material.color.setRGB(color.r, color.g, color.b);
-            }
-          });
+        // Tint each highlighted sector's slice of the merged surface's colors
+        for (const pulse of pulses) {
+          const color =
+            pulse.type === "war"
+              ? warTweenColor
+              : pulse.type === "focus"
+                ? focusTweenColor
+                : questTweenColor;
+          for (let i = 0; i < pulse.terrain.length; i += 3) {
+            surfaceColorValues[pulse.offset + i] = (pulse.terrain[i] ?? 0) * color.r;
+            surfaceColorValues[pulse.offset + i + 1] =
+              (pulse.terrain[i + 1] ?? 0) * color.g;
+            surfaceColorValues[pulse.offset + i + 2] =
+              (pulse.terrain[i + 2] ?? 0) * color.b;
+          }
+          // Upload only the pulsed vertices, not the whole 400k-vertex buffer
+          surfaceColors.addUpdateRange(pulse.offset, pulse.terrain.length);
         }
+        if (pulses.length > 0) surfaceColors.needsUpdate = true;
         // Intersections with mouse: https://threejs.org/docs/index.html#api/en/core/Raycaster
         const cameraOrPointerMoved =
           camera.position.x !== lastRaycastCamX ||
@@ -996,57 +962,7 @@ const GlobalMap: React.FC<MapProps> = (props) => {
           lastRaycastMouseY = mouse.y;
           // Labels and pins take hover precedence over the tiles behind them;
           // hovering one outlines its target sector, matching what a click does
-          const labelSector = pickLabelTarget(mouse);
-          if (labelSector !== null) {
-            if (hoveredLabelSector !== labelSector) {
-              hoveredLabelSector = labelSector;
-              intersected = undefined;
-              setHoverOutline(labelSector);
-              hoverCanvas.style.cursor = "pointer";
-              const tile = hexasphere?.tiles[labelSector];
-              if (props.onTileHover && tile) props.onTileHover(labelSector, tile);
-              setHoverSector(labelSector);
-            }
-          } else {
-            if (hoveredLabelSector !== null) {
-              hoveredLabelSector = null;
-              setHoverOutline(null);
-              hoverCanvas.style.cursor = "default";
-              setHoverSector(null);
-            }
-            // Marker-only travel still needs bare-sector inspection while the
-            // ownership layer is enabled. This restores hover information
-            // without making those sectors clickable travel targets.
-            if (!props.markerOnlyInteraction || showOwnership) {
-              raycaster.setFromCamera(mouse, camera);
-              const intersects = raycaster.intersectObjects(group_tiles.children);
-              if (intersects.length > 0) {
-                // if the closest object intersected is not the currently stored intersection object
-                if (intersects[0] && intersects[0].object !== intersected) {
-                  intersected = intersects[0].object as HexagonalFaceMesh;
-                  const sector = intersected.userData.id;
-                  setHoverOutline(sector);
-                  hoverCanvas.style.cursor = props.markerOnlyInteraction
-                    ? "crosshair"
-                    : "pointer";
-                  const tile = hexasphere?.tiles[sector];
-                  if (props.onTileHover && tile) props.onTileHover(sector, tile);
-                  setHoverSector(sector);
-                }
-              } else if (intersected) {
-                // Pointer moved off the globe: clear the outline and the pointer
-                intersected = undefined;
-                setHoverOutline(null);
-                hoverCanvas.style.cursor = "default";
-                setHoverSector(null);
-              }
-            } else if (intersected) {
-              intersected = undefined;
-              setHoverOutline(null);
-              hoverCanvas.style.cursor = "default";
-              setHoverSector(null);
-            }
-          }
+          highlightSector(pickSector(mouse));
         }
 
         // Auto-rotate around the same fixed north-south axis as manual drags.
@@ -1083,13 +999,7 @@ const GlobalMap: React.FC<MapProps> = (props) => {
         // Remove event listeners safely
         try {
           if (props.intersection) {
-            sceneRef.removeEventListener("mousemove", onDocumentMouseMove);
-          }
-          if (onDblClick) {
-            renderer.domElement.removeEventListener("dblclick", onDblClick, true);
-          }
-          if (onTouchEnd) {
-            renderer.domElement.removeEventListener("touchend", onTouchEnd);
+            hoverCanvas.removeEventListener("mousemove", onDocumentMouseMove);
           }
           if (onLabelPointerDown) {
             renderer.domElement.removeEventListener("pointerdown", onLabelPointerDown);
@@ -1130,7 +1040,6 @@ const GlobalMap: React.FC<MapProps> = (props) => {
     props.highlights,
     props.usersHighlighted,
     props.intersection,
-    props.markerOnlyInteraction,
     props.focusSector,
     showOwnership,
     ownershipData,
@@ -1156,10 +1065,10 @@ const GlobalMap: React.FC<MapProps> = (props) => {
     <div className="relative">
       <div ref={mountRef} id={"tutorial-global-map"}></div>
       {webglError && <WebGlError />}
-      <div className="absolute top-0 left-0 m-5">
+      <div className="pointer-events-none absolute top-0 left-0 m-5">
         <ul>
           {hoverSector !== null && showOwnership && (
-            <li className="pointer-events-none flex min-w-36 items-center gap-2 rounded-lg border border-white/20 bg-black/75 px-3 py-2 shadow-lg backdrop-blur-sm">
+            <li className="flex min-w-36 items-center gap-2 rounded-lg border border-white/20 bg-black/75 px-3 py-2 shadow-lg backdrop-blur-sm">
               <span
                 className="h-3 w-3 shrink-0 rounded-sm border border-white/50 shadow-sm"
                 style={{ backgroundColor: hoveredOwnerColor }}
@@ -1177,7 +1086,7 @@ const GlobalMap: React.FC<MapProps> = (props) => {
           {hoverSector !== null && !showOwnership && (
             <li className="flex flex-row items-center">
               <span className="mr-1 animate-pulse text-2xl text-orange-500">⬢</span>{" "}
-              {props.markerOnlyInteraction ? "Travel marker" : "Quest"}
+              Quest
             </li>
           )}
           {props.focusSector !== undefined && props.focusSector !== null && (
@@ -1188,13 +1097,8 @@ const GlobalMap: React.FC<MapProps> = (props) => {
           )}
         </ul>
       </div>
-      <div className="absolute top-0 right-0 m-5">
+      <div className="pointer-events-none absolute top-0 right-0 m-5">
         <ul className="flex flex-col items-end gap-2">
-          {props.markerOnlyInteraction && (
-            <li className="pointer-events-none max-w-56 rounded-lg border border-white/20 bg-black/75 px-3 py-2 text-right text-sm text-white shadow-lg backdrop-blur-sm">
-              Click a village label to travel
-            </li>
-          )}
           {hoverSector !== null && (
             <>
               <li>- Highlighting sector {hoverSector}</li>

--- a/app/src/layout/Map.tsx
+++ b/app/src/layout/Map.tsx
@@ -98,6 +98,9 @@ const GlobalMap: React.FC<MapProps> = (props) => {
   const { data: userData } = useUserData();
   const [webglError, setWebglError] = useState<boolean>(false);
   const [hoverSector, setHoverSector] = useState<number | null>(null);
+  // Whether the built scene actually carries quest pins, so the legend below
+  // only explains markers that are on the globe
+  const [hasQuestMarkers, setHasQuestMarkers] = useState<boolean>(false);
   const mountRef = useRef<HTMLDivElement | null>(null);
   // Bridges the overlay zoom buttons into the three.js scene built below
   const zoomActionRef = useRef<((factor: number) => void) | null>(null);
@@ -793,6 +796,10 @@ const GlobalMap: React.FC<MapProps> = (props) => {
         }
       });
 
+      setHasQuestMarkers(
+        sectorsToHighlight.some((highlight) => highlight.type === "quest"),
+      );
+
       // Pulsing a sector means rewriting its slice of the merged surface's
       // shared color buffer every frame. Snapshot each one's terrain colors up
       // front - taken lazily they would capture an already-pulsed slice
@@ -1089,7 +1096,7 @@ const GlobalMap: React.FC<MapProps> = (props) => {
               </span>
             </li>
           )}
-          {hoverSector !== null && !showOwnership && (
+          {hasQuestMarkers && (
             <li className="flex flex-row items-center">
               <span className="mr-1 animate-pulse text-2xl text-orange-500">⬢</span>{" "}
               Quest

--- a/app/src/layout/WarSystem.tsx
+++ b/app/src/layout/WarSystem.tsx
@@ -590,7 +590,7 @@ export const WarMap: React.FC<{
               setShowModal(true);
             }
           }}
-          actionExplanation="Double click tile to declare war on sector"
+          actionExplanation="Click tile to declare war on sector"
           hexasphere={globe}
         />
       )}

--- a/app/src/libs/sector-map/world-grid.ts
+++ b/app/src/libs/sector-map/world-grid.ts
@@ -1,4 +1,5 @@
 import {
+  MAP_NAVIGABLE_LATITUDE_LIMIT,
   MAP_TOTAL_SECTORS,
   MAP_WORLD_COLUMNS,
   MAP_WORLD_ROWS,
@@ -62,4 +63,22 @@ export const sectorGridEntryEdges = (
     neighbors[2] < 0 ? -1 : 0,
     neighbors[3] < 0 ? -1 : 1,
   ];
+};
+
+/**
+ * Sector covering a geographic position, or -1 for the non-navigable polar
+ * caps. Exact inverse of the generator's uniform longitude/latitude layout, so
+ * a point on the globe resolves to its sector arithmetically instead of by
+ * raycasting the rendered terrain.
+ */
+export const sectorAtGeographic = (latitude: number, longitude: number): number => {
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return -1;
+  if (Math.abs(latitude) > MAP_NAVIGABLE_LATITUDE_LIMIT) return -1;
+  const latitudeStep = (MAP_NAVIGABLE_LATITUDE_LIMIT * 2) / MAP_WORLD_ROWS;
+  const row = Math.min(
+    MAP_WORLD_ROWS - 1,
+    Math.max(0, Math.floor((MAP_NAVIGABLE_LATITUDE_LIMIT - latitude) / latitudeStep)),
+  );
+  const column = Math.floor((longitude + 180) / (360 / MAP_WORLD_COLUMNS));
+  return sectorIdAt(column, row);
 };

--- a/app/src/libs/threejs/globe.ts
+++ b/app/src/libs/threejs/globe.ts
@@ -1,15 +1,20 @@
 import {
+  BufferAttribute,
   BufferGeometry,
+  type Color,
   Group,
   LinearFilter,
   LineBasicMaterial,
   LineSegments,
+  type Raycaster,
+  Sphere,
   Sprite,
   SpriteMaterial,
   Vector3,
 } from "three";
 import { IMG_SECTOR_USER_SPRITE_MASK } from "@/drizzle/constants";
 import { safeLocalStorageGetItem, safeLocalStorageSetItem } from "@/hooks/localstorage";
+import { sectorAtGeographic } from "@/libs/sector-map/world-grid";
 import type { GlobalMapData, GlobalPoint, GlobalTile } from "@/libs/threejs/types";
 import {
   createBorderTexture,
@@ -155,101 +160,177 @@ export const createUserAvatarSprite = (info: {
 
 type Point3 = { x: number; y: number; z: number };
 
+/** Quads per sector edge, falling back to a flat quad without a color field. */
+const sectorVisualScale = (hexasphere: GlobalMapData, tile: GlobalTile) =>
+  hexasphere.visualScale && tile.vc?.length === (hexasphere.visualScale + 1) ** 2
+    ? hexasphere.visualScale
+    : 1;
+
+const FALLBACK_TERRAIN_COLORS: Record<number, number> = {
+  0: 0x3f9ed9,
+  1: 0x3cc164,
+  2: 0xe7cd89,
+  3: 0xe8f6f8,
+};
+
+export interface GlobeSurface {
+  /** Every navigable sector merged into one indexed geometry. */
+  geometry: BufferGeometry;
+  /** Vertex [start, count] pairs per sector id, for recoloring a single tile. */
+  vertexRanges: Int32Array;
+}
+
+/** Evenly spaced points along one sector edge, as flat xyz triples. */
+const interpolateEdge = (
+  from: GlobalPoint,
+  to: GlobalPoint,
+  stride: number,
+  scale: number,
+) => {
+  const points = new Float64Array(stride * 3);
+  for (let step = 0; step < stride; step++) {
+    const amount = step / scale;
+    points[step * 3] = Number(from.x) + (Number(to.x) - Number(from.x)) * amount;
+    points[step * 3 + 1] = Number(from.y) + (Number(to.y) - Number(from.y)) * amount;
+    points[step * 3 + 2] = Number(from.z) + (Number(to.z) - Number(from.z)) * amount;
+  }
+  return points;
+};
+
 /**
- * Geometry for one logical sector, subdivided and colored at its climate-field
- * vertices. Three.js interpolates those colors across each triangle, producing
- * gradual coast and biome transitions without changing sector interaction.
+ * One indexed geometry for the whole navigable globe, subdivided and colored at
+ * each sector's climate-field vertices. Three.js interpolates those colors
+ * across the triangles, producing gradual coast and biome transitions.
+ *
+ * Merging matters: a mesh per sector meant ~1,950 draw calls every frame, which
+ * is what made the map crawl on mobile. Sector identity survives as the
+ * vertexRanges lookup, and picking is arithmetic (see pickGlobeSector) rather
+ * than a raycast, so nothing needs the tiles to stay separate objects.
  */
-export const buildGlobeTileGeometry = (
+export const buildGlobeSurface = (
   hexasphere: GlobalMapData,
-  tile: GlobalTile,
-): { positions: Float32Array; colors: Float32Array } | null => {
-  if (tile.b.length !== 4) return null;
-  const positions: number[] = [];
-  const colors: number[] = [];
-  const visualScale =
-    hexasphere.visualScale && tile.vc?.length === (hexasphere.visualScale + 1) ** 2
-      ? hexasphere.visualScale
-      : 1;
+  sectorTint?: (sector: number) => Color | null,
+): GlobeSurface => {
+  const tiles = hexasphere.tiles;
+  const radius = hexasphere.radius / 3;
 
-  const fallbackColors: Record<number, number> = {
-    0: 0x3f9ed9,
-    1: 0x3cc164,
-    2: 0xe7cd89,
-    3: 0xe8f6f8,
-  };
-  const colorAt = (x: number, y: number): Point3 => {
-    const packed =
-      tile.vc?.[y * (visualScale + 1) + x] ?? fallbackColors[tile.t] ?? 0x3cc164;
-    return {
-      x: ((packed >> 16) & 0xff) / 255,
-      y: ((packed >> 8) & 0xff) / 255,
-      z: (packed & 0xff) / 255,
-    };
-  };
+  // Size the buffers up front: a sector contributes (scale + 1)^2 vertices and
+  // scale^2 quads, and sectors without a proper quad boundary contribute none.
+  const scales = new Int32Array(tiles.length);
+  let vertexTotal = 0;
+  let indexTotal = 0;
+  for (let sector = 0; sector < tiles.length; sector++) {
+    const tile = tiles[sector];
+    if (!tile || tile.b.length !== 4) continue;
+    const scale = sectorVisualScale(hexasphere, tile);
+    scales[sector] = scale;
+    vertexTotal += (scale + 1) ** 2;
+    indexTotal += scale * scale * 6;
+  }
 
-  /** Curved bilinear point for a subdivision corner on the globe surface. */
-  const pointAt = (u: number, v: number): Point3 => {
+  const positions = new Float32Array(vertexTotal * 3);
+  const colors = new Float32Array(vertexTotal * 3);
+  const indices = new Uint32Array(indexTotal);
+  const vertexRanges = new Int32Array(tiles.length * 2).fill(-1);
+  let vertexCursor = 0;
+  let indexCursor = 0;
+
+  for (let sector = 0; sector < tiles.length; sector++) {
+    const scale = scales[sector];
+    const tile = tiles[sector];
+    if (!scale || !tile) continue;
     const [nw, ne, se, sw] = tile.b as [
       GlobalPoint,
       GlobalPoint,
       GlobalPoint,
       GlobalPoint,
     ];
-    const top = {
-      x: Number(nw.x) + (Number(ne.x) - Number(nw.x)) * u,
-      y: Number(nw.y) + (Number(ne.y) - Number(nw.y)) * u,
-      z: Number(nw.z) + (Number(ne.z) - Number(nw.z)) * u,
-    };
-    const bottom = {
-      x: Number(sw.x) + (Number(se.x) - Number(sw.x)) * u,
-      y: Number(sw.y) + (Number(se.y) - Number(sw.y)) * u,
-      z: Number(sw.z) + (Number(se.z) - Number(sw.z)) * u,
-    };
-    const point = {
-      x: top.x + (bottom.x - top.x) * v,
-      y: top.y + (bottom.y - top.y) * v,
-      z: top.z + (bottom.z - top.z) * v,
-    };
-    const length = Math.hypot(point.x, point.y, point.z) || 1;
-    const radius = hexasphere.radius / 3;
-    return {
-      x: (point.x / length) * radius,
-      y: (point.y / length) * radius,
-      z: (point.z / length) * radius,
-    };
-  };
-  const pushTri = (
-    p0: Point3,
-    p1: Point3,
-    p2: Point3,
-    c0: Point3,
-    c1: Point3,
-    c2: Point3,
-  ) => {
-    positions.push(p0.x, p0.y, p0.z, p1.x, p1.y, p1.z, p2.x, p2.y, p2.z);
-    colors.push(c0.x, c0.y, c0.z, c1.x, c1.y, c1.z, c2.x, c2.y, c2.z);
-  };
+    const stride = scale + 1;
+    const base = vertexCursor;
+    const tint = sectorTint?.(sector) ?? null;
 
-  for (let y = 0; y < visualScale; y++) {
-    for (let x = 0; x < visualScale; x++) {
-      const u0 = x / visualScale;
-      const u1 = (x + 1) / visualScale;
-      const v0 = y / visualScale;
-      const v1 = (y + 1) / visualScale;
-      const nw = pointAt(u0, v0);
-      const ne = pointAt(u1, v0);
-      const se = pointAt(u1, v1);
-      const sw = pointAt(u0, v1);
-      const nwColor = colorAt(x, y);
-      const neColor = colorAt(x + 1, y);
-      const seColor = colorAt(x + 1, y + 1);
-      const swColor = colorAt(x, y + 1);
-      pushTri(nw, ne, se, nwColor, neColor, seColor);
-      pushTri(nw, se, sw, nwColor, seColor, swColor);
+    // Bilinear interpolation over the quad, evaluated as a north edge and a
+    // south edge that the row loop then blends between.
+    const north = interpolateEdge(nw, ne, stride, scale);
+    const south = interpolateEdge(sw, se, stride, scale);
+
+    for (let y = 0; y < stride; y++) {
+      const v = y / scale;
+      for (let x = 0; x < stride; x++) {
+        // Blended point pushed back onto the sphere, so the surface stays
+        // curved rather than faceted.
+        const edge = x * 3;
+        const nx = north[edge] ?? 0;
+        const ny = north[edge + 1] ?? 0;
+        const nz = north[edge + 2] ?? 0;
+        const px = nx + ((south[edge] ?? 0) - nx) * v;
+        const py = ny + ((south[edge + 1] ?? 0) - ny) * v;
+        const pz = nz + ((south[edge + 2] ?? 0) - nz) * v;
+        const length = Math.hypot(px, py, pz) || 1;
+        const offset = (base + y * stride + x) * 3;
+        positions[offset] = (px / length) * radius;
+        positions[offset + 1] = (py / length) * radius;
+        positions[offset + 2] = (pz / length) * radius;
+
+        const packed =
+          tile.vc?.[y * stride + x] ?? FALLBACK_TERRAIN_COLORS[tile.t] ?? 0x3cc164;
+        const red = ((packed >> 16) & 0xff) / 255;
+        const green = ((packed >> 8) & 0xff) / 255;
+        const blue = (packed & 0xff) / 255;
+        colors[offset] = tint ? red * tint.r : red;
+        colors[offset + 1] = tint ? green * tint.g : green;
+        colors[offset + 2] = tint ? blue * tint.b : blue;
+      }
     }
+
+    for (let y = 0; y < scale; y++) {
+      for (let x = 0; x < scale; x++) {
+        const topLeft = base + y * stride + x;
+        const topRight = topLeft + 1;
+        const bottomLeft = topLeft + stride;
+        const bottomRight = bottomLeft + 1;
+        indices[indexCursor++] = topLeft;
+        indices[indexCursor++] = topRight;
+        indices[indexCursor++] = bottomRight;
+        indices[indexCursor++] = topLeft;
+        indices[indexCursor++] = bottomRight;
+        indices[indexCursor++] = bottomLeft;
+      }
+    }
+
+    vertexRanges[sector * 2] = base;
+    vertexRanges[sector * 2 + 1] = stride * stride;
+    vertexCursor += stride * stride;
   }
-  return { positions: new Float32Array(positions), colors: new Float32Array(colors) };
+
+  const geometry = new BufferGeometry();
+  geometry.setAttribute("position", new BufferAttribute(positions, 3));
+  geometry.setAttribute("color", new BufferAttribute(colors, 3));
+  geometry.setIndex(new BufferAttribute(indices, 1));
+  return { geometry, vertexRanges };
+};
+
+// Reused across picks so hover testing allocates nothing per frame.
+const pickSphere = new Sphere(new Vector3(0, 0, 0), 1);
+const pickPoint = new Vector3();
+
+/**
+ * Sector under a ray, or null off the globe and over the non-navigable polar
+ * caps. The sector grid is a uniform longitude/latitude layout, so the surface
+ * hit resolves arithmetically - no per-triangle raycast, and no dependency on
+ * how the terrain happens to be split into meshes.
+ */
+export const pickGlobeSector = (
+  raycaster: Raycaster,
+  hexasphere: GlobalMapData,
+): number | null => {
+  pickSphere.radius = hexasphere.radius / 3;
+  if (!raycaster.ray.intersectSphere(pickSphere, pickPoint)) return null;
+  const length = pickPoint.length() || 1;
+  const latitude = (Math.asin(pickPoint.y / length) * 180) / Math.PI;
+  const longitude = (Math.atan2(pickPoint.z, pickPoint.x) * 180) / Math.PI;
+  const sector = sectorAtGeographic(latitude, longitude);
+  return sector < 0 || sector >= hexasphere.tiles.length ? null : sector;
 };
 
 /**

--- a/app/tests/libs/globe-surface.test.ts
+++ b/app/tests/libs/globe-surface.test.ts
@@ -1,0 +1,164 @@
+import { Color } from "three";
+import { describe, expect, it } from "vitest";
+import globe from "@/data/hexasphere.json";
+import {
+  MAP_NAVIGABLE_LATITUDE_LIMIT,
+  MAP_TOTAL_SECTORS,
+  MAP_WORLD_COLUMNS,
+  MAP_WORLD_ROWS,
+} from "@/drizzle/constants";
+import { sectorAtGeographic } from "@/libs/sector-map/world-grid";
+import { buildGlobeSurface } from "@/libs/threejs/globe";
+import type { GlobalMapData, GlobalPoint } from "@/libs/threejs/types";
+
+const hexasphere = globe as unknown as GlobalMapData;
+
+const toGeographic = (point: GlobalPoint) => {
+  const x = Number(point.x);
+  const y = Number(point.y);
+  const z = Number(point.z);
+  const length = Math.hypot(x, y, z) || 1;
+  return {
+    latitude: (Math.asin(y / length) * 180) / Math.PI,
+    longitude: (Math.atan2(z, x) * 180) / Math.PI,
+  };
+};
+
+describe("sectorAtGeographic", () => {
+  it("resolves every sector center back to its own id", () => {
+    const mismatches: number[] = [];
+    for (let sector = 0; sector < hexasphere.tiles.length; sector++) {
+      const tile = hexasphere.tiles[sector];
+      if (!tile) continue;
+      const { latitude, longitude } = toGeographic(tile.c);
+      if (sectorAtGeographic(latitude, longitude) !== sector) mismatches.push(sector);
+    }
+    expect(mismatches).toEqual([]);
+  });
+
+  it("resolves points sampled inside every sector quad", () => {
+    // Boundaries are shared, so sample strictly inside each tile: getting this
+    // wrong by one grid step is exactly how picking lands on a neighbour.
+    const mismatches: { sector: number; got: number }[] = [];
+    for (let sector = 0; sector < hexasphere.tiles.length; sector++) {
+      const tile = hexasphere.tiles[sector];
+      if (!tile || tile.b.length !== 4) continue;
+      const [nw, ne, , sw] = tile.b.map(toGeographic) as [
+        { latitude: number; longitude: number },
+        { latitude: number; longitude: number },
+        { latitude: number; longitude: number },
+        { latitude: number; longitude: number },
+      ];
+      // The last column wraps across the +/-180 seam; unwrap before blending.
+      const west = nw.longitude;
+      const east = ne.longitude < west ? ne.longitude + 360 : ne.longitude;
+      for (const u of [0.1, 0.5, 0.9]) {
+        for (const v of [0.1, 0.5, 0.9]) {
+          const blended = ((west + (east - west) * u + 540) % 360) - 180;
+          const longitude = (blended + 360) % 360;
+          const got = sectorAtGeographic(
+            nw.latitude + (sw.latitude - nw.latitude) * v,
+            longitude > 180 ? longitude - 360 : longitude,
+          );
+          if (got !== sector) mismatches.push({ sector, got });
+        }
+      }
+    }
+    expect(mismatches).toEqual([]);
+  });
+
+  it("rejects the non-navigable polar caps", () => {
+    expect(sectorAtGeographic(MAP_NAVIGABLE_LATITUDE_LIMIT + 0.5, 0)).toBe(-1);
+    expect(sectorAtGeographic(-MAP_NAVIGABLE_LATITUDE_LIMIT - 0.5, 0)).toBe(-1);
+    expect(sectorAtGeographic(90, 0)).toBe(-1);
+    expect(sectorAtGeographic(Number.NaN, 0)).toBe(-1);
+  });
+
+  it("keeps the latitude limits and the longitude seam inside the grid", () => {
+    expect(sectorAtGeographic(MAP_NAVIGABLE_LATITUDE_LIMIT, -180)).toBe(0);
+    expect(sectorAtGeographic(-MAP_NAVIGABLE_LATITUDE_LIMIT, -180)).toBe(
+      (MAP_WORLD_ROWS - 1) * MAP_WORLD_COLUMNS,
+    );
+    // +180 and -180 are the same meridian and must not fall off the east edge.
+    expect(sectorAtGeographic(0, 180)).toBe(sectorAtGeographic(0, -180));
+  });
+});
+
+describe("buildGlobeSurface", () => {
+  const surface = buildGlobeSurface(hexasphere);
+  const positions = surface.geometry.getAttribute("position");
+  const colors = surface.geometry.getAttribute("color");
+
+  it("covers every sector with a contiguous, non-overlapping vertex range", () => {
+    let expectedStart = 0;
+    for (let sector = 0; sector < MAP_TOTAL_SECTORS; sector++) {
+      const start = surface.vertexRanges[sector * 2];
+      const count = surface.vertexRanges[sector * 2 + 1];
+      expect(start).toBe(expectedStart);
+      expect(count).toBeGreaterThan(0);
+      expectedStart += count as number;
+    }
+    expect(expectedStart).toBe(positions.count);
+    expect(colors.count).toBe(positions.count);
+  });
+
+  it("places every vertex on the globe surface", () => {
+    const radius = hexasphere.radius / 3;
+    let worst = 0;
+    for (let i = 0; i < positions.count; i++) {
+      const distance = Math.hypot(
+        positions.getX(i),
+        positions.getY(i),
+        positions.getZ(i),
+      );
+      worst = Math.max(worst, Math.abs(distance - radius));
+    }
+    expect(worst).toBeLessThan(1e-3);
+  });
+
+  it("indexes only vertices belonging to the sector that emitted them", () => {
+    const index = surface.geometry.getIndex();
+    expect(index).not.toBeNull();
+    const owner = new Int32Array(positions.count).fill(-1);
+    for (let sector = 0; sector < MAP_TOTAL_SECTORS; sector++) {
+      const start = surface.vertexRanges[sector * 2] as number;
+      const count = surface.vertexRanges[sector * 2 + 1] as number;
+      owner.fill(sector, start, start + count);
+    }
+    const triangles = (index?.count ?? 0) / 3;
+    let straddling = 0;
+    for (let triangle = 0; triangle < triangles; triangle++) {
+      const a = owner[index?.getX(triangle * 3) ?? 0];
+      const b = owner[index?.getX(triangle * 3 + 1) ?? 0];
+      const c = owner[index?.getX(triangle * 3 + 2) ?? 0];
+      if (a !== b || b !== c) straddling++;
+    }
+    expect(straddling).toBe(0);
+  });
+
+  it("applies an ownership tint to exactly the tinted sector", () => {
+    const tinted = 500;
+    const plain = buildGlobeSurface(hexasphere);
+    const shaded = buildGlobeSurface(hexasphere, (sector) =>
+      sector === tinted ? new Color(0.5, 0.25, 0.125) : null,
+    );
+    const plainColors = plain.geometry.getAttribute("color").array as Float32Array;
+    const shadedColors = shaded.geometry.getAttribute("color").array as Float32Array;
+    const start = (shaded.vertexRanges[tinted * 2] as number) * 3;
+    const count = (shaded.vertexRanges[tinted * 2 + 1] as number) * 3;
+
+    for (let i = 0; i < count; i += 3) {
+      expect(shadedColors[start + i]).toBeCloseTo(
+        (plainColors[start + i] ?? 0) * 0.5,
+        6,
+      );
+      expect(shadedColors[start + i + 1]).toBeCloseTo(
+        (plainColors[start + i + 1] ?? 0) * 0.25,
+        6,
+      );
+    }
+    // Neighbouring sectors keep their terrain colors untouched.
+    const neighbourStart = (shaded.vertexRanges[(tinted + 1) * 2] as number) * 3;
+    expect(shadedColors[neighbourStart]).toBe(plainColors[neighbourStart]);
+  });
+});


### PR DESCRIPTION
Fixes #1449

## The dead spots

Two separate causes, both reproduced locally:

1. **`markerOnlyInteraction={true}`** on the travel map (added in `5c1a4660`, Jul 21) made bare sectors non-clickable — only village labels and pins responded. That is most of the map.
2. **The hover/legend overlays swallowed clicks.** The `<ul>` in the top-right renders `- Highlighting sector N` *while you are hovering*, directly over the globe, and had no `pointer-events-none`. Verified on `main`: `document.elementFromPoint()` over the globe there returns `UL`/`LI`, not the canvas. This one also affected the war-declaration and map-editor globes, which never used marker-only mode.

## What changed

**One pointer gesture for everything.** A single click or tap selects whatever is under it — village label, map pin, or bare terrain — outlines it, and hands it to the existing confirmation modal (which is the "then click to go" step). This replaces the desktop `dblclick` handler *and* the hand-rolled mobile double-tap detector; the drag/pinch guards that already protected label taps now cover every sector, so rotating or pinching never starts travel. Net effect on `Map.tsx` is ~90 fewer lines.

**One mesh for the globe.** Each of the 1,944 sectors was its own `Mesh` + `MeshBasicMaterial` — 1,981 draw calls and 3,914 GPU buffer uploads every scene build. `buildGlobeSurface()` now merges them into a single indexed geometry. Ownership tint is baked into vertex colors; quest/war/focus highlights rewrite only their own vertex slice via `addUpdateRange`.

**Arithmetic picking.** The world is a uniform longitude/latitude grid, so a sector no longer needs to be found by raycasting triangles: `sectorAtGeographic()` is the exact inverse of the generator's `sectorGeographicBounds()`, and `pickGlobeSector()` gets there with one ray-sphere intersection. This is what keeps hover cheap now that bare sectors are interactive again — and it removes the last reason for the tiles to be separate objects.

## Profiling

Chrome DevTools Protocol against `/travel`, real CPU throttling, 591px globe. 6× ≈ mid-range phone, 10× ≈ low-end.

| | before | after |
|---|---|---|
| **6× throttle** — fps | 12.1 | **60.2** |
| fps while picking a sector | 12.0¹ | **57.8** |
| scene build (longest task) | 2448 ms | **477 ms** |
| tab → first globe frame | 4592 ms | **2988 ms** |
| **10× throttle** — fps | 7.3 | **52.9** |
| fps while picking a sector | 7.2¹ | **28.8** |
| scene build (longest task) | 4124 ms | **895 ms** |
| tab → first globe frame | 9573 ms | **5944 ms** |
| **both** — draw calls / frame | 1981 | **38** |
| GPU buffer uploads | 3914 | **29** |
| **1× (desktop)** — fps | 59.9 | 59.9 (already capped) |
| scene build | 302 ms | **104 ms** |

¹ the "before" numbers didn't even include sector picking — marker-only mode skipped that raycast entirely. The "after" numbers pay for it.

## Verification

- **Rendering is pixel-identical.** Screenshot diffs of the globe before/after: 0 differing pixels across the terrain, the ownership layer (village tints, reserved sectors) and the quest/war/focus highlight tints.
- **Interaction, real input events via CDP.** Desktop: hover picks the correct sector everywhere (outline lands under the cursor); clicking bare terrain opens the modal for exactly the hovered sector; dragging does not. Village labels away from their own tile still travel to their village (verified for Horizon/301 and Wake Island/222), and your own sector still refuses with "already in that sector".
- **Mobile, 390×844 viewport with touch events at 6× throttle:** tap on bare terrain → travel modal; drag → nothing; pinch → nothing.
- **Tests:** `app/tests/libs/globe-surface.test.ts` checks `sectorAtGeographic` against all 1,944 sector centres plus 9 interior samples each (17,496 points), the polar-cap rejection and the ±180 seam; and checks the merged surface for contiguous per-sector vertex ranges, on-sphere vertices, no triangle straddling two sectors, and correct tint isolation. Both suites were mutation-checked (an off-by-one in the column maths and a wrong index stride each fail them). Full suite: 1154 pass.

## Also in this PR

**The travel dialog names its destination.** "You are about to move from sector 301 to 222" said nothing about where 222 is; it now reads "from sector 301 (Horizon) to sector 222 (Wake Island)", falling back to the bare number for empty wilderness. Only names what the player can already see marked on the globe, so a hideout is named for its own faction and nobody else.

**A buffer-range leak found while self-reviewing the above.** The render loop keeps running through a lost WebGL context, and the per-frame highlight pulse kept appending `updateRange` entries to a colour buffer that never gets uploaded — three.js only clears them after a successful upload, so the list grew for as long as the context stayed lost. iOS drops the context often enough for that to matter. Now guarded behind the same context check as the draw call.

**Three follow-ups from the AI reviewers**, each reproduced against the running app before and after:

- *The orange "Quest" legend fired on any hover* (Cursor Bugbot, and CodeRabbit independently). It is a legend for the quest markers, like the purple "Target" row below it — but it was gated on `hoverSector !== null`, which only stayed hidden while bare terrain wasn't hoverable. It now follows the markers it explains.
- *The hover pick ran from a pointer nobody placed* (CodeRabbit). An unset `Vector2` is the canvas centre in NDC, so the globe highlighted whatever sat there before anyone pointed at it — and on touch, where `mousemove` never fires, that stale centre reclaimed the outline a tap had just set (measured: `943 → 655` after a rotate). The pick now waits for a real pointer, and a tap does not pretend a finger stayed behind.
- *A stale mouse position outlived a touch tap on hybrid devices* (CodeRabbit). Mouse hovers 505, finger taps 943, rotate → `507`. A non-mouse primary pointer now retires the hover position; the same sequence ends 505 / 943 / **943**.

CodeRabbit also proposed gating the Quest legend on pin creation; that one was withdrawn after checking — a quest sector under a village label gets no pin but still gets the orange tile pulse, so the legend is right to stay.

## Not done: reducing the sector count to 1,000

The issue also asks to cut sectors to ~1,000. That is not a constant change — sector ids are persisted on users, villages, quests, wars, overworld AI placements, authored sector maps, `MAP_RESERVED_SECTORS`, and the 72×27 grid drives wrapping and sector crossing. It needs its own migration with an explicit id remap. The lag it was meant to relieve is addressed here instead, so the 1,944 ids can stay.

Possible follow-up, deliberately left out: `tile.v` in `hexasphere.json` (~141 KB of the 1.77 MB payload) is written by the generator and read by nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core travel/war/map-editor globe interaction and WebGL rendering. Picking and highlight pulsing are rewritten, so wrong sector hits or mobile context-loss bugs would affect gameplay.
> 
> **Overview**
> Makes **every globe sector clickable** with a single tap, and **collapses ~2k per-sector meshes into one draw call** so travel stays usable on phones.
> 
> Travel, war declaration, and map editing no longer require double-click/double-tap. `markerOnlyInteraction` is gone: labels, pins, and bare terrain share one pointer-gesture path (drag/pinch still do not start travel). Overlay legends now use `pointer-events-none` so they stop eating clicks.
> 
> The globe is built as a single indexed `buildGlobeSurface` mesh. Hover/click picking is arithmetic (`sectorAtGeographic` / `pickGlobeSector`) instead of raycasting thousands of tiles. Quest/war/focus pulses rewrite only that sector’s vertex slice, and those buffer updates are skipped while WebGL context is lost.
> 
> The travel confirm dialog now names known destinations (e.g. `sector 222 (Wake Island)`), matching labels already on the globe. Tests cover picking at every sector center plus interior samples, polar-cap rejection, and merged-surface vertex ranges/tints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f973010494aff305c6f9f789112ba39712022d08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Travel confirmations now show descriptive source and destination sector names.
  - Visible villages, your hideout, and the War-Torn Battleground are labeled on travel maps.
  - Map clicks now select sectors and terrain directly, with improved hover and marker interactions.
  - Globe highlights and map overlays provide clearer visual feedback.

- **Bug Fixes**
  - Updated map guidance so selecting sectors and declaring war require a single click instead of a double-click.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

