### PR TITLE
Fix AI-moderation calls broken by the AI SDK 7 bump

### DIFF
--- a/app/src/libs/moderator.ts
+++ b/app/src/libs/moderator.ts
@@ -460,19 +460,16 @@ export const classifyNsfwPrompt = async (
     reason: z.string(),
   });
 
+  // AI SDK 7 rejects system-role entries inside `messages`; system prompts
+  // must be passed via the top-level `system` option.
   const { object } = await generateObject({
     model: openaiSdk(OPENAI_MODERATION_MODEL),
     schema: classificationSchema,
-    messages: [
-      {
-        role: "system",
-        content: `You are a content classifier for an anime-style RPG game's AI art generator.
+    system: `You are a content classifier for an anime-style RPG game's AI art generator.
 Analyze the user-provided prompt and determine if it is attempting to generate NSFW content.
 NSFW includes: sexual content, nudity, explicit violence/gore, content sexualizing minors, explicit drug use, hate symbols.
 Allowed: action/combat scenes, anime-style characters in appropriate clothing, fantasy violence (ninja RPG), dramatic scenes.`,
-      },
-      { role: "user", content: prompt },
-    ],
+    prompt,
   });
   return object as z.infer<typeof classificationSchema>;
 };
@@ -519,10 +516,7 @@ export const validateUserUpdateReason = async (
   const { object } = await generateObject({
     model: openaiSdk(OPENAI_MODERATION_MODEL),
     schema: validationSchema,
-    messages: [
-      {
-        role: "system",
-        content: `You validate reasons supplied by content members for game content updates.
+    system: `You validate reasons supplied by content members for game content updates.
 Determine if the reason is descriptive and if the update should be allowed.
 Content members are tasked with testing things, helping users, etc, and thus the reason serves mostly as transparency for end users.
 You are not to judge the validity of the update, only verify that the reason is clear.
@@ -531,12 +525,7 @@ You are not to judge the validity of the update, only verify that the reason is 
 - Ignore spelling errors, this is not important to the moderation process.
 - If the reason is not valid, please provide a comment explaining why the update should not be allowed.
 - The reason does not have to include details about the update, the previous state, or new state.`,
-      },
-      {
-        role: "user",
-        content: `Reason: ${reason}\n\nUpdate: ${update}`,
-      },
-    ],
+    prompt: `Reason: ${reason}\n\nUpdate: ${update}`,
   });
   return object as z.infer<typeof validationSchema>;
 };

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -2262,11 +2262,18 @@ export const computeUserContentChanges = async (props: {
   oldItemIds: string[];
   newItemIds: string[];
 }) => {
-  const { client, oldJutsuIds, newJutsuIds, oldItemIds, newItemIds } = props;
+  const { client } = props;
+
+  // The diff is positional (deep-object-diff walks array indices), so compare
+  // and render in a canonical order — without mutating the caller's arrays.
+  const oldJutsuIds = props.oldJutsuIds.slice().sort();
+  const newJutsuIds = props.newJutsuIds.slice().sort();
+  const oldItemIds = props.oldItemIds.slice().sort();
+  const newItemIds = props.newItemIds.slice().sort();
 
   const changed =
-    oldJutsuIds.slice().sort().join(",") !== newJutsuIds.slice().sort().join(",") ||
-    oldItemIds.slice().sort().join(",") !== newItemIds.slice().sort().join(",");
+    oldJutsuIds.join(",") !== newJutsuIds.join(",") ||
+    oldItemIds.join(",") !== newItemIds.join(",");
 
   // difference arrays
   let jutsuChanges: string[] = [];

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -1240,10 +1240,11 @@ export const profileRouter = createTRPCRouter({
         if (target.clanId) return errorResponse(`Leave ${clanName} first`);
         if (target.status !== "AWAKE") return errorResponse("AWAKE to change village");
       }
-      // Update jutsus & items
-      const { jutsuChanges, itemChanges } = await updateUserContent({
+      // Compute jutsu & item changes (read-only; the writes run after the AI
+      // check below — PlanetScale has no transactions, so a rejected reason
+      // must not leave partially applied jutsu/item rows behind)
+      const contentChanges = await computeUserContentChanges({
         client: ctx.drizzle,
-        userId: target.userId,
         oldJutsuIds,
         newJutsuIds,
         oldItemIds,
@@ -1258,8 +1259,8 @@ export const profileRouter = createTRPCRouter({
         ),
         input.data,
       )
-        .concat(jutsuChanges)
-        .concat(itemChanges);
+        .concat(contentChanges.jutsuChanges)
+        .concat(contentChanges.itemChanges);
       // AI moderation of reason
       const aiCheck = await validateUserUpdateReason(
         diff.join(". "),
@@ -1280,6 +1281,14 @@ export const profileRouter = createTRPCRouter({
 
       // Update database
       await Promise.all([
+        applyUserContentChanges({
+          client: ctx.drizzle,
+          userId: target.userId,
+          deletedJutsuIds: contentChanges.deletedJutsuIds,
+          deletedItemIds: contentChanges.deletedItemIds,
+          insertedJutsuIds: contentChanges.insertedJutsuIds,
+          insertedItemIds: contentChanges.insertedItemIds,
+        }),
         ctx.drizzle
           .update(userData)
           .set({
@@ -2241,27 +2250,30 @@ export const fetchUser = async (client: DrizzleClient, userId: string) => {
   return user;
 };
 
-export const updateUserContent = async (props: {
+/**
+ * Compute human-readable jutsu/item diffs and the id sets to delete/insert.
+ * Read-only, so callers can run moderation or other guards on the diff before
+ * committing anything (PlanetScale has no transactions to roll back with).
+ */
+export const computeUserContentChanges = async (props: {
   client: DrizzleClient;
-  userId: string;
   oldJutsuIds: string[];
   newJutsuIds: string[];
   oldItemIds: string[];
   newItemIds: string[];
 }) => {
-  // Destructure
-  const { client, userId, oldJutsuIds, newJutsuIds, oldItemIds, newItemIds } = props;
+  const { client, oldJutsuIds, newJutsuIds, oldItemIds, newItemIds } = props;
 
-  // Store any new jutsus
-  const newJ = oldJutsuIds.sort().join(",") !== newJutsuIds.sort().join(",");
-  const newI = oldItemIds.sort().join(",") !== newItemIds.sort().join(",");
+  const changed =
+    oldJutsuIds.slice().sort().join(",") !== newJutsuIds.slice().sort().join(",") ||
+    oldItemIds.slice().sort().join(",") !== newItemIds.slice().sort().join(",");
 
   // difference arrays
   let jutsuChanges: string[] = [];
   let itemChanges: string[] = [];
 
-  // If jutsus are different, then update with jutsu names for diff calculation only
-  if (newJ || newI) {
+  // Resolve names for the diff shown to users & the action log
+  if (changed) {
     const [jutsuData, itemData] = await Promise.all([
       client.query.jutsu.findMany({
         where: inArray(jutsu.id, oldJutsuIds.concat(newJutsuIds).concat(["non-empty"])),
@@ -2280,66 +2292,115 @@ export const updateUserContent = async (props: {
       { items: oldItemIds.map((id) => itemData.find((j) => j.id === id)?.name) },
       { items: newItemIds.map((id) => itemData.find((j) => j.id === id)?.name) },
     );
-
-    // Updated content
-    const deletedJ = oldJutsuIds.filter((id) => !newJutsuIds.includes(id));
-    const deletedI = oldItemIds.filter((id) => !newItemIds.includes(id));
-    const insertedJ = newJutsuIds.filter((id) => !oldJutsuIds.includes(id));
-    const insertedI = newItemIds.filter((id) => !oldItemIds.includes(id));
-
-    // Run updates
-    await Promise.all([
-      ...(deletedJ.length > 0
-        ? [
-            client
-              .delete(userJutsu)
-              .where(
-                and(eq(userJutsu.userId, userId), inArray(userJutsu.jutsuId, deletedJ)),
-              ),
-          ]
-        : []),
-      ...(deletedI.length > 0
-        ? [
-            client
-              .delete(userItem)
-              .where(
-                and(eq(userItem.userId, userId), inArray(userItem.itemId, deletedI)),
-              ),
-          ]
-        : []),
-      // Use onDuplicateKeyUpdate to handle race conditions
-      ...(insertedJ.length > 0
-        ? [
-            client
-              .insert(userJutsu)
-              .values(
-                insertedJ.map((jutsuId) => ({
-                  id: nanoid(),
-                  userId: userId,
-                  jutsuId: jutsuId,
-                  level: 1,
-                  equipped: true,
-                })),
-              )
-              .onDuplicateKeyUpdate({ set: { id: sql`id` } }),
-          ]
-        : []),
-      ...(insertedI.length > 0
-        ? [
-            client.insert(userItem).values(
-              insertedI.map((itemId) => ({
-                id: nanoid(),
-                userId: userId,
-                itemId: itemId,
-                equipped: "CHEST" as const,
-              })),
-            ),
-          ]
-        : []),
-    ]);
   }
 
-  return { jutsuChanges, itemChanges };
+  return {
+    jutsuChanges,
+    itemChanges,
+    deletedJutsuIds: changed
+      ? oldJutsuIds.filter((id) => !newJutsuIds.includes(id))
+      : [],
+    deletedItemIds: changed ? oldItemIds.filter((id) => !newItemIds.includes(id)) : [],
+    insertedJutsuIds: changed
+      ? newJutsuIds.filter((id) => !oldJutsuIds.includes(id))
+      : [],
+    insertedItemIds: changed ? newItemIds.filter((id) => !oldItemIds.includes(id)) : [],
+  };
+};
+
+/** Apply the delete/insert sets produced by computeUserContentChanges. */
+export const applyUserContentChanges = async (props: {
+  client: DrizzleClient;
+  userId: string;
+  deletedJutsuIds: string[];
+  deletedItemIds: string[];
+  insertedJutsuIds: string[];
+  insertedItemIds: string[];
+}) => {
+  const {
+    client,
+    userId,
+    deletedJutsuIds,
+    deletedItemIds,
+    insertedJutsuIds,
+    insertedItemIds,
+  } = props;
+  await Promise.all([
+    ...(deletedJutsuIds.length > 0
+      ? [
+          client
+            .delete(userJutsu)
+            .where(
+              and(
+                eq(userJutsu.userId, userId),
+                inArray(userJutsu.jutsuId, deletedJutsuIds),
+              ),
+            ),
+        ]
+      : []),
+    ...(deletedItemIds.length > 0
+      ? [
+          client
+            .delete(userItem)
+            .where(
+              and(
+                eq(userItem.userId, userId),
+                inArray(userItem.itemId, deletedItemIds),
+              ),
+            ),
+        ]
+      : []),
+    // Use onDuplicateKeyUpdate to handle race conditions
+    ...(insertedJutsuIds.length > 0
+      ? [
+          client
+            .insert(userJutsu)
+            .values(
+              insertedJutsuIds.map((jutsuId) => ({
+                id: nanoid(),
+                userId: userId,
+                jutsuId: jutsuId,
+                level: 1,
+                equipped: true,
+              })),
+            )
+            .onDuplicateKeyUpdate({ set: { id: sql`id` } }),
+        ]
+      : []),
+    ...(insertedItemIds.length > 0
+      ? [
+          client.insert(userItem).values(
+            insertedItemIds.map((itemId) => ({
+              id: nanoid(),
+              userId: userId,
+              itemId: itemId,
+              equipped: "CHEST" as const,
+            })),
+          ),
+        ]
+      : []),
+  ]);
+};
+
+export const updateUserContent = async (props: {
+  client: DrizzleClient;
+  userId: string;
+  oldJutsuIds: string[];
+  newJutsuIds: string[];
+  oldItemIds: string[];
+  newItemIds: string[];
+}) => {
+  const { client, userId, ...idSets } = props;
+  const changes = await computeUserContentChanges({ client, ...idSets });
+  await applyUserContentChanges({
+    client,
+    userId,
+    deletedJutsuIds: changes.deletedJutsuIds,
+    deletedItemIds: changes.deletedItemIds,
+    insertedJutsuIds: changes.insertedJutsuIds,
+    insertedItemIds: changes.insertedItemIds,
+  });
+  return { jutsuChanges: changes.jutsuChanges, itemChanges: changes.itemChanges };
 };
 
 /**
@@ -2835,7 +2896,10 @@ const persistPassiveRegenToDb = async ({
     userForRegenPersist,
   );
 
-  await client.update(userData).set(derivedUserUpdate).where(eq(userData.userId, userId));
+  await client
+    .update(userData)
+    .set(derivedUserUpdate)
+    .where(eq(userData.userId, userId));
 };
 
 export const fetchPublicUsers = async (info: {


### PR DESCRIPTION
## Summary
- The AI SDK 7 bump (823d8fc4f, Aug 22) broke every `generateObject` call that put a `role: "system"` entry inside `messages` — the SDK now throws **"System messages are not allowed in the prompt or messages fields. Use the instructions option instead."** client-side, before any API request. `profile.updateUser` (AI reason validation) and `classifyNsfwPrompt` (AI art NSFW gate) have been failing deterministically in every environment since then. Surfaced by TNR issue-repro run [32718009395](https://github.com/studie-tech/TheNinjaRPG/actions/runs/32718009395) on #1290.
- Both call sites now pass the system text via the top-level `system` option with the user content as `prompt` (behavior otherwise identical).
- `updateUser` used to write jutsu/item rows **before** the AI reason check, so the thrown error left partial writes behind (no transactions on PlanetScale). `updateUserContent` is split into read-only `computeUserContentChanges` + `applyUserContentChanges`; `updateUser` now computes the diff, runs the AI check, and only then applies the content changes alongside the `userData` update. `updateAi` keeps the combined helper — its behavior is unchanged.

## Verification
- Reproduced old-vs-new against the real SDK: the old shape throws the exact error client-side (no HTTP involved); the new shape passes `standardizePrompt` and produces a well-formed Responses API request (system text in `input`, `json_schema` output format).
- `make typecheck` (with tsbuildinfo cleared), `make lint`, and `make test` (1255 pass) are all green.

## Test plan
- [ ] As a content member on a preview, run an AI/user update via the manual editor with a reason — expect the update to succeed and the diff to appear in the action log.
- [ ] Submit a junk reason (e.g. "asdf") — expect a clean AI rejection with **no** jutsu/item rows applied.
- [ ] Trigger the AI avatar generator with a normal prompt — expect NSFW classification to run instead of erroring.

Note: `ChatBox`'s system `UIMessage` flowing into the `/api/chat/*` routes looks affected by the same SDK change; left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches staff profile updates and NSFW prompt classification. Content writes now happen after AI moderation, which is the intended safety fix but still changes a privileged mutation path.
> 
> **Overview**
> Restores `generateObject` calls that have been failing since the AI SDK 7 bump by moving system text to the top-level `system` option (and user text to `prompt`) in `classifyNsfwPrompt` and `validateUserUpdateReason`.
> 
> Staff `updateUser` no longer writes jutsu/item rows before the AI reason check. `updateUserContent` is split into read-only `computeUserContentChanges` and `applyUserContentChanges`, so a rejected reason cannot leave partial inventory changes (PlanetScale has no transactions). `updateAi` still uses the combined helper. Diff arrays are now sorted on copies so callers’ id lists are not mutated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9a67c16eda8cecb55492c95c934986ab3c2c094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Profile content changes are now reviewed before being saved.
  - Unapproved jutsu and item updates are no longer applied to profiles.
  - Approved updates are applied only after moderation succeeds.
  - Improved moderation request handling provides more reliable content validation.
  - Profile updates now preserve existing content accurately while changes are being reviewed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->