### PR TITLE
feat(profile): show content moderation summary on public profiles

### DIFF
--- a/app/src/layout/Comment.tsx
+++ b/app/src/layout/Comment.tsx
@@ -281,6 +281,7 @@ const BaseComment: React.FC<BaseCommentProps> = (props) => {
             {userData && (isAuthor || canSeeSecretData(userData.role)) && (
               <ModerationSummary
                 userId={props.user.userId}
+                username={props.user.username}
                 trigger={
                   <BarChart2 className="h-6 w-6 cursor-pointer hover:text-orange-500" />
                 }

--- a/app/src/layout/Confirm2.tsx
+++ b/app/src/layout/Confirm2.tsx
@@ -53,7 +53,7 @@ const Confirm2: React.FC<Confirm2Props> = (props) => {
             setShowModal(true);
           }
         }}
-        className={`inline-block ${props.disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}
+        className={`inline-flex items-center ${props.disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}
       >
         {props.button}
       </div>

--- a/app/src/layout/ModerationSummary.tsx
+++ b/app/src/layout/ModerationSummary.tsx
@@ -21,11 +21,13 @@ import {
 
 interface ModerationSummaryProps {
   userId?: string;
+  username?: string;
   trigger: React.ReactNode;
 }
 
 export const ModerationSummary: React.FC<ModerationSummaryProps> = ({
   userId,
+  username,
   trigger,
 }) => {
   const [open, setOpen] = React.useState(false);
@@ -139,9 +141,13 @@ export const ModerationSummary: React.FC<ModerationSummaryProps> = ({
       <DialogTrigger asChild>{trigger}</DialogTrigger>
       <DialogContent className="max-w-3xl">
         <DialogHeader>
-          <DialogTitle>Content Moderation Summary</DialogTitle>
+          <DialogTitle>
+            {username
+              ? `${username}'s Content Moderation Summary`
+              : "Content Moderation Summary"}
+          </DialogTitle>
           <DialogDescription>
-            This shows an overview of content moderation flags on your account
+            Overview of automated content moderation flags on this account
           </DialogDescription>
         </DialogHeader>
 
@@ -155,7 +161,8 @@ export const ModerationSummary: React.FC<ModerationSummaryProps> = ({
               No moderation flags found
             </p>
             <p className="text-center text-gray-500 text-sm">
-              Your content hasn&apos;t triggered any automated moderation flags.
+              This account&apos;s content hasn&apos;t triggered any automated moderation
+              flags.
             </p>
           </div>
         ) : (
@@ -203,7 +210,7 @@ export const ModerationSummary: React.FC<ModerationSummaryProps> = ({
               <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0 text-orange-500" />
               <div>
                 <h4 className="font-medium text-orange-800">
-                  Understanding Your Moderation Data
+                  Understanding This Moderation Data
                 </h4>
                 <p className="mt-1 text-orange-700 text-sm">
                   Content moderation is performed automatically to ensure community

--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -10,6 +10,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Chart as ChartJS } from "chart.js/auto";
 import {
   Award,
+  BarChart2,
   Coins,
   CopyCheck,
   Droplets,
@@ -95,6 +96,7 @@ import Image from "@/layout/Image";
 import ItemWithEffects from "@/layout/ItemWithEffects";
 import Loader from "@/layout/Loader";
 import Modal2 from "@/layout/Modal2";
+import { ModerationSummary } from "@/layout/ModerationSummary";
 import Post from "@/layout/Post";
 import ReportUser from "@/layout/Report";
 import RichInput from "@/layout/RichInput";
@@ -634,6 +636,18 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = (props) => {
               </Confirm2>
             )}
 
+            {userData && (userData.userId === profile.userId || canSeeSecrets) && (
+              <ModerationSummary
+                userId={profile.userId}
+                username={profile.username}
+                trigger={
+                  <BarChart2
+                    className="h-6 w-6 cursor-pointer hover:text-orange-500"
+                    aria-label="Moderation Summary"
+                  />
+                }
+              />
+            )}
             {userData && (
               <ReportUser
                 user={profile}

--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -399,7 +399,7 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = (props) => {
         subtitle={`Profile: ${profileName}`}
         initialBreak={userData ? initialBreak : true}
         topRightContent={
-          <div className="flex flex-row gap-1">
+          <div className="flex flex-row items-center gap-1 [&_svg]:block">
             {userData && canCloneUser(userData.role) && (
               <>
                 <TooltipProvider delayDuration={50}>
@@ -415,12 +415,14 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = (props) => {
                 </TooltipProvider>
                 <TooltipProvider delayDuration={50}>
                   <Tooltip>
-                    <TooltipTrigger>
-                      <UpdateUserIdButton
-                        userId={profile.userId}
-                        username={profile.username}
-                        updateUserIdMutation={updateUserId}
-                      />
+                    <TooltipTrigger asChild>
+                      <span className="inline-flex">
+                        <UpdateUserIdButton
+                          userId={profile.userId}
+                          username={profile.username}
+                          updateUserIdMutation={updateUserId}
+                        />
+                      </span>
                     </TooltipTrigger>
                     <TooltipContent>Update User ID</TooltipContent>
                   </Tooltip>
@@ -685,8 +687,10 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = (props) => {
                 </TooltipProvider>
                 <TooltipProvider delayDuration={50}>
                   <Tooltip>
-                    <TooltipTrigger>
-                      <DeleteUserButton userData={profile} />
+                    <TooltipTrigger asChild>
+                      <span className="inline-flex">
+                        <DeleteUserButton userData={profile} />
+                      </span>
                     </TooltipTrigger>
                     <TooltipContent>Delete User</TooltipContent>
                   </Tooltip>
@@ -2519,15 +2523,11 @@ const AdjustSeichiSilver: React.FC<AdjustSeichiSilverProps> = ({
       <TooltipProvider delayDuration={50}>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
+            <Coins
+              className="h-6 w-6 cursor-pointer hover:text-orange-500"
               aria-label="Adjust Seichi Silver"
-              className="hover:text-orange-500"
               onClick={() => setIsOpen(true)}
-            >
-              <Coins className="h-6 w-6" />
-            </Button>
+            />
           </TooltipTrigger>
           <TooltipContent>Adjust Seichi Silver</TooltipContent>
         </Tooltip>
@@ -2627,15 +2627,11 @@ const BloodlinePoolManager: React.FC<BloodlinePoolManagerProps> = ({
       <TooltipProvider delayDuration={50}>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
+            <Droplets
+              className="h-6 w-6 cursor-pointer hover:text-orange-500"
               aria-label="Manage Bloodline Pool"
-              className="hover:text-orange-500"
               onClick={() => setIsOpen(true)}
-            >
-              <Droplets className="h-6 w-6" />
-            </Button>
+            />
           </TooltipTrigger>
           <TooltipContent>Manage Bloodline Pool</TooltipContent>
         </Tooltip>

--- a/app/src/layout/Report.tsx
+++ b/app/src/layout/Report.tsx
@@ -133,7 +133,7 @@ const ReportUser: React.FC<ReportUserProps> = (props) => {
           e.stopPropagation();
           setShowModal(true);
         }}
-        className="cursor-pointer"
+        className="inline-flex cursor-pointer items-center p-0"
       >
         {props.button}
       </button>


### PR DESCRIPTION
## Summary
- Add the conversation content-moderation chart to public profiles (e.g. `/username/Mad`) for the profile owner and staff with secret-data access.
- Reuse the existing `ModerationSummary` dialog and `getUserModerationSummary` endpoint; no new API.
- Neutralize dialog copy so it reads correctly when viewing another user's account.

## Test plan
- [ ] Log in as Terriator (or another role with `canSeeSecretData`) and open a public profile such as `/username/Mad`.
- [ ] Click the bar-chart icon in the profile toolbar and confirm the moderation dialog loads.
- [ ] Open your own public profile and confirm the same icon is available.
- [ ] Log in as a regular user and confirm you cannot see another player's moderation summary.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a moderation summary option to public user profiles for authorized viewers.
  - Moderation dialogs now display the account username when available.
  - Updated moderation descriptions and empty-state guidance with clearer terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->