### PR TITLE
docs(skill): browser login must use localhost, not 127.0.0.1

### DIFF
--- a/.agents/skills/tnr-dev-server/SKILL.md
+++ b/.agents/skills/tnr-dev-server/SKILL.md
@@ -101,14 +101,16 @@ curl -s -X POST "http://127.0.0.1:$PORT/api/ai-test-user/call-endpoint" \
 
 ## 5. Browser login
 
-Open `http://127.0.0.1:$PORT/login?__clerk_ticket=<signInToken>`. Clerk consumes the ticket and the
+Open `http://localhost:$PORT/login?__clerk_ticket=<signInToken>`. Clerk consumes the ticket and the
 session is signed in as that user. Single-use — provision a fresh user for another login.
 
-**Automated browsers can stall here.** Under both the in-app browser pane and the Chrome
-extension, clerk-js has been seen loading its script but sitting at `Clerk.status === "loading"`
-forever, never calling its Frontend API — so the ticket is never consumed and the login page stays
-blank. If that happens, skip the browser entirely and use the headless flow below; don't burn
-tickets on reloads (each is single-use, ~300 s).
+**Browser pages MUST use `localhost`, never `127.0.0.1`.** On a `127.0.0.1` origin the Next dev
+server 403s its own chunks ("Blocked cross-origin request to Next.js dev resource … from
+\"127.0.0.1\"" in the server log), so React never hydrates and clerk-js sits at
+`Clerk.status === "loading"` forever without ever calling its Frontend API — the login page stays
+blank and reloads just burn the single-use (~300 s) ticket. The symptom looks identical in the
+in-app pane, the Chrome extension, and headless drivers. Plain `curl` calls to API routes are
+unaffected (no hydration involved), which is why the earlier sections work with either host.
 
 ## 5b. Headless auth for plain API routes (non-tRPC)
 


### PR DESCRIPTION
Follow-up to the dev-server skill lessons in #1469: the clerk-js login stall is not an automation quirk — on a `127.0.0.1` origin the Next dev server blocks its own chunks cross-origin, so React never hydrates and the ticket is never consumed. The same URL on `localhost` signs in within seconds (re-verified live today). The skill's login section now leads with that, and notes the curl-only sections are host-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an agent skill; no application or security logic is modified.
> 
> **Overview**
> Updates the tnr-dev-server skill so browser Clerk ticket login uses `localhost`, not `127.0.0.1`.
> 
> The previous “automation stall” note is replaced with the real cause: Next’s dev server 403s its own chunks on a `127.0.0.1` origin, so React never hydrates and clerk-js never consumes the single-use ticket. Curl/API sections stay host-agnostic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ddf21f8e52426264ce4b123651f8e12978506f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->