### PR TITLE
Fix AI chat assistants broken by the AI SDK 7 bump

### DIFF
--- a/.agents/skills/tnr-dev-server/SKILL.md
+++ b/.agents/skills/tnr-dev-server/SKILL.md
@@ -54,6 +54,10 @@ TOKEN=$(grep '^AI_TEST_USER_BROKER_TOKEN=' "$(realpath app/.env)" | cut -d= -f2-
 : "${TOKEN:?set AI_TEST_USER_BROKER_TOKEN in the real app/.env}"
 ```
 
+This quote-stripping applies to EVERY value read out of `app/.env`, not just this one — several
+keys (e.g. `OPENAI_API_KEY`) are stored single-quoted. A key extracted with quotes attached
+authenticates as garbage and produces misleading 401s ("the key is dead") when the key is fine.
+
 ## 3. Provision test users
 
 Creates real users in the shared dev database, visible to every worktree's server at once.
@@ -99,6 +103,45 @@ curl -s -X POST "http://127.0.0.1:$PORT/api/ai-test-user/call-endpoint" \
 
 Open `http://127.0.0.1:$PORT/login?__clerk_ticket=<signInToken>`. Clerk consumes the ticket and the
 session is signed in as that user. Single-use — provision a fresh user for another login.
+
+**Automated browsers can stall here.** Under both the in-app browser pane and the Chrome
+extension, clerk-js has been seen loading its script but sitting at `Clerk.status === "loading"`
+forever, never calling its Frontend API — so the ticket is never consumed and the login page stays
+blank. If that happens, skip the browser entirely and use the headless flow below; don't burn
+tickets on reloads (each is single-use, ~300 s).
+
+## 5b. Headless auth for plain API routes (non-tRPC)
+
+The call-endpoint broker only reaches tRPC procedures. Next.js API routes that call Clerk's
+`auth()` directly (`/api/chat/*`, etc.) need a real Clerk session — which can be minted without a
+browser by doing what clerk-js does internally against the dev instance's Frontend API
+(`https://talented-kit-66.clerk.accounts.dev`):
+
+```js
+const FAPI = "https://talented-kit-66.clerk.accounts.dev";
+// 1. dev-browser token (dev instances only)
+const { token: dbJwt } = await (await fetch(`${FAPI}/v1/dev_browser`, { method: "POST" })).json();
+// 2. consume the broker's signInToken as a ticket sign-in
+const signIn = await (await fetch(`${FAPI}/v1/client/sign_ins?__clerk_db_jwt=${dbJwt}`, {
+  method: "POST",
+  headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  body: new URLSearchParams({ strategy: "ticket", ticket: signInToken }),
+})).json();
+const sessionId = signIn.client.last_active_session_id;
+// 3. mint a session JWT (~60 s validity — mint right before each burst of calls)
+const { jwt } = await (await fetch(`${FAPI}/v1/client/sessions/${sessionId}/tokens?__clerk_db_jwt=${dbJwt}`, {
+  method: "POST",
+})).json();
+// 4. the Next server accepts it as a Bearer token
+await fetch(`http://127.0.0.1:${PORT}/api/chat/support`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json", Authorization: `Bearer ${jwt}` },
+  body: JSON.stringify({ messages: [...] }),
+});
+```
+
+Chat routes expect the `useChat` wire shape: `{ messages: [{ id, role, parts: [{ type: "text",
+text }] }] }` — UIMessages with `parts`, not ModelMessages with `content`.
 
 ## 6. Cleanup
 

--- a/app/src/app/api/chat/badge/route.ts
+++ b/app/src/app/api/chat/badge/route.ts
@@ -1,8 +1,8 @@
 import { openai } from "@ai-sdk/openai";
-import type { ModelMessage } from "ai";
+import type { UIMessage } from "ai";
 import { stepCountIs, streamText } from "ai";
 import { OPENAI_CONTENT_MODEL } from "@/drizzle/constants";
-import { checkContentAiAuth } from "@/libs/llm";
+import { checkContentAiAuth, prepareChatPrompt } from "@/libs/llm";
 import { convertToOpenaiCompatibleSchema } from "@/libs/zod_utils";
 import { BadgeValidator } from "@/validators/badge";
 
@@ -11,16 +11,20 @@ export async function POST(req: Request) {
   await checkContentAiAuth();
 
   // Call LLM
-  const { messages } = (await req.json()) as { messages: ModelMessage[] };
+  const { messages: uiMessages } = (await req.json()) as { messages: UIMessage[] };
   const schema = convertToOpenaiCompatibleSchema(BadgeValidator.omit({ image: true }));
-  const result = streamText({
-    model: openai(OPENAI_CONTENT_MODEL),
-    system: `You are a helpful assistant tasked with creating new badges set in the ninja world of Seichi.
+  const { system, messages } = await prepareChatPrompt(
+    uiMessages,
+    `You are a helpful assistant tasked with creating new badges set in the ninja world of Seichi.
     Your primary task is to call the function 'updateBadge' with appropriate parameters to update the badge shown to the user.
     Do not give detailed instructions to the user on what badge is created, instead just give a brief summary and start creating it.
     Do not use markdown.
     Do not ask the user for clarifying questions; if details are left out, simply fill in best guesses for the badge.
     Only update the badge if the user asks you to do so or asks you to create a new badge.`,
+  );
+  const result = streamText({
+    model: openai(OPENAI_CONTENT_MODEL),
+    system,
     messages,
     tools: {
       updateBadge: {

--- a/app/src/app/api/chat/bloodline/route.ts
+++ b/app/src/app/api/chat/bloodline/route.ts
@@ -1,8 +1,8 @@
 import { openai } from "@ai-sdk/openai";
-import type { ModelMessage } from "ai";
+import type { UIMessage } from "ai";
 import { stepCountIs, streamText } from "ai";
 import { OPENAI_CONTENT_MODEL } from "@/drizzle/constants";
-import { checkContentAiAuth } from "@/libs/llm";
+import { checkContentAiAuth, prepareChatPrompt } from "@/libs/llm";
 import { convertToOpenaiCompatibleSchema } from "@/libs/zod_utils";
 import { BloodlineValidator } from "@/validators/combat";
 
@@ -11,18 +11,22 @@ export async function POST(req: Request) {
   await checkContentAiAuth();
 
   // Call LLM
-  const { messages } = (await req.json()) as { messages: ModelMessage[] };
+  const { messages: uiMessages } = (await req.json()) as { messages: UIMessage[] };
   const schema = convertToOpenaiCompatibleSchema(
     BloodlineValidator.omit({ effects: true, villageId: true }),
   );
-  const result = streamText({
-    model: openai(OPENAI_CONTENT_MODEL),
-    system: `You are a helpful assistant tasked with creating new bloodlines set in the ninja world of Seichi.
+  const { system, messages } = await prepareChatPrompt(
+    uiMessages,
+    `You are a helpful assistant tasked with creating new bloodlines set in the ninja world of Seichi.
     Your primary task is to call the function 'updateBloodline' with appropriate parameters to update the bloodline shown to the user.
     Do not give detailed instructions to the user on what bloodline is created, instead just give a brief summary and start creating it.
     Do not use markdown.
     Do not ask the user for clarifying questions; if details are left out, simply fill in best guesses for the bloodline.
     Only update the bloodline if the user asks you to do so or asks you to create a new bloodline.`,
+  );
+  const result = streamText({
+    model: openai(OPENAI_CONTENT_MODEL),
+    system,
     messages,
     tools: {
       updateBloodline: {

--- a/app/src/app/api/chat/item/route.ts
+++ b/app/src/app/api/chat/item/route.ts
@@ -1,8 +1,8 @@
 import { openai } from "@ai-sdk/openai";
-import type { ModelMessage } from "ai";
+import type { UIMessage } from "ai";
 import { stepCountIs, streamText } from "ai";
 import { OPENAI_CONTENT_MODEL } from "@/drizzle/constants";
-import { checkContentAiAuth } from "@/libs/llm";
+import { checkContentAiAuth, prepareChatPrompt } from "@/libs/llm";
 import { convertToOpenaiCompatibleSchema } from "@/libs/zod_utils";
 import { ItemValidatorRawSchema } from "@/validators/combat";
 
@@ -10,18 +10,22 @@ export async function POST(req: Request) {
   // Auth guard
   await checkContentAiAuth();
   // Call LLM
-  const { messages } = (await req.json()) as { messages: ModelMessage[] };
+  const { messages: uiMessages } = (await req.json()) as { messages: UIMessage[] };
   const schema = convertToOpenaiCompatibleSchema(
     ItemValidatorRawSchema.omit({ effects: true }),
   );
-  const result = streamText({
-    model: openai(OPENAI_CONTENT_MODEL),
-    system: `You are a helpful assistant tasked with creating new items set in the ninja world of Seichi.
+  const { system, messages } = await prepareChatPrompt(
+    uiMessages,
+    `You are a helpful assistant tasked with creating new items set in the ninja world of Seichi.
     Your primary task is to call the function 'updateItem' with appropriate parameters to update the item shown to the user.
     Do not give detailed instructions to the user on what item is created, instead just give a brief summary and start creating it.
     Do not use markdown.
     Do not ask the user for clarifying questions; if details are left out, simply fill in best guesses for the item.
     Only update the item if the user asks you to do so or asks you to create a new item.`,
+  );
+  const result = streamText({
+    model: openai(OPENAI_CONTENT_MODEL),
+    system,
     messages,
     tools: {
       updateItem: {

--- a/app/src/app/api/chat/jutsu/route.ts
+++ b/app/src/app/api/chat/jutsu/route.ts
@@ -1,8 +1,8 @@
 import { openai } from "@ai-sdk/openai";
-import type { ModelMessage } from "ai";
+import type { UIMessage } from "ai";
 import { stepCountIs, streamText } from "ai";
 import { OPENAI_CONTENT_MODEL } from "@/drizzle/constants";
-import { checkContentAiAuth } from "@/libs/llm";
+import { checkContentAiAuth, prepareChatPrompt } from "@/libs/llm";
 import { convertToOpenaiCompatibleSchema } from "@/libs/zod_utils";
 import { JutsuValidatorRawSchema } from "@/validators/combat";
 
@@ -11,7 +11,7 @@ export async function POST(req: Request) {
   await checkContentAiAuth();
 
   // Call LLM
-  const { messages } = (await req.json()) as { messages: ModelMessage[] };
+  const { messages: uiMessages } = (await req.json()) as { messages: UIMessage[] };
   const schema = convertToOpenaiCompatibleSchema(
     JutsuValidatorRawSchema.omit({
       effects: true,
@@ -19,14 +19,18 @@ export async function POST(req: Request) {
       bloodlineId: true,
     }),
   );
-  const result = streamText({
-    model: openai(OPENAI_CONTENT_MODEL),
-    system: `You are a helpful assistant tasked with creating new jutsus set in the ninja world of Seichi.
+  const { system, messages } = await prepareChatPrompt(
+    uiMessages,
+    `You are a helpful assistant tasked with creating new jutsus set in the ninja world of Seichi.
     Your primary task is to call the function 'updateJutsu' with appropriate parameters to update the jutsu shown to the user.
     Do not give detailed instructions to the user on what jutsu is created, instead just give a brief summary and start creating it.
     Do not use markdown.
     Do not ask the user for clarifying questions; if details are left out, simply fill in best guesses for the jutsu.
     Only update the jutsu if the user asks you to do so or asks you to create a new jutsu.`,
+  );
+  const result = streamText({
+    model: openai(OPENAI_CONTENT_MODEL),
+    system,
     messages,
     tools: {
       updateJutsu: {

--- a/app/src/app/api/chat/quest/route.ts
+++ b/app/src/app/api/chat/quest/route.ts
@@ -1,8 +1,8 @@
 import { openai } from "@ai-sdk/openai";
-import type { ModelMessage } from "ai";
+import type { UIMessage } from "ai";
 import { stepCountIs, streamText } from "ai";
 import { OPENAI_CONTENT_MODEL } from "@/drizzle/constants";
-import { checkContentAiAuth } from "@/libs/llm";
+import { checkContentAiAuth, prepareChatPrompt } from "@/libs/llm";
 import { convertToOpenaiCompatibleSchema } from "@/libs/zod_utils";
 import { QuestValidatorRawSchema } from "@/validators/objectives";
 
@@ -11,7 +11,7 @@ export async function POST(req: Request) {
   await checkContentAiAuth();
 
   // Call LLM
-  const { messages } = (await req.json()) as { messages: ModelMessage[] };
+  const { messages: uiMessages } = (await req.json()) as { messages: UIMessage[] };
   const schema = convertToOpenaiCompatibleSchema(
     QuestValidatorRawSchema.omit({
       image: true,
@@ -19,14 +19,18 @@ export async function POST(req: Request) {
       content: true,
     }),
   );
-  const result = streamText({
-    model: openai(OPENAI_CONTENT_MODEL),
-    system: `You are a helpful assistant tasked with creating new quests set in the ninja world of Seichi.
+  const { system, messages } = await prepareChatPrompt(
+    uiMessages,
+    `You are a helpful assistant tasked with creating new quests set in the ninja world of Seichi.
     Your primary task is to call the function 'updateQuest' with appropriate parameters to update the quest shown to the user.
     Do not give detailed instructions to the user on what quest is created, instead just give a brief summary and start creating it.
     Do not use markdown.
     Do not ask the user for clarifying questions; if details are left out, simply fill in best guesses for the quest.
     Only update the quest if the user asks you to do so or asks you to create a new quest.`,
+  );
+  const result = streamText({
+    model: openai(OPENAI_CONTENT_MODEL),
+    system,
     messages,
     tools: {
       updateQuest: {

--- a/app/src/app/api/chat/support/route.ts
+++ b/app/src/app/api/chat/support/route.ts
@@ -1,10 +1,11 @@
 import { openai } from "@ai-sdk/openai";
 import { auth } from "@clerk/nextjs/server";
-import type { ModelMessage } from "ai";
+import type { UIMessage } from "ai";
 import { stepCountIs, streamText } from "ai";
 import { and, eq, lte, sql } from "drizzle-orm";
 import { MAX_DAILY_AI_CALLS, OPENAI_CHAT_MODEL } from "@/drizzle/constants";
 import { userData } from "@/drizzle/schema";
+import { prepareChatPrompt } from "@/libs/llm";
 import { drizzleDB } from "@/server/db";
 import { BadgeValidator } from "@/validators/badge";
 
@@ -30,10 +31,10 @@ export async function POST(req: Request) {
   }
 
   // Call LLM
-  const { messages } = (await req.json()) as { messages: ModelMessage[] };
-  const result = streamText({
-    model: openai(OPENAI_CHAT_MODEL),
-    system: `
+  const { messages: uiMessages } = (await req.json()) as { messages: UIMessage[] };
+  const { system, messages } = await prepareChatPrompt(
+    uiMessages,
+    `
 As an AI assistant, your role is to promptly assist the clients of TheNinja-RPG, adopting the persona of Seichi AI.
 
 This document outlines various screens, menus, and gameplay systems available in the game. Each section details a specific aspect of your in-game experience—from managing your character profile to engaging in combat and customizing advanced features.
@@ -461,6 +462,10 @@ This document outlines various screens, menus, and gameplay systems available in
 - **Bloodline Class:**  
   - Determines whether the jutsu class is "Highest" or class-locked.
 `,
+  );
+  const result = streamText({
+    model: openai(OPENAI_CHAT_MODEL),
+    system,
     messages,
     tools: {
       updateBadge: {

--- a/app/src/libs/llm.ts
+++ b/app/src/libs/llm.ts
@@ -1,4 +1,6 @@
 import { auth } from "@clerk/nextjs/server";
+import type { ModelMessage, UIMessage } from "ai";
+import { convertToModelMessages } from "ai";
 import { fetchUser } from "@/routers/profile";
 import { drizzleDB } from "@/server/db";
 import { canChangeContent } from "@/utils/permissions";
@@ -13,4 +15,33 @@ export const checkContentAiAuth = async () => {
   if (!canChangeContent(user.role)) {
     throw new Error("You are not allowed to change content");
   }
+};
+
+/**
+ * Turn the UIMessages a useChat client posts into streamText inputs.
+ *
+ * AI SDK 7 no longer converts UIMessages implicitly and rejects system-role
+ * entries inside `messages`, so the page context ChatBox sends as a hidden
+ * system message is folded into the system prompt here instead. Incomplete
+ * tool calls are dropped — the editor chats run their tools client-side and
+ * never report results back.
+ */
+export const prepareChatPrompt = async (
+  uiMessages: UIMessage[],
+  baseSystem: string,
+): Promise<{ system: string; messages: ModelMessage[] }> => {
+  const pageContext = (uiMessages ?? [])
+    .filter((message) => message.role === "system")
+    .flatMap((message) => message.parts)
+    .map((part) => (part.type === "text" ? part.text : ""))
+    .filter(Boolean)
+    .join("\n");
+  const messages = await convertToModelMessages(
+    (uiMessages ?? []).filter((message) => message.role !== "system"),
+    { ignoreIncompleteToolCalls: true },
+  );
+  return {
+    system: pageContext ? `${baseSystem}\n\n${pageContext}` : baseSystem,
+    messages,
+  };
 };

--- a/app/src/libs/zod_utils.ts
+++ b/app/src/libs/zod_utils.ts
@@ -9,8 +9,11 @@ import { z } from "zod";
  * @returns The OpenAI compatible schema.
  */
 export const convertToOpenaiCompatibleSchema = <T extends ZodType>(input: T) => {
+  // These schemas describe tool INPUTS, so serialize the input side: the
+  // output side throws for validators containing .transform() (item, jutsu,
+  // bloodline), since transformed output types have no JSON Schema form.
   const schema = jsonSchema(
-    z.toJSONSchema(input, { target: "draft-07" }) as JSONSchema7,
+    z.toJSONSchema(input, { target: "draft-07", io: "input" }) as JSONSchema7,
   );
   return schema;
 };


### PR DESCRIPTION
## Summary
- Companion to #1468: the AI SDK 7 bump (823d8fc4f) also broke every ChatBox surface — the manual content-editor assistants (badge/bloodline/item/jutsu/quest) and the support helper. `streamText` no longer converts the UIMessages that `useChat` posts (they fail ModelMessage validation), and the hidden system message ChatBox sends as page context now throws "System messages are not allowed in the prompt or messages fields" client-side, before any API request.
- New `prepareChatPrompt` helper in `@/libs/llm`: folds system-role UIMessages into the route's system prompt, converts the rest with `convertToModelMessages`, and drops incomplete tool calls (the editor chats run their tools client-side and never report results). All six routes migrated; no client changes needed.
- Second, pre-existing bug found while verifying: `convertToOpenaiCompatibleSchema` serialized the zod OUTPUT side, so validators containing `.transform()` threw "Transforms cannot be represented in JSON Schema" — the item, jutsu and bloodline editors 500'd at request time even before the SDK bump surfaced. Tool schemas describe inputs, so it now serializes the input side (`io: "input"`).
- `staffreview` and the moderator generateObject calls (fixed in #1468) use `prompt:`/`system:` and were audited as unaffected.

## Verification
- SDK-level harness against the installed `ai@7.0.77`: old route shape reproduces both errors; fixed shape reaches OpenAI; `ignoreIncompleteToolCalls` confirmed to drop dangling client-side tool calls that would otherwise produce unanswered `tool-call` entries.
- Full-stack E2E on a local dev server with real Clerk auth (dev-browser + ticket sign-in, `Authorization: Bearer` session JWT) and the real OpenAI key: `/api/chat/support` streams text completions and `/api/chat/item` streams `updateItem` tool calls, both with ChatBox's hidden system message included in the payload; all five editor schema conversions now succeed.
- `make typecheck` (tsbuildinfo cleared), `make lint`, `make test` (1263 pass) green.

## Test plan
- [ ] Open a manual editor (e.g. item edit) as a content member and ask the assistant to create/update the entity — expect a reply plus the form updating via the tool call.
- [ ] Use the support helper as a regular player — expect streamed answers.
- [ ] Continue a conversation after a tool call — expect no dangling-tool-call API errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authenticated LLM chat routes and how user/page context is merged into system prompts, but does not change auth or billing. Schema serialization change could alter tool-call payloads for transformed validators.
> 
> **Overview**
> Restores the content-editor assistants and support chat after the AI SDK 7 bump, which stopped implicitly converting `useChat` `UIMessage`s and rejected hidden system messages used as page context.
> 
> Adds `prepareChatPrompt` to fold system-role UI messages into the route system prompt, convert the rest with `convertToModelMessages`, and drop incomplete client-side tool calls. All six `/api/chat/*` routes now use it.
> 
> Also serializes tool schemas from the Zod **input** side (`io: "input"`), so validators with `.transform()` (item, jutsu, bloodline) no longer 500 at request time.
> 
> Dev-server skill docs cover quote-stripping env values and a headless Clerk session flow for hitting these non-tRPC routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc33da60af1335a5f7c13b6db83fafb229f237a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->