### PR TITLE
fix(travel): keep the player on the sector map and drop those who left

### DIFF
--- a/app/src/layout/Sector.tsx
+++ b/app/src/layout/Sector.tsx
@@ -2382,6 +2382,7 @@ const Sector: React.FC<SectorProps> = (props) => {
             lastTime: lastTime,
             angle: userAngle,
             minBracket: minBracketDrawRef.current,
+            selfUserId: userRef.current.userId,
           });
           lastTime = Date.now();
           endUsers();

--- a/app/src/libs/threejs/sector.ts
+++ b/app/src/libs/threejs/sector.ts
@@ -1283,12 +1283,24 @@ export const drawUsers = (info: {
   lastTime: number;
   angle: number;
   minBracket: number;
+  /** The viewing player, whose own marker the scouting filter must never hide */
+  selfUserId?: string;
+  /** Overridable so marker tests can run without a browser texture loader */
+  textureForPath?: typeof loadTexture;
 }) => {
+  const textureForPath = info.textureForPath ?? loadTexture;
   const endMark = profiler.mark("drawUsers");
-  // Group the users by their location
+  // Group the users by their location. The scouting bracket filter picks one
+  // exact bracket, so it hides the viewer too unless they are exempted here -
+  // leaving the player with no marker and no way to tell where they stand.
   const groups = groupBy(
     info.users
-      .filter((user) => user.isNpc || passesBracketFilter(user, info.minBracket))
+      .filter(
+        (user) =>
+          user.isNpc ||
+          user.userId === info.selfUserId ||
+          passesBracketFilter(user, info.minBracket),
+      )
       .map((user) => ({
         ...user,
         group: `${user.latitude},${user.longitude}`,
@@ -1330,7 +1342,7 @@ export const drawUsers = (info: {
           }
 
           if (!userMesh) {
-            userMesh = createUserSprite(user, hex);
+            userMesh = createUserSprite(user, hex, textureForPath);
             info.group_users.add(userMesh);
             userMeshCache.set(cacheKey, userMesh);
           }
@@ -1369,7 +1381,13 @@ export const drawUsers = (info: {
             }
 
             if (!userMesh) {
-              userMesh = createCombatSprite(firstUser, secondUser, battleId, hex);
+              userMesh = createCombatSprite(
+                firstUser,
+                secondUser,
+                battleId,
+                hex,
+                textureForPath,
+              );
               info.group_users.add(userMesh);
               userMeshCache.set(battleId, userMesh);
             }

--- a/app/src/server/api/routers/travel.ts
+++ b/app/src/server/api/routers/travel.ts
@@ -533,9 +533,14 @@ export const travelRouter = createTRPCRouter({
         user.latitude = destination.y;
         user.status = "TRAVEL";
         user.travelFinishAt = endTime;
-        // Only broadcast if user is NOT stealthed
+        // Only broadcast if user is NOT stealthed. The sector being left is told
+        // too, the same way a sector crossing already does it, so the departing
+        // player stops being drawn there instead of lingering until the next poll.
         if (!isUserCurrentlyStealthed(user)) {
-          void updateUserOnMap(pusher, user.sector, user);
+          after(() => updateUserOnMap(pusher, input.sector, user));
+          if (departureSector !== input.sector) {
+            after(() => updateUserOnMap(pusher, departureSector, user));
+          }
         }
         return {
           success: true,
@@ -879,9 +884,9 @@ export const travelRouter = createTRPCRouter({
             experience: user.experience,
             rank: user.rank,
           };
-          void updateUserOnMap(pusher, targetSector, broadcast);
+          after(() => updateUserOnMap(pusher, targetSector, broadcast));
           if (targetSector !== sector) {
-            void updateUserOnMap(pusher, sector, broadcast);
+            after(() => updateUserOnMap(pusher, sector, broadcast));
           }
         }
         return { success: true, message: "OK", data: output };
@@ -897,7 +902,7 @@ export const travelRouter = createTRPCRouter({
         }
         // Force an update on the map of the real information (only if not stealthed)
         if (!isUserCurrentlyStealthed(latest)) {
-          void updateUserOnMap(pusher, latest.sector, latest);
+          after(() => updateUserOnMap(pusher, latest.sector, latest));
         }
         // Figure out return message
         if (latest.status !== "AWAKE") {

--- a/app/tests/libs/threejs.drawUsers.test.ts
+++ b/app/tests/libs/threejs.drawUsers.test.ts
@@ -1,0 +1,95 @@
+import { Group, Texture } from "three";
+import { describe, expect, it } from "vitest";
+
+import { drawUsers } from "@/libs/threejs/sector";
+
+/** One flat-topped hex per column/row, enough for findHex and sprite placement. */
+const grid = {
+  getHex: ({ col, row }: { col: number; row: number }) => ({
+    col,
+    row,
+    width: 20,
+    height: 20,
+    center: { x: col * 20, y: row * 20 },
+  }),
+} as never;
+
+/** Returns an unloaded Three.js texture so markers build without a browser. */
+const textureForPath = () => new Texture();
+
+/** Minimal awake player fixture; `experience` decides the user's XP bracket. */
+const player = (patch: Record<string, unknown> = {}) =>
+  ({
+    userId: "other-1",
+    username: "Other",
+    rank: "JONIN",
+    allianceStatus: "NEUTRAL",
+    status: "AWAKE",
+    avatar: "avatar.webp",
+    avatarLight: "avatar-light.webp",
+    longitude: 5,
+    latitude: 5,
+    experience: 0,
+    ...patch,
+  }) as never;
+
+/** Names of the markers drawUsers left visible in the scene group. */
+const visibleMarkers = (group: Group) =>
+  group.children.filter((child) => child.visible).map((child) => child.name);
+
+const draw = (users: unknown[], minBracket: number, selfUserId?: string) => {
+  const group_users = new Group();
+  drawUsers({
+    group_users,
+    users: users as never,
+    grid,
+    lastTime: Date.now(),
+    angle: 0,
+    minBracket,
+    selfUserId,
+    textureForPath,
+  });
+  return group_users;
+};
+
+describe("drawUsers bracket filtering", () => {
+  it("draws everyone while no bracket is selected", () => {
+    const group = draw(
+      [player({ userId: "self" }), player({ userId: "other-1", longitude: 6 })],
+      -1,
+      "self",
+    );
+
+    expect(visibleMarkers(group).sort()).toEqual(["other-1", "self"]);
+  });
+
+  it("keeps the viewer's own marker when their bracket is filtered out", () => {
+    // Bracket 2 starts above 500k XP, so a 0 XP viewer does not match it
+    const group = draw([player({ userId: "self" })], 2, "self");
+
+    expect(visibleMarkers(group)).toEqual(["self"]);
+  });
+
+  it("still hides other players who do not match the selected bracket", () => {
+    const group = draw(
+      [player({ userId: "self" }), player({ userId: "other-1", longitude: 6 })],
+      2,
+      "self",
+    );
+
+    expect(visibleMarkers(group)).toEqual(["self"]);
+  });
+
+  it("draws other players who do match the selected bracket", () => {
+    const group = draw(
+      [
+        player({ userId: "self" }),
+        player({ userId: "other-1", longitude: 6, experience: 600_000 }),
+      ],
+      2,
+      "self",
+    );
+
+    expect(visibleMarkers(group).sort()).toEqual(["other-1", "self"]);
+  });
+});


### PR DESCRIPTION
Fixes #1456.

## What was wrong

**1. The scouting filter empties the whole sector map, including your own marker.**

The scouting menu's slider ("Select bracket to show") persists one *exact* bracket in `minBracketOnScout`, and `drawUsers` applies that same filter to every marker it draws. You are in exactly one bracket, so selecting any other one filters *you* out along with everyone who does not match — the map ends up with no markers at all and no way to tell where you are standing. That is precisely the pair of screenshots in the issue: "Filter selected" is empty, "No Filter" shows one marker.

This is a behaviour change from ac33a596e (`Filter by bracket instead of level`): the old map filter was `user.level >= minLevel`, which the viewer almost always passed. The exact-bracket match does not.

**2. Players who leave by global travel are never removed from the sector they left.**

`startGlobalMove` mutates `user.sector` to the destination *before* broadcasting, so only the destination sector's channel is notified. The sector being left never hears that the player is gone and keeps drawing them until the 10s `getSectorData` poll happens to run — and React Query pauses that poll entirely while the tab is in the background. `moveInSector` already gets this right for sector crossings, announcing to both sides.

**3. The sector-presence broadcasts sit immediately before the response.**

Same case d0447d47d fixed for `finishGlobalMove`: on Vercel the invocation is frozen as soon as the handler resolves, so a voided `updateUserOnMap` promise with nothing left to make progress against is often discarded. That is the "players have to refresh the map to see when a new player joins" half of the report.

## What changed

- `drawUsers` takes `selfUserId` and never filters the viewing player's own marker. Other players are still matched against the selected bracket exactly as before.
- `startGlobalMove` announces the move to the departure sector as well as the destination.
- The four sector-presence broadcasts in `travel.ts` (`startGlobalMove` ×2, `moveInSector` success ×2, `moveInSector` failure) are deferred with `after()` instead of voided, matching `finishGlobalMove` and `staff.ts`.
- `drawUsers` accepts an injectable texture resolver, the way `createUserSprite` and `createCombatSprite` already do, so the new test can build markers under `bun test`.

## Verification

Local dev server, two provisioned users in the same sector, driven from two independent browsers.

**Own marker** — with `minBracketOnScout` set to a bracket nobody in the sector matches:

| | before | after |
|---|---|---|
| markers drawn | none at all | own marker drawn; non-matching players still hidden |

Confirmed in both browsers, including a second client whose own bracket (0) differed from the selected filter (5).

**Departures** — second user sent out of the sector with `travel.startGlobalMove`, watched from a backgrounded tab so the 10s poll never ran (verified: exactly one `getSectorData` request for the life of the page):

| | before | after |
|---|---|---|
| departed player's marker | stayed on the map indefinitely | removed immediately |

`app/tests/libs/threejs.drawUsers.test.ts` covers all four filter cases and fails on 3 of them without the `drawUsers` change. `make test` (1236 pass), `make typecheck` and `make lint` are green.

## Not changed

The exact-bracket semantics of the filter itself are left alone — the UI says "Select bracket to show" and the scouting list already reports "No awake users match your scouting filters (bracket N)", so that part is working as labelled. Only the viewer's exemption from it is new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live sector-presence Pusher broadcasts and map rendering for all players. Logic is small and stealthed users stay unbroadcast, but a bad channel or `after()` timing issue would show stale or missing markers.
> 
> **Overview**
> Keeps the viewing player visible on the sector map when scouting by exact XP bracket, and makes global travel actually remove them from the sector they left.
> 
> `drawUsers` now exempts `selfUserId` from `passesBracketFilter` so selecting another bracket no longer hides your own pin. Other players still match the selected bracket exactly.
> 
> `startGlobalMove` broadcasts to the **departure** sector as well as the destination (matching sector crossings). Presence updates in `startGlobalMove` and `moveInSector` use `after()` instead of fire-and-forget `void`, so they are less likely to be dropped when the handler returns.
> 
> Adds unit coverage for the four bracket-filter cases, with an injectable texture loader so markers can be built under `bun test`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63986065d8c4a6dd17e6c226cb7064c538ebe47e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Your own player marker now remains visible even when bracket filtering is enabled.
  - Player and combat markers display with the correct textures.
  - Map updates during travel now refresh both departure and destination areas reliably.
  - Failed movement recovery now applies map corrections more consistently.

- **Tests**
  - Added coverage for player-marker visibility and bracket filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->