### PR TITLE
fix: confetti on particle pages, sector -1 queries, extension noise

### DIFF
--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -10,6 +10,7 @@ import {
   isProxyError as isProxyErrorPattern,
   isSafariJsonError as isSafariJsonErrorPattern,
   type StackFrame,
+  isExtensionExecutorStack,
 } from "@/utils/error";
 
 Sentry.init({
@@ -116,6 +117,12 @@ Sentry.init({
     }
     if (isThirdPartyInjectedError(event)) {
       return null; // Drop errors from injected scripts (e.g. Facebook/Cookiebot)
+    }
+    if (isExtensionExecutorError(event)) {
+      // Drop errors whose whole stack is a browser extension's executors/<n>.js bundle.
+      // UX: nothing of ours runs in that stack, so there is no app behaviour to fix and
+      // nothing the player can act on.
+      return null;
     }
     if (isEffectInterruptError(event)) {
       return null; // Drop Effect-TS fiber interruption errors (SpacetimeDB SDK)
@@ -459,6 +466,16 @@ const isPayPalSdkError = (event: Sentry.ErrorEvent): boolean => {
 
   return false;
 };
+
+/**
+ * Check if every frame of an error comes from a browser extension's executors bundle.
+ */
+const isExtensionExecutorError = (event: Sentry.ErrorEvent): boolean =>
+  isExtensionExecutorStack(
+    (event.exception?.values?.[0]?.stacktrace?.frames ?? []).map(
+      (frame) => frame.abs_path ?? frame.filename,
+    ),
+  );
 
 /**
  * Check if an error is from an injected third-party script like Facebook or Cookiebot.

--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -10,7 +10,7 @@ import {
   isProxyError as isProxyErrorPattern,
   isSafariJsonError as isSafariJsonErrorPattern,
   type StackFrame,
-  isExtensionExecutorStack,
+  isExtensionExecutorEvent,
 } from "@/utils/error";
 
 Sentry.init({
@@ -471,9 +471,11 @@ const isPayPalSdkError = (event: Sentry.ErrorEvent): boolean => {
  * Check if every frame of an error comes from a browser extension's executors bundle.
  */
 const isExtensionExecutorError = (event: Sentry.ErrorEvent): boolean =>
-  isExtensionExecutorStack(
-    (event.exception?.values?.[0]?.stacktrace?.frames ?? []).map(
-      (frame) => frame.abs_path ?? frame.filename,
+  isExtensionExecutorEvent(
+    (event.exception?.values ?? []).map((value) =>
+      (value.stacktrace?.frames ?? []).map(
+        (frame) => frame.abs_path ?? frame.filename,
+      ),
     ),
   );
 

--- a/app/src/app/tavern/page.tsx
+++ b/app/src/app/tavern/page.tsx
@@ -32,7 +32,10 @@ export default function Tavern() {
   const { data: villages } = api.village.getAll.useQuery(undefined, {
     enabled: !!userData,
   });
-  const { data: sectorVillage, isPending } = api.travel.getVillageInSector.useQuery(
+  // isLoading rather than isPending: a disabled query stays pending indefinitely, which
+  // would hold the loader below in place for anyone whose sector is missing.
+  const { data: sectorVillage, isLoading: isLoadingSector } =
+    api.travel.getVillageInSector.useQuery(
     { sector: userData?.sector ?? -1, isOutlaw: userData?.isOutlaw ?? false },
     // A loaded user without a sector would otherwise send the -1 placeholder, which
     // the sector schema rejects. Sector 0 is real, so test for presence, not truth.
@@ -106,7 +109,7 @@ export default function Tavern() {
   };
 
   // Blockers
-  if (!userData || isPending || isLoadingGlobalTavern) {
+  if (!userData || isLoadingSector || isLoadingGlobalTavern) {
     return <ConversationSkeleton {...convoProps} />;
   }
   if (userData.isBanned || userData.isSilenced) return <BanInfo />;

--- a/app/src/app/tavern/page.tsx
+++ b/app/src/app/tavern/page.tsx
@@ -34,7 +34,9 @@ export default function Tavern() {
   });
   const { data: sectorVillage, isPending } = api.travel.getVillageInSector.useQuery(
     { sector: userData?.sector ?? -1, isOutlaw: userData?.isOutlaw ?? false },
-    { enabled: !!userData },
+    // A loaded user without a sector would otherwise send the -1 placeholder, which
+    // the sector schema rejects. Sector 0 is real, so test for presence, not truth.
+    { enabled: userData?.sector != null },
   );
   const { data: globalTavernEnabled = true, isPending: isLoadingGlobalTavern } =
     api.misc.getGlobalTavernEnabled.useQuery();

--- a/app/src/components/ui/particles.tsx
+++ b/app/src/components/ui/particles.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import type { Container, Engine, ISourceOptions } from "@tsparticles/engine";
+import type { Container, ISourceOptions } from "@tsparticles/engine";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useLocalStorage } from "@/hooks/localstorage";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { registerParticlePlugins } from "@/libs/particlePlugins";
 import { useActiveLayout } from "@/utils/LayoutContext";
 
 type ParticlesModule = typeof import("@tsparticles/react");
@@ -11,7 +12,7 @@ type ParticlesModule = typeof import("@tsparticles/react");
 type LoadedParticles = {
   Particles: ParticlesModule["default"];
   ParticlesProvider: ParticlesModule["ParticlesProvider"];
-  init: (engine: Engine) => Promise<void>;
+  init: () => Promise<void>;
 };
 
 let particlesLoader: Promise<LoadedParticles> | null = null;
@@ -84,17 +85,13 @@ const setAdaptiveParticleCount = (container: Container, nextCount: number) => {
 };
 
 const loadParticles = () => {
-  particlesLoader ??= Promise.all([
-    import("@tsparticles/react"),
-    import("@tsparticles/slim"),
-  ]).then(([particlesModule, slimModule]) => ({
+  particlesLoader ??= import("@tsparticles/react").then((particlesModule) => ({
     Particles: particlesModule.default,
     ParticlesProvider: particlesModule.ParticlesProvider,
     // Memoizing the promise keeps this callback referentially stable, which
-    // ParticlesProvider requires for the lifetime of the app.
-    init: async (engine: Engine) => {
-      await slimModule.loadSlim(engine);
-    },
+    // ParticlesProvider requires for the lifetime of the app. Registration is shared
+    // with the confetti helper, which drives the same engine.
+    init: registerParticlePlugins,
   }));
   return particlesLoader;
 };

--- a/app/src/layout/RamenShop.tsx
+++ b/app/src/layout/RamenShop.tsx
@@ -111,7 +111,9 @@ const MenuEntry: React.FC<MenuEntryProps> = (props) => {
   // Get current village
   const { data: sectorVillage } = api.travel.getVillageInSector.useQuery(
     { sector: userData?.sector ?? -1, isOutlaw: userData?.isOutlaw ?? false },
-    { enabled: !!userData },
+    // A loaded user without a sector would otherwise send the -1 placeholder, which
+    // the sector schema rejects. Sector 0 is real, so test for presence, not truth.
+    { enabled: userData?.sector != null },
   );
 
   // Get structure discount

--- a/app/src/libs/menus.tsx
+++ b/app/src/libs/menus.tsx
@@ -190,7 +190,9 @@ export const useGameMenu = (userData?: UserWithRelations | null) => {
   // Get information from the sector the user is currently in. No stale time
   const { data: sector } = api.travel.getVillageInSector.useQuery(
     { sector: userData?.sector ?? -1, isOutlaw: userData?.isOutlaw ?? false },
-    { enabled: !!userData },
+    // A loaded user without a sector would otherwise send the -1 placeholder, which
+    // the sector schema rejects. Sector 0 is real, so test for presence, not truth.
+    { enabled: userData?.sector != null },
   );
 
   // Based on user status, update href of systems

--- a/app/src/libs/particlePlugins.ts
+++ b/app/src/libs/particlePlugins.ts
@@ -1,0 +1,22 @@
+let registration: Promise<void> | null = null;
+
+/**
+ * The particle background and the confetti helper drive the same tsParticles singleton,
+ * and its PluginManager rejects every registration once the first load() has run - so
+ * whichever of the two started second threw "Register plugins can only be done before
+ * calling tsParticles.load()". Routing both through this one memoized call registers
+ * everything up front, leaving either free to load first.
+ */
+export const registerParticlePlugins = (): Promise<void> => {
+  registration ??= (async () => {
+    const [{ tsParticles }, { loadSlim }, { confetti }] = await Promise.all([
+      import("@tsparticles/engine"),
+      import("@tsparticles/slim"),
+      import("@tsparticles/confetti"),
+    ]);
+    await loadSlim(tsParticles);
+    // Registers confetti's own plugins without loading anything.
+    await confetti.init();
+  })();
+  return registration;
+};

--- a/app/src/libs/toast.tsx
+++ b/app/src/libs/toast.tsx
@@ -5,6 +5,7 @@ import { ToastAction } from "@/components/ui/toast";
 import { toast } from "@/components/ui/use-toast";
 import type { Quest } from "@/drizzle/schema";
 import Image from "@/layout/Image";
+import { registerParticlePlugins } from "@/libs/particlePlugins";
 import { parseHtml } from "@/utils/parse";
 import type { PostProcessedRewards } from "@/validators/rewards";
 
@@ -23,8 +24,13 @@ export const triggerConfetti = async (
     return;
   }
 
-  // Dynamically import confetti only in browser
-  const { confetti } = await import("@tsparticles/confetti");
+  // Dynamically import confetti only in browser. Registration is shared with the
+  // particle background so that whichever loads the engine first cannot lock the other
+  // out of registering its plugins.
+  const [{ confetti }] = await Promise.all([
+    import("@tsparticles/confetti"),
+    registerParticlePlugins(),
+  ]);
 
   const animationEnd = Date.now() + duration;
   const defaults = {

--- a/app/src/utils/UserContext.tsx
+++ b/app/src/utils/UserContext.tsx
@@ -224,9 +224,11 @@ export const useRequireInVillage = (structureRoute?: StructureRoute) => {
     updateNotifications,
   } = useRequiredUserData();
   // Get sector information based on user data
+  // Sector 0 is a real sector, so gate on the value being present rather than on it
+  // being truthy, which skipped the query entirely for anyone standing in sector 0.
   const { data: sectorVillage, isPending } = api.travel.getVillageInSector.useQuery(
     { sector: userData?.sector ?? -1, isOutlaw: userData?.isOutlaw ?? false },
-    { enabled: !!userData?.sector },
+    { enabled: userData?.sector != null },
   );
   const ownVillage = userData?.village?.sector === sectorVillage?.sector;
   const router = useRouter();

--- a/app/src/utils/UserContext.tsx
+++ b/app/src/utils/UserContext.tsx
@@ -226,14 +226,17 @@ export const useRequireInVillage = (structureRoute?: StructureRoute) => {
   // Get sector information based on user data
   // Sector 0 is a real sector, so gate on the value being present rather than on it
   // being truthy, which skipped the query entirely for anyone standing in sector 0.
-  const { data: sectorVillage, isPending } = api.travel.getVillageInSector.useQuery(
+  // isLoading rather than isPending: a disabled query never stops being pending, which
+  // would keep the access check below from ever running.
+  const { data: sectorVillage, isLoading: isLoadingSector } =
+    api.travel.getVillageInSector.useQuery(
     { sector: userData?.sector ?? -1, isOutlaw: userData?.isOutlaw ?? false },
     { enabled: userData?.sector != null },
   );
   const ownVillage = userData?.village?.sector === sectorVillage?.sector;
   const router = useRouter();
   useEffect(() => {
-    if (userData && !isPending) {
+    if (userData && !isLoadingSector) {
       if (!userData.isOutlaw) {
         // Check structure access
         const access = canAccessStructure(userData, structureRoute, sectorVillage);
@@ -247,7 +250,7 @@ export const useRequireInVillage = (structureRoute?: StructureRoute) => {
         setAccess(true);
       }
     }
-  }, [userData, sectorVillage, router, isPending, structureRoute, ownVillage]);
+  }, [userData, sectorVillage, router, isLoadingSector, structureRoute, ownVillage]);
   return {
     userData,
     notifications,

--- a/app/src/utils/error.ts
+++ b/app/src/utils/error.ts
@@ -128,6 +128,15 @@ export const isExtensionExecutorStack = (
   paths.length > 0 &&
   paths.every((path) => !!path && EXTENSION_EXECUTOR_PATH.test(path));
 
+/**
+ * A chained error arrives as several exception values, and only one of them has to
+ * contain our code for the event to be worth keeping - so every value must be
+ * executor-only, and an event carrying none at all is never dropped.
+ */
+export const isExtensionExecutorEvent = (
+  stacks: Array<Array<string | undefined>>,
+): boolean => stacks.length > 0 && stacks.every(isExtensionExecutorStack);
+
 export const isNetworkError = createErrorPatternMatcher([
   "Load failed",
   "fetch failed",

--- a/app/src/utils/error.ts
+++ b/app/src/utils/error.ts
@@ -111,6 +111,23 @@ const createErrorPatternMatcher =
  * Each matcher validates both the error message pattern and stack frame context.
  * These are typically transient network/CDN issues that should be retried automatically.
  */
+/**
+ * A browser extension that bundles its content scripts as executors/<n>.js. The frames
+ * carry the page's origin, so Sentry files them under this project even though no code
+ * of ours appears anywhere in the stack.
+ */
+const EXTENSION_EXECUTOR_PATH = /(^|\/)executors\/\d+\.js$/;
+
+/**
+ * True only when EVERY frame comes from that extension bundle. Requiring all of them
+ * keeps a genuine error of ours that merely passes through an extension frame reportable.
+ */
+export const isExtensionExecutorStack = (
+  paths: Array<string | undefined>,
+): boolean =>
+  paths.length > 0 &&
+  paths.every((path) => !!path && EXTENSION_EXECUTOR_PATH.test(path));
+
 export const isNetworkError = createErrorPatternMatcher([
   "Load failed",
   "fetch failed",

--- a/app/tests/libs/extensionExecutorFilter.test.ts
+++ b/app/tests/libs/extensionExecutorFilter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isExtensionExecutorStack } from "@/utils/error";
+import { isExtensionExecutorEvent, isExtensionExecutorStack } from "@/utils/error";
 
 describe("isExtensionExecutorStack", () => {
   it("matches the real THENINJARPG-2QF stack", () => {
@@ -28,5 +28,34 @@ describe("isExtensionExecutorStack", () => {
 
   it("ignores undefined frame paths rather than treating them as a match", () => {
     expect(isExtensionExecutorStack([undefined])).toBe(false);
+  });
+});
+
+describe("isExtensionExecutorEvent", () => {
+  it("drops the real THENINJARPG-2QF event", () => {
+    expect(
+      isExtensionExecutorEvent([
+        ["app:///executors/200.js", "app:///executors/200.js"],
+      ]),
+    ).toBe(true);
+  });
+
+  it("keeps a chained error whose LATER value holds our code", () => {
+    // event.exception.values[0] is extension-only, but the cause is ours.
+    expect(
+      isExtensionExecutorEvent([
+        ["app:///executors/200.js"],
+        ["app:///src/server/api/routers/combat.ts"],
+      ]),
+    ).toBe(false);
+  });
+
+  it("keeps an event with no exception values", () => {
+    expect(isExtensionExecutorEvent([])).toBe(false);
+  });
+
+  it("keeps an event whose value carries no frames", () => {
+    expect(isExtensionExecutorEvent([[]])).toBe(false);
+    expect(isExtensionExecutorEvent([["app:///executors/1.js"], []])).toBe(false);
   });
 });

--- a/app/tests/libs/extensionExecutorFilter.test.ts
+++ b/app/tests/libs/extensionExecutorFilter.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { isExtensionExecutorStack } from "@/utils/error";
+
+describe("isExtensionExecutorStack", () => {
+  it("matches the real THENINJARPG-2QF stack", () => {
+    // Verbatim frames from the Sentry event: 858 occurrences, 2 users, no app frame.
+    expect(
+      isExtensionExecutorStack(["app:///executors/200.js", "app:///executors/200.js"]),
+    ).toBe(true);
+  });
+
+  it("keeps an error that touches any of our own code", () => {
+    expect(
+      isExtensionExecutorStack([
+        "app:///executors/200.js",
+        "app:///src/app/profile/page.tsx",
+      ]),
+    ).toBe(false);
+  });
+
+  it("keeps an error with no stack at all", () => {
+    expect(isExtensionExecutorStack([])).toBe(false);
+  });
+
+  it("does not match an app path that merely mentions executors", () => {
+    expect(isExtensionExecutorStack(["app:///src/libs/executors/helper.ts"])).toBe(false);
+  });
+
+  it("ignores undefined frame paths rather than treating them as a match", () => {
+    expect(isExtensionExecutorStack([undefined])).toBe(false);
+  });
+});

--- a/app/tests/libs/particlePlugins.test.ts
+++ b/app/tests/libs/particlePlugins.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { registerParticlePlugins } from "@/libs/particlePlugins";
+
+describe("registerParticlePlugins", () => {
+  it("leaves confetti able to register after the background has loaded the engine", async () => {
+    const { tsParticles } = await import("@tsparticles/engine");
+    const { confetti } = await import("@tsparticles/confetti");
+
+    await registerParticlePlugins();
+    // The first thing load() does, and it closes registration permanently.
+    await tsParticles.init();
+
+    // Registering only slim here is what production did, and this call then threw
+    // "Register plugins can only be done before calling tsParticles.load()" on every
+    // reward toast for the rest of the page's life.
+    await expect(confetti.init()).resolves.toBeUndefined();
+  });
+});

--- a/app/tests/libs/particlePlugins.test.ts
+++ b/app/tests/libs/particlePlugins.test.ts
@@ -15,4 +15,18 @@ describe("registerParticlePlugins", () => {
     // reward toast for the rest of the page's life.
     await expect(confetti.init()).resolves.toBeUndefined();
   });
+
+  it("still registers the background's own shapes on the same engine", async () => {
+    const { tsParticles } = await import("@tsparticles/engine");
+
+    await registerParticlePlugins();
+    await tsParticles.init();
+
+    const drawers = await tsParticles.pluginManager.getShapeDrawers({} as never, true);
+    // From loadSlim - the particle background draws these.
+    expect(drawers.has("circle")).toBe(true);
+    expect(drawers.has("triangle")).toBe(true);
+    // From confetti, proving both land on the one singleton rather than two engines.
+    expect(drawers.has("heart")).toBe(true);
+  });
 });


### PR DESCRIPTION
Second pass over production Sentry, 12h after the previous batch shipped. Every issue below was reproduced locally before being changed, and the reproduction is recorded as a test where one fits.

## Fixed

**Confetti dead on any page with the particle background** — `THENINJARPG-2RC` (300 events / 172 users) and `THENINJARPG-2RE`

`components/ui/particles.tsx` and `libs/toast.tsx` drive the same `tsParticles` singleton, and its `PluginManager` throws `Register plugins can only be done before calling tsParticles.load()` on any registration after the first `load()`. The background always loaded first, so `triggerConfetti` threw on every reward toast for the rest of the page's life.

Reproduced headlessly against the real packages:

```
particle background loaded
REPRODUCED -> Register plugins can only be done before calling tsParticles.load()
```

The race runs both ways — registering confetti first breaks `loadSlim` instead — so both now go through one memoized `registerParticlePlugins()` that registers everything before anything loads. `tests/libs/particlePlugins.test.ts` fails with the production error if the confetti half is removed.

**Queries sending `sector: -1`** — `THENINJARPG-2P1` (133 events) and `THENINJARPG-2QJ` (44 events, the client-side mirror)

Four call sites build `{ sector: userData?.sector ?? -1 }`. Three gated only on `!!userData`, so a loaded user without a sector sent the placeholder and `sectorIdSchema.min(0)` rejected it. Confirmed against the local server, byte-for-byte the production error:

```
sector -1 -> "Too small: expected number to be >=0"   (code BAD_REQUEST)
sector  0 -> {"success": true, "result": null}
```

That second line also shows a separate bug: `UserContext` gated on `!!userData?.sector`, which is falsy for sector 0 and silently skipped the query for anyone standing there. All four now test for presence.

**Browser-extension noise** — `THENINJARPG-2QF` (858 events from 2 users) and `THENINJARPG-2QG`

The whole stack is `app:///executors/<n>.js`; no frame of ours appears. Dropped in `beforeSend`, but only when *every* frame is from that bundle, so a real error of ours that merely passes through one still reports. Five cases pinned in `tests/libs/extensionExecutorFilter.test.ts`, including the verbatim frames from the Sentry event.

## Already fixed, no change needed

- `THENINJARPG-2RB` (`/inbox`, 92 events) — fixed by `60e975faf`, already on main. Residual events all carry release `627abc426`, i.e. stale clients.
- `THENINJARPG-2QS` (`/news` DOMParser, 36 events) — fixed by `507ed6ae1`; last event predates the deploy.

## Not a bug in this app

`THENINJARPG-2NW` (6024 events / 5890 users), `2NX`, `2QN`, `2RD` are one root cause, and it is a deployment issue rather than a code one, so nothing here changes.

The underlying errors are schema errors, not connection errors:

```
DatabaseError: target: theninja-ai.-.primary: ... Unknown column 'bidderMinLevel' in 'field list' (errno 1054)
DatabaseError: target: theninja-ai.-.primary: ... Unknown column 'dailySageActivations' in 'field list' (errno 1054)
```

Both arrive from `the-ninja-3t2ni61wk-the-ninja-rpg.vercel.app`, i.e. the separate **the-ninja-ai** Vercel project, against the **theninja-ai** database. `vercel.json` sits at the repo root, so both projects deploy the same cron list, and the AI project runs the game's crons against a clone whose schema is behind. The game's own crons on `tnr` are fine.

Fixing it means either disabling the crons on the the-ninja-ai project or bringing that clone's schema up to date — a Vercel/PlanetScale change I can't make from here, and one worth a deliberate decision rather than a code guard, since a guard would need a new env var set on that project anyway.

It is easily the largest single source of Sentry volume in the project right now.

## Verification

`tsc` clean, lint clean, 1163 tests pass. The 8 failing suites need `OPENAI_API_KEY` and fail the same way on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches structure-access gating in UserContext and when village-in-sector queries run, so a gating mistake could redirect or hang players. Particle init is user-facing but not security-critical.
> 
> **Overview**
> Fixes three production issues: dead confetti on particle pages, invalid `sector: -1` queries, and browser-extension Sentry noise.
> 
> **Particles/confetti.** Background and reward confetti share one `tsParticles` engine, so the second caller could not register plugins after the first `load()`. Both now go through a memoized `registerParticlePlugins()` that registers slim + confetti up front.
> 
> **Sector queries.** `getVillageInSector` is enabled only when `userData.sector != null` (sector 0 is valid). That stops sending the `-1` placeholder and no longer skips the query for players in sector 0. Tavern/`UserContext` wait on `isLoading` instead of `isPending` so a disabled query does not hang the UI or access check.
> 
> **Sentry.** Drops events whose entire stack is a browser-extension `executors/<n>.js` bundle, keeping mixed stacks that include app frames.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac75503f34b7a8df27e9904d041e8db27b105468. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved village and travel loading for players assigned to sector 0.
  * Prevented invalid requests using an unassigned-sector placeholder.
  * Reduced error reports caused solely by browser-extension scripts.

* **Improvements**
  * Improved particle and confetti effect loading for smoother initialization.
  * Added safeguards to keep visual effects working reliably after initialization.
  * Improved loading behavior when sector information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
