### PR TITLE
fix(travel): make overworld NPC bodies clickable in the sector view

### DIFF
--- a/app/src/layout/Sector.tsx
+++ b/app/src/layout/Sector.tsx
@@ -89,6 +89,7 @@ import type { GlobalTile, SectorPoint, SectorUser } from "@/libs/threejs/types";
 import {
   cleanUp,
   disposeGroupPreservingShared,
+  isObjectChainVisible,
   isRendererContextValid,
   pickSpriteAvatar,
   profiler,
@@ -2214,7 +2215,7 @@ const Sector: React.FC<SectorProps> = (props) => {
           group_quest,
         ]);
         intersects
-          .filter((i) => i.object.visible)
+          .filter((i) => isObjectChainVisible(i.object))
           .every((i) => {
             if (i.object.userData.type === "tile") {
               const target = i.object.userData.tile as TerrainHex;
@@ -2247,18 +2248,43 @@ const Sector: React.FC<SectorProps> = (props) => {
                 targetEntry.dy - currentEntry.dy,
               );
               return false;
-            } else if (showUsersRef.current && i.object.userData.type === "talk") {
-              handleNpcTileInteraction(
-                i.object.userData.npcPlacementId as string | undefined,
-              );
-              return false;
-            } else if (showUsersRef.current && i.object.userData.type === "attack") {
+            } else if (
+              showUsersRef.current &&
+              i.object.userData.type === "avatar" &&
+              i.object.userData.npcPlacementId
+            ) {
+              // An NPC's body is a click target like its interaction icon;
+              // without this, the click would fall through the sprite onto
+              // the tile visually behind the NPC and walk the player there.
               if (
                 handleNpcTileInteraction(
                   i.object.userData.npcPlacementId as string | undefined,
                 )
               ) {
                 return false;
+              }
+              return true;
+            } else if (showUsersRef.current && i.object.userData.type === "talk") {
+              if (
+                handleNpcTileInteraction(
+                  i.object.userData.npcPlacementId as string | undefined,
+                )
+              ) {
+                return false;
+              }
+              // Stale sprite (placement despawned): keep the tile clickable
+              return true;
+            } else if (showUsersRef.current && i.object.userData.type === "attack") {
+              const npcPlacementId = i.object.userData.npcPlacementId as
+                | string
+                | undefined;
+              if (npcPlacementId) {
+                if (handleNpcTileInteraction(npcPlacementId)) {
+                  return false;
+                }
+                // Stale NPC sprite: fall through to the tile rather than
+                // re-targeting whatever user shares the template's userId
+                return true;
               }
               const target = usersRef.current?.find(
                 (u) => u.userId === i.object.userData.userId,

--- a/app/src/libs/threejs/sector.ts
+++ b/app/src/libs/threejs/sector.ts
@@ -92,6 +92,7 @@ import { applyWaveShader } from "@/libs/threejs/shaders";
 import type { SectorUser } from "@/libs/threejs/types";
 import {
   createTexture,
+  isObjectChainVisible,
   loadTexture,
   pickSpriteAvatar,
   profiler,
@@ -819,6 +820,12 @@ export const createUserSprite = (
       });
   const sprite = new Sprite(material);
   sprite.userData.type = "avatar";
+  // NPC bodies are click targets in their own right (players are targeted via
+  // their hover icons instead), so carry the placement identity on the sprite.
+  if (userData.isNpc) {
+    sprite.userData.userId = userData.userId;
+    sprite.userData.npcPlacementId = userData.npcPlacementId;
+  }
   const avatarScale = userData.isNpc ? h * 1.3 : h * 0.8;
   Object.assign(sprite.scale, new Vector3(avatarScale, avatarScale, 1));
   Object.assign(sprite.position, new Vector3(w / 2, h * 1.0, USER_LAYER));
@@ -1462,6 +1469,7 @@ export const intersectUsers = (info: {
   const newUserTooltips = new Set<string>();
   const userMesh = intersects.find(
     (i) =>
+      isObjectChainVisible(i.object) &&
       i.object.parent?.userData.type === "user" &&
       i.object.parent?.userData.userId !== userData.userId,
   )?.object.parent;
@@ -1475,6 +1483,13 @@ export const intersectUsers = (info: {
         g.userId !== userData.userId,
     );
     if (userMesh.userData.battleId) {
+      if (document.body.style.cursor !== "wait") {
+        document.body.style.cursor = "pointer";
+        newUserTooltips.add(userMesh.name);
+      }
+    }
+    // NPC bodies are direct click targets, so signal that on hover
+    if (userMesh.userData.isNpc) {
       if (document.body.style.cursor !== "wait") {
         document.body.style.cursor = "pointer";
         newUserTooltips.add(userMesh.name);

--- a/app/src/libs/threejs/util.ts
+++ b/app/src/libs/threejs/util.ts
@@ -703,6 +703,21 @@ export const setRaycasterFromMouse = (
 };
 
 /**
+ * Whether an object and every ancestor up to the scene root are visible.
+ * Raycasts ignore visibility, and despawned sector users are hidden at the
+ * group level (their child sprites keep `visible = true`), so a click hit
+ * must clear the whole chain before it is allowed to consume the click.
+ */
+export const isObjectChainVisible = (object: Object3D): boolean => {
+  let current: Object3D | null = object;
+  while (current) {
+    if (!current.visible) return false;
+    current = current.parent;
+  }
+  return true;
+};
+
+/**
  * Performance profiler for benchmarking code segments.
  * Provides detailed timing, frame budget analysis, and renderer stats.
  * Only active in development mode.

--- a/app/tests/libs/threejs.objectVisibility.test.ts
+++ b/app/tests/libs/threejs.objectVisibility.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { Group, Sprite } from "three";
+
+import { isObjectChainVisible } from "@/libs/threejs/util";
+
+/** Builds a scene-like chain: root -> group -> sprite, returning all three. */
+const buildChain = () => {
+  const root = new Group();
+  const group = new Group();
+  const sprite = new Sprite();
+  group.add(sprite);
+  root.add(group);
+  return { root, group, sprite };
+};
+
+describe("isObjectChainVisible", () => {
+  it("accepts an object whose whole ancestor chain is visible", () => {
+    const { sprite } = buildChain();
+    expect(isObjectChainVisible(sprite)).toBe(true);
+  });
+
+  it("rejects an object that is itself hidden", () => {
+    const { sprite } = buildChain();
+    sprite.visible = false;
+    expect(isObjectChainVisible(sprite)).toBe(false);
+  });
+
+  it("rejects a visible sprite inside a hidden group, as left by despawned users", () => {
+    const { group, sprite } = buildChain();
+    // drawUsers hides stale user groups at the group level only
+    group.visible = false;
+    expect(sprite.visible).toBe(true);
+    expect(isObjectChainVisible(sprite)).toBe(false);
+  });
+
+  it("rejects any hidden ancestor higher up the chain", () => {
+    const { root, sprite } = buildChain();
+    root.visible = false;
+    expect(isObjectChainVisible(sprite)).toBe(false);
+  });
+});

--- a/app/tests/libs/threejs.userSprite.test.ts
+++ b/app/tests/libs/threejs.userSprite.test.ts
@@ -77,6 +77,17 @@ describe("createUserSprite compatibility", () => {
       npcPlacementId: "placement-1",
       npcPositionVersion: 4,
     });
+    // The body doubles as a click target, so it must identify its placement
+    expect(group.children[0]?.userData).toMatchObject({
+      userId: "ai-template",
+      npcPlacementId: "placement-1",
+    });
+  });
+
+  it("keeps player avatar sprites free of placement identity", () => {
+    const group = createUserSprite(user(), hex, textureForPath);
+    const avatar = group.children.find((child) => child.userData.type === "avatar");
+    expect(avatar?.userData.npcPlacementId).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Fixes #1463

## Problem

When an overworld AI stands in a sector, there are times when the player can't click the sector tiles around it or click the AI itself to start the quest objective.

Reproduced locally with a hostile placement ("Sad Puppy") on the sector map. Instrumenting the sector click handler showed the raycast hits for a click on the AI's body:

```
hits: [
  { t: "avatar", name: "i1463-repro-placement" },   ← unhandled type, click falls through
  { t: "tile",   tile: { c: 12, r: 8 } }            ← tile visually BEHIND the NPC
]
```

Three holes combined into the reported behaviour:

1. **NPC avatar sprites were not click targets.** Only the small floating talk/attack icon (~0.8 hex) was handled. A click on the NPC's body fell through the sprite quad onto the tile visually behind it — walking the player somewhere else instead of engaging the NPC — or did nothing at all when that tile was blocked (trees/buildings, which NPCs often stand in front of).
2. **Ghost sprites of despawned users swallowed clicks.** `drawUsers` hides stale user groups at the *group* level, but the click filter only checked the leaf sprite's `visible` flag, and raycasts ignore visibility entirely. A despawned AI left an invisible attack icon that kept consuming clicks over its area — "can't click on the sector".
3. **Stale icon clicks mis-targeted.** A stale NPC attack icon fell back to a lookup by the AI template's `userId`, which can match a *different* placement of the same template, walking the player to the wrong NPC; stale talk icons swallowed the click silently.

## Fix

- `createUserSprite`: NPC avatar sprites now carry their `npcPlacementId`/`userId`, and the sector click handler treats them exactly like the interaction icon — route toward the NPC, or interact when already standing on its tile.
- New `isObjectChainVisible` helper: click hits (and the hover pass in `intersectUsers`) must clear the whole ancestor visibility chain, so hidden ghost groups no longer consume clicks or hover.
- Stale talk/attack icon clicks now fall through to the tile underneath instead of swallowing the click or re-targeting by template `userId`.
- Hovering an NPC body shows a pointer cursor, matching its new clickability.

## Verification

Manually verified on a local dev server against the dev DB with a hostile placement:

- Clicking the AI's body from a distance now routes the player onto the NPC's tile and pops the arrival prompt ("Attack Sad Puppy?" with Attack/Leave) — previously the player walked to the tile behind the sprite and no prompt appeared.
- Clicking the AI's body while standing on its tile starts the interaction directly ("Battle started", redirect to /combat).
- Plain tile clicks, structure cards and pathing highlights behave as before.

## Tests

- `threejs.objectVisibility.test.ts`: pins `isObjectChainVisible`, including the visible-sprite-inside-hidden-group ghost case.
- `threejs.userSprite.test.ts`: pins that NPC avatar sprites carry placement identity and player avatar sprites do not.

`make test` (1260 pass), `make typecheck`, and biome on the touched files are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sector click routing for NPCs and PvP attack icons. A bug here could mis-route movement or start the wrong interaction, but the change is localized and covered by tests.
> 
> **Overview**
> Clicks on overworld NPCs in the sector map now hit the character sprite, not the tile behind it, so players can route to or interact with an AI by clicking its body.
> 
> NPC avatars carry `npcPlacementId` and are handled like talk/attack icons. Raycast hits must pass `isObjectChainVisible`, so hidden (despawned) user groups no longer swallow clicks. Stale talk/attack sprites fall through to the tile instead of no-oping or retargeting another placement that shares the template `userId`. Hovering an NPC body shows a pointer cursor.
> 
> Adds unit tests for ancestor visibility and NPC vs player avatar `userData`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 313e92c7b60e8526ed29d0e9b172974a6c08ccad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved click and hover behavior for hidden objects and nested scenes.
  * NPC avatar clicks now open NPC interactions instead of selecting the underlying tile.
  * Stale NPC interaction visuals no longer block normal tile or player interactions.
  * NPC hover states now show the correct interaction tooltip and pointer cursor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->