### PR TITLE
Fix: Dailies Completion

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -4,10 +4,8 @@ jobs:
   test_build:
     name: test_build
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    # The daily quest reset clears trackers with raw JSON_SEARCH/JSON_REMOVE surgery. Asserting
-    # the rendered statement cannot show whether the engine drops the element we meant, so
-    # tests/server/api/quests.trackerSql.test.ts executes it here for real. 8.0 matches
-    # PlanetScale. Without TEST_MYSQL_URL that suite skips, so local runs stay dependency-free.
+    # Database for tests that need to execute real SQL. 8.0 matches PlanetScale. Suites that use
+    # it skip when TEST_MYSQL_URL is unset, so a local `bun test` needs no database.
     services:
       mysql:
         image: mysql:8.0

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -4,6 +4,23 @@ jobs:
   test_build:
     name: test_build
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # The daily quest reset clears trackers with raw JSON_SEARCH/JSON_REMOVE surgery. Asserting
+    # the rendered statement cannot show whether the engine drops the element we meant, so
+    # tests/server/api/quests.trackerSql.test.ts executes it here for real. 8.0 matches
+    # PlanetScale. Without TEST_MYSQL_URL that suite skips, so local runs stay dependency-free.
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+          MYSQL_DATABASE: tnr_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
     steps:
       - uses: actions/checkout@v7
         with:
@@ -31,3 +48,4 @@ jobs:
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
       CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
       NODE_OPTIONS: "--max-old-space-size=4096"
+      TEST_MYSQL_URL: "mysql://root@127.0.0.1:3306/tnr_test"

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -4,8 +4,9 @@ jobs:
   test_build:
     name: test_build
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    # Database for tests that need to execute real SQL. 8.0 matches PlanetScale. Suites that use
-    # it skip when TEST_MYSQL_URL is unset, so a local `bun test` needs no database.
+    # Database for tests that need to execute real SQL. 8.0 matches PlanetScale. Every table in
+    # it is truncated on setup, hence the explicit opt-in below. Suites that use it skip when
+    # the variables are unset, so a local `bun test` needs no database.
     services:
       mysql:
         image: mysql:8.0
@@ -47,3 +48,4 @@ jobs:
       CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
       NODE_OPTIONS: "--max-old-space-size=4096"
       TEST_MYSQL_URL: "mysql://root@127.0.0.1:3306/tnr_test"
+      TEST_MYSQL_ALLOW_DESTRUCTIVE: "1"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ All make commands should be run from the root directory `/`, not from `/app`.
 **Primary Development:**
 
 - `make build` - Build the Next.js application. Only run if explicitly asked.
-- `make test` - Run unit tests with vitest. Suites that execute real SQL skip unless `TEST_MYSQL_URL` points at a throwaway database (CI supplies one; locally the dev stack's MySQL works: `TEST_MYSQL_URL='mysql://root:placeholder@127.0.0.1:3307/tnr_test'`).
+- `make test` - Run unit tests with vitest. Suites that execute real SQL skip unless a throwaway database is configured; every table in it is truncated, so the opt-in is explicit. CI supplies one, and locally the dev stack's MySQL works: `TEST_MYSQL_ALLOW_DESTRUCTIVE=1 TEST_MYSQL_URL='mysql://root:placeholder@127.0.0.1:3307/tnr_test' make test`.
 - `make lint` - Run biome on the codebase
 - `make typecheck` - Run typechecking on the codebase
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ All make commands should be run from the root directory `/`, not from `/app`.
 **Primary Development:**
 
 - `make build` - Build the Next.js application. Only run if explicitly asked.
-- `make test` - Run unit tests with vitest. The tracker-SQL suite executes real `JSON_SEARCH`/`JSON_REMOVE` statements and skips unless `TEST_MYSQL_URL` points at a throwaway database (CI supplies one; locally the dev stack's MySQL works: `TEST_MYSQL_URL='mysql://root:placeholder@127.0.0.1:3307/tnr_test'`).
+- `make test` - Run unit tests with vitest. Suites that execute real SQL skip unless `TEST_MYSQL_URL` points at a throwaway database (CI supplies one; locally the dev stack's MySQL works: `TEST_MYSQL_URL='mysql://root:placeholder@127.0.0.1:3307/tnr_test'`).
 - `make lint` - Run biome on the codebase
 - `make typecheck` - Run typechecking on the codebase
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ All make commands should be run from the root directory `/`, not from `/app`.
 **Primary Development:**
 
 - `make build` - Build the Next.js application. Only run if explicitly asked.
-- `make test` - Run unit tests with vitest
+- `make test` - Run unit tests with vitest. The tracker-SQL suite executes real `JSON_SEARCH`/`JSON_REMOVE` statements and skips unless `TEST_MYSQL_URL` points at a throwaway database (CI supplies one; locally the dev stack's MySQL works: `TEST_MYSQL_URL='mysql://root:placeholder@127.0.0.1:3307/tnr_test'`).
 - `make lint` - Run biome on the codebase
 - `make typecheck` - Run typechecking on the codebase
 

--- a/app/bunfig.toml
+++ b/app/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./tests/setup/preload.ts"]

--- a/app/drizzle/migrations/0039_quest_history_unique_user_quest.sql
+++ b/app/drizzle/migrations/0039_quest_history_unique_user_quest.sql
@@ -1,0 +1,62 @@
+-- Restore the uniqueUserIdQuestId constraint on QuestHistory.
+--
+-- schema.ts has declared it since 0000, but the deployed database does not have
+-- it: only PRIMARY(id) is unique there. Every upsert keyed on (userId, questId)
+-- -- upsertQuestEntry's insert branch, upsertQuestEntries' bulk insert, the
+-- completion row created in commitQuestObjectiveRewards -- therefore inserts a
+-- second row instead of updating the existing one, and reads go through
+-- findFirst, so which of the rows a request sees is arbitrary.
+--
+-- The constraint cannot be added until the table holds one row per pair.
+
+-- Lifetime counters gate availability (isAvailableUserQuests compares them to
+-- maxCompletes/maxAttempts), and they were split across the duplicates. Lift the
+-- highest value in each group onto every row of that group so the survivor keeps
+-- it. MAX rather than SUM: summing could push a player past maxAttempts and lock
+-- them out of a quest they can play today.
+UPDATE `QuestHistory` AS `h`
+JOIN (
+    SELECT `userId`, `questId`,
+           MAX(`previousCompletes`) AS `keepCompletes`,
+           MAX(`previousAttempts`) AS `keepAttempts`
+    FROM `QuestHistory`
+    GROUP BY `userId`, `questId`
+    HAVING COUNT(*) > 1
+  ) AS `d`
+  ON `d`.`userId` = `h`.`userId` AND `d`.`questId` = `h`.`questId`
+SET `h`.`previousCompletes` = `d`.`keepCompletes`,
+    `h`.`previousAttempts` = `d`.`keepAttempts`;
+--> statement-breakpoint
+-- Keep one row per pair: an attempt that is still open wins, so a quest a player
+-- is part way through stays playable; otherwise the most recently started one.
+-- The id breaks ties so the choice is deterministic on a rerun.
+--
+-- The winner is picked with MAX over a sortable string rather than ROW_NUMBER so
+-- the statement needs nothing beyond grouping and string functions. Ordering the
+-- period columns alongside it would let periodCompletes and periodStartAt come
+-- from different rows, so those stay whole on whichever row survives.
+DELETE FROM `QuestHistory`
+WHERE `id` IN (
+  SELECT `id` FROM (
+    SELECT `h`.`id`
+    FROM `QuestHistory` AS `h`
+    JOIN (
+        SELECT `userId`, `questId`,
+               SUBSTRING_INDEX(
+                 MAX(CONCAT(
+                   IF(`completed` = 0 AND `endedAt` IS NULL, '1', '0'),
+                   DATE_FORMAT(`startedAt`, '%Y%m%d%H%i%s%f'),
+                   '|', `id`
+                 )),
+                 '|', -1
+               ) AS `keepId`
+        FROM `QuestHistory`
+        GROUP BY `userId`, `questId`
+        HAVING COUNT(*) > 1
+      ) AS `k`
+      ON `k`.`userId` = `h`.`userId` AND `k`.`questId` = `h`.`questId`
+    WHERE `h`.`id` <> `k`.`keepId`
+  ) AS `losers`
+);
+--> statement-breakpoint
+ALTER TABLE `QuestHistory` ADD CONSTRAINT `uniqueUserIdQuestId` UNIQUE(`userId`,`questId`);

--- a/app/drizzle/migrations/0039_quest_history_unique_user_quest.sql
+++ b/app/drizzle/migrations/0039_quest_history_unique_user_quest.sql
@@ -32,9 +32,15 @@ SET `h`.`previousCompletes` = `d`.`keepCompletes`,
 -- The id breaks ties so the choice is deterministic on a rerun.
 --
 -- The winner is picked with MAX over a sortable string rather than ROW_NUMBER so
--- the statement needs nothing beyond grouping and string functions. Ordering the
--- period columns alongside it would let periodCompletes and periodStartAt come
--- from different rows, so those stay whole on whichever row survives.
+-- the statement needs nothing beyond grouping and string functions. The key is a
+-- 1-character flag and a 20-character timestamp (%Y%m%d%H%i%s%f is fixed width
+-- for every legal datetime) followed by the id, so the id is recovered by
+-- dropping 21 leading characters. No separator: id is varchar(191) and any
+-- delimiter it could contain would truncate the recovered value, which would
+-- match no row and delete the whole group.
+--
+-- Ordering the period columns alongside it would let periodCompletes and
+-- periodStartAt come from different rows, so those stay whole on the survivor.
 DELETE FROM `QuestHistory`
 WHERE `id` IN (
   SELECT `id` FROM (
@@ -42,13 +48,13 @@ WHERE `id` IN (
     FROM `QuestHistory` AS `h`
     JOIN (
         SELECT `userId`, `questId`,
-               SUBSTRING_INDEX(
+               SUBSTRING(
                  MAX(CONCAT(
                    IF(`completed` = 0 AND `endedAt` IS NULL, '1', '0'),
                    DATE_FORMAT(`startedAt`, '%Y%m%d%H%i%s%f'),
-                   '|', `id`
+                   `id`
                  )),
-                 '|', -1
+                 22
                ) AS `keepId`
         FROM `QuestHistory`
         GROUP BY `userId`, `questId`

--- a/app/drizzle/migrations/meta/0039_snapshot.json
+++ b/app/drizzle/migrations/meta/0039_snapshot.json
@@ -1,0 +1,15982 @@
+{
+  "id": "35340799-1414-45a7-a98c-7204bb3d92bd",
+  "prevId": "d1106c80-5668-4b2b-bb4d-55262496a4e5",
+  "version": "5",
+  "dialect": "mysql",
+  "tables": {
+    "AbEvent": {
+      "name": "AbEvent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "experiment": {
+          "name": "experiment",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "AbEvent_userId_idx": {
+          "name": "AbEvent_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "AbEvent_experiment_idx": {
+          "name": "AbEvent_experiment_idx",
+          "columns": [
+            "experiment"
+          ],
+          "isUnique": false
+        },
+        "AbEvent_event_idx": {
+          "name": "AbEvent_event_idx",
+          "columns": [
+            "event"
+          ],
+          "isUnique": false
+        },
+        "AbEvent_source_idx": {
+          "name": "AbEvent_source_idx",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "AbEvent_experiment_event_ip_key": {
+          "name": "AbEvent_experiment_event_ip_key",
+          "columns": [
+            "experiment",
+            "event",
+            "ip"
+          ],
+          "isUnique": true
+        },
+        "AbEvent_createdAt_idx": {
+          "name": "AbEvent_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AbEvent_id": {
+          "name": "AbEvent_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ActionLog": {
+      "name": "ActionLog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "tableName": {
+          "name": "tableName",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relatedId": {
+          "name": "relatedId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "relatedText": {
+          "name": "relatedText",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "relatedImage": {
+          "name": "relatedImage",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "relatedValue": {
+          "name": "relatedValue",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ActionLog_userId_idx": {
+          "name": "ActionLog_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "ActionLog_relatedId_idx": {
+          "name": "ActionLog_relatedId_idx",
+          "columns": [
+            "relatedId"
+          ],
+          "isUnique": false
+        },
+        "ActionLog_tableName_idx": {
+          "name": "ActionLog_tableName_idx",
+          "columns": [
+            "tableName"
+          ],
+          "isUnique": false
+        },
+        "ActionLog_createdAt_idx": {
+          "name": "ActionLog_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ActionLog_id": {
+          "name": "ActionLog_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ActivityStreakConfig": {
+      "name": "ActivityStreakConfig",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "totalDays": {
+          "name": "totalDays",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 14
+        },
+        "streakType": {
+          "name": "streakType",
+          "type": "enum('RECURRING','EVENT_PASS')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'RECURRING'"
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "ryoCost": {
+          "name": "ryoCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "repsCost": {
+          "name": "repsCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "seichiSilverCost": {
+          "name": "seichiSilverCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ActivityStreakConfig_id": {
+          "name": "ActivityStreakConfig_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ActivityStreakReward": {
+      "name": "ActivityStreakReward",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "configId": {
+          "name": "configId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dayNumber": {
+          "name": "dayNumber",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewards": {
+          "name": "rewards",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "ActivityStreakReward_configId_idx": {
+          "name": "ActivityStreakReward_configId_idx",
+          "columns": [
+            "configId"
+          ],
+          "isUnique": false
+        },
+        "ActivityStreakReward_dayNumber_idx": {
+          "name": "ActivityStreakReward_dayNumber_idx",
+          "columns": [
+            "dayNumber"
+          ],
+          "isUnique": false
+        },
+        "ActivityStreakReward_configId_dayNumber_key": {
+          "name": "ActivityStreakReward_configId_dayNumber_key",
+          "columns": [
+            "configId",
+            "dayNumber"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ActivityStreakReward_id": {
+          "name": "ActivityStreakReward_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "AiProfile": {
+      "name": "AiProfile",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "includeDefaultRules": {
+          "name": "includeDefaultRules",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "AiProfile_userId_idx": {
+          "name": "AiProfile_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AiProfile_id": {
+          "name": "AiProfile_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "AnbuSquad": {
+      "name": "AnbuSquad",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "leaderId": {
+          "name": "leaderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memberCount": {
+          "name": "memberCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pvpActivity": {
+          "name": "pvpActivity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "kageOrderId": {
+          "name": "kageOrderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "points": {
+          "name": "points",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "espionageLevel": {
+          "name": "espionageLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stealthLevel": {
+          "name": "stealthLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "leaderOrderId": {
+          "name": "leaderOrderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "AnbuSquad_name_key": {
+          "name": "AnbuSquad_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "AnbuSquad_leaderId_idx": {
+          "name": "AnbuSquad_leaderId_idx",
+          "columns": [
+            "leaderId"
+          ],
+          "isUnique": false
+        },
+        "AnbuSquad_villageId_idx": {
+          "name": "AnbuSquad_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AnbuSquad_id": {
+          "name": "AnbuSquad_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "AuctionBid": {
+      "name": "AuctionBid",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auctionId": {
+          "name": "auctionId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bidderId": {
+          "name": "bidderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('ACTIVE','REFUNDED','WON')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "AuctionBid_auctionId_idx": {
+          "name": "AuctionBid_auctionId_idx",
+          "columns": [
+            "auctionId"
+          ],
+          "isUnique": false
+        },
+        "AuctionBid_bidderId_idx": {
+          "name": "AuctionBid_bidderId_idx",
+          "columns": [
+            "bidderId"
+          ],
+          "isUnique": false
+        },
+        "AuctionBid_amount_idx": {
+          "name": "AuctionBid_amount_idx",
+          "columns": [
+            "amount"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AuctionBid_id": {
+          "name": "AuctionBid_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "AuctionListing": {
+      "name": "AuctionListing",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sellerId": {
+          "name": "sellerId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "buyerId": {
+          "name": "buyerId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userItemId": {
+          "name": "userItemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "listingType": {
+          "name": "listingType",
+          "type": "enum('AUCTION','DIRECT')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startingPrice": {
+          "name": "startingPrice",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "buyoutPrice": {
+          "name": "buyoutPrice",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currentPrice": {
+          "name": "currentPrice",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currencyType": {
+          "name": "currencyType",
+          "type": "enum('MONEY','REPUTATION')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'MONEY'"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('ACTIVE','SOLD','EXPIRED','CANCELLED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "bidderMinLevel": {
+          "name": "bidderMinLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "bidderMaxLevel": {
+          "name": "bidderMaxLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "AuctionListing_sellerId_idx": {
+          "name": "AuctionListing_sellerId_idx",
+          "columns": [
+            "sellerId"
+          ],
+          "isUnique": false
+        },
+        "AuctionListing_buyerId_idx": {
+          "name": "AuctionListing_buyerId_idx",
+          "columns": [
+            "buyerId"
+          ],
+          "isUnique": false
+        },
+        "AuctionListing_userItemId_idx": {
+          "name": "AuctionListing_userItemId_idx",
+          "columns": [
+            "userItemId"
+          ],
+          "isUnique": false
+        },
+        "AuctionListing_targetUserId_idx": {
+          "name": "AuctionListing_targetUserId_idx",
+          "columns": [
+            "targetUserId"
+          ],
+          "isUnique": false
+        },
+        "AuctionListing_status_idx": {
+          "name": "AuctionListing_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "AuctionListing_expiresAt_idx": {
+          "name": "AuctionListing_expiresAt_idx",
+          "columns": [
+            "expiresAt"
+          ],
+          "isUnique": false
+        },
+        "AuctionListing_status_listingType_bidderLevels_idx": {
+          "name": "AuctionListing_status_listingType_bidderLevels_idx",
+          "columns": [
+            "status",
+            "listingType",
+            "bidderMinLevel",
+            "bidderMaxLevel"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AuctionListing_id": {
+          "name": "AuctionListing_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "AutomatedModeration": {
+      "name": "AutomatedModeration",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relationType": {
+          "name": "relationType",
+          "type": "enum('comment','privateMessage','forumPost','userReport','userNindo','clanOrder','anbuOrder','kageOrder','userAvatar')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sexual": {
+          "name": "sexual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sexual_minors": {
+          "name": "sexual_minors",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "harassment": {
+          "name": "harassment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "harassment_threatening": {
+          "name": "harassment_threatening",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hate": {
+          "name": "hate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hate_threatening": {
+          "name": "hate_threatening",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "illicit": {
+          "name": "illicit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "illicit_violent": {
+          "name": "illicit_violent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "self_harm": {
+          "name": "self_harm",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "self_harm_intent": {
+          "name": "self_harm_intent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "self_harm_instructions": {
+          "name": "self_harm_instructions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "violence": {
+          "name": "violence",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "violence_graphic": {
+          "name": "violence_graphic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "AutoMod_userId_idx": {
+          "name": "AutoMod_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "AutoMod_relationType_idx": {
+          "name": "AutoMod_relationType_idx",
+          "columns": [
+            "relationType"
+          ],
+          "isUnique": false
+        },
+        "AutoMod_createdAt_idx": {
+          "name": "AutoMod_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AutomatedModeration_id": {
+          "name": "AutomatedModeration_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Badge": {
+      "name": "Badge",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "Badge_name_key": {
+          "name": "Badge_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Badge_id": {
+          "name": "Badge_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BankTransfers": {
+      "name": "BankTransfers",
+      "columns": {
+        "senderId": {
+          "name": "senderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "receiverId": {
+          "name": "receiverId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('bank','sensei','recruiter')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'bank'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "BankTransfers_senderId_idx": {
+          "name": "BankTransfers_senderId_idx",
+          "columns": [
+            "senderId"
+          ],
+          "isUnique": false
+        },
+        "BankTransfers_receiverId_idx": {
+          "name": "BankTransfers_receiverId_idx",
+          "columns": [
+            "receiverId"
+          ],
+          "isUnique": false
+        },
+        "BankTransfers_senderId_receiverId_idx": {
+          "name": "BankTransfers_senderId_receiverId_idx",
+          "columns": [
+            "senderId",
+            "receiverId"
+          ],
+          "isUnique": false
+        },
+        "BankTransfers_createdAt_idx": {
+          "name": "BankTransfers_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Battle": {
+      "name": "Battle",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "roundStartAt": {
+          "name": "roundStartAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "background": {
+          "name": "background",
+          "type": "enum('ocean','ground','dessert','ice','snow','arena','default')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 13
+        },
+        "height": {
+          "name": "height",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 9
+        },
+        "battleType": {
+          "name": "battleType",
+          "type": "enum('ARENA','COMBAT','SPARRING','KAGE_AI','KAGE_PVP','CLAN_CHALLENGE','CLAN_BATTLE','SHRINE_WAR','TOURNAMENT','QUEST','RANDOM_ENCOUNTER','VILLAGE_PROTECTOR','TRAINING','RANKED_PVP','RANKED_SPARRING','RAID','OVERWORLD')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usersState": {
+          "name": "usersState",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usersEffects": {
+          "name": "usersEffects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "groundEffects": {
+          "name": "groundEffects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extraState": {
+          "name": "extraState",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewardScaling": {
+          "name": "rewardScaling",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "version": {
+          "name": "version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "round": {
+          "name": "round",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "forceKeepPools": {
+          "name": "forceKeepPools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "activeUserId": {
+          "name": "activeUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Battle_id_version_key": {
+          "name": "Battle_id_version_key",
+          "columns": [
+            "id",
+            "version"
+          ],
+          "isUnique": true
+        },
+        "Battle_updatedAt_idx": {
+          "name": "Battle_updatedAt_idx",
+          "columns": [
+            "updatedAt"
+          ],
+          "isUnique": false
+        },
+        "Battle_battleType_createdAt_idx": {
+          "name": "Battle_battleType_createdAt_idx",
+          "columns": [
+            "battleType",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Battle_id": {
+          "name": "Battle_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BattleAction": {
+      "name": "BattleAction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "battleId": {
+          "name": "battleId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleVersion": {
+          "name": "battleVersion",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleRound": {
+          "name": "battleRound",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "actionId": {
+          "name": "actionId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appliedEffects": {
+          "name": "appliedEffects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "BattleAction_round_key": {
+          "name": "BattleAction_round_key",
+          "columns": [
+            "battleId",
+            "battleVersion",
+            "battleRound"
+          ],
+          "isUnique": true
+        },
+        "BattleAction_createdAt_idx": {
+          "name": "BattleAction_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "BattleAction_battleId_idx": {
+          "name": "BattleAction_battleId_idx",
+          "columns": [
+            "battleId"
+          ],
+          "isUnique": false
+        },
+        "BattleAction_updatedAt_battleId_idx": {
+          "name": "BattleAction_updatedAt_battleId_idx",
+          "columns": [
+            "updatedAt",
+            "battleId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BattleAction_id": {
+          "name": "BattleAction_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BattleHistory": {
+      "name": "BattleHistory",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "battleId": {
+          "name": "battleId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleType": {
+          "name": "battleType",
+          "type": "enum('ARENA','COMBAT','SPARRING','KAGE_AI','KAGE_PVP','CLAN_CHALLENGE','CLAN_BATTLE','SHRINE_WAR','TOURNAMENT','QUEST','RANDOM_ENCOUNTER','VILLAGE_PROTECTOR','TRAINING','RANKED_PVP','RANKED_SPARRING','RAID','OVERWORLD')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attackedId": {
+          "name": "attackedId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "defenderId": {
+          "name": "defenderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "BattleHistory_createdAt_idx": {
+          "name": "BattleHistory_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "BattleHistory_battleId_idx": {
+          "name": "BattleHistory_battleId_idx",
+          "columns": [
+            "battleId"
+          ],
+          "isUnique": false
+        },
+        "BattleHistory_battleType_idx": {
+          "name": "BattleHistory_battleType_idx",
+          "columns": [
+            "battleType"
+          ],
+          "isUnique": false
+        },
+        "BattleHistory_attackedId_idx": {
+          "name": "BattleHistory_attackedId_idx",
+          "columns": [
+            "attackedId"
+          ],
+          "isUnique": false
+        },
+        "BattleHistory_defenderId_idx": {
+          "name": "BattleHistory_defenderId_idx",
+          "columns": [
+            "defenderId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BattleHistory_id": {
+          "name": "BattleHistory_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Bloodline": {
+      "name": "Bloodline",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "statClassification": {
+          "name": "statClassification",
+          "type": "enum('Highest','Ninjutsu','Genjutsu','Taijutsu','Bukijutsu')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "regenIncrease": {
+          "name": "regenIncrease",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "NULL"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "enum('D','C','B','A','S','H')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "enum('Easy','Medium','Hard','Expert')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "traits": {
+          "name": "traits",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Bloodline_name_key": {
+          "name": "Bloodline_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "Bloodline_image_key": {
+          "name": "Bloodline_image_key",
+          "columns": [
+            "image"
+          ],
+          "isUnique": false
+        },
+        "Bloodline_village_idx": {
+          "name": "Bloodline_village_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        },
+        "Bloodline_rank_idx": {
+          "name": "Bloodline_rank_idx",
+          "columns": [
+            "rank"
+          ],
+          "isUnique": false
+        },
+        "Bloodline_difficulty_idx": {
+          "name": "Bloodline_difficulty_idx",
+          "columns": [
+            "difficulty"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Bloodline_id": {
+          "name": "Bloodline_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BloodlineReskin": {
+      "name": "BloodlineReskin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bloodlineId": {
+          "name": "bloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "BloodlineReskin_bloodlineId_idx": {
+          "name": "BloodlineReskin_bloodlineId_idx",
+          "columns": [
+            "bloodlineId"
+          ],
+          "isUnique": false
+        },
+        "BloodlineReskin_createdBy_idx": {
+          "name": "BloodlineReskin_createdBy_idx",
+          "columns": [
+            "createdBy"
+          ],
+          "isUnique": false
+        },
+        "BloodlineReskin_bloodlineId_name_key": {
+          "name": "BloodlineReskin_bloodlineId_name_key",
+          "columns": [
+            "bloodlineId",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BloodlineReskin_id": {
+          "name": "BloodlineReskin_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BloodlineRolls": {
+      "name": "BloodlineRolls",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bloodlineId": {
+          "name": "bloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used": {
+          "name": "used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pityRolls": {
+          "name": "pityRolls",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('NATURAL','ITEM','PITY','DIRECT','QUEST','REGISTRATION')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NATURAL'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "enum('D','C','B','A','S','H')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "naturalRollDedupeKey": {
+          "name": "naturalRollDedupeKey",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "type": "stored",
+            "as": "CASE WHEN `type` = 'NATURAL' THEN `userId` ELSE NULL END"
+          }
+        }
+      },
+      "indexes": {
+        "BloodlineRolls_userId_idx": {
+          "name": "BloodlineRolls_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "BloodlineRolls_bloodlineId_idx": {
+          "name": "BloodlineRolls_bloodlineId_idx",
+          "columns": [
+            "bloodlineId"
+          ],
+          "isUnique": false
+        },
+        "BloodlineRolls_natural_roll_per_user_key": {
+          "name": "BloodlineRolls_natural_roll_per_user_key",
+          "columns": [
+            "naturalRollDedupeKey"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BloodlineRolls_id": {
+          "name": "BloodlineRolls_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Bounty": {
+      "name": "Bounty",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creatorUserId": {
+          "name": "creatorUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amountRyo": {
+          "name": "amountRyo",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "originalAmountRyo": {
+          "name": "originalAmountRyo",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('OPEN','CLAIMED','EXPIRED','CANCELLED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'OPEN'"
+        },
+        "claimedByUserId": {
+          "name": "claimedByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "collectedAt": {
+          "name": "collectedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimedAt": {
+          "name": "claimedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "Bounty_targetUserId_idx": {
+          "name": "Bounty_targetUserId_idx",
+          "columns": [
+            "targetUserId"
+          ],
+          "isUnique": false
+        },
+        "Bounty_creatorUserId_idx": {
+          "name": "Bounty_creatorUserId_idx",
+          "columns": [
+            "creatorUserId"
+          ],
+          "isUnique": false
+        },
+        "Bounty_status_idx": {
+          "name": "Bounty_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Bounty_id": {
+          "name": "Bounty_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BountyContribution": {
+      "name": "BountyContribution",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bountyId": {
+          "name": "bountyId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contributorUserId": {
+          "name": "contributorUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amountRyo": {
+          "name": "amountRyo",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "BountyContribution_bountyId_idx": {
+          "name": "BountyContribution_bountyId_idx",
+          "columns": [
+            "bountyId"
+          ],
+          "isUnique": false
+        },
+        "BountyContribution_contributorUserId_idx": {
+          "name": "BountyContribution_contributorUserId_idx",
+          "columns": [
+            "contributorUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BountyContribution_id": {
+          "name": "BountyContribution_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "BountySignup": {
+      "name": "BountySignup",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bountyId": {
+          "name": "bountyId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hunterUserId": {
+          "name": "hunterUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "BountySignup_bounty_hunter_key": {
+          "name": "BountySignup_bounty_hunter_key",
+          "columns": [
+            "bountyId",
+            "hunterUserId"
+          ],
+          "isUnique": true
+        },
+        "BountySignup_bountyId_idx": {
+          "name": "BountySignup_bountyId_idx",
+          "columns": [
+            "bountyId"
+          ],
+          "isUnique": false
+        },
+        "BountySignup_hunterUserId_idx": {
+          "name": "BountySignup_hunterUserId_idx",
+          "columns": [
+            "hunterUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BountySignup_id": {
+          "name": "BountySignup_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "CannedResponse": {
+      "name": "CannedResponse",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "CannedResponse_createdByUserId_idx": {
+          "name": "CannedResponse_createdByUserId_idx",
+          "columns": [
+            "createdByUserId"
+          ],
+          "isUnique": false
+        },
+        "CannedResponse_title_idx": {
+          "name": "CannedResponse_title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "CannedResponse_id": {
+          "name": "CannedResponse_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Captcha": {
+      "name": "Captcha",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "captcha": {
+          "name": "captcha",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3) + INTERVAL 1 DAY )"
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "Captcha_userId_key": {
+          "name": "Captcha_userId_key",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "Captcha_used_idx": {
+          "name": "Captcha_used_idx",
+          "columns": [
+            "used"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Captcha_id": {
+          "name": "Captcha_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Clan": {
+      "name": "Clan",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "founderId": {
+          "name": "founderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "leaderId": {
+          "name": "leaderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "coLeader1": {
+          "name": "coLeader1",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coLeader2": {
+          "name": "coLeader2",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coLeader3": {
+          "name": "coLeader3",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin1": {
+          "name": "assassin1",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin2": {
+          "name": "assassin2",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin3": {
+          "name": "assassin3",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin4": {
+          "name": "assassin4",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin5": {
+          "name": "assassin5",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin6": {
+          "name": "assassin6",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin7": {
+          "name": "assassin7",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin8": {
+          "name": "assassin8",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin9": {
+          "name": "assassin9",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assassin10": {
+          "name": "assassin10",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "leaderOrderId": {
+          "name": "leaderOrderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trainingBoost": {
+          "name": "trainingBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "ryoBoost": {
+          "name": "ryoBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "regenBoost": {
+          "name": "regenBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionRewardBoost": {
+          "name": "missionRewardBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "craftingTimeBoost": {
+          "name": "craftingTimeBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "craftingExpBoost": {
+          "name": "craftingExpBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hunterExpBoost": {
+          "name": "hunterExpBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gathererExpBoost": {
+          "name": "gathererExpBoost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "elderNomineeId": {
+          "name": "elderNomineeId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "elderCutoffMonth": {
+          "name": "elderCutoffMonth",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "elderCutoffYear": {
+          "name": "elderCutoffYear",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "elderCutoffRank": {
+          "name": "elderCutoffRank",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "activityPoints": {
+          "name": "activityPoints",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "points": {
+          "name": "points",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bank": {
+          "name": "bank",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pvpActivity": {
+          "name": "pvpActivity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "repTreasury": {
+          "name": "repTreasury",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hasHideout": {
+          "name": "hasHideout",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "Clan_name_key": {
+          "name": "Clan_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "Clan_village_idx": {
+          "name": "Clan_village_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Clan_id": {
+          "name": "Clan_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ConceptImage": {
+      "name": "ConceptImage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video": {
+          "name": "video",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mediaType": {
+          "name": "mediaType",
+          "type": "enum('image','video')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'image'"
+        },
+        "replicateId": {
+          "name": "replicateId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'started'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "varchar(5000)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "negative_prompt": {
+          "name": "negative_prompt",
+          "type": "varchar(5000)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "seed": {
+          "name": "seed",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 42
+        },
+        "guidance_scale": {
+          "name": "guidance_scale",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 4
+        },
+        "n_likes": {
+          "name": "n_likes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "n_loves": {
+          "name": "n_loves",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "n_laugh": {
+          "name": "n_laugh",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "n_comments": {
+          "name": "n_comments",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "concept_image_key": {
+          "name": "concept_image_key",
+          "columns": [
+            "image"
+          ],
+          "isUnique": true
+        },
+        "image_done_idx": {
+          "name": "image_done_idx",
+          "columns": [
+            "done"
+          ],
+          "isUnique": false
+        },
+        "image_userId_idx": {
+          "name": "image_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ConceptImage_id": {
+          "name": "ConceptImage_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ContentBackup": {
+      "name": "ContentBackup",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('bloodline','jutsu','item','ai')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sqlText": {
+          "name": "sqlText",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "ContentBackup_type_idx": {
+          "name": "ContentBackup_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "ContentBackup_createdAt_idx": {
+          "name": "ContentBackup_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ContentBackup_id": {
+          "name": "ContentBackup_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ContentTag": {
+      "name": "ContentTag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ContentTag_name_key": {
+          "name": "ContentTag_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ContentTag_id": {
+          "name": "ContentTag_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Conversation": {
+      "name": "Conversation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "isLocked": {
+          "name": "isLocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "isStaffAvailable": {
+          "name": "isStaffAvailable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "Conversation_title_key": {
+          "name": "Conversation_title_key",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "Conversation_createdById_idx": {
+          "name": "Conversation_createdById_idx",
+          "columns": [
+            "createdById"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Conversation_id": {
+          "name": "Conversation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ConversationComment": {
+      "name": "ConversationComment",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reactions": {
+          "name": "reactions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('{}')"
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isReported": {
+          "name": "isReported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isStaffOnly": {
+          "name": "isStaffOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "ConversationComment_userId_idx": {
+          "name": "ConversationComment_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "ConversationComment_createdAt_idx": {
+          "name": "ConversationComment_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "ConversationComment_conversationId_idx": {
+          "name": "ConversationComment_conversationId_idx",
+          "columns": [
+            "conversationId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ConversationComment_id": {
+          "name": "ConversationComment_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "CraftingRequirement": {
+      "name": "CraftingRequirement",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "craftItemId": {
+          "name": "craftItemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requirementItemId": {
+          "name": "requirementItemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "CraftingRequirement_craftItemId_idx": {
+          "name": "CraftingRequirement_craftItemId_idx",
+          "columns": [
+            "craftItemId"
+          ],
+          "isUnique": false
+        },
+        "CraftingRequirement_requirementItemId_idx": {
+          "name": "CraftingRequirement_requirementItemId_idx",
+          "columns": [
+            "requirementItemId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "CraftingRequirement_id": {
+          "name": "CraftingRequirement_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "DailyBankInterest": {
+      "name": "DailyBankInterest",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed": {
+          "name": "claimed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "interestPercent": {
+          "name": "interestPercent",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "DailyBankInterest_userId_idx": {
+          "name": "DailyBankInterest_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "DailyBankInterest_updatedAt_idx": {
+          "name": "DailyBankInterest_updatedAt_idx",
+          "columns": [
+            "updatedAt"
+          ],
+          "isUnique": false
+        },
+        "DailyBankInterest_claimed_updatedAt_idx": {
+          "name": "DailyBankInterest_claimed_updatedAt_idx",
+          "columns": [
+            "claimed",
+            "updatedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "DailyBankInterest_id": {
+          "name": "DailyBankInterest_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "DailyBankInterest_userId_date_key": {
+          "name": "DailyBankInterest_userId_date_key",
+          "columns": [
+            "userId",
+            "date"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "DamageCalculation": {
+      "name": "DamageCalculation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "state": {
+          "name": "state",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "DamageCalculation_userId_idx": {
+          "name": "DamageCalculation_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "DamageCalculation_createdAt_idx": {
+          "name": "DamageCalculation_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "DamageCalculation_id": {
+          "name": "DamageCalculation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "DataBattleAction": {
+      "name": "DataBattleAction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('jutsu','item','bloodline','basic','ai')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contentId": {
+          "name": "contentId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relatedBloodlineId": {
+          "name": "relatedBloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "battleType": {
+          "name": "battleType",
+          "type": "enum('ARENA','COMBAT','SPARRING','KAGE_AI','KAGE_PVP','CLAN_CHALLENGE','CLAN_BATTLE','SHRINE_WAR','TOURNAMENT','QUEST','RANDOM_ENCOUNTER','VILLAGE_PROTECTOR','TRAINING','RANKED_PVP','RANKED_SPARRING','RAID','OVERWORLD')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "battleWon": {
+          "name": "battleWon",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "DataBattleActions_type_idx": {
+          "name": "DataBattleActions_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "DataBattleActions_battleWon_idx": {
+          "name": "DataBattleActions_battleWon_idx",
+          "columns": [
+            "battleWon"
+          ],
+          "isUnique": false
+        },
+        "DataBattleActions_battleType_idx": {
+          "name": "DataBattleActions_battleType_idx",
+          "columns": [
+            "battleType"
+          ],
+          "isUnique": false
+        },
+        "DataBattleActions_contentId_idx": {
+          "name": "DataBattleActions_contentId_idx",
+          "columns": [
+            "contentId"
+          ],
+          "isUnique": false
+        },
+        "DataBattleActions_count_idx": {
+          "name": "DataBattleActions_count_idx",
+          "columns": [
+            "count"
+          ],
+          "isUnique": false
+        },
+        "DataBattleActions_createdAt": {
+          "name": "DataBattleActions_createdAt",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "DataBattleActions_updatedAt_idx": {
+          "name": "DataBattleActions_updatedAt_idx",
+          "columns": [
+            "updatedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "DataBattleAction_id": {
+          "name": "DataBattleAction_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "uniqueContentId": {
+          "name": "uniqueContentId",
+          "columns": [
+            "type",
+            "contentId",
+            "battleType",
+            "battleWon",
+            "relatedBloodlineId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "EmailReminder": {
+      "name": "EmailReminder",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callName": {
+          "name": "callName",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latestRejoinRequest": {
+          "name": "latestRejoinRequest",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastActivity": {
+          "name": "lastActivity",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "validated": {
+          "name": "validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "EmailReminder_userId_idx": {
+          "name": "EmailReminder_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "EmailReminder_id": {
+          "name": "EmailReminder_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ForumBoard": {
+      "name": "ForumBoard",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "nPosts": {
+          "name": "nPosts",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "nThreads": {
+          "name": "nThreads",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ForumBoard_name_key": {
+          "name": "ForumBoard_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ForumBoard_id": {
+          "name": "ForumBoard_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ForumPost": {
+      "name": "ForumPost",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isReported": {
+          "name": "isReported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "ForumPost_userId_idx": {
+          "name": "ForumPost_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "ForumPost_threadId_idx": {
+          "name": "ForumPost_threadId_idx",
+          "columns": [
+            "threadId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ForumPost_id": {
+          "name": "ForumPost_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ForumThread": {
+      "name": "ForumThread",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "boardId": {
+          "name": "boardId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nPosts": {
+          "name": "nPosts",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isLocked": {
+          "name": "isLocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "ForumThread_boardId_idx": {
+          "name": "ForumThread_boardId_idx",
+          "columns": [
+            "boardId"
+          ],
+          "isUnique": false
+        },
+        "ForumThread_userId_idx": {
+          "name": "ForumThread_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ForumThread_id": {
+          "name": "ForumThread_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "GameAsset": {
+      "name": "GameAsset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('STATIC','ANIMATION','SCENE_BACKGROUND','SCENE_CHARACTER','SFX','MUSIC')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "frames": {
+          "name": "frames",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "speed": {
+          "name": "speed",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "folder": {
+          "name": "folder",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "licenseDetails": {
+          "name": "licenseDetails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('TNR')"
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "onInitialBattleField": {
+          "name": "onInitialBattleField",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "GameAsset_type_idx": {
+          "name": "GameAsset_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "GameAsset_id": {
+          "name": "GameAsset_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "GameAssetTag": {
+      "name": "GameAssetTag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "GameAssetTag_assetId_tag_key": {
+          "name": "GameAssetTag_assetId_tag_key",
+          "columns": [
+            "assetId",
+            "tagId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "GameAssetTag_id": {
+          "name": "GameAssetTag_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "GameSetting": {
+      "name": "GameSetting",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "name": {
+          "name": "name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "GameSetting_id": {
+          "name": "GameSetting_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "HistoricalAvatar": {
+      "name": "HistoricalAvatar",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatarLight": {
+          "name": "avatarLight",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replicateId": {
+          "name": "replicateId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'started'"
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "HistoricalAvatar_replicateId_key": {
+          "name": "HistoricalAvatar_replicateId_key",
+          "columns": [
+            "replicateId"
+          ],
+          "isUnique": true
+        },
+        "HistoricalAvatar_avatar_key": {
+          "name": "HistoricalAvatar_avatar_key",
+          "columns": [
+            "avatar"
+          ],
+          "isUnique": true
+        },
+        "HistoricalAvatar_done_idx": {
+          "name": "HistoricalAvatar_done_idx",
+          "columns": [
+            "done"
+          ],
+          "isUnique": false
+        },
+        "HistoricalAvatar_status_idx": {
+          "name": "HistoricalAvatar_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "HistoricalAvatar_userId_idx": {
+          "name": "HistoricalAvatar_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "HistoricalAvatar_id": {
+          "name": "HistoricalAvatar_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "HistoricalIp": {
+      "name": "HistoricalIp",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usedAt": {
+          "name": "usedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "HistoricalIp_userId_ip_key": {
+          "name": "HistoricalIp_userId_ip_key",
+          "columns": [
+            "userId",
+            "ip"
+          ],
+          "isUnique": true
+        },
+        "HistoricalIp_userId_idx": {
+          "name": "HistoricalIp_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "HistoricalIp_userIp_idx": {
+          "name": "HistoricalIp_userIp_idx",
+          "columns": [
+            "ip"
+          ],
+          "isUnique": false
+        },
+        "HistoricalIp_usedAt_idx": {
+          "name": "HistoricalIp_usedAt_idx",
+          "columns": [
+            "usedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "HistoricalIp_id": {
+          "name": "HistoricalIp_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "HistoricalSoundEffect": {
+      "name": "HistoricalSoundEffect",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "relationId": {
+          "name": "relationId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replicateId": {
+          "name": "replicateId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "secondsTotal": {
+          "name": "secondsTotal",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "negativePrompt": {
+          "name": "negativePrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'started'"
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "HistoricalSoundEffect_replicateId_idx": {
+          "name": "HistoricalSoundEffect_replicateId_idx",
+          "columns": [
+            "replicateId"
+          ],
+          "isUnique": false
+        },
+        "HistoricalSoundEffect_relationId_idx": {
+          "name": "HistoricalSoundEffect_relationId_idx",
+          "columns": [
+            "relationId"
+          ],
+          "isUnique": false
+        },
+        "HistoricalSoundEffect_userId_idx": {
+          "name": "HistoricalSoundEffect_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "HistoricalSoundEffect_done_idx": {
+          "name": "HistoricalSoundEffect_done_idx",
+          "columns": [
+            "done"
+          ],
+          "isUnique": false
+        },
+        "HistoricalSoundEffect_status_idx": {
+          "name": "HistoricalSoundEffect_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "HistoricalSoundEffect_id": {
+          "name": "HistoricalSoundEffect_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Item": {
+      "name": "Item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "expireFromStoreAt": {
+          "name": "expireFromStoreAt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "itemType": {
+          "name": "itemType",
+          "type": "enum('WEAPON','CONSUMABLE','ARMOR','ACCESSORY','MATERIAL','KEYSTONE','CRYSTAL','OTHER')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "enum('COMMON','RARE','EPIC','LEGENDARY')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot": {
+          "name": "slot",
+          "type": "enum('HEAD','CHEST','LEGS','FEET','HAND','THROWN','ITEM','WAIST','KEYSTONE','NONE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cooldown": {
+          "name": "cooldown",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "weaponType": {
+          "name": "weaponType",
+          "type": "enum('STAFF','AXE','FIST_WEAPON','SHURIKEN','SICKLE','DAGGER','SWORD','POLEARM','FLAIL','CHAIN','FAN','BOW','HAMMER','NONE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "target": {
+          "name": "target",
+          "type": "enum('SELF','OTHER_USER','OPPONENT','ALLY','CHARACTER','GROUND','EMPTY_GROUND')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "enum('SINGLE','ALL','AOE_CIRCLE_SPAWN','AOE_LINE_SHOOT','AOE_WALL_SHOOT','AOE_LARGE_WALL_SHOOT','AOE_CIRCLE_SHOOT','AOE_SPIRAL_SHOOT')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'SINGLE'"
+        },
+        "cost": {
+          "name": "cost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "reputationCost": {
+          "name": "reputationCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "seichiSilverCost": {
+          "name": "seichiSilverCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stackSize": {
+          "name": "stackSize",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destroyOnUse": {
+          "name": "destroyOnUse",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "range": {
+          "name": "range",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "chakraCost": {
+          "name": "chakraCost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "staminaCost": {
+          "name": "staminaCost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "healthCost": {
+          "name": "healthCost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "staminaCostReducePerLvl": {
+          "name": "staminaCostReducePerLvl",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "chakraCostReducePerLvl": {
+          "name": "chakraCostReducePerLvl",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "healthCostReducePerLvl": {
+          "name": "healthCostReducePerLvl",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "actionCostPerc": {
+          "name": "actionCostPerc",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "battleDescription": {
+          "name": "battleDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('')"
+        },
+        "canStack": {
+          "name": "canStack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "maxImbueNumber": {
+          "name": "maxImbueNumber",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "maxDurability": {
+          "name": "maxDurability",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "inShop": {
+          "name": "inShop",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "isEventItem": {
+          "name": "isEventItem",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "maxEquips": {
+          "name": "maxEquips",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "preventBattleUsage": {
+          "name": "preventBattleUsage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "requiredLevel": {
+          "name": "requiredLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "xpToLevel": {
+          "name": "xpToLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "parentItemId": {
+          "name": "parentItemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredNinjutsuOffence": {
+          "name": "requiredNinjutsuOffence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredNinjutsuDefence": {
+          "name": "requiredNinjutsuDefence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredGenjutsuOffence": {
+          "name": "requiredGenjutsuOffence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredGenjutsuDefence": {
+          "name": "requiredGenjutsuDefence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredTaijutsuOffence": {
+          "name": "requiredTaijutsuOffence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredTaijutsuDefence": {
+          "name": "requiredTaijutsuDefence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredBukijutsuOffence": {
+          "name": "requiredBukijutsuOffence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredBukijutsuDefence": {
+          "name": "requiredBukijutsuDefence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredStrength": {
+          "name": "requiredStrength",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredSpeed": {
+          "name": "requiredSpeed",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredIntelligence": {
+          "name": "requiredIntelligence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredWillpower": {
+          "name": "requiredWillpower",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canBeCrafted": {
+          "name": "canBeCrafted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "canBeImbued": {
+          "name": "canBeImbued",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "canBeHunted": {
+          "name": "canBeHunted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "canBeGathered": {
+          "name": "canBeGathered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "canBeTraded": {
+          "name": "canBeTraded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "craftingExperience": {
+          "name": "craftingExperience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crystalTargetTypes": {
+          "name": "crystalTargetTypes",
+          "type": "enum('WEAPON','CONSUMABLE','ARMOR','ACCESSORY','MATERIAL','KEYSTONE','CRYSTAL','OTHER')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bloodlineId": {
+          "name": "bloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "battleUsageType": {
+          "name": "battleUsageType",
+          "type": "enum('PVE','PVP','BOTH')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'BOTH'"
+        }
+      },
+      "indexes": {
+        "Item_name_key": {
+          "name": "Item_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "Item_rarity_idx": {
+          "name": "Item_rarity_idx",
+          "columns": [
+            "rarity"
+          ],
+          "isUnique": false
+        },
+        "Item_itemType_idx": {
+          "name": "Item_itemType_idx",
+          "columns": [
+            "itemType"
+          ],
+          "isUnique": false
+        },
+        "Item_slot_idx": {
+          "name": "Item_slot_idx",
+          "columns": [
+            "slot"
+          ],
+          "isUnique": false
+        },
+        "Item_method_idx": {
+          "name": "Item_method_idx",
+          "columns": [
+            "method"
+          ],
+          "isUnique": false
+        },
+        "Item_target_idx": {
+          "name": "Item_target_idx",
+          "columns": [
+            "target"
+          ],
+          "isUnique": false
+        },
+        "Item_isEventItem_idx": {
+          "name": "Item_isEventItem_idx",
+          "columns": [
+            "isEventItem"
+          ],
+          "isUnique": false
+        },
+        "Item_onlyInShop_idx": {
+          "name": "Item_onlyInShop_idx",
+          "columns": [
+            "inShop"
+          ],
+          "isUnique": false
+        },
+        "Item_cost_idx": {
+          "name": "Item_cost_idx",
+          "columns": [
+            "cost"
+          ],
+          "isUnique": false
+        },
+        "Item_repsCost_idx": {
+          "name": "Item_repsCost_idx",
+          "columns": [
+            "reputationCost"
+          ],
+          "isUnique": false
+        },
+        "Item_requiredLevel_idx": {
+          "name": "Item_requiredLevel_idx",
+          "columns": [
+            "requiredLevel"
+          ],
+          "isUnique": false
+        },
+        "Item_bloodlineId_idx": {
+          "name": "Item_bloodlineId_idx",
+          "columns": [
+            "bloodlineId"
+          ],
+          "isUnique": false
+        },
+        "Item_parentItemId_idx": {
+          "name": "Item_parentItemId_idx",
+          "columns": [
+            "parentItemId"
+          ],
+          "isUnique": false
+        },
+        "Item_parentItemId_hidden_idx": {
+          "name": "Item_parentItemId_hidden_idx",
+          "columns": [
+            "parentItemId",
+            "hidden"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Item_id": {
+          "name": "Item_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ItemLoadout": {
+      "name": "ItemLoadout",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "itemData": {
+          "name": "itemData",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "ItemLoadout_userId_idx": {
+          "name": "ItemLoadout_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ItemLoadout_id": {
+          "name": "ItemLoadout_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ItemVariant": {
+      "name": "ItemVariant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "itemId": {
+          "name": "itemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "costType": {
+          "name": "costType",
+          "type": "enum('MONEY','REPUTATION','SEICHI_SILVER','VILLAGE_PRESTIGE','VARIANT_TOKEN')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "order": {
+          "name": "order",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "battleDescription": {
+          "name": "battleDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "ItemVariant_itemId_idx": {
+          "name": "ItemVariant_itemId_idx",
+          "columns": [
+            "itemId"
+          ],
+          "isUnique": false
+        },
+        "ItemVariant_itemId_order_key": {
+          "name": "ItemVariant_itemId_order_key",
+          "columns": [
+            "itemId",
+            "order"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ItemVariant_id": {
+          "name": "ItemVariant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Jutsu": {
+      "name": "Jutsu",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "extraBaseCost": {
+          "name": "extraBaseCost",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "enum('SELF','OTHER_USER','OPPONENT','ALLY','CHARACTER','GROUND','EMPTY_GROUND')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "range": {
+          "name": "range",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cooldown": {
+          "name": "cooldown",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bloodlineId": {
+          "name": "bloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredLevel": {
+          "name": "requiredLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "requiredRank": {
+          "name": "requiredRank",
+          "type": "enum('STUDENT','GENIN','CHUNIN','JONIN','ELITE JONIN','ELDER','NONE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jutsuType": {
+          "name": "jutsuType",
+          "type": "enum('NORMAL','SPECIAL','BLOODLINE','FORBIDDEN','LOYALTY','CLAN','EVENT','AI')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jutsuWeapon": {
+          "name": "jutsuWeapon",
+          "type": "enum('STAFF','AXE','FIST_WEAPON','SHURIKEN','SICKLE','DAGGER','SWORD','POLEARM','FLAIL','CHAIN','FAN','BOW','HAMMER','NONE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "statClassification": {
+          "name": "statClassification",
+          "type": "enum('Highest','Ninjutsu','Genjutsu','Taijutsu','Bukijutsu')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "battleDescription": {
+          "name": "battleDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jutsuRank": {
+          "name": "jutsuRank",
+          "type": "enum('D','C','B','A','S','H')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'D'"
+        },
+        "actionCostPerc": {
+          "name": "actionCostPerc",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 80
+        },
+        "staminaCost": {
+          "name": "staminaCost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.05
+        },
+        "chakraCost": {
+          "name": "chakraCost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.05
+        },
+        "staminaCostReducePerLvl": {
+          "name": "staminaCostReducePerLvl",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "chakraCostReducePerLvl": {
+          "name": "chakraCostReducePerLvl",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "healthCostReducePerLvl": {
+          "name": "healthCostReducePerLvl",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "healthCost": {
+          "name": "healthCost",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "enum('SINGLE','ALL','AOE_CIRCLE_SPAWN','AOE_LINE_SHOOT','AOE_WALL_SHOOT','AOE_LARGE_WALL_SHOOT','AOE_CIRCLE_SHOOT','AOE_SPIRAL_SHOOT')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'SINGLE'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "injectableInBattle": {
+          "name": "injectableInBattle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "battleUsageType": {
+          "name": "battleUsageType",
+          "type": "enum('PVE','PVP','BOTH')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'BOTH'"
+        },
+        "parentJutsuId": {
+          "name": "parentJutsuId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredNinjutsuOffence": {
+          "name": "requiredNinjutsuOffence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredNinjutsuDefence": {
+          "name": "requiredNinjutsuDefence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredGenjutsuOffence": {
+          "name": "requiredGenjutsuOffence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredGenjutsuDefence": {
+          "name": "requiredGenjutsuDefence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredTaijutsuOffence": {
+          "name": "requiredTaijutsuOffence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredTaijutsuDefence": {
+          "name": "requiredTaijutsuDefence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredBukijutsuOffence": {
+          "name": "requiredBukijutsuOffence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredBukijutsuDefence": {
+          "name": "requiredBukijutsuDefence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredStrength": {
+          "name": "requiredStrength",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredSpeed": {
+          "name": "requiredSpeed",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredIntelligence": {
+          "name": "requiredIntelligence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredWillpower": {
+          "name": "requiredWillpower",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredBloodlineItemId": {
+          "name": "requiredBloodlineItemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Jutsu_name_key": {
+          "name": "Jutsu_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "Jutsu_image_key": {
+          "name": "Jutsu_image_key",
+          "columns": [
+            "image"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_bloodlineId_idx": {
+          "name": "Jutsu_bloodlineId_idx",
+          "columns": [
+            "bloodlineId"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_villageId_idx": {
+          "name": "Jutsu_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_injectable_idx": {
+          "name": "Jutsu_injectable_idx",
+          "columns": [
+            "injectableInBattle"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_parentJutsuId_idx": {
+          "name": "Jutsu_parentJutsuId_idx",
+          "columns": [
+            "parentJutsuId"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_parentJutsuId_hidden_idx": {
+          "name": "Jutsu_parentJutsuId_hidden_idx",
+          "columns": [
+            "parentJutsuId",
+            "hidden"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_requiredBloodlineItemId_idx": {
+          "name": "Jutsu_requiredBloodlineItemId_idx",
+          "columns": [
+            "requiredBloodlineItemId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Jutsu_id": {
+          "name": "Jutsu_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "JutsuLoadout": {
+      "name": "JutsuLoadout",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "JutsuLoadout_userId_idx": {
+          "name": "JutsuLoadout_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "JutsuLoadout_id": {
+          "name": "JutsuLoadout_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "JutsuReskin": {
+      "name": "JutsuReskin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jutsuId": {
+          "name": "jutsuId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleDescription": {
+          "name": "battleDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "JutsuReskin_userId_idx": {
+          "name": "JutsuReskin_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "JutsuReskin_jutsuId_idx": {
+          "name": "JutsuReskin_jutsuId_idx",
+          "columns": [
+            "jutsuId"
+          ],
+          "isUnique": false
+        },
+        "JutsuReskin_userId_jutsuId_key": {
+          "name": "JutsuReskin_userId_jutsuId_key",
+          "columns": [
+            "userId",
+            "jutsuId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "JutsuReskin_id": {
+          "name": "JutsuReskin_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "KageDefendedChallenges": {
+      "name": "KageDefendedChallenges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleId": {
+          "name": "battleId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kageId": {
+          "name": "kageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "didWin": {
+          "name": "didWin",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "rounds": {
+          "name": "rounds",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "KageDefendedChallenges_battleId_key": {
+          "name": "KageDefendedChallenges_battleId_key",
+          "columns": [
+            "battleId"
+          ],
+          "isUnique": true
+        },
+        "VillageKageChallenges_villageId_idx": {
+          "name": "VillageKageChallenges_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        },
+        "VillageKageChallenges_userId_idx": {
+          "name": "VillageKageChallenges_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "VillageKageChallenges_kageID_idx": {
+          "name": "VillageKageChallenges_kageID_idx",
+          "columns": [
+            "kageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "KageDefendedChallenges_id": {
+          "name": "KageDefendedChallenges_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "LinkPromotion": {
+      "name": "LinkPromotion",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "points": {
+          "name": "points",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "reviewedBy": {
+          "name": "reviewedBy",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewedAt": {
+          "name": "reviewedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "LinkPromotion_userId_idx": {
+          "name": "LinkPromotion_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "LinkPromotion_reviewedBy_idx": {
+          "name": "LinkPromotion_reviewedBy_idx",
+          "columns": [
+            "reviewedBy"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LinkPromotion_id": {
+          "name": "LinkPromotion_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "LogTimeDurations": {
+      "name": "LogTimeDurations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "battleType": {
+          "name": "battleType",
+          "type": "enum('ARENA','COMBAT','SPARRING','KAGE_AI','KAGE_PVP','CLAN_CHALLENGE','CLAN_BATTLE','SHRINE_WAR','TOURNAMENT','QUEST','RANDOM_ENCOUNTER','VILLAGE_PROTECTOR','TRAINING','RANKED_PVP','RANKED_SPARRING','RAID','OVERWORLD')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "winnerLevel": {
+          "name": "winnerLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "loserLevel": {
+          "name": "loserLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rounds": {
+          "name": "rounds",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "LogBattleLengths_battleType_idx": {
+          "name": "LogBattleLengths_battleType_idx",
+          "columns": [
+            "battleType"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LogTimeDurations_id": {
+          "name": "LogTimeDurations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "uniqueEntry": {
+          "name": "uniqueEntry",
+          "columns": [
+            "battleType",
+            "winnerLevel",
+            "loserLevel",
+            "rounds"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "LogQueueLengths": {
+      "name": "LogQueueLengths",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "rankedRank": {
+          "name": "rankedRank",
+          "type": "enum('Unranked','Wood','Adept','Master','Legend','Sannin')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ceiledMinutes": {
+          "name": "ceiledMinutes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LogQueueLengths_id": {
+          "name": "LogQueueLengths_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "uniqueEntry": {
+          "name": "uniqueEntry",
+          "columns": [
+            "rankedRank",
+            "ceiledMinutes"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "LogRankedPicks": {
+      "name": "LogRankedPicks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('jutsu','item','consumable')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contentId": {
+          "name": "contentId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleType": {
+          "name": "battleType",
+          "type": "enum('ARENA','COMBAT','SPARRING','KAGE_AI','KAGE_PVP','CLAN_CHALLENGE','CLAN_BATTLE','SHRINE_WAR','TOURNAMENT','QUEST','RANDOM_ENCOUNTER','VILLAGE_PROTECTOR','TRAINING','RANKED_PVP','RANKED_SPARRING','RAID','OVERWORLD')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LogRankedPicks_id": {
+          "name": "LogRankedPicks_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "uniqueContentId": {
+          "name": "uniqueContentId",
+          "columns": [
+            "type",
+            "contentId",
+            "battleType"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "MapAsset": {
+      "name": "MapAsset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "windAffected": {
+          "name": "windAffected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "small": {
+          "name": "small",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "randomRotation": {
+          "name": "randomRotation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "renderScale": {
+          "name": "renderScale",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "licenseDetails": {
+          "name": "licenseDetails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('TNR')"
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "MapAsset_key_key": {
+          "name": "MapAsset_key_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "MapAsset_category_idx": {
+          "name": "MapAsset_category_idx",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "MapAsset_id": {
+          "name": "MapAsset_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "MapTerrain": {
+      "name": "MapTerrain",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "colors": {
+          "name": "colors",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "textureUrl": {
+          "name": "textureUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "swatchColor": {
+          "name": "swatchColor",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleBiome": {
+          "name": "battleBiome",
+          "type": "enum('ocean','ground','dessert','ice','snow','arena','default')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ground'"
+        },
+        "isWater": {
+          "name": "isWater",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "depression": {
+          "name": "depression",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "defaultWalkCost": {
+          "name": "defaultWalkCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "protected": {
+          "name": "protected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "licenseDetails": {
+          "name": "licenseDetails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('TNR')"
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "MapTerrain_key_key": {
+          "name": "MapTerrain_key_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "MapTerrain_id": {
+          "name": "MapTerrain_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "MpvpBattleQueue": {
+      "name": "MpvpBattleQueue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "winnerId": {
+          "name": "winnerId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "battleId": {
+          "name": "battleId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "battleType": {
+          "name": "battleType",
+          "type": "enum('CLAN_BATTLE','SHRINE_BATTLE','RAID_BATTLE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CLAN_BATTLE'"
+        },
+        "attackerEntityId": {
+          "name": "attackerEntityId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "defenderEntityId": {
+          "name": "defenderEntityId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "MpvpBattleQueue_battleId_idx": {
+          "name": "MpvpBattleQueue_battleId_idx",
+          "columns": [
+            "battleId"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleQueue_winnerId_idx": {
+          "name": "MpvpBattleQueue_winnerId_idx",
+          "columns": [
+            "winnerId"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleQueue_battleType_idx": {
+          "name": "MpvpBattleQueue_battleType_idx",
+          "columns": [
+            "battleType"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleQueue_sector_idx": {
+          "name": "MpvpBattleQueue_sector_idx",
+          "columns": [
+            "sector"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleQueue_attackerEntityId_idx": {
+          "name": "MpvpBattleQueue_attackerEntityId_idx",
+          "columns": [
+            "attackerEntityId"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleQueue_defenderEntityId_idx": {
+          "name": "MpvpBattleQueue_defenderEntityId_idx",
+          "columns": [
+            "defenderEntityId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "MpvpBattleQueue_id": {
+          "name": "MpvpBattleQueue_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "MpvpBattleUser": {
+      "name": "MpvpBattleUser",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clanBattleId": {
+          "name": "clanBattleId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "side": {
+          "name": "side",
+          "type": "enum('ATTACKER','DEFENDER')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot": {
+          "name": "slot",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "MpvpBattleUser_clanBattleId_idx": {
+          "name": "MpvpBattleUser_clanBattleId_idx",
+          "columns": [
+            "clanBattleId"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleUser_userId_idx": {
+          "name": "MpvpBattleUser_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleUser_side_idx": {
+          "name": "MpvpBattleUser_side_idx",
+          "columns": [
+            "side"
+          ],
+          "isUnique": false
+        },
+        "MpvpBattleUser_clanBattleId_side_slot_key": {
+          "name": "MpvpBattleUser_clanBattleId_side_slot_key",
+          "columns": [
+            "clanBattleId",
+            "side",
+            "slot"
+          ],
+          "isUnique": true
+        },
+        "MpvpBattleUser_userId_key": {
+          "name": "MpvpBattleUser_userId_key",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "MpvpBattleUser_id": {
+          "name": "MpvpBattleUser_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Notification": {
+      "name": "Notification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Notification_createdAt_idx": {
+          "name": "Notification_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Notification_id": {
+          "name": "Notification_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "OverworldAiPlacement": {
+      "name": "OverworldAiPlacement",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "aiTemplateUserId": {
+          "name": "aiTemplateUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "interactionType": {
+          "name": "interactionType",
+          "type": "enum('FRIENDLY','HOSTILE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "sectorType": {
+          "name": "sectorType",
+          "type": "enum('specific','random','from_list')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'specific'"
+        },
+        "locationType": {
+          "name": "locationType",
+          "type": "enum('specific','random')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'specific'"
+        },
+        "sectorList": {
+          "name": "sectorList",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "positionVersion": {
+          "name": "positionVersion",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "OverworldAiPlacement_aiTemplateUserId_idx": {
+          "name": "OverworldAiPlacement_aiTemplateUserId_idx",
+          "columns": [
+            "aiTemplateUserId"
+          ],
+          "isUnique": false
+        },
+        "OverworldAiPlacement_isActive_sector_idx": {
+          "name": "OverworldAiPlacement_isActive_sector_idx",
+          "columns": [
+            "isActive",
+            "sector"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "OverworldAiPlacement_id": {
+          "name": "OverworldAiPlacement_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "OverworldAiPlacementQuest": {
+      "name": "OverworldAiPlacementQuest",
+      "columns": {
+        "placementId": {
+          "name": "placementId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questId": {
+          "name": "questId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chance": {
+          "name": "chance",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "OverworldAiPlacementQuest_questId_idx": {
+          "name": "OverworldAiPlacementQuest_questId_idx",
+          "columns": [
+            "questId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "OverworldAiPlacementQuest_placementId_questId_pk": {
+          "name": "OverworldAiPlacementQuest_placementId_questId_pk",
+          "columns": [
+            "placementId",
+            "questId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "PaypalSubscription": {
+      "name": "PaypalSubscription",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "affectedUserId": {
+          "name": "affectedUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "federalStatus": {
+          "name": "federalStatus",
+          "type": "enum('NONE','NORMAL','SILVER','GOLD')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "PaypalSubscription_subscriptionId_key": {
+          "name": "PaypalSubscription_subscriptionId_key",
+          "columns": [
+            "subscriptionId"
+          ],
+          "isUnique": true
+        },
+        "PaypalSubscription_orderId_key": {
+          "name": "PaypalSubscription_orderId_key",
+          "columns": [
+            "orderId"
+          ],
+          "isUnique": true
+        },
+        "PaypalSubscription_createdById_idx": {
+          "name": "PaypalSubscription_createdById_idx",
+          "columns": [
+            "createdById"
+          ],
+          "isUnique": false
+        },
+        "PaypalSubscription_affectedUserId_idx": {
+          "name": "PaypalSubscription_affectedUserId_idx",
+          "columns": [
+            "affectedUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "PaypalSubscription_id": {
+          "name": "PaypalSubscription_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "PaypalTransaction": {
+      "name": "PaypalTransaction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "affectedUserId": {
+          "name": "affectedUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transactionId": {
+          "name": "transactionId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transactionUpdatedDate": {
+          "name": "transactionUpdatedDate",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invoiceId": {
+          "name": "invoiceId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('REP_PURCHASE','REFERRAL')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'REP_PURCHASE'"
+        },
+        "reputationPoints": {
+          "name": "reputationPoints",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rawData": {
+          "name": "rawData",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "PaypalTransaction_orderId_key": {
+          "name": "PaypalTransaction_orderId_key",
+          "columns": [
+            "orderId"
+          ],
+          "isUnique": true
+        },
+        "PaypalTransaction_createdById_idx": {
+          "name": "PaypalTransaction_createdById_idx",
+          "columns": [
+            "createdById"
+          ],
+          "isUnique": false
+        },
+        "PaypalTransaction_transactionId_idx": {
+          "name": "PaypalTransaction_transactionId_idx",
+          "columns": [
+            "transactionId"
+          ],
+          "isUnique": false
+        },
+        "PaypalTransaction_invoiceId_idx": {
+          "name": "PaypalTransaction_invoiceId_idx",
+          "columns": [
+            "invoiceId"
+          ],
+          "isUnique": false
+        },
+        "PaypalTransaction_affectedUserId_idx": {
+          "name": "PaypalTransaction_affectedUserId_idx",
+          "columns": [
+            "affectedUserId"
+          ],
+          "isUnique": false
+        },
+        "PaypalTransaction_reputationPoints_idx": {
+          "name": "PaypalTransaction_reputationPoints_idx",
+          "columns": [
+            "reputationPoints"
+          ],
+          "isUnique": false
+        },
+        "PaypalTransaction_type_idx": {
+          "name": "PaypalTransaction_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "PaypalTransaction_amount_idx": {
+          "name": "PaypalTransaction_amount_idx",
+          "columns": [
+            "amount"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "PaypalTransaction_id": {
+          "name": "PaypalTransaction_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "PaypalWebhookMessage": {
+      "name": "PaypalWebhookMessage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rawData": {
+          "name": "rawData",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "handled": {
+          "name": "handled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "PaypalWebhookMessage_id": {
+          "name": "PaypalWebhookMessage_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Poll": {
+      "name": "Poll",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allowCustomOptions": {
+          "name": "allowCustomOptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "Poll_createdByUserId_idx": {
+          "name": "Poll_createdByUserId_idx",
+          "columns": [
+            "createdByUserId"
+          ],
+          "isUnique": false
+        },
+        "Poll_isActive_idx": {
+          "name": "Poll_isActive_idx",
+          "columns": [
+            "isActive"
+          ],
+          "isUnique": false
+        },
+        "Poll_endDate_idx": {
+          "name": "Poll_endDate_idx",
+          "columns": [
+            "endDate"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Poll_id": {
+          "name": "Poll_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "PollOption": {
+      "name": "PollOption",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollId": {
+          "name": "pollId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "optionType": {
+          "name": "optionType",
+          "type": "enum('text','user')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isCustomOption": {
+          "name": "isCustomOption",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "PollOption_pollId_idx": {
+          "name": "PollOption_pollId_idx",
+          "columns": [
+            "pollId"
+          ],
+          "isUnique": false
+        },
+        "PollOption_createdByUserId_idx": {
+          "name": "PollOption_createdByUserId_idx",
+          "columns": [
+            "createdByUserId"
+          ],
+          "isUnique": false
+        },
+        "PollOption_targetUserId_idx": {
+          "name": "PollOption_targetUserId_idx",
+          "columns": [
+            "targetUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "PollOption_id": {
+          "name": "PollOption_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Quest": {
+      "name": "Quest",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(5000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "successDescription": {
+          "name": "successDescription",
+          "type": "varchar(5000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "questRank": {
+          "name": "questRank",
+          "type": "enum('D','C','B','A','S','H')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'D'"
+        },
+        "medicalRank": {
+          "name": "medicalRank",
+          "type": "enum('NONE','NOVICE','APPRENTICE','MASTER','LEGENDARY')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "huntingRank": {
+          "name": "huntingRank",
+          "type": "enum('NONE','D RANK','C RANK','B RANK','A RANK','S RANK')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "gatheringRank": {
+          "name": "gatheringRank",
+          "type": "enum('NONE','D RANK','C RANK','B RANK','A RANK','S RANK')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "requiredLevel": {
+          "name": "requiredLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "prerequisiteQuestId": {
+          "name": "prerequisiteQuestId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tierLevel": {
+          "name": "tierLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "questType": {
+          "name": "questType",
+          "type": "enum('starter','tier','daily','mission','errand','crime','exam','event','story','anbu','medical','hunting','gathering','battlepyramid','pvp','achievement','war','raid','overworld')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "consecutiveObjectives": {
+          "name": "consecutiveObjectives",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "requiredVillage": {
+          "name": "requiredVillage",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredBloodlineId": {
+          "name": "requiredBloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredSageModeId": {
+          "name": "requiredSageModeId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiredSageRank": {
+          "name": "requiredSageRank",
+          "type": "enum('NONE','INITIATE','ADEPT','MASTER','LEGENDARY')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "maxLevel": {
+          "name": "maxLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "maxAttempts": {
+          "name": "maxAttempts",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "maxCompletes": {
+          "name": "maxCompletes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "retryDelay": {
+          "name": "retryDelay",
+          "type": "enum('daily','weekly','monthly','none')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "attemptDelay": {
+          "name": "attemptDelay",
+          "type": "enum('daily','weekly','monthly','none')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "endsAt": {
+          "name": "endsAt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startsAt": {
+          "name": "startsAt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raidBossMaxHealth": {
+          "name": "raidBossMaxHealth",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raidBossCurrentHealth": {
+          "name": "raidBossCurrentHealth",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raidEndsAt": {
+          "name": "raidEndsAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raidCaptureDeadline": {
+          "name": "raidCaptureDeadline",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raidGracePeriodEnd": {
+          "name": "raidGracePeriodEnd",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Quest_questType_idx": {
+          "name": "Quest_questType_idx",
+          "columns": [
+            "questType"
+          ],
+          "isUnique": false
+        },
+        "Quest_questRank_idx": {
+          "name": "Quest_questRank_idx",
+          "columns": [
+            "questRank"
+          ],
+          "isUnique": false
+        },
+        "Quest_requiredLevel_idx": {
+          "name": "Quest_requiredLevel_idx",
+          "columns": [
+            "requiredLevel"
+          ],
+          "isUnique": false
+        },
+        "Quest_maxLevel_idx": {
+          "name": "Quest_maxLevel_idx",
+          "columns": [
+            "maxLevel"
+          ],
+          "isUnique": false
+        },
+        "Quest_requiredVillage_idx": {
+          "name": "Quest_requiredVillage_idx",
+          "columns": [
+            "requiredVillage"
+          ],
+          "isUnique": false
+        },
+        "Quest_requiredBloodline_idx": {
+          "name": "Quest_requiredBloodline_idx",
+          "columns": [
+            "requiredBloodlineId"
+          ],
+          "isUnique": false
+        },
+        "Quest_requiredSageMode_idx": {
+          "name": "Quest_requiredSageMode_idx",
+          "columns": [
+            "requiredSageModeId"
+          ],
+          "isUnique": false
+        },
+        "Quest_endsAt_idx": {
+          "name": "Quest_endsAt_idx",
+          "columns": [
+            "endsAt"
+          ],
+          "isUnique": false
+        },
+        "Quest_startsAt_idx": {
+          "name": "Quest_startsAt_idx",
+          "columns": [
+            "startsAt"
+          ],
+          "isUnique": false
+        },
+        "Quest_prerequisiteQuestId_idx": {
+          "name": "Quest_prerequisiteQuestId_idx",
+          "columns": [
+            "prerequisiteQuestId"
+          ],
+          "isUnique": false
+        },
+        "Quest_questType_questRank_requiredLevel_idx": {
+          "name": "Quest_questType_questRank_requiredLevel_idx",
+          "columns": [
+            "questType",
+            "questRank",
+            "requiredLevel"
+          ],
+          "isUnique": false
+        },
+        "Quest_raidEndsAt_idx": {
+          "name": "Quest_raidEndsAt_idx",
+          "columns": [
+            "raidEndsAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Quest_id": {
+          "name": "Quest_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "tierLevel": {
+          "name": "tierLevel",
+          "columns": [
+            "tierLevel"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "QuestHistory": {
+      "name": "QuestHistory",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questId": {
+          "name": "questId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questType": {
+          "name": "questType",
+          "type": "enum('starter','tier','daily','mission','errand','crime','exam','event','story','anbu','medical','hunting','gathering','battlepyramid','pvp','achievement','war','raid','overworld')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "previousCompletes": {
+          "name": "previousCompletes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "previousAttempts": {
+          "name": "previousAttempts",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "periodCompletes": {
+          "name": "periodCompletes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "periodStartAt": {
+          "name": "periodStartAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "QuestHistory_userId_idx": {
+          "name": "QuestHistory_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_questType_idx": {
+          "name": "QuestHistory_questType_idx",
+          "columns": [
+            "questType"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_endedAt_idx": {
+          "name": "QuestHistory_endedAt_idx",
+          "columns": [
+            "endedAt"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_questId_idx": {
+          "name": "QuestHistory_questId_idx",
+          "columns": [
+            "questId"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_completed_idx": {
+          "name": "QuestHistory_completed_idx",
+          "columns": [
+            "completed"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_userId_completed_idx": {
+          "name": "QuestHistory_userId_completed_idx",
+          "columns": [
+            "userId",
+            "completed"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_userId_questType_idx": {
+          "name": "QuestHistory_userId_questType_idx",
+          "columns": [
+            "userId",
+            "questType"
+          ],
+          "isUnique": false
+        },
+        "QuestHistory_questId_userId_completed_idx": {
+          "name": "QuestHistory_questId_userId_completed_idx",
+          "columns": [
+            "questId",
+            "userId",
+            "completed"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "QuestHistory_id": {
+          "name": "QuestHistory_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "uniqueUserIdQuestId": {
+          "name": "uniqueUserIdQuestId",
+          "columns": [
+            "userId",
+            "questId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "RaidDamageThreshold": {
+      "name": "RaidDamageThreshold",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questId": {
+          "name": "questId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "damageRequired": {
+          "name": "damageRequired",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rewards": {
+          "name": "rewards",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "effectDurationMinutes": {
+          "name": "effectDurationMinutes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "RaidDamageThreshold_questId_idx": {
+          "name": "RaidDamageThreshold_questId_idx",
+          "columns": [
+            "questId"
+          ],
+          "isUnique": false
+        },
+        "RaidDamageThreshold_sortOrder_idx": {
+          "name": "RaidDamageThreshold_sortOrder_idx",
+          "columns": [
+            "sortOrder"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RaidDamageThreshold_id": {
+          "name": "RaidDamageThreshold_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "RaidParticipation": {
+      "name": "RaidParticipation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questId": {
+          "name": "questId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "damageDealt": {
+          "name": "damageDealt",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "battleCount": {
+          "name": "battleCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rewardsClaimed": {
+          "name": "rewardsClaimed",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "RaidParticipation_questId_idx": {
+          "name": "RaidParticipation_questId_idx",
+          "columns": [
+            "questId"
+          ],
+          "isUnique": false
+        },
+        "RaidParticipation_userId_idx": {
+          "name": "RaidParticipation_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "RaidParticipation_damageDealt_idx": {
+          "name": "RaidParticipation_damageDealt_idx",
+          "columns": [
+            "damageDealt"
+          ],
+          "isUnique": false
+        },
+        "RaidParticipation_questId_damageDealt_idx": {
+          "name": "RaidParticipation_questId_damageDealt_idx",
+          "columns": [
+            "questId",
+            "damageDealt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RaidParticipation_id": {
+          "name": "RaidParticipation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "RaidParticipation_questId_userId": {
+          "name": "RaidParticipation_questId_userId",
+          "columns": [
+            "questId",
+            "userId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "RankedLoadout": {
+      "name": "RankedLoadout",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "loadout": {
+          "name": "loadout",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RankedLoadout_id": {
+          "name": "RankedLoadout_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "RankedPvpQueue": {
+      "name": "RankedPvpQueue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rankedLp": {
+          "name": "rankedLp",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "queueStartTime": {
+          "name": "queueStartTime",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "RankedPvpQueue_userId_idx": {
+          "name": "RankedPvpQueue_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "RankedPvpQueue_rankedLp_idx": {
+          "name": "RankedPvpQueue_rankedLp_idx",
+          "columns": [
+            "rankedLp"
+          ],
+          "isUnique": false
+        },
+        "RankedPvpQueue_createdAt_idx": {
+          "name": "RankedPvpQueue_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RankedPvpQueue_id": {
+          "name": "RankedPvpQueue_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "RankedSeason": {
+      "name": "RankedSeason",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewards": {
+          "name": "rewards",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RankedSeason_id": {
+          "name": "RankedSeason_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "RankedUserRewards": {
+      "name": "RankedUserRewards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seasonId": {
+          "name": "seasonId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "enum('Unranked','Wood','Adept','Master','Legend','Sannin')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed": {
+          "name": "claimed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "claimedAt": {
+          "name": "claimedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RankedUserRewards_id": {
+          "name": "RankedUserRewards_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "RecruitmentRewards": {
+      "name": "RecruitmentRewards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('MONEY','REPUTATION','PRESTIGE','CLAN_POINTS')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recruitedUserId": {
+          "name": "recruitedUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "RecruitmentRewards_userId_idx": {
+          "name": "RecruitmentRewards_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "RecruitmentRewards_recruitedUserId_idx": {
+          "name": "RecruitmentRewards_recruitedUserId_idx",
+          "columns": [
+            "recruitedUserId"
+          ],
+          "isUnique": false
+        },
+        "RecruitmentRewards_type_idx": {
+          "name": "RecruitmentRewards_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RecruitmentRewards_id": {
+          "name": "RecruitmentRewards_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ReferralSource": {
+      "name": "ReferralSource",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ReferralSource_userId_idx": {
+          "name": "ReferralSource_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "ReferralSource_source_idx": {
+          "name": "ReferralSource_source_idx",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ReferralSource_id": {
+          "name": "ReferralSource_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "ReportLog": {
+      "name": "ReportLog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staffUserId": {
+          "name": "staffUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ReportLog_targetUserId_idx": {
+          "name": "ReportLog_targetUserId_idx",
+          "columns": [
+            "targetUserId"
+          ],
+          "isUnique": false
+        },
+        "ReportLog_staffUserId_idx": {
+          "name": "ReportLog_staffUserId_idx",
+          "columns": [
+            "staffUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ReportLog_id": {
+          "name": "ReportLog_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "RyoTrade": {
+      "name": "RyoTrade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creatorUserId": {
+          "name": "creatorUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repsForSale": {
+          "name": "repsForSale",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requestedRyo": {
+          "name": "requestedRyo",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ryoPerRep": {
+          "name": "ryoPerRep",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purchaserUserId": {
+          "name": "purchaserUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowedPurchaserId": {
+          "name": "allowedPurchaserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "RyoTrade_creatorUserId_idx": {
+          "name": "RyoTrade_creatorUserId_idx",
+          "columns": [
+            "creatorUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "RyoTrade_id": {
+          "name": "RyoTrade_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SageMode": {
+      "name": "SageMode",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "battleDescription": {
+          "name": "battleDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "afterEffects": {
+          "name": "afterEffects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "level2Effects": {
+          "name": "level2Effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "activationRounds": {
+          "name": "activationRounds",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "afterEffectRounds": {
+          "name": "afterEffectRounds",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "chakraCostPerc": {
+          "name": "chakraCostPerc",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "staminaCostPerc": {
+          "name": "staminaCostPerc",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "actionCostPerc": {
+          "name": "actionCostPerc",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 80
+        },
+        "level": {
+          "name": "level",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "requiredSageMastery": {
+          "name": "requiredSageMastery",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "SageMode_name_key": {
+          "name": "SageMode_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "SageMode_level_idx": {
+          "name": "SageMode_level_idx",
+          "columns": [
+            "level"
+          ],
+          "isUnique": false
+        },
+        "SageMode_villageId_idx": {
+          "name": "SageMode_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        },
+        "SageMode_hidden_idx": {
+          "name": "SageMode_hidden_idx",
+          "columns": [
+            "hidden"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SageMode_id": {
+          "name": "SageMode_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SageModeRolls": {
+      "name": "SageModeRolls",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sageModeId": {
+          "name": "sageModeId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('ITEM','QUEST')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "SageModeRolls_userId_idx": {
+          "name": "SageModeRolls_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "SageModeRolls_sageModeId_idx": {
+          "name": "SageModeRolls_sageModeId_idx",
+          "columns": [
+            "sageModeId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SageModeRolls_id": {
+          "name": "SageModeRolls_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Sector": {
+      "name": "Sector",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "sector": {
+          "name": "sector",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "shrineLevel": {
+          "name": "shrineLevel",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "capturedAt": {
+          "name": "capturedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nextMaintainanceDueDate": {
+          "name": "nextMaintainanceDueDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Sector_sector_key": {
+          "name": "Sector_sector_key",
+          "columns": [
+            "sector"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Sector_id": {
+          "name": "Sector_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SectorMap": {
+      "name": "SectorMap",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('DRAFT','PUBLISHED','ARCHIVED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sourceHash": {
+          "name": "sourceHash",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rawTiledJson": {
+          "name": "rawTiledJson",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "normalizedJson": {
+          "name": "normalizedJson",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publishedByUserId": {
+          "name": "publishedByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "SectorMap_sector_version_key": {
+          "name": "SectorMap_sector_version_key",
+          "columns": [
+            "sector",
+            "version"
+          ],
+          "isUnique": true
+        },
+        "SectorMap_sector_status_idx": {
+          "name": "SectorMap_sector_status_idx",
+          "columns": [
+            "sector",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SectorMap_id": {
+          "name": "SectorMap_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SkillTree": {
+      "name": "SkillTree",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "enum('SELF','ENEMIES','ALLIES')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'SELF'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "requiredSkillIds": {
+          "name": "requiredSkillIds",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "costSkillPoints": {
+          "name": "costSkillPoints",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "skillType": {
+          "name": "skillType",
+          "type": "enum('DEFAULT','SPECIAL')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'DEFAULT'"
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "SkillTree_name_key": {
+          "name": "SkillTree_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "SkillTree_tier_idx": {
+          "name": "SkillTree_tier_idx",
+          "columns": [
+            "tier"
+          ],
+          "isUnique": false
+        },
+        "SkillTree_hidden_idx": {
+          "name": "SkillTree_hidden_idx",
+          "columns": [
+            "hidden"
+          ],
+          "isUnique": false
+        },
+        "SkillTree_skillType_idx": {
+          "name": "SkillTree_skillType_idx",
+          "columns": [
+            "skillType"
+          ],
+          "isUnique": false
+        },
+        "SkillTree_folderId_idx": {
+          "name": "SkillTree_folderId_idx",
+          "columns": [
+            "folderId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SkillTree_id": {
+          "name": "SkillTree_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SkillTreeFolder": {
+      "name": "SkillTreeFolder",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "SkillTreeFolder_name_idx": {
+          "name": "SkillTreeFolder_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "SkillTreeFolder_order_idx": {
+          "name": "SkillTreeFolder_order_idx",
+          "columns": [
+            "order"
+          ],
+          "isUnique": false
+        },
+        "SkillTreeFolder_hidden_idx": {
+          "name": "SkillTreeFolder_hidden_idx",
+          "columns": [
+            "hidden"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SkillTreeFolder_id": {
+          "name": "SkillTreeFolder_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "StaffApplication": {
+      "name": "StaffApplication",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applicantUserId": {
+          "name": "applicantUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetRole": {
+          "name": "targetRole",
+          "type": "enum('USER','OWNER','CODING-ADMIN','CONTENT-ADMIN','EVENT-ADMIN','MODERATOR-ADMIN','HEAD_MODERATOR','MODERATOR','JR_MODERATOR','HEAD_CONTENT','HEAD_BALANCE','CONTENT','BALANCE','HEAD_EVENT','EVENT','CODER')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum('PENDING','APPROVED','REJECTED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING'"
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "StaffApplication_applicantUserId_idx": {
+          "name": "StaffApplication_applicantUserId_idx",
+          "columns": [
+            "applicantUserId"
+          ],
+          "isUnique": false
+        },
+        "StaffApplication_targetRole_idx": {
+          "name": "StaffApplication_targetRole_idx",
+          "columns": [
+            "targetRole"
+          ],
+          "isUnique": false
+        },
+        "StaffApplication_state_idx": {
+          "name": "StaffApplication_state_idx",
+          "columns": [
+            "state"
+          ],
+          "isUnique": false
+        },
+        "StaffApplication_createdAt_idx": {
+          "name": "StaffApplication_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "StaffApplication_id": {
+          "name": "StaffApplication_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "StaffApplicationApproval": {
+      "name": "StaffApplicationApproval",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applicationId": {
+          "name": "applicationId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approverUserId": {
+          "name": "approverUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "enum('EVENT-ADMIN','CODING-ADMIN','MODERATOR-ADMIN','CONTENT-ADMIN')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum('APPROVED','REJECTED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'APPROVED'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "StaffApplicationApproval_applicationId_idx": {
+          "name": "StaffApplicationApproval_applicationId_idx",
+          "columns": [
+            "applicationId"
+          ],
+          "isUnique": false
+        },
+        "StaffApplicationApproval_approverUserId_idx": {
+          "name": "StaffApplicationApproval_approverUserId_idx",
+          "columns": [
+            "approverUserId"
+          ],
+          "isUnique": false
+        },
+        "StaffApplicationApproval_applicationId_group_key": {
+          "name": "StaffApplicationApproval_applicationId_group_key",
+          "columns": [
+            "applicationId",
+            "group"
+          ],
+          "isUnique": true
+        },
+        "StaffApplicationApproval_applicationId_approverUserId_key": {
+          "name": "StaffApplicationApproval_applicationId_approverUserId_key",
+          "columns": [
+            "applicationId",
+            "approverUserId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "StaffApplicationApproval_id": {
+          "name": "StaffApplicationApproval_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SupportReview": {
+      "name": "SupportReview",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "apiRoute": {
+          "name": "apiRoute",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chatHistory": {
+          "name": "chatHistory",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "enum('POSITIVE','NEGATIVE','NEUTRAL')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SupportReview_id": {
+          "name": "SupportReview_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SupportTicket": {
+      "name": "SupportTicket",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "enum('BUG_REPORT','FEATURE_REQUEST','ACCOUNT_ISSUE','GAMEPLAY_QUESTION','PAYMENT_ISSUE','TECHNICAL_SUPPORT','MODERATION_SUPPORT','OTHER')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "enum('LOW','MEDIUM','HIGH','URGENT')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'MEDIUM'"
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('OPEN','IN_PROGRESS','WAITING_FOR_USER','WAITING_FOR_STAFF','RESOLVED','CLOSED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'OPEN'"
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assignedToUserId": {
+          "name": "assignedToUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "githubIssueUrl": {
+          "name": "githubIssueUrl",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "SupportTicket_createdByUserId_idx": {
+          "name": "SupportTicket_createdByUserId_idx",
+          "columns": [
+            "createdByUserId"
+          ],
+          "isUnique": false
+        },
+        "SupportTicket_assignedToUserId_idx": {
+          "name": "SupportTicket_assignedToUserId_idx",
+          "columns": [
+            "assignedToUserId"
+          ],
+          "isUnique": false
+        },
+        "SupportTicket_status_idx": {
+          "name": "SupportTicket_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "SupportTicket_category_idx": {
+          "name": "SupportTicket_category_idx",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        },
+        "SupportTicket_priority_idx": {
+          "name": "SupportTicket_priority_idx",
+          "columns": [
+            "priority"
+          ],
+          "isUnique": false
+        },
+        "SupportTicket_isPublic_idx": {
+          "name": "SupportTicket_isPublic_idx",
+          "columns": [
+            "isPublic"
+          ],
+          "isUnique": false
+        },
+        "SupportTicket_createdAt_idx": {
+          "name": "SupportTicket_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SupportTicket_id": {
+          "name": "SupportTicket_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SupportTicketActivity": {
+      "name": "SupportTicketActivity",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ticketId": {
+          "name": "ticketId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "enum('CREATED','UPDATED','ASSIGNED','UNASSIGNED','STATUS_CHANGED','PRIORITY_CHANGED','CATEGORY_CHANGED','TAGGED','UNTAGGED','MERGED','ESCALATED_TO_GITHUB','COMMENTED','CLOSED','REOPENED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oldValue": {
+          "name": "oldValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "newValue": {
+          "name": "newValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('{}')"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "SupportTicketActivity_ticketId_idx": {
+          "name": "SupportTicketActivity_ticketId_idx",
+          "columns": [
+            "ticketId"
+          ],
+          "isUnique": false
+        },
+        "SupportTicketActivity_authorId_idx": {
+          "name": "SupportTicketActivity_authorId_idx",
+          "columns": [
+            "authorId"
+          ],
+          "isUnique": false
+        },
+        "SupportTicketActivity_action_idx": {
+          "name": "SupportTicketActivity_action_idx",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        },
+        "SupportTicketActivity_createdAt_idx": {
+          "name": "SupportTicketActivity_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SupportTicketActivity_id": {
+          "name": "SupportTicketActivity_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Tournament": {
+      "name": "Tournament",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "round": {
+          "name": "round",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('CLAN')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewards": {
+          "name": "rewards",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3) + INTERVAL 1 DAY )"
+        },
+        "roundStartedAt": {
+          "name": "roundStartedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3) + INTERVAL 1 DAY )"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('OPEN','IN_PROGRESS','COMPLETED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'OPEN'"
+        }
+      },
+      "indexes": {
+        "Tournament_name_key": {
+          "name": "Tournament_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Tournament_id": {
+          "name": "Tournament_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "TournamentMatch": {
+      "name": "TournamentMatch",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tournamentId": {
+          "name": "tournamentId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "round": {
+          "name": "round",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match": {
+          "name": "match",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum('WAITING','PLAYED','NO_SHOW')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'WAITING'"
+        },
+        "winnerId": {
+          "name": "winnerId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "battleId": {
+          "name": "battleId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId1": {
+          "name": "userId1",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId2": {
+          "name": "userId2",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "TournamentMatch_tournamentId_idx": {
+          "name": "TournamentMatch_tournamentId_idx",
+          "columns": [
+            "tournamentId"
+          ],
+          "isUnique": false
+        },
+        "TournamentMatch_userId1_idx": {
+          "name": "TournamentMatch_userId1_idx",
+          "columns": [
+            "userId1"
+          ],
+          "isUnique": false
+        },
+        "TournamentMatch_userId2_idx": {
+          "name": "TournamentMatch_userId2_idx",
+          "columns": [
+            "userId2"
+          ],
+          "isUnique": false
+        },
+        "TournamentMatch_winnerId_idx": {
+          "name": "TournamentMatch_winnerId_idx",
+          "columns": [
+            "winnerId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TournamentMatch_id": {
+          "name": "TournamentMatch_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "TournamentRecord": {
+      "name": "TournamentRecord",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "round": {
+          "name": "round",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('CLAN')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewards": {
+          "name": "rewards",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3) + INTERVAL 1 DAY )"
+        },
+        "winnerId": {
+          "name": "winnerId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "HistoricalTournament_name_key": {
+          "name": "HistoricalTournament_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TournamentRecord_id": {
+          "name": "TournamentRecord_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "TowerDefenseCharacter": {
+      "name": "TowerDefenseCharacter",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isPlayer": {
+          "name": "isPlayer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "baseHealth": {
+          "name": "baseHealth",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "baseSpeed": {
+          "name": "baseSpeed",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.4
+        },
+        "baseDamage": {
+          "name": "baseDamage",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "attackCooldown": {
+          "name": "attackCooldown",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "healthScaling": {
+          "name": "healthScaling",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.15
+        },
+        "speedScaling": {
+          "name": "speedScaling",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.02
+        },
+        "damageScaling": {
+          "name": "damageScaling",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "firstAppearWave": {
+          "name": "firstAppearWave",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "baseCount": {
+          "name": "baseCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "countScaling": {
+          "name": "countScaling",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1.5
+        },
+        "scaleFactor": {
+          "name": "scaleFactor",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2.8
+        },
+        "assetConfig": {
+          "name": "assetConfig",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "('null')"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "TowerDefenseCharacter_name_idx": {
+          "name": "TowerDefenseCharacter_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseCharacter_firstAppearWave_idx": {
+          "name": "TowerDefenseCharacter_firstAppearWave_idx",
+          "columns": [
+            "firstAppearWave"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseCharacter_isPlayer_idx": {
+          "name": "TowerDefenseCharacter_isPlayer_idx",
+          "columns": [
+            "isPlayer"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TowerDefenseCharacter_id": {
+          "name": "TowerDefenseCharacter_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "TowerDefenseRun": {
+      "name": "TowerDefenseRun",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wave": {
+          "name": "wave",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gridSize": {
+          "name": "gridSize",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('ACTIVE','COMPLETED','ABANDONED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "state": {
+          "name": "state",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "TowerDefenseRun_userId_idx": {
+          "name": "TowerDefenseRun_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseRun_status_idx": {
+          "name": "TowerDefenseRun_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseRun_userId_status_idx": {
+          "name": "TowerDefenseRun_userId_status_idx",
+          "columns": [
+            "userId",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseRun_score_idx": {
+          "name": "TowerDefenseRun_score_idx",
+          "columns": [
+            "score"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseRun_startedAt_idx": {
+          "name": "TowerDefenseRun_startedAt_idx",
+          "columns": [
+            "startedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TowerDefenseRun_id": {
+          "name": "TowerDefenseRun_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "TowerDefenseUpgrade": {
+      "name": "TowerDefenseUpgrade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "maxLevel": {
+          "name": "maxLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "baseCost": {
+          "name": "baseCost",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "costMultiplier": {
+          "name": "costMultiplier",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1.5
+        },
+        "upgradeType": {
+          "name": "upgradeType",
+          "type": "enum('DAMAGE','ATTACK_SPEED','RANGE','CRIT_CHANCE','DAMAGE_PER_TILE','HEALTH','HEALTH_REGEN','DEFENSE_PERCENT','DEFENSE_FLAT','LIFESTEAL','KNOCKBACK_CHANCE','KNOCKBACK_FORCE','TOKENS_PER_WAVE','TOKENS_PER_KILL','INTEREST_PER_WAVE','SKIP_ENEMY_CHANCE','ABILITY_UNLOCK')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effectValue": {
+          "name": "effectValue",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "TowerDefenseUpgrade_name_idx": {
+          "name": "TowerDefenseUpgrade_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "TowerDefenseUpgrade_upgradeType_idx": {
+          "name": "TowerDefenseUpgrade_upgradeType_idx",
+          "columns": [
+            "upgradeType"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TowerDefenseUpgrade_id": {
+          "name": "TowerDefenseUpgrade_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "TrainingLog": {
+      "name": "TrainingLog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stat": {
+          "name": "stat",
+          "type": "enum('ninjutsuOffence','taijutsuOffence','genjutsuOffence','bukijutsuOffence','ninjutsuDefence','taijutsuDefence','genjutsuDefence','bukijutsuDefence','intelligence','speed','willpower','strength')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "enum('15min','1hr','4hrs','8hrs','12hrs','24hrs')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trainingFinishedAt": {
+          "name": "trainingFinishedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "TrainingLog_userId_idx": {
+          "name": "TrainingLog_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "TrainingLog_speed_idx": {
+          "name": "TrainingLog_speed_idx",
+          "columns": [
+            "speed"
+          ],
+          "isUnique": false
+        },
+        "TrainingLog_stat_idx": {
+          "name": "TrainingLog_stat_idx",
+          "columns": [
+            "stat"
+          ],
+          "isUnique": false
+        },
+        "TrainingLog_trainingFinishedAt_idx": {
+          "name": "TrainingLog_trainingFinishedAt_idx",
+          "columns": [
+            "trainingFinishedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TrainingLog_id": {
+          "name": "TrainingLog_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UsersInConversation": {
+      "name": "UsersInConversation",
+      "columns": {
+        "conversationId": {
+          "name": "conversationId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assignedAt": {
+          "name": "assignedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "lastReadAt": {
+          "name": "lastReadAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "UsersInConversation_userId_idx": {
+          "name": "UsersInConversation_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UsersInConversation_conversationId_userId_pk": {
+          "name": "UsersInConversation_conversationId_userId_pk",
+          "columns": [
+            "conversationId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserActivityEvent": {
+      "name": "UserActivityEvent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "streak": {
+          "name": "streak",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserActivityEvent_createdAt_idx": {
+          "name": "UserActivityEvent_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserActivityEvent_id": {
+          "name": "UserActivityEvent_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserAssociation": {
+      "name": "UserAssociation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userOne": {
+          "name": "userOne",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userTwo": {
+          "name": "userTwo",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "associationType": {
+          "name": "associationType",
+          "type": "enum('MARRIAGE','DIVORCED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'MARRIAGE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserOne_UserTwo_UserAssociation_key": {
+          "name": "UserOne_UserTwo_UserAssociation_key",
+          "columns": [
+            "userOne",
+            "userTwo",
+            "associationType"
+          ],
+          "isUnique": true
+        },
+        "UserAttribute_userOne_idx": {
+          "name": "UserAttribute_userOne_idx",
+          "columns": [
+            "userOne"
+          ],
+          "isUnique": false
+        },
+        "UserAttribute_userTwo_idx": {
+          "name": "UserAttribute_userTwo_idx",
+          "columns": [
+            "userTwo"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserAssociation_id": {
+          "name": "UserAssociation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserAttribute": {
+      "name": "UserAttribute",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attribute": {
+          "name": "attribute",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "UserAttribute_attribute_userId_key": {
+          "name": "UserAttribute_attribute_userId_key",
+          "columns": [
+            "attribute",
+            "userId"
+          ],
+          "isUnique": true
+        },
+        "UserAttribute_userId_idx": {
+          "name": "UserAttribute_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserAttribute_id": {
+          "name": "UserAttribute_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserBadge": {
+      "name": "UserBadge",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "badgeId": {
+          "name": "badgeId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserBadge_userId_idx": {
+          "name": "UserBadge_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserBadge_badgeId_idx": {
+          "name": "UserBadge_badgeId_idx",
+          "columns": [
+            "badgeId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserBlackList": {
+      "name": "UserBlackList",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "creatorUserId": {
+          "name": "creatorUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "BlackList_creatorUserId_idx": {
+          "name": "BlackList_creatorUserId_idx",
+          "columns": [
+            "creatorUserId"
+          ],
+          "isUnique": false
+        },
+        "BlackList_targetUserId_idx": {
+          "name": "BlackList_targetUserId_idx",
+          "columns": [
+            "targetUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserBlackList_id": {
+          "name": "UserBlackList_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserData": {
+      "name": "UserData",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recruiterId": {
+          "name": "recruiterId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anbuId": {
+          "name": "anbuId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "clanId": {
+          "name": "clanId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "jutsuLoadout": {
+          "name": "jutsuLoadout",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "itemLoadout": {
+          "name": "itemLoadout",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rankedLoadout": {
+          "name": "rankedLoadout",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nRecruited": {
+          "name": "nRecruited",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastIp": {
+          "name": "lastIp",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "curHealth": {
+          "name": "curHealth",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "maxHealth": {
+          "name": "maxHealth",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "curChakra": {
+          "name": "curChakra",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "maxChakra": {
+          "name": "maxChakra",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "curStamina": {
+          "name": "curStamina",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "maxStamina": {
+          "name": "maxStamina",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "regeneration": {
+          "name": "regeneration",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "money": {
+          "name": "money",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "bank": {
+          "name": "bank",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "experience": {
+          "name": "experience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "earnedExperience": {
+          "name": "earnedExperience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2000
+        },
+        "rank": {
+          "name": "rank",
+          "type": "enum('STUDENT','GENIN','CHUNIN','JONIN','ELITE JONIN','ELDER','NONE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'STUDENT'"
+        },
+        "isOutlaw": {
+          "name": "isOutlaw",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "level": {
+          "name": "level",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bloodlineId": {
+          "name": "bloodlineId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bloodlineReskinId": {
+          "name": "bloodlineReskinId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sageModeId": {
+          "name": "sageModeId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sageMasteryExperience": {
+          "name": "sageMasteryExperience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('AWAKE','HOSPITALIZED','TRAVEL','BATTLE','QUEUED','KAGE_QUEUED','ASLEEP')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'AWAKE'"
+        },
+        "strength": {
+          "name": "strength",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "intelligence": {
+          "name": "intelligence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "willpower": {
+          "name": "willpower",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "speed": {
+          "name": "speed",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "ninjutsuOffence": {
+          "name": "ninjutsuOffence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "ninjutsuDefence": {
+          "name": "ninjutsuDefence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "genjutsuOffence": {
+          "name": "genjutsuOffence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "genjutsuDefence": {
+          "name": "genjutsuDefence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "taijutsuOffence": {
+          "name": "taijutsuOffence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "taijutsuDefence": {
+          "name": "taijutsuDefence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "bukijutsuDefence": {
+          "name": "bukijutsuDefence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "bukijutsuOffence": {
+          "name": "bukijutsuOffence",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "statsMultiplier": {
+          "name": "statsMultiplier",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "poolsMultiplier": {
+          "name": "poolsMultiplier",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "primaryElement": {
+          "name": "primaryElement",
+          "type": "enum('Fire','Water','Wind','Earth','Lightning','Ice','Crystal','Dust','Shadow','Wood','Scorch','Storm','Magnet','Yin-Yang','Lava','Explosion','Light','Boil','Metal','Sand','None')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "secondaryElement": {
+          "name": "secondaryElement",
+          "type": "enum('Fire','Water','Wind','Earth','Lightning','Ice','Crystal','Dust','Shadow','Wood','Scorch','Storm','Magnet','Yin-Yang','Lava','Explosion','Light','Boil','Metal','Sand','None')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reputationPoints": {
+          "name": "reputationPoints",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 11
+        },
+        "reputationPointsTotal": {
+          "name": "reputationPointsTotal",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 11
+        },
+        "seichiSilver": {
+          "name": "seichiSilver",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "villagePrestige": {
+          "name": "villagePrestige",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "federalStatus": {
+          "name": "federalStatus",
+          "type": "enum('NONE','NORMAL','SILVER','GOLD')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "approvedTos": {
+          "name": "approvedTos",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatarLight": {
+          "name": "avatarLight",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar3d": {
+          "name": "avatar3d",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatarFacing": {
+          "name": "avatarFacing",
+          "type": "enum('left','right')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'left'"
+        },
+        "sector": {
+          "name": "sector",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 7
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "joinedVillageAt": {
+          "name": "joinedVillageAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3) - INTERVAL 7 DAY)"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "questFinishAt": {
+          "name": "questFinishAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "deletionAt": {
+          "name": "deletionAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "travelFinishAt": {
+          "name": "travelFinishAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isBanned": {
+          "name": "isBanned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isSilenced": {
+          "name": "isSilenced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isWarned": {
+          "name": "isWarned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isTradeBanned": {
+          "name": "isTradeBanned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('USER','OWNER','CODING-ADMIN','CONTENT-ADMIN','EVENT-ADMIN','MODERATOR-ADMIN','HEAD_MODERATOR','MODERATOR','JR_MODERATOR','HEAD_CONTENT','HEAD_BALANCE','CONTENT','BALANCE','HEAD_EVENT','EVENT','CODER')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USER'"
+        },
+        "battleId": {
+          "name": "battleId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isAi": {
+          "name": "isAi",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isSummon": {
+          "name": "isSummon",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isEvent": {
+          "name": "isEvent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "inShrines": {
+          "name": "inShrines",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "inArena": {
+          "name": "inArena",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "inboxNews": {
+          "name": "inboxNews",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "regenAt": {
+          "name": "regenAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "immunityUntil": {
+          "name": "immunityUntil",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "robImmunityUntil": {
+          "name": "robImmunityUntil",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "bracketImmunityLiftedUntil": {
+          "name": "bracketImmunityLiftedUntil",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "warParticipantUntil": {
+          "name": "warParticipantUntil",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "trainingStartedAt": {
+          "name": "trainingStartedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trainingSpeed": {
+          "name": "trainingSpeed",
+          "type": "enum('15min','1hr','4hrs','8hrs','12hrs','24hrs')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'15min'"
+        },
+        "currentlyTraining": {
+          "name": "currentlyTraining",
+          "type": "enum('ninjutsuOffence','taijutsuOffence','genjutsuOffence','bukijutsuOffence','ninjutsuDefence','taijutsuDefence','genjutsuDefence','bukijutsuDefence','intelligence','speed','willpower','strength')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unreadNotifications": {
+          "name": "unreadNotifications",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "unreadNews": {
+          "name": "unreadNews",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "questData": {
+          "name": "questData",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "activeNpcQuestId": {
+          "name": "activeNpcQuestId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "senseiId": {
+          "name": "senseiId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "medicalExperience": {
+          "name": "medicalExperience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "craftingExperience": {
+          "name": "craftingExperience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "huntingExperience": {
+          "name": "huntingExperience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gatheringExperience": {
+          "name": "gatheringExperience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "preferredStat": {
+          "name": "preferredStat",
+          "type": "enum('Highest','Ninjutsu','Genjutsu','Taijutsu','Bukijutsu')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferredGeneral1": {
+          "name": "preferredGeneral1",
+          "type": "enum('Highest','Strength','Intelligence','Willpower','Speed')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferredGeneral2": {
+          "name": "preferredGeneral2",
+          "type": "enum('Highest','Strength','Intelligence','Willpower','Speed')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "showBattleDescription": {
+          "name": "showBattleDescription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "defaultAutoCombat": {
+          "name": "defaultAutoCombat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pvpFights": {
+          "name": "pvpFights",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pveFights": {
+          "name": "pveFights",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pvpActivity": {
+          "name": "pvpActivity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pvpStreak": {
+          "name": "pvpStreak",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "errands": {
+          "name": "errands",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionsD": {
+          "name": "missionsD",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionsC": {
+          "name": "missionsC",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionsB": {
+          "name": "missionsB",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionsA": {
+          "name": "missionsA",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionsS": {
+          "name": "missionsS",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionsH": {
+          "name": "missionsH",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crimesD": {
+          "name": "crimesD",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crimesC": {
+          "name": "crimesC",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crimesB": {
+          "name": "crimesB",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crimesA": {
+          "name": "crimesA",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crimesS": {
+          "name": "crimesS",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crimesH": {
+          "name": "crimesH",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyArenaFights": {
+          "name": "dailyArenaFights",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailySageActivations": {
+          "name": "dailySageActivations",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyMissions": {
+          "name": "dailyMissions",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyErrands": {
+          "name": "dailyErrands",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyMedicalMissions": {
+          "name": "dailyMedicalMissions",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyPvpMissions": {
+          "name": "dailyPvpMissions",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyWarMissions": {
+          "name": "dailyWarMissions",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyTrainings": {
+          "name": "dailyTrainings",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dailyOverworldQuestRolls": {
+          "name": "dailyOverworldQuestRolls",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "movedTooFastCount": {
+          "name": "movedTooFastCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "extraItemSlots": {
+          "name": "extraItemSlots",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "extraJutsuSlots": {
+          "name": "extraJutsuSlots",
+          "type": "tinyint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "extraReskinSlots": {
+          "name": "extraReskinSlots",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "customTitle": {
+          "name": "customTitle",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "marriageSlots": {
+          "name": "marriageSlots",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "aiProfileId": {
+          "name": "aiProfileId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "openaiCalls": {
+          "name": "openaiCalls",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tavernMessages": {
+          "name": "tavernMessages",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "musicOn": {
+          "name": "musicOn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "sfxOn": {
+          "name": "sfxOn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "buttonSfxOn": {
+          "name": "buttonSfxOn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "iframesMuted": {
+          "name": "iframesMuted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "tutorialStep": {
+          "name": "tutorialStep",
+          "type": "tinyint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tutorialOn": {
+          "name": "tutorialOn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "homeType": {
+          "name": "homeType",
+          "type": "enum('NONE','STUDIO_APARTMENT','ONE_BED_APARTMENT','TWO_BED_HOUSE','TOWN_HOUSE','SMALL_MANSION','SMALL_ESTATE','LARGE_ESTATE','PALACE','MARSHMALLOWOPOLIS')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "staffAccount": {
+          "name": "staffAccount",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rankedLp": {
+          "name": "rankedLp",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rankedBattles": {
+          "name": "rankedBattles",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rankedWins": {
+          "name": "rankedWins",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rankedStreak": {
+          "name": "rankedStreak",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skillPoints": {
+          "name": "skillPoints",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "towerDefensePoints": {
+          "name": "towerDefensePoints",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "enum('GATHERING','HUNTER','CRAFTING')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occupationSignupAt": {
+          "name": "occupationSignupAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stealth": {
+          "name": "stealth",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "sensory": {
+          "name": "sensory",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "stealthActive": {
+          "name": "stealthActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "stealthActivatedAt": {
+          "name": "stealthActivatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stealthCooldownAt": {
+          "name": "stealthCooldownAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastSensoryAt": {
+          "name": "lastSensoryAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "covertTrainingType": {
+          "name": "covertTrainingType",
+          "type": "enum('stealth','sensory')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "covertTrainingStartedAt": {
+          "name": "covertTrainingStartedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "covertTrainingMinutes": {
+          "name": "covertTrainingMinutes",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "UserData_isAi_idx": {
+          "name": "UserData_isAi_idx",
+          "columns": [
+            "isAi"
+          ],
+          "isUnique": false
+        },
+        "UserData_isAi_rankedLp_experience_idx": {
+          "name": "UserData_isAi_rankedLp_experience_idx",
+          "columns": [
+            "isAi",
+            "rankedLp",
+            "experience"
+          ],
+          "isUnique": false
+        },
+        "UserData_isEvent_idx": {
+          "name": "UserData_isEvent_idx",
+          "columns": [
+            "isEvent"
+          ],
+          "isUnique": false
+        },
+        "UserData_inArena_idx": {
+          "name": "UserData_inArena_idx",
+          "columns": [
+            "inArena"
+          ],
+          "isUnique": false
+        },
+        "UserData_inShrines_idx": {
+          "name": "UserData_inShrines_idx",
+          "columns": [
+            "inShrines"
+          ],
+          "isUnique": false
+        },
+        "UserData_isSummon_idx": {
+          "name": "UserData_isSummon_idx",
+          "columns": [
+            "isSummon"
+          ],
+          "isUnique": false
+        },
+        "UserData_rank_idx": {
+          "name": "UserData_rank_idx",
+          "columns": [
+            "rank"
+          ],
+          "isUnique": false
+        },
+        "UserData_role_idx": {
+          "name": "UserData_role_idx",
+          "columns": [
+            "role"
+          ],
+          "isUnique": false
+        },
+        "UserData_clanId_idx": {
+          "name": "UserData_clanId_idx",
+          "columns": [
+            "clanId"
+          ],
+          "isUnique": false
+        },
+        "UserData_anbuId_idx": {
+          "name": "UserData_anbuId_idx",
+          "columns": [
+            "anbuId"
+          ],
+          "isUnique": false
+        },
+        "UserData_jutsuLoadout_idx": {
+          "name": "UserData_jutsuLoadout_idx",
+          "columns": [
+            "jutsuLoadout"
+          ],
+          "isUnique": false
+        },
+        "UserData_rankedLoadout_idx": {
+          "name": "UserData_rankedLoadout_idx",
+          "columns": [
+            "rankedLoadout"
+          ],
+          "isUnique": false
+        },
+        "UserData_rankedLp_idx": {
+          "name": "UserData_rankedLp_idx",
+          "columns": [
+            "rankedLp"
+          ],
+          "isUnique": false
+        },
+        "UserData_experience_idx": {
+          "name": "UserData_experience_idx",
+          "columns": [
+            "experience"
+          ],
+          "isUnique": false
+        },
+        "UserData_level_idx": {
+          "name": "UserData_level_idx",
+          "columns": [
+            "level"
+          ],
+          "isUnique": false
+        },
+        "UserData_username_key": {
+          "name": "UserData_username_key",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "UserData_bloodlineId_idx": {
+          "name": "UserData_bloodlineId_idx",
+          "columns": [
+            "bloodlineId"
+          ],
+          "isUnique": false
+        },
+        "UserData_bloodlineReskinId_idx": {
+          "name": "UserData_bloodlineReskinId_idx",
+          "columns": [
+            "bloodlineReskinId"
+          ],
+          "isUnique": false
+        },
+        "UserData_sageModeId_idx": {
+          "name": "UserData_sageModeId_idx",
+          "columns": [
+            "sageModeId"
+          ],
+          "isUnique": false
+        },
+        "UserData_villageId_idx": {
+          "name": "UserData_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        },
+        "UserData_battleId_idx": {
+          "name": "UserData_battleId_idx",
+          "columns": [
+            "battleId"
+          ],
+          "isUnique": false
+        },
+        "UserData_status_idx": {
+          "name": "UserData_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "UserData_sector_idx": {
+          "name": "UserData_sector_idx",
+          "columns": [
+            "sector"
+          ],
+          "isUnique": false
+        },
+        "UserData_sector_stealthActive_idx": {
+          "name": "UserData_sector_stealthActive_idx",
+          "columns": [
+            "sector",
+            "stealthActive"
+          ],
+          "isUnique": false
+        },
+        "UserData_senseiId_idx": {
+          "name": "UserData_senseiId_idx",
+          "columns": [
+            "senseiId"
+          ],
+          "isUnique": false
+        },
+        "UserData_latitude_idx": {
+          "name": "UserData_latitude_idx",
+          "columns": [
+            "latitude"
+          ],
+          "isUnique": false
+        },
+        "UserData_longitude_idx": {
+          "name": "UserData_longitude_idx",
+          "columns": [
+            "longitude"
+          ],
+          "isUnique": false
+        },
+        "UserData_createdAt_idx": {
+          "name": "UserData_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserData_userId": {
+          "name": "UserData_userId",
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserItem": {
+      "name": "UserItem",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "itemId": {
+          "name": "itemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "level": {
+          "name": "level",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "experience": {
+          "name": "experience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "equipped": {
+          "name": "equipped",
+          "type": "enum('HEAD','CHEST','LEGS','FEET','HAND_1','HAND_2','THROWN','WAIST','KEYSTONE','ITEM_1','ITEM_2','ITEM_3','ITEM_4','ITEM_5','ITEM_6','NONE')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NONE'"
+        },
+        "durability": {
+          "name": "durability",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "storedAtHome": {
+          "name": "storedAtHome",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "craftingFinishedAt": {
+          "name": "craftingFinishedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isInAuction": {
+          "name": "isInAuction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "activeVariantId": {
+          "name": "activeVariantId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dropChancePerc": {
+          "name": "dropChancePerc",
+          "type": "smallint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "UserItem_userId_idx": {
+          "name": "UserItem_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserItem_itemId_idx": {
+          "name": "UserItem_itemId_idx",
+          "columns": [
+            "itemId"
+          ],
+          "isUnique": false
+        },
+        "UserItem_quantity_idx": {
+          "name": "UserItem_quantity_idx",
+          "columns": [
+            "quantity"
+          ],
+          "isUnique": false
+        },
+        "UserItem_equipped_idx": {
+          "name": "UserItem_equipped_idx",
+          "columns": [
+            "equipped"
+          ],
+          "isUnique": false
+        },
+        "UserItem_userId_equipped_idx": {
+          "name": "UserItem_userId_equipped_idx",
+          "columns": [
+            "userId",
+            "equipped"
+          ],
+          "isUnique": false
+        },
+        "UserItem_activeVariantId_idx": {
+          "name": "UserItem_activeVariantId_idx",
+          "columns": [
+            "activeVariantId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserItem_id": {
+          "name": "UserItem_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserItemImbuement": {
+      "name": "UserItemImbuement",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userItemId": {
+          "name": "userItemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imbuementItemId": {
+          "name": "imbuementItemId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "craftingFinishedAt": {
+          "name": "craftingFinishedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "UserItemImbuement_userItemId_idx": {
+          "name": "UserItemImbuement_userItemId_idx",
+          "columns": [
+            "userItemId"
+          ],
+          "isUnique": false
+        },
+        "UserItemImbuement_imbuementItemId_idx": {
+          "name": "UserItemImbuement_imbuementItemId_idx",
+          "columns": [
+            "imbuementItemId"
+          ],
+          "isUnique": false
+        },
+        "UserItemImbuement_userItem_imbuement_key": {
+          "name": "UserItemImbuement_userItem_imbuement_key",
+          "columns": [
+            "userItemId",
+            "imbuementItemId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserItemImbuement_id": {
+          "name": "UserItemImbuement_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserItemVariant": {
+      "name": "UserItemVariant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variantId": {
+          "name": "variantId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserItemVariant_userId_idx": {
+          "name": "UserItemVariant_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserItemVariant_userId_variantId_key": {
+          "name": "UserItemVariant_userId_variantId_key",
+          "columns": [
+            "userId",
+            "variantId"
+          ],
+          "isUnique": true
+        },
+        "UserItemVariant_variantId_idx": {
+          "name": "UserItemVariant_variantId_idx",
+          "columns": [
+            "variantId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserItemVariant_id": {
+          "name": "UserItemVariant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserJutsu": {
+      "name": "UserJutsu",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jutsuId": {
+          "name": "jutsuId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "level": {
+          "name": "level",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "experience": {
+          "name": "experience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "equipped": {
+          "name": "equipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "finishTraining": {
+          "name": "finishTraining",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reskinId": {
+          "name": "reskinId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "UserJutsu_userId_jutsuId_key": {
+          "name": "UserJutsu_userId_jutsuId_key",
+          "columns": [
+            "userId",
+            "jutsuId"
+          ],
+          "isUnique": true
+        },
+        "UserJutsu_jutsuId_idx": {
+          "name": "UserJutsu_jutsuId_idx",
+          "columns": [
+            "jutsuId"
+          ],
+          "isUnique": false
+        },
+        "Jutsu_equipped_idx": {
+          "name": "Jutsu_equipped_idx",
+          "columns": [
+            "equipped"
+          ],
+          "isUnique": false
+        },
+        "UserJutsu_userId_equipped_idx": {
+          "name": "UserJutsu_userId_equipped_idx",
+          "columns": [
+            "userId",
+            "equipped"
+          ],
+          "isUnique": false
+        },
+        "UserJutsu_reskinId_idx": {
+          "name": "UserJutsu_reskinId_idx",
+          "columns": [
+            "reskinId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserJutsu_id": {
+          "name": "UserJutsu_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserLikes": {
+      "name": "UserLikes",
+      "columns": {
+        "type": {
+          "name": "type",
+          "type": "enum('like','love','laugh')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imageId": {
+          "name": "imageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "userLikes_userId_idx": {
+          "name": "userLikes_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "userLikes_imageId_idx": {
+          "name": "userLikes_imageId_idx",
+          "columns": [
+            "imageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserNindo": {
+      "name": "UserNindo",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "UserNindo_userId_idx": {
+          "name": "UserNindo_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserNindo_id": {
+          "name": "UserNindo_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserPollVote": {
+      "name": "UserPollVote",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollId": {
+          "name": "pollId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "optionId": {
+          "name": "optionId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserPollVote_userId_pollId_idx": {
+          "name": "UserPollVote_userId_pollId_idx",
+          "columns": [
+            "userId",
+            "pollId"
+          ],
+          "isUnique": true
+        },
+        "UserPollVote_userId_idx": {
+          "name": "UserPollVote_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserPollVote_pollId_idx": {
+          "name": "UserPollVote_pollId_idx",
+          "columns": [
+            "pollId"
+          ],
+          "isUnique": false
+        },
+        "UserPollVote_optionId_idx": {
+          "name": "UserPollVote_optionId_idx",
+          "columns": [
+            "optionId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserPollVote_id": {
+          "name": "UserPollVote_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserQuestAttempt": {
+      "name": "UserQuestAttempt",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questId": {
+          "name": "questId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastAttemptAt": {
+          "name": "lastAttemptAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "UserQuestAttempt_questId_idx": {
+          "name": "UserQuestAttempt_questId_idx",
+          "columns": [
+            "questId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserQuestAttempt_userId_questId_pk": {
+          "name": "UserQuestAttempt_userId_questId_pk",
+          "columns": [
+            "userId",
+            "questId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserRaidBuff": {
+      "name": "UserRaidBuff",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questId": {
+          "name": "questId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserRaidBuff_userId_idx": {
+          "name": "UserRaidBuff_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserRaidBuff_questId_idx": {
+          "name": "UserRaidBuff_questId_idx",
+          "columns": [
+            "questId"
+          ],
+          "isUnique": false
+        },
+        "UserRaidBuff_expiresAt_idx": {
+          "name": "UserRaidBuff_expiresAt_idx",
+          "columns": [
+            "expiresAt"
+          ],
+          "isUnique": false
+        },
+        "UserRaidBuff_userId_expiresAt_idx": {
+          "name": "UserRaidBuff_userId_expiresAt_idx",
+          "columns": [
+            "userId",
+            "expiresAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserRaidBuff_id": {
+          "name": "UserRaidBuff_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserReport": {
+      "name": "UserReport",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reporterUserId": {
+          "name": "reporterUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reportedUserId": {
+          "name": "reportedUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "system": {
+          "name": "system",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "infraction": {
+          "name": "infraction",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "banEnd": {
+          "name": "banEnd",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "adminResolved": {
+          "name": "adminResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('UNVIEWED','REPORT_CLEARED','BAN_ACTIVATED','SILENCE_ACTIVATED','TIMEOUT_ACTIVATED','BAN_ESCALATED','SILENCE_ESCALATED','OFFICIAL_WARNING','TRADE_BAN_ACTIVATED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UNVIEWED'"
+        },
+        "aiInterpretation": {
+          "name": "aiInterpretation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "predictedStatus": {
+          "name": "predictedStatus",
+          "type": "enum('UNVIEWED','REPORT_CLEARED','BAN_ACTIVATED','SILENCE_ACTIVATED','TIMEOUT_ACTIVATED','BAN_ESCALATED','SILENCE_ESCALATED','OFFICIAL_WARNING','TRADE_BAN_ACTIVATED')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "additionalContext": {
+          "name": "additionalContext",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        }
+      },
+      "indexes": {
+        "UserReport_reporterUserId_idx": {
+          "name": "UserReport_reporterUserId_idx",
+          "columns": [
+            "reporterUserId"
+          ],
+          "isUnique": false
+        },
+        "UserReport_reportedUserId_idx": {
+          "name": "UserReport_reportedUserId_idx",
+          "columns": [
+            "reportedUserId"
+          ],
+          "isUnique": false
+        },
+        "UserReport_status_idx": {
+          "name": "UserReport_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserReport_id": {
+          "name": "UserReport_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserReportComment": {
+      "name": "UserReportComment",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reportId": {
+          "name": "reportId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "enum('UNVIEWED','REPORT_CLEARED','BAN_ACTIVATED','SILENCE_ACTIVATED','TIMEOUT_ACTIVATED','BAN_ESCALATED','SILENCE_ESCALATED','OFFICIAL_WARNING','TRADE_BAN_ACTIVATED')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isReported": {
+          "name": "isReported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "UserReportComment_userId_idx": {
+          "name": "UserReportComment_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserReportComment_reportId_idx": {
+          "name": "UserReportComment_reportId_idx",
+          "columns": [
+            "reportId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserReportComment_id": {
+          "name": "UserReportComment_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserRequest": {
+      "name": "UserRequest",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "receiverId": {
+          "name": "receiverId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('PENDING','ACCEPTED','REJECTED','CANCELLED','EXPIRED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('SPAR','ALLIANCE','SURRENDER','SENSEI','ANBU','CLAN','MARRIAGE','KAGE','WAR_ALLY')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "relatedId": {
+          "name": "relatedId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pendingAnbuSenderId": {
+          "name": "pendingAnbuSenderId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "type": "stored",
+            "as": "CASE WHEN `type` = 'ANBU' AND `status` = 'PENDING' THEN `senderId` ELSE NULL END"
+          }
+        },
+        "useRankedRules": {
+          "name": "useRankedRules",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "spectatable": {
+          "name": "spectatable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserRequest_createdAt_idx": {
+          "name": "UserRequest_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "UserRequest_senderId_idx": {
+          "name": "UserRequest_senderId_idx",
+          "columns": [
+            "senderId"
+          ],
+          "isUnique": false
+        },
+        "UserRequest_receiverId_idx": {
+          "name": "UserRequest_receiverId_idx",
+          "columns": [
+            "receiverId"
+          ],
+          "isUnique": false
+        },
+        "UserRequest_type_idx": {
+          "name": "UserRequest_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "UserRequest_relatedId_type_createdAt_idx": {
+          "name": "UserRequest_relatedId_type_createdAt_idx",
+          "columns": [
+            "relatedId",
+            "type",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserRequest_id": {
+          "name": "UserRequest_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "UserRequest_pending_anbu_sender_unique": {
+          "name": "UserRequest_pending_anbu_sender_unique",
+          "columns": [
+            "pendingAnbuSenderId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "UserReview": {
+      "name": "UserReview",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorUserId": {
+          "name": "authorUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "positive": {
+          "name": "positive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorIp": {
+          "name": "authorIp",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserReview_authorUserId_idx": {
+          "name": "UserReview_authorUserId_idx",
+          "columns": [
+            "authorUserId"
+          ],
+          "isUnique": false
+        },
+        "UserReview_targetUserId_idx": {
+          "name": "UserReview_targetUserId_idx",
+          "columns": [
+            "targetUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserReview_id": {
+          "name": "UserReview_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserRewards": {
+      "name": "UserRewards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "awardedById": {
+          "name": "awardedById",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "receiverId": {
+          "name": "receiverId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reputationAmount": {
+          "name": "reputationAmount",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "moneyAmount": {
+          "name": "moneyAmount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserRewards_awardedById_idx": {
+          "name": "UserRewards_awardedById_idx",
+          "columns": [
+            "awardedById"
+          ],
+          "isUnique": false
+        },
+        "UserRewards_receiverId_idx": {
+          "name": "UserRewards_receiverId_idx",
+          "columns": [
+            "receiverId"
+          ],
+          "isUnique": false
+        },
+        "UserRewards_createdAt_idx": {
+          "name": "UserRewards_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserRewards_id": {
+          "name": "UserRewards_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserSkill": {
+      "name": "UserSkill",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skillId": {
+          "name": "skillId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purchasedAt": {
+          "name": "purchasedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "activated": {
+          "name": "activated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "UserSkill_userId_skillId_key": {
+          "name": "UserSkill_userId_skillId_key",
+          "columns": [
+            "userId",
+            "skillId"
+          ],
+          "isUnique": true
+        },
+        "UserSkill_userId_idx": {
+          "name": "UserSkill_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserSkill_skillId_idx": {
+          "name": "UserSkill_skillId_idx",
+          "columns": [
+            "skillId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserSkill_id": {
+          "name": "UserSkill_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserStreakProgress": {
+      "name": "UserStreakProgress",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "configId": {
+          "name": "configId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currentDay": {
+          "name": "currentDay",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastClaimDate": {
+          "name": "lastClaimDate",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserStreakProgress_userId_idx": {
+          "name": "UserStreakProgress_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserStreakProgress_configId_idx": {
+          "name": "UserStreakProgress_configId_idx",
+          "columns": [
+            "configId"
+          ],
+          "isUnique": false
+        },
+        "UserStreakProgress_userId_configId_key": {
+          "name": "UserStreakProgress_userId_configId_key",
+          "columns": [
+            "userId",
+            "configId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserStreakProgress_id": {
+          "name": "UserStreakProgress_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserTowerDefenseUpgrade": {
+      "name": "UserTowerDefenseUpgrade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upgradeId": {
+          "name": "upgradeId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "purchasedAt": {
+          "name": "purchasedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserTowerDefenseUpgrade_userId_idx": {
+          "name": "UserTowerDefenseUpgrade_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "UserTowerDefenseUpgrade_upgradeId_idx": {
+          "name": "UserTowerDefenseUpgrade_upgradeId_idx",
+          "columns": [
+            "upgradeId"
+          ],
+          "isUnique": false
+        },
+        "UserTowerDefenseUpgrade_userId_upgradeId_key": {
+          "name": "UserTowerDefenseUpgrade_userId_upgradeId_key",
+          "columns": [
+            "userId",
+            "upgradeId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserTowerDefenseUpgrade_id": {
+          "name": "UserTowerDefenseUpgrade_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserUpload": {
+      "name": "UserUpload",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserUpload_userId_idx": {
+          "name": "UserUpload_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserUpload_id": {
+          "name": "UserUpload_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UserVote": {
+      "name": "UserVote",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topWebGames": {
+          "name": "topWebGames",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "top100Arena": {
+          "name": "top100Arena",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "mmoHub": {
+          "name": "mmoHub",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "arenaTop100": {
+          "name": "arenaTop100",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "xtremeTop100": {
+          "name": "xtremeTop100",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "topOnlineMmorpg": {
+          "name": "topOnlineMmorpg",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "browserMmorpg": {
+          "name": "browserMmorpg",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "apexWebGaming": {
+          "name": "apexWebGaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bbogd": {
+          "name": "bbogd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "claimed": {
+          "name": "claimed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "totalClaims": {
+          "name": "totalClaims",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastVoteAt": {
+          "name": "lastVoteAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "UserVote_userId_idx": {
+          "name": "UserVote_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UserVote_id": {
+          "name": "UserVote_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Village": {
+      "name": "Village",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mapName": {
+          "name": "mapName",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "kageId": {
+          "name": "kageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('VILLAGE','OUTLAW','SAFEZONE','HIDEOUT','TOWN')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'VILLAGE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "leaderUpdatedAt": {
+          "name": "leaderUpdatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "hexColor": {
+          "name": "hexColor",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#000000'"
+        },
+        "populationCount": {
+          "name": "populationCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "allianceSystem": {
+          "name": "allianceSystem",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "joinable": {
+          "name": "joinable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "pvpDisabled": {
+          "name": "pvpDisabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "villageLogo": {
+          "name": "villageLogo",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "villageGraphic": {
+          "name": "villageGraphic",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "lastMaintenancePaidAt": {
+          "name": "lastMaintenancePaidAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "wasDowngraded": {
+          "name": "wasDowngraded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "openForChallenges": {
+          "name": "openForChallenges",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "openForChallengesAt": {
+          "name": "openForChallengesAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "wallpaperOverwrite": {
+          "name": "wallpaperOverwrite",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warExhaustionEndedAt": {
+          "name": "warExhaustionEndedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastWarEndedAt": {
+          "name": "lastWarEndedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shrineSettings": {
+          "name": "shrineSettings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('{\"unlockedAiIds\":[],\"activeBoosts\":{},\"activeAiIds\":[]}')"
+        }
+      },
+      "indexes": {
+        "Village_name_key": {
+          "name": "Village_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "Village_sector_key": {
+          "name": "Village_sector_key",
+          "columns": [
+            "sector"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Village_id": {
+          "name": "Village_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "VillageAlliance": {
+      "name": "VillageAlliance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageIdA": {
+          "name": "villageIdA",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageIdB": {
+          "name": "villageIdB",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('NEUTRAL','ALLY','ENEMY')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "VillageAlliance_villageIdA_idx": {
+          "name": "VillageAlliance_villageIdA_idx",
+          "columns": [
+            "villageIdA"
+          ],
+          "isUnique": false
+        },
+        "VillageAlliance_villageIdB_idx": {
+          "name": "VillageAlliance_villageIdB_idx",
+          "columns": [
+            "villageIdB"
+          ],
+          "isUnique": false
+        },
+        "VillageAlliance_status_idx": {
+          "name": "VillageAlliance_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "VillageAlliance_id": {
+          "name": "VillageAlliance_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "VillageElderVote": {
+      "name": "VillageElderVote",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('WAR_DECLARATION','KAGE_REMOVAL')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initiatedByUserId": {
+          "name": "initiatedByUserId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "targetId": {
+          "name": "targetId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warType": {
+          "name": "warType",
+          "type": "enum('VILLAGE_WAR','SECTOR_WAR','WAR_RAID')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "targetStructureRoute": {
+          "name": "targetStructureRoute",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('PENDING','APPROVED','REJECTED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING'"
+        },
+        "activeFlag": {
+          "name": "activeFlag",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "type": "stored",
+            "as": "CASE WHEN `status` = 'PENDING' THEN 1 ELSE NULL END"
+          }
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "endsAt": {
+          "name": "endsAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "VillageElderVote_villageId_idx": {
+          "name": "VillageElderVote_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        },
+        "VillageElderVote_type_idx": {
+          "name": "VillageElderVote_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "VillageElderVote_status_idx": {
+          "name": "VillageElderVote_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "VillageElderVote_endsAt_idx": {
+          "name": "VillageElderVote_endsAt_idx",
+          "columns": [
+            "endsAt"
+          ],
+          "isUnique": false
+        },
+        "VillageElderVote_initiatedByUserId_idx": {
+          "name": "VillageElderVote_initiatedByUserId_idx",
+          "columns": [
+            "initiatedByUserId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "VillageElderVote_id": {
+          "name": "VillageElderVote_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "VillageElderVote_active_pending_unique": {
+          "name": "VillageElderVote_active_pending_unique",
+          "columns": [
+            "villageId",
+            "type",
+            "targetId",
+            "activeFlag"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "VillageElderVoteEntry": {
+      "name": "VillageElderVoteEntry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voteId": {
+          "name": "voteId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vote": {
+          "name": "vote",
+          "type": "enum('YES','NO')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "VillageElderVoteEntry_voteId_idx": {
+          "name": "VillageElderVoteEntry_voteId_idx",
+          "columns": [
+            "voteId"
+          ],
+          "isUnique": false
+        },
+        "VillageElderVoteEntry_userId_idx": {
+          "name": "VillageElderVoteEntry_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "VillageElderVoteEntry_id": {
+          "name": "VillageElderVoteEntry_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "VillageElderVoteEntry_voteId_userId_unique": {
+          "name": "VillageElderVoteEntry_voteId_userId_unique",
+          "columns": [
+            "voteId",
+            "userId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "VillageStructure": {
+      "name": "VillageStructure",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "route": {
+          "name": "route",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "hasPage": {
+          "name": "hasPage",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "curSp": {
+          "name": "curSp",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "maxSp": {
+          "name": "maxSp",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "allyAccess": {
+          "name": "allyAccess",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "showInVillagePage": {
+          "name": "showInVillagePage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "level": {
+          "name": "level",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "maxLevel": {
+          "name": "maxLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "lastUpgradedAt": {
+          "name": "lastUpgradedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anbuSquadsPerLvl": {
+          "name": "anbuSquadsPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "arenaRewardPerLvl": {
+          "name": "arenaRewardPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bankInterestPerLvl": {
+          "name": "bankInterestPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "blackDiscountPerLvl": {
+          "name": "blackDiscountPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "clansPerLvl": {
+          "name": "clansPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hospitalSpeedupPerLvl": {
+          "name": "hospitalSpeedupPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "itemDiscountPerLvl": {
+          "name": "itemDiscountPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missionRewardPerLvl": {
+          "name": "missionRewardPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "patrolsPerLvl": {
+          "name": "patrolsPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "ramenDiscountPerLvl": {
+          "name": "ramenDiscountPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "regenIncreasePerLvl": {
+          "name": "regenIncreasePerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "sleepRegenPerLvl": {
+          "name": "sleepRegenPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "structureDiscountPerLvl": {
+          "name": "structureDiscountPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "trainBoostPerLvl": {
+          "name": "trainBoostPerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "villageDefencePerLvl": {
+          "name": "villageDefencePerLvl",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "temporaryLevelBonus": {
+          "name": "temporaryLevelBonus",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "temporaryLevelBonusExpiresAt": {
+          "name": "temporaryLevelBonusExpiresAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "VillageStructure_name_villageId_key": {
+          "name": "VillageStructure_name_villageId_key",
+          "columns": [
+            "name",
+            "villageId"
+          ],
+          "isUnique": true
+        },
+        "VillageStructure_villageId_idx": {
+          "name": "VillageStructure_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "VillageStructure_id": {
+          "name": "VillageStructure_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "VisitorLog": {
+      "name": "VisitorLog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref": {
+          "name": "ref",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmSource": {
+          "name": "utmSource",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "VisitorLog_ip_key": {
+          "name": "VisitorLog_ip_key",
+          "columns": [
+            "ip"
+          ],
+          "isUnique": true
+        },
+        "VisitorLog_ref_idx": {
+          "name": "VisitorLog_ref_idx",
+          "columns": [
+            "ref"
+          ],
+          "isUnique": false
+        },
+        "VisitorLog_utmSource_idx": {
+          "name": "VisitorLog_utmSource_idx",
+          "columns": [
+            "utmSource"
+          ],
+          "isUnique": false
+        },
+        "VisitorLog_createdAt_idx": {
+          "name": "VisitorLog_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "VisitorLog_ip_utmSource_idx": {
+          "name": "VisitorLog_ip_utmSource_idx",
+          "columns": [
+            "ip",
+            "utmSource"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "VisitorLog_id": {
+          "name": "VisitorLog_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "War": {
+      "name": "War",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attackerVillageId": {
+          "name": "attackerVillageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "defenderVillageId": {
+          "name": "defenderVillageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('ACTIVE','ATTACKER_VICTORY','DEFENDER_VICTORY','DRAW')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('VILLAGE_WAR','SECTOR_WAR','WAR_RAID')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attackerShrineHp": {
+          "name": "attackerShrineHp",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 500
+        },
+        "attackerShrineMaxHp": {
+          "name": "attackerShrineMaxHp",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 500
+        },
+        "attackerShrineStatus": {
+          "name": "attackerShrineStatus",
+          "type": "enum('ACTIVE','CAPTURED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "defenderShrineHp": {
+          "name": "defenderShrineHp",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3000
+        },
+        "defenderShrineMaxHp": {
+          "name": "defenderShrineMaxHp",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3000
+        },
+        "defenderShrineStatus": {
+          "name": "defenderShrineStatus",
+          "type": "enum('ACTIVE','CAPTURED')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "lastTokenReductionAt": {
+          "name": "lastTokenReductionAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        },
+        "targetStructureRoute": {
+          "name": "targetStructureRoute",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'/townhall'"
+        },
+        "attackerWarHealth": {
+          "name": "attackerWarHealth",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10000
+        },
+        "defenderWarHealth": {
+          "name": "defenderWarHealth",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10000
+        },
+        "attackerWarHealthMax": {
+          "name": "attackerWarHealthMax",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10000
+        },
+        "defenderWarHealthMax": {
+          "name": "defenderWarHealthMax",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10000
+        }
+      },
+      "indexes": {
+        "War_attackerVillageId_idx": {
+          "name": "War_attackerVillageId_idx",
+          "columns": [
+            "attackerVillageId"
+          ],
+          "isUnique": false
+        },
+        "War_defenderVillageId_idx": {
+          "name": "War_defenderVillageId_idx",
+          "columns": [
+            "defenderVillageId"
+          ],
+          "isUnique": false
+        },
+        "War_sector_idx": {
+          "name": "War_sector_idx",
+          "columns": [
+            "sector"
+          ],
+          "isUnique": false
+        },
+        "War_status_idx": {
+          "name": "War_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "War_id": {
+          "name": "War_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "WarAlly": {
+      "name": "WarAlly",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warId": {
+          "name": "warId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "villageId": {
+          "name": "villageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supportVillageId": {
+          "name": "supportVillageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tokensPaid": {
+          "name": "tokensPaid",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "joinedAt": {
+          "name": "joinedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "WarAlly_warId_idx": {
+          "name": "WarAlly_warId_idx",
+          "columns": [
+            "warId"
+          ],
+          "isUnique": false
+        },
+        "WarAlly_villageId_idx": {
+          "name": "WarAlly_villageId_idx",
+          "columns": [
+            "villageId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "WarAlly_id": {
+          "name": "WarAlly_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "WarKill": {
+      "name": "WarKill",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warId": {
+          "name": "warId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "killerId": {
+          "name": "killerId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "victimId": {
+          "name": "victimId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "killerVillageId": {
+          "name": "killerVillageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "victimVillageId": {
+          "name": "victimVillageId",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1337
+        },
+        "shrineHpChange": {
+          "name": "shrineHpChange",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1337
+        },
+        "townhallHpChange": {
+          "name": "townhallHpChange",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1337
+        },
+        "killedAt": {
+          "name": "killedAt",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP(3))"
+        }
+      },
+      "indexes": {
+        "WarKill_warId_idx": {
+          "name": "WarKill_warId_idx",
+          "columns": [
+            "warId"
+          ],
+          "isUnique": false
+        },
+        "WarKill_killerId_idx": {
+          "name": "WarKill_killerId_idx",
+          "columns": [
+            "killerId"
+          ],
+          "isUnique": false
+        },
+        "WarKill_victimId_idx": {
+          "name": "WarKill_victimId_idx",
+          "columns": [
+            "victimId"
+          ],
+          "isUnique": false
+        },
+        "WarKill_killerVillageId_idx": {
+          "name": "WarKill_killerVillageId_idx",
+          "columns": [
+            "killerVillageId"
+          ],
+          "isUnique": false
+        },
+        "WarKill_victimVillageId_idx": {
+          "name": "WarKill_victimVillageId_idx",
+          "columns": [
+            "victimVillageId"
+          ],
+          "isUnique": false
+        },
+        "WarKill_killedAt_idx": {
+          "name": "WarKill_killedAt_idx",
+          "columns": [
+            "killedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "WarKill_id": {
+          "name": "WarKill_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/app/drizzle/migrations/meta/_journal.json
+++ b/app/drizzle/migrations/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1788001986694,
       "tag": "0038_relocate_tutorial_puppy",
       "breakpoints": false
+    },
+    {
+      "idx": 39,
+      "version": "5",
+      "when": 1788079296452,
+      "tag": "0039_quest_history_unique_user_quest",
+      "breakpoints": false
     }
   ]
 }

--- a/app/src/app/api/daily-quest/route.ts
+++ b/app/src/app/api/daily-quest/route.ts
@@ -44,33 +44,48 @@ export async function GET() {
   if (!timerCheck.isNewDay && timerCheck.response) return timerCheck.response;
 
   try {
-    // Reset all current dailies
-    const [dailies, villages, userRankPerVillageLevel] = await Promise.all([
-      drizzleDB.query.quest.findMany({
-        where: and(
-          eq(quest.questType, "daily"),
-          isNotNull(quest.content),
-          eq(quest.hidden, false),
-        ),
-      }),
-      drizzleDB.query.village.findMany({
-        with: { structures: true },
-      }),
-      drizzleDB
-        .select({
-          rank: userData.rank,
-          villageId: userData.villageId,
-          level: userData.level,
-          count: sql`count(${userData.userId})`.mapWith(Number),
-        })
-        .from(userData)
-        .where(eq(userData.isAi, false))
-        .groupBy(userData.rank, userData.villageId, userData.level),
-      drizzleDB
-        .update(questHistory)
-        .set({ completed: 0, endAt: new Date() })
-        .where(and(eq(questHistory.questType, "daily"), eq(questHistory.completed, 0))),
-    ]);
+    // Reset all current dailies. The tier-quest lookup for the tutorial re-enable below rides
+    // along here: the daily reset only writes daily rows, so its result is the same either way
+    // and this saves a round-trip.
+    const [dailies, villages, userRankPerVillageLevel, , usersWithActiveTierQuests] =
+      await Promise.all([
+        drizzleDB.query.quest.findMany({
+          where: and(
+            eq(quest.questType, "daily"),
+            isNotNull(quest.content),
+            eq(quest.hidden, false),
+          ),
+        }),
+        drizzleDB.query.village.findMany({
+          with: { structures: true },
+        }),
+        drizzleDB
+          .select({
+            rank: userData.rank,
+            villageId: userData.villageId,
+            level: userData.level,
+            count: sql`count(${userData.userId})`.mapWith(Number),
+          })
+          .from(userData)
+          .where(eq(userData.isAi, false))
+          .groupBy(userData.rank, userData.villageId, userData.level),
+        drizzleDB
+          .update(questHistory)
+          .set({ completed: 0, endAt: new Date() })
+          .where(
+            and(eq(questHistory.questType, "daily"), eq(questHistory.completed, 0)),
+          ),
+        drizzleDB
+          .select({ userId: questHistory.userId })
+          .from(questHistory)
+          .where(
+            and(
+              eq(questHistory.questType, "tier"),
+              eq(questHistory.completed, 0),
+              isNull(questHistory.endAt),
+            ),
+          ),
+      ]);
 
     // Book-keeping to do upsert afterwards more efficiently
     const memory: {
@@ -137,17 +152,6 @@ export async function GET() {
 
     // Re-enable tutorials for users with active tier quests who have completed all tutorial steps
     // This helps users who previously disabled tutorials get guidance on tier quests
-    const usersWithActiveTierQuests = await drizzleDB
-      .select({ userId: questHistory.userId })
-      .from(questHistory)
-      .where(
-        and(
-          eq(questHistory.questType, "tier"),
-          eq(questHistory.completed, 0),
-          isNull(questHistory.endAt),
-        ),
-      );
-
     if (usersWithActiveTierQuests.length > 0) {
       const userIdsWithTierQuests = usersWithActiveTierQuests.map(
         (u: (typeof usersWithActiveTierQuests)[number]) => u.userId,

--- a/app/src/server/api/routers/quests.ts
+++ b/app/src/server/api/routers/quests.ts
@@ -2012,6 +2012,12 @@ export const fetchUncompletedQuests = async (
 /** Row locks the bulk quest reset may hold in one statement. */
 const QUEST_RESET_BATCH_SIZE = 100;
 
+/** Drop one quest's tracker so a restarted/reassigned quest always starts fresh. */
+const removeQuestTrackerByQuestId = (
+  trackers: z.infer<typeof QuestTracker>[] | null | undefined,
+  questId: string,
+) => (trackers ?? []).filter((tracker) => tracker.id !== questId);
+
 /** Upsert quest entries for all users by selector. NOTE: selector determined which users get updated/inserted entries */
 export const upsertQuestEntries = async (
   client: DrizzleClient,
@@ -2060,16 +2066,39 @@ export const upsertQuestEntries = async (
     // reset never contends with itself either, and share one timestamp so a batch that
     // has to be retried still stamps what the rest of the reset did.
     const startedAt = new Date();
-    const batches = chunkArray(
-      allUsers.map((user) => user.userId),
-      QUEST_RESET_BATCH_SIZE,
-    );
+    const batches = chunkArray(allUsers, QUEST_RESET_BATCH_SIZE);
     for (const batch of batches) {
+      const batchUserIds = batch.map((user) => user.userId);
+      const trackerPath = sql`JSON_UNQUOTE(JSON_SEARCH(
+        ${userData.questData},
+        'one',
+        REPLACE(REPLACE(REPLACE(${quest.id}, '#', '##'), '%', '#%'), '_', '#_'),
+        '#',
+        '$[*].id'
+      ))`;
       await client
         .update(questHistory)
         .set({ completed: 0, endAt: null, startedAt })
         .where(
-          and(inArray(questHistory.userId, batch), eq(questHistory.questId, quest.id)),
+          and(
+            inArray(questHistory.userId, batchUserIds),
+            eq(questHistory.questId, quest.id),
+          ),
+        );
+
+      // Remove only this quest's tracker in SQL. Updating the JSON document atomically avoids
+      // overwriting progress another request may have recorded for an unrelated active quest
+      // after this reset selected its users.
+      await client
+        .update(userData)
+        .set({
+          questData: sql`JSON_REMOVE(
+            ${userData.questData},
+            REPLACE(${trackerPath}, '.id', '')
+          )`,
+        })
+        .where(
+          and(inArray(userData.userId, batchUserIds), sql`${trackerPath} IS NOT NULL`),
         );
     }
   }
@@ -2462,6 +2491,8 @@ export const upsertQuestEntry = async (
         });
   // Promises to be executed
   const promises: Promise<unknown>[] = [];
+  // Restarting a quest must discard any stale tracker from prior attempts before recomputing.
+  user.questData = removeQuestTrackerByQuestId(user.questData, quest.id);
   // Check if the quest has already been started
   if (entry) {
     const startedAt = new Date();
@@ -2687,6 +2718,10 @@ export const commitQuestObjectiveRewards = async (info: {
   } = info;
 
   user.questData = filterQuestTrackersForDbPersist(trackers, user);
+  // Once a quest resolves, remove its tracker so replayed assignments cannot inherit done goals.
+  if (resolved && userQuest) {
+    user.questData = removeQuestTrackerByQuestId(user.questData, userQuest.questId);
+  }
 
   // Persist completion before snapshot CAS so we cannot commit questData/updatedAt and then
   // lose the completion race; if snapshot claim fails, revert completion below.

--- a/app/src/server/api/routers/quests.ts
+++ b/app/src/server/api/routers/quests.ts
@@ -112,7 +112,7 @@ import { periodStart, secondsFromNow } from "@/utils/time";
 import type { QueryCondition } from "@/utils/typeutils";
 import { setEmptyStringsToNulls } from "@/utils/typeutils";
 import { canAccessStructure } from "@/utils/village";
-import type { AllObjectivesType } from "@/validators/objectives";
+import type { AllObjectivesType, QuestTrackerType } from "@/validators/objectives";
 import { QuestTracker, QuestValidator } from "@/validators/objectives";
 import { questFilteringSchema } from "@/validators/quest";
 import { PostProcessedRewardSchema } from "@/validators/rewards";
@@ -1322,6 +1322,12 @@ export const questsRouter = createTRPCRouter({
 /**
  * COMMON QUERIES WHICH ARE REUSED
  */
+/** Drop one quest's tracker so a restarted/reassigned quest always starts fresh. */
+const removeQuestTrackerByQuestId = (
+  trackers: QuestTrackerType[] | null | undefined,
+  questId: string,
+) => (trackers ?? []).filter((tracker) => tracker.id !== questId);
+
 /**
  * Callers must win an endpoint-specific idempotency / CAS claim before invoking
  * this helper. `updateRewards` itself does not provide replay protection.
@@ -1348,6 +1354,10 @@ export const updateRewards = async (info: {
   // same round-trip instead of a trailing sequential write. Values may be raw scalars or `sql`
   // expressions and win over the reward keys on any name clash.
   postClaimUserDataPatch?: Record<string, unknown>;
+  // Quest this payout terminally completes, if any. The herbs fold below recomputes trackers
+  // from `questUser`, whose in-memory history row still reads active (the completion CAS only
+  // touched the DB), so without this it would rebuild a tracker the caller just dropped.
+  dropTrackerForQuestId?: string;
 }) => {
   // Destructure
   const {
@@ -1358,6 +1368,7 @@ export const updateRewards = async (info: {
     reason,
     questUser,
     postClaimUserDataPatch,
+    dropTrackerForQuestId,
   } = info;
   // Check if we need to fetch war data
   const hasWarRewards =
@@ -1541,7 +1552,10 @@ export const updateRewards = async (info: {
     const { trackers } = getNewTrackers({ ...questUser, questData: user.questData }, [
       { task: "herbs_gathered", increment: droppedGatheringItems.length },
     ]);
-    user.questData = filterQuestTrackersForDbPersist(trackers, questUser);
+    const persisted = filterQuestTrackersForDbPersist(trackers, questUser);
+    user.questData = dropTrackerForQuestId
+      ? removeQuestTrackerByQuestId(persisted, dropTrackerForQuestId)
+      : persisted;
   }
 
   // Update userdata
@@ -2012,12 +2026,6 @@ export const fetchUncompletedQuests = async (
 /** Row locks the bulk quest reset may hold in one statement. */
 const QUEST_RESET_BATCH_SIZE = 100;
 
-/** Drop one quest's tracker so a restarted/reassigned quest always starts fresh. */
-const removeQuestTrackerByQuestId = (
-  trackers: z.infer<typeof QuestTracker>[] | null | undefined,
-  questId: string,
-) => (trackers ?? []).filter((tracker) => tracker.id !== questId);
-
 /** Upsert quest entries for all users by selector. NOTE: selector determined which users get updated/inserted entries */
 export const upsertQuestEntries = async (
   client: DrizzleClient,
@@ -2030,22 +2038,25 @@ export const upsertQuestEntries = async (
       "Overworld quests cannot be assigned to users in bulk.",
     );
   }
-  // Users to insert for
-  const users = await client
-    .select({ userId: userData.userId, username: userData.username })
+  // One pass over the selector for both branches: the LEFT JOIN already tells us who lacks a
+  // QuestHistory row, so splitting the rows in JS costs one extra column instead of a second
+  // round-trip that re-scans the same users.
+  const candidates = await client
+    .select({ userId: userData.userId, historyId: questHistory.id })
     .from(userData)
     .leftJoin(
       questHistory,
       and(eq(questHistory.userId, userData.userId), eq(questHistory.questId, quest.id)),
     )
-    .where(and(updateSelector, isNull(questHistory.id)));
-  if (users.length > 0) {
+    .where(updateSelector);
+  const missingHistory = candidates.filter((row) => row.historyId === null);
+  if (missingHistory.length > 0) {
     await client
       .insert(questHistory)
       .values(
-        users.map((user) => ({
+        missingHistory.map((row) => ({
           id: nanoid(),
-          userId: user.userId,
+          userId: row.userId,
           questId: quest.id,
           questType: quest.questType,
         })),
@@ -2055,50 +2066,56 @@ export const upsertQuestEntries = async (
       });
   }
   // Users to update for (including those we just inserted for)
-  const allUsers = await client
-    .select({ userId: userData.userId })
-    .from(userData)
-    .where(updateSelector);
-  if (allUsers.length > 0) {
+  if (candidates.length > 0) {
     // One statement over every eligible user held hundreds of QuestHistory row locks
     // while ordinary quest traffic wrote the same table through its unique key, and the
     // daily reset lost the resulting lock cycle. Bounded batches run sequentially so the
     // reset never contends with itself either, and share one timestamp so a batch that
     // has to be retried still stamps what the rest of the reset did.
     const startedAt = new Date();
-    const batches = chunkArray(allUsers, QUEST_RESET_BATCH_SIZE);
-    for (const batch of batches) {
-      const batchUserIds = batch.map((user) => user.userId);
-      const trackerPath = sql`JSON_UNQUOTE(JSON_SEARCH(
-        ${userData.questData},
-        'one',
-        REPLACE(REPLACE(REPLACE(${quest.id}, '#', '##'), '%', '#%'), '_', '#_'),
-        '#',
-        '$[*].id'
-      ))`;
+    // Bound as a parameter, never interpolated: `quest` here is the row argument, not the table.
+    const questId = quest.id;
+    // Path of this quest's tracker inside the questData array, e.g. `$[2].id`. JSON_SEARCH
+    // matches with LIKE semantics, so the id must be escaped first — nanoid ids contain `_`,
+    // which would otherwise match any single character and drop the wrong tracker.
+    const trackerPath = sql`JSON_UNQUOTE(JSON_SEARCH(
+      ${userData.questData},
+      'one',
+      REPLACE(REPLACE(REPLACE(${questId}, '#', '##'), '%', '#%'), '_', '#_'),
+      '#',
+      '$[*].id'
+    ))`;
+    const batches = chunkArray(
+      candidates.map((row) => row.userId),
+      QUEST_RESET_BATCH_SIZE,
+    );
+    for (const batchUserIds of batches) {
+      // Drop the tracker BEFORE reopening the history row, and never in parallel with it: the
+      // caller has already closed every daily, so while the quest is shut a request cannot
+      // rebuild a tracker for it. Reopening first would leave a window where the quest is
+      // active with last run's fully-done tracker, which getReward reads as resolved and pays
+      // out again. Removing it in SQL (rather than read-modify-write) also keeps progress a
+      // concurrent request recorded for an unrelated active quest.
+      await client
+        .update(userData)
+        .set({
+          questData: sql`JSON_REMOVE(
+            ${userData.questData},
+            TRIM(TRAILING '.id' FROM ${trackerPath})
+          )`,
+        })
+        .where(
+          and(inArray(userData.userId, batchUserIds), sql`${trackerPath} IS NOT NULL`),
+        );
+
       await client
         .update(questHistory)
         .set({ completed: 0, endAt: null, startedAt })
         .where(
           and(
             inArray(questHistory.userId, batchUserIds),
-            eq(questHistory.questId, quest.id),
+            eq(questHistory.questId, questId),
           ),
-        );
-
-      // Remove only this quest's tracker in SQL. Updating the JSON document atomically avoids
-      // overwriting progress another request may have recorded for an unrelated active quest
-      // after this reset selected its users.
-      await client
-        .update(userData)
-        .set({
-          questData: sql`JSON_REMOVE(
-            ${userData.questData},
-            REPLACE(${trackerPath}, '.id', '')
-          )`,
-        })
-        .where(
-          and(inArray(userData.userId, batchUserIds), sql`${trackerPath} IS NOT NULL`),
         );
     }
   }
@@ -2875,6 +2892,7 @@ export const commitQuestObjectiveRewards = async (info: {
       // here is the fully-hydrated row (with quest relations).
       questUser: user,
       postClaimUserDataPatch: mergedUserDataPatch,
+      dropTrackerForQuestId: resolved ? userQuest?.questId : undefined,
     }),
     // Credit the sensei their per-mission ryo bonus
     ...(senseiId

--- a/app/src/server/api/routers/quests.ts
+++ b/app/src/server/api/routers/quests.ts
@@ -2102,6 +2102,7 @@ export const upsertQuestEntries = async (
       // quest. JSON_SEARCH 'one' drops a single tracker and questData is not guaranteed to hold
       // only one per quest, so repeat until a pass changes nothing; each pass shrinks the
       // array, making the cap a guard against a wedged cron rather than a real bound.
+      let cleared = false;
       for (let pass = 0; pass < QUEST_RESET_MAX_TRACKER_PASSES; pass++) {
         const removed = await client
           .update(userData)
@@ -2117,8 +2118,17 @@ export const upsertQuestEntries = async (
               sql`${trackerPath} IS NOT NULL`,
             ),
           );
-        if (removed.rowsAffected === 0) break;
+        if (removed.rowsAffected === 0) {
+          cleared = true;
+          break;
+        }
       }
+
+      // Only a pass that found nothing left proves every tracker is gone. Reopening on an
+      // exhausted cap would hand this batch the state the removal exists to prevent: an active
+      // quest still carrying last run's completed goals. Leave them shut instead; each pass has
+      // shortened the arrays, so the next run finishes the job.
+      if (!cleared) continue;
 
       await client
         .update(questHistory)

--- a/app/src/server/api/routers/quests.ts
+++ b/app/src/server/api/routers/quests.ts
@@ -2026,6 +2026,12 @@ export const fetchUncompletedQuests = async (
 /** Row locks the bulk quest reset may hold in one statement. */
 const QUEST_RESET_BATCH_SIZE = 100;
 
+/**
+ * Ceiling on the repeated tracker-removal passes per batch. Above the largest questData array
+ * seen in production, so it only ever stops a pass that is somehow not shrinking the document.
+ */
+const QUEST_RESET_MAX_TRACKER_PASSES = 50;
+
 /** Upsert quest entries for all users by selector. NOTE: selector determined which users get updated/inserted entries */
 export const upsertQuestEntries = async (
   client: DrizzleClient,
@@ -2085,8 +2091,10 @@ export const upsertQuestEntries = async (
       '#',
       '$[*].id'
     ))`;
+    // A user with several QuestHistory rows for this quest fans the LEFT JOIN out; dedupe so a
+    // batch still covers QUEST_RESET_BATCH_SIZE distinct users.
     const batches = chunkArray(
-      candidates.map((row) => row.userId),
+      [...new Set(candidates.map((row) => row.userId))],
       QUEST_RESET_BATCH_SIZE,
     );
     for (const batchUserIds of batches) {
@@ -2096,17 +2104,28 @@ export const upsertQuestEntries = async (
       // active with last run's fully-done tracker, which getReward reads as resolved and pays
       // out again. Removing it in SQL (rather than read-modify-write) also keeps progress a
       // concurrent request recorded for an unrelated active quest.
-      await client
-        .update(userData)
-        .set({
-          questData: sql`JSON_REMOVE(
-            ${userData.questData},
-            TRIM(TRAILING '.id' FROM ${trackerPath})
-          )`,
-        })
-        .where(
-          and(inArray(userData.userId, batchUserIds), sql`${trackerPath} IS NOT NULL`),
-        );
+      //
+      // JSON_SEARCH 'one' finds a single tracker, and questData is not guaranteed to hold only
+      // one per quest — duplicates exist in production. Repeat until a pass changes nothing, or
+      // the survivor becomes the tracker getNewTrackers reads and the quest still opens done.
+      // Each pass strictly shrinks the array, so the cap is only a guard against a wedged cron.
+      for (let pass = 0; pass < QUEST_RESET_MAX_TRACKER_PASSES; pass++) {
+        const removed = await client
+          .update(userData)
+          .set({
+            questData: sql`JSON_REMOVE(
+              ${userData.questData},
+              TRIM(TRAILING '.id' FROM ${trackerPath})
+            )`,
+          })
+          .where(
+            and(
+              inArray(userData.userId, batchUserIds),
+              sql`${trackerPath} IS NOT NULL`,
+            ),
+          );
+        if (removed.rowsAffected === 0) break;
+      }
 
       await client
         .update(questHistory)

--- a/app/src/server/api/routers/quests.ts
+++ b/app/src/server/api/routers/quests.ts
@@ -2026,10 +2026,7 @@ export const fetchUncompletedQuests = async (
 /** Row locks the bulk quest reset may hold in one statement. */
 const QUEST_RESET_BATCH_SIZE = 100;
 
-/**
- * Ceiling on the repeated tracker-removal passes per batch. Above the largest questData array
- * seen in production, so it only ever stops a pass that is somehow not shrinking the document.
- */
+/** Ceiling on the repeated tracker-removal passes per batch; a stuck-loop guard, not a bound. */
 const QUEST_RESET_MAX_TRACKER_PASSES = 50;
 
 /** Upsert quest entries for all users by selector. NOTE: selector determined which users get updated/inserted entries */
@@ -2098,17 +2095,13 @@ export const upsertQuestEntries = async (
       QUEST_RESET_BATCH_SIZE,
     );
     for (const batchUserIds of batches) {
-      // Drop the tracker BEFORE reopening the history row, and never in parallel with it: the
-      // caller has already closed every daily, so while the quest is shut a request cannot
-      // rebuild a tracker for it. Reopening first would leave a window where the quest is
-      // active with last run's fully-done tracker, which getReward reads as resolved and pays
-      // out again. Removing it in SQL (rather than read-modify-write) also keeps progress a
-      // concurrent request recorded for an unrelated active quest.
-      //
-      // JSON_SEARCH 'one' finds a single tracker, and questData is not guaranteed to hold only
-      // one per quest — duplicates exist in production. Repeat until a pass changes nothing, or
-      // the survivor becomes the tracker getNewTrackers reads and the quest still opens done.
-      // Each pass strictly shrinks the array, so the cap is only a guard against a wedged cron.
+      // Drop the tracker before reopening the history row, never in parallel with it: between
+      // the two the quest would be active carrying last run's fully-done tracker, which
+      // getReward reads as resolved and pays out again. Removing it in SQL rather than
+      // read-modify-write also preserves progress a concurrent request recorded for another
+      // quest. JSON_SEARCH 'one' drops a single tracker and questData is not guaranteed to hold
+      // only one per quest, so repeat until a pass changes nothing; each pass shrinks the
+      // array, making the cap a guard against a wedged cron rather than a real bound.
       for (let pass = 0; pass < QUEST_RESET_MAX_TRACKER_PASSES; pass++) {
         const removed = await client
           .update(userData)
@@ -2529,10 +2522,9 @@ export const upsertQuestEntry = async (
   const promises: Promise<unknown>[] = [];
   // Restarting a quest must discard any stale tracker from prior attempts before recomputing.
   // An attempt that is still open is being re-entered, not restarted — a `start_quest`
-  // objective consequence can name a quest the player is already working through — so keep its
-  // tracker. Every genuine restart arrives here with the row closed (completed, or ended by the
-  // daily reset / abandon), and the mission-hall and overworld paths reject a quest that is
-  // still open before they ever call this.
+  // objective consequence can name a quest the player is part way through — so keep its tracker.
+  // A genuine restart always arrives with the row closed: completed, or ended by the daily reset
+  // or abandon.
   const isOpenAttempt = !!entry && entry.completed === 0 && entry.endAt === null;
   if (!isOpenAttempt) {
     user.questData = removeQuestTrackerByQuestId(user.questData, quest.id);

--- a/app/src/server/api/routers/quests.ts
+++ b/app/src/server/api/routers/quests.ts
@@ -2528,7 +2528,15 @@ export const upsertQuestEntry = async (
   // Promises to be executed
   const promises: Promise<unknown>[] = [];
   // Restarting a quest must discard any stale tracker from prior attempts before recomputing.
-  user.questData = removeQuestTrackerByQuestId(user.questData, quest.id);
+  // An attempt that is still open is being re-entered, not restarted — a `start_quest`
+  // objective consequence can name a quest the player is already working through — so keep its
+  // tracker. Every genuine restart arrives here with the row closed (completed, or ended by the
+  // daily reset / abandon), and the mission-hall and overworld paths reject a quest that is
+  // still open before they ever call this.
+  const isOpenAttempt = !!entry && entry.completed === 0 && entry.endAt === null;
+  if (!isOpenAttempt) {
+    user.questData = removeQuestTrackerByQuestId(user.questData, quest.id);
+  }
   // Check if the quest has already been started
   if (entry) {
     const startedAt = new Date();

--- a/app/tests/app/api/daily-quest/route.test.ts
+++ b/app/tests/app/api/daily-quest/route.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type DailyQuestTestMocks = {
+  lock: ReturnType<typeof vi.fn>;
+  rollback: ReturnType<typeof vi.fn>;
+  handleError: ReturnType<typeof vi.fn>;
+  findQuests: ReturnType<typeof vi.fn>;
+  findVillages: ReturnType<typeof vi.fn>;
+  select: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  upsertQuestEntries: ReturnType<typeof vi.fn>;
+  calls: string[];
+  updateSets: Record<string, unknown>[];
+};
+
+/** Returns Bun-compatible module mocks shared by the hoisted route factories. */
+function getDailyQuestTestMocks(): DailyQuestTestMocks {
+  const globals = globalThis as unknown as { __dailyQuestTestMocks?: DailyQuestTestMocks };
+  globals.__dailyQuestTestMocks ??= {
+    lock: vi.fn(),
+    rollback: vi.fn(),
+    handleError: vi.fn(),
+    findQuests: vi.fn(),
+    findVillages: vi.fn(),
+    select: vi.fn(),
+    update: vi.fn(),
+    upsertQuestEntries: vi.fn(),
+    calls: [],
+    updateSets: [],
+  };
+  return globals.__dailyQuestTestMocks;
+}
+
+const mocks = getDailyQuestTestMocks();
+
+vi.mock("next/headers", () => ({ cookies: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@/libs/gamesettings", () => ({
+  lockWithDailyTimer: getDailyQuestTestMocks().lock,
+  updateGameSetting: getDailyQuestTestMocks().rollback,
+  handleEndpointError: getDailyQuestTestMocks().handleError,
+}));
+vi.mock("@/routers/quests", () => ({
+  upsertQuestEntries: getDailyQuestTestMocks().upsertQuestEntries,
+}));
+vi.mock("@/server/db", () => ({
+  drizzleDB: {
+    query: {
+      quest: { findMany: getDailyQuestTestMocks().findQuests },
+      village: { findMany: getDailyQuestTestMocks().findVillages },
+    },
+    select: getDailyQuestTestMocks().select,
+    update: getDailyQuestTestMocks().update,
+  },
+}));
+
+import { GET } from "@/app/api/daily-quest/route";
+
+const daily = {
+  id: "daily-1",
+  name: "Daily",
+  questType: "daily",
+  questRank: "D",
+  requiredLevel: 1,
+  maxLevel: 100,
+  requiredVillage: null,
+  content: { objectives: [], reward: {} },
+};
+
+/** One D-rank GENIN in one village, plus one player holding an open tier quest. */
+const seedHappyPath = () => {
+  mocks.findQuests.mockResolvedValue([daily]);
+  mocks.findVillages.mockResolvedValue([
+    { id: "village-1", type: "VILLAGE", sector: 1, structures: [] },
+  ]);
+  // 1st select: rank/village/level aggregate. 2nd: users holding an open tier quest.
+  mocks.select
+    .mockReturnValueOnce({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          groupBy: vi
+            .fn()
+            .mockResolvedValue([
+              { rank: "GENIN", villageId: "village-1", level: 10, count: 1 },
+            ]),
+        })),
+      })),
+    })
+    .mockReturnValueOnce({
+      from: vi.fn(() => ({
+        where: vi.fn().mockResolvedValue([{ userId: "user-1" }]),
+      })),
+    });
+  mocks.update.mockImplementation(() => ({
+    set: (value: Record<string, unknown>) => {
+      mocks.updateSets.push(value);
+      mocks.calls.push(`update:${Object.keys(value).join(",")}`);
+      return { where: vi.fn().mockResolvedValue({ rowsAffected: 1 }) };
+    },
+  }));
+  mocks.upsertQuestEntries.mockImplementation(async () => {
+    mocks.calls.push("upsertQuestEntries");
+  });
+};
+
+describe("daily-quest cron", () => {
+  beforeEach(() => {
+    for (const mock of [
+      mocks.lock,
+      mocks.rollback,
+      mocks.handleError,
+      mocks.findQuests,
+      mocks.findVillages,
+      mocks.select,
+      mocks.update,
+      mocks.upsertQuestEntries,
+    ]) {
+      mock.mockReset();
+    }
+    mocks.calls.length = 0;
+    mocks.updateSets.length = 0;
+    mocks.lock.mockResolvedValue({ isNewDay: true, prevTime: 1 });
+  });
+
+  it("closes every open daily before any quest is reassigned", async () => {
+    // upsertQuestEntries reopens the chosen daily and clears its tracker while the quest is
+    // shut. If the close has not landed first, a quest can be active with last run's
+    // fully-done tracker, which getReward reads as resolved and pays out again.
+    seedHappyPath();
+
+    await GET();
+
+    const closeIndex = mocks.calls.indexOf("update:completed,endAt");
+    const assignIndex = mocks.calls.indexOf("upsertQuestEntries");
+    expect(closeIndex).toBeGreaterThanOrEqual(0);
+    expect(assignIndex).toBeGreaterThan(closeIndex);
+    expect(mocks.updateSets[0]).toMatchObject({ completed: 0 });
+  });
+
+  it("assigns one daily per rank/village/level combo and re-enables tier tutorials", async () => {
+    seedHappyPath();
+
+    const response = await GET();
+
+    expect(await response.json()).toBe("OK");
+    expect(mocks.upsertQuestEntries).toHaveBeenCalledOnce();
+    expect(mocks.upsertQuestEntries.mock.calls[0]?.[1]).toMatchObject({ id: daily.id });
+    // The tier lookup moved into the opening Promise.all; its result must still drive this write.
+    expect(mocks.updateSets.some((set) => set.tutorialOn === true)).toBe(true);
+    expect(mocks.rollback).not.toHaveBeenCalled();
+  });
+
+  it("skips the reset when the daily timer says it is not a new day", async () => {
+    mocks.lock.mockResolvedValue({ isNewDay: false, response: new Response("locked") });
+
+    await GET();
+
+    expect(mocks.findQuests).not.toHaveBeenCalled();
+    expect(mocks.upsertQuestEntries).not.toHaveBeenCalled();
+  });
+
+  it("rolls the timer back when reassignment throws", async () => {
+    seedHappyPath();
+    mocks.upsertQuestEntries.mockRejectedValue(new Error("reset failed"));
+    mocks.handleError.mockResolvedValue(new Response("error", { status: 500 }));
+
+    await GET();
+
+    expect(mocks.rollback).toHaveBeenCalledOnce();
+    expect(mocks.rollback.mock.calls[0]?.[3]).toBe(1);
+    expect(mocks.handleError).toHaveBeenCalledOnce();
+  });
+});

--- a/app/tests/server/api/questHistory.uniqueMigration.test.ts
+++ b/app/tests/server/api/questHistory.uniqueMigration.test.ts
@@ -2,20 +2,22 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import mysql from "mysql2/promise";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { asc } from "drizzle-orm";
+import { afterEach, beforeEach, expect, it } from "vitest";
+import { questHistory } from "@/drizzle/schema";
+import { insertQuestHistory } from "../../setup/factories";
+import {
+  describeWithDatabase,
+  getTestDatabase,
+  indexColumns,
+  resetTables,
+  runRawSql,
+} from "../../setup/testDatabase";
 
 /**
  * Runs migration 0039 — deduplicate QuestHistory, then add uniqueUserIdQuestId — against a real
- * MySQL, so the winner it keeps and the counters it merges are checked rather than assumed.
- *
- * Set TEST_MYSQL_URL to a THROWAWAY database — this creates and drops `QuestHistory` in it:
- *   TEST_MYSQL_URL='mysql://root:placeholder@127.0.0.1:3307/tnr_test' bun test
+ * MySQL, so the row it keeps and the counters it merges are checked rather than assumed.
  */
-const url = process.env.TEST_MYSQL_URL;
-const dbName = url ? new URL(url).pathname.replace(/^\//, "") : "";
-const enabled = !!url && /test/i.test(dbName);
-
 const statements = readFileSync(
   join(
     import.meta.dirname,
@@ -27,92 +29,57 @@ const statements = readFileSync(
   .map((statement) => statement.trim())
   .filter(Boolean);
 
-let connection: mysql.Connection;
-
-type Row = {
-  id: string;
-  userId: string;
-  questId: string;
-  completed?: number;
-  endedAt?: Date | null;
-  startedAt: string;
-  previousCompletes?: number;
-  previousAttempts?: number;
-};
-
-const seed = async (rows: Row[]) => {
-  await connection.query(
-    "INSERT INTO QuestHistory (id, userId, questId, questType, completed, endedAt, startedAt, previousCompletes, previousAttempts) VALUES ?",
-    [
-      rows.map((row) => [
-        row.id,
-        row.userId,
-        row.questId,
-        "tier",
-        row.completed ?? 0,
-        row.endedAt ?? null,
-        row.startedAt,
-        row.previousCompletes ?? 0,
-        row.previousAttempts ?? 0,
-      ]),
-    ],
-  );
-};
-
-const migrate = async () => {
+const applyMigration = async () => {
   for (const statement of statements) {
-    await connection.query(statement);
+    await runRawSql(statement);
   }
 };
 
 const survivors = async () => {
-  const [rows] = await connection.query<mysql.RowDataPacket[]>(
-    "SELECT id, userId, questId, completed, endedAt, previousCompletes, previousAttempts FROM QuestHistory ORDER BY userId, questId",
-  );
-  return rows;
+  const database = await getTestDatabase();
+  return database
+    .select({
+      id: questHistory.id,
+      userId: questHistory.userId,
+      previousCompletes: questHistory.previousCompletes,
+      previousAttempts: questHistory.previousAttempts,
+    })
+    .from(questHistory)
+    .orderBy(asc(questHistory.id));
 };
 
-describe.skipIf(!enabled)("QuestHistory unique (userId, questId) migration", () => {
-  beforeAll(async () => {
-    connection = await mysql.createConnection({ uri: url, multipleStatements: true });
+const at = (iso: string) => new Date(iso);
+
+describeWithDatabase("QuestHistory unique (userId, questId) migration", () => {
+  beforeEach(async () => {
+    await resetTables(questHistory);
+    // The schema already carries the constraint, so drop it to reach the pre-migration shape
+    // the deployed database is in.
+    await runRawSql("ALTER TABLE `QuestHistory` DROP INDEX `uniqueUserIdQuestId`");
+  });
+
+  afterEach(async () => {
+    // Leave the schema as the rest of the suite expects, whatever this test did.
+    await resetTables(questHistory);
+    await runRawSql(
+      "ALTER TABLE `QuestHistory` ADD CONSTRAINT `uniqueUserIdQuestId` UNIQUE(`userId`,`questId`)",
+    ).catch(() => undefined);
+  });
+
+  it("has the three statements the assertions below depend on", () => {
     expect(statements).toHaveLength(3);
   });
 
-  afterAll(async () => {
-    await connection?.query("DROP TABLE IF EXISTS QuestHistory");
-    await connection?.end();
-  });
-
-  beforeEach(async () => {
-    // Rebuilt per test so each run starts from the pre-migration shape: no unique key.
-    await connection.query(`
-      DROP TABLE IF EXISTS QuestHistory;
-      CREATE TABLE QuestHistory (
-        id varchar(191) NOT NULL PRIMARY KEY,
-        userId varchar(191) NOT NULL,
-        questId varchar(191) NOT NULL,
-        questType varchar(191) NOT NULL,
-        completed tinyint NOT NULL DEFAULT 0,
-        endedAt datetime(3) NULL,
-        startedAt datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-        previousCompletes int NOT NULL DEFAULT 0,
-        previousAttempts int NOT NULL DEFAULT 0,
-        periodCompletes int NOT NULL DEFAULT 0,
-        periodStartAt datetime(3) NULL
-      );
-    `);
-  });
-
   it("keeps the open attempt and lifts the highest lifetime counters onto it", async () => {
-    await seed([
+    await insertQuestHistory([
       // Newer, but finished — losing to the open attempt is the point.
       {
         id: "closed",
         userId: "u1",
         questId: "q1",
         completed: 1,
-        endedAt: new Date("2026-05-01T00:00:00Z"),
-        startedAt: "2026-05-01 00:00:00.000",
+        endAt: at("2026-05-02T00:00:00Z"),
+        startedAt: at("2026-05-01T00:00:00Z"),
         previousCompletes: 3,
         previousAttempts: 9,
       },
@@ -121,125 +88,123 @@ describe.skipIf(!enabled)("QuestHistory unique (userId, questId) migration", () 
         userId: "u1",
         questId: "q1",
         completed: 0,
-        endedAt: null,
-        startedAt: "2026-01-01 00:00:00.000",
+        endAt: null,
+        startedAt: at("2026-01-01T00:00:00Z"),
         previousCompletes: 1,
         previousAttempts: 2,
       },
     ]);
 
-    await migrate();
+    await applyMigration();
 
-    const rows = await survivors();
-    expect(rows).toHaveLength(1);
-    expect(rows[0]?.id).toBe("open");
-    expect(rows[0]?.previousCompletes).toBe(3);
-    expect(rows[0]?.previousAttempts).toBe(9);
+    expect(await survivors()).toEqual([
+      { id: "open", userId: "u1", previousCompletes: 3, previousAttempts: 9 },
+    ]);
   });
 
   it("falls back to the most recently started attempt when none is open", async () => {
-    await seed([
+    await insertQuestHistory([
       {
         id: "older",
         userId: "u1",
         questId: "q1",
         completed: 1,
-        endedAt: new Date("2026-01-02T00:00:00Z"),
-        startedAt: "2026-01-01 00:00:00.000",
+        endAt: at("2026-01-02T00:00:00Z"),
+        startedAt: at("2026-01-01T00:00:00Z"),
       },
       {
         id: "newer",
         userId: "u1",
         questId: "q1",
         completed: 1,
-        endedAt: new Date("2026-06-02T00:00:00Z"),
-        startedAt: "2026-06-01 00:00:00.000",
+        endAt: at("2026-06-02T00:00:00Z"),
+        startedAt: at("2026-06-01T00:00:00Z"),
       },
     ]);
 
-    await migrate();
+    await applyMigration();
 
-    const rows = await survivors();
-    expect(rows.map((row) => row.id)).toEqual(["newer"]);
-  });
-
-  it("collapses a deep group and leaves unduplicated pairs untouched", async () => {
-    await seed([
-      ...Array.from({ length: 28 }, (_, i) => ({
-        id: `dupe-${i}`,
-        userId: "u1",
-        questId: "q1",
-        completed: 1,
-        endedAt: new Date("2026-01-02T00:00:00Z"),
-        startedAt: `2026-01-${String(i + 1).padStart(2, "0")} 00:00:00.000`,
-        previousAttempts: i,
-      })),
-      { id: "solo", userId: "u2", questId: "q1", startedAt: "2026-01-01 00:00:00.000" },
-      { id: "other", userId: "u1", questId: "q2", startedAt: "2026-01-01 00:00:00.000" },
-    ]);
-
-    await migrate();
-
-    const rows = await survivors();
-    expect(rows.map((row) => row.id).sort()).toEqual(["dupe-27", "other", "solo"].sort());
-    expect(rows.find((row) => row.id === "dupe-27")?.previousAttempts).toBe(27);
-  });
-
-  it("adds the constraint so a second row for the same pair is rejected", async () => {
-    await seed([
-      { id: "a", userId: "u1", questId: "q1", startedAt: "2026-01-01 00:00:00.000" },
-      { id: "b", userId: "u1", questId: "q1", startedAt: "2026-01-02 00:00:00.000" },
-    ]);
-
-    await migrate();
-
-    await expect(
-      seed([{ id: "c", userId: "u1", questId: "q1", startedAt: "2026-02-01 00:00:00.000" }]),
-    ).rejects.toThrow(/Duplicate entry/i);
-
-    // The key the app's onDuplicateKeyUpdate relies on, by the name schema.ts declares.
-    const [indexes] = await connection.query<mysql.RowDataPacket[]>(
-      "SHOW INDEX FROM QuestHistory WHERE Key_name = 'uniqueUserIdQuestId'",
-    );
-    expect(indexes.map((row) => row.Column_name)).toEqual(["userId", "questId"]);
-    expect(indexes.every((row) => row.Non_unique === 0)).toBe(true);
+    expect((await survivors()).map((row) => row.id)).toEqual(["newer"]);
   });
 
   it("keeps a survivor whose id contains the characters used to build the sort key", async () => {
     // id is varchar(191); a separator-based key would truncate here, match no row, and delete
-    // the entire group. The key is fixed width instead, so the id is recovered whole.
-    await seed([
+    // the whole group. The key is fixed width instead, so the id is recovered intact.
+    await insertQuestHistory([
       {
         id: "open|attempt 2026",
         userId: "u1",
         questId: "q1",
         completed: 0,
-        endedAt: null,
-        startedAt: "2026-01-01 00:00:00.000",
+        endAt: null,
+        startedAt: at("2026-01-01T00:00:00Z"),
       },
       {
         id: "loser",
         userId: "u1",
         questId: "q1",
         completed: 1,
-        endedAt: new Date("2026-05-02T00:00:00Z"),
-        startedAt: "2026-05-01 00:00:00.000",
+        endAt: at("2026-05-02T00:00:00Z"),
+        startedAt: at("2026-05-01T00:00:00Z"),
       },
     ]);
 
-    await migrate();
+    await applyMigration();
 
     expect((await survivors()).map((row) => row.id)).toEqual(["open|attempt 2026"]);
   });
 
-  it("is a no-op when the table already holds one row per pair", async () => {
-    await seed([
-      { id: "a", userId: "u1", questId: "q1", startedAt: "2026-01-01 00:00:00.000" },
-      { id: "b", userId: "u2", questId: "q1", startedAt: "2026-01-01 00:00:00.000" },
+  it("collapses a deep group and leaves unduplicated pairs untouched", async () => {
+    await insertQuestHistory([
+      ...Array.from({ length: 28 }, (_, i) => ({
+        id: `dupe-${String(i).padStart(2, "0")}`,
+        userId: "u1",
+        questId: "q1",
+        completed: 1,
+        endAt: at("2026-01-02T00:00:00Z"),
+        startedAt: at(`2026-01-${String(i + 1).padStart(2, "0")}T00:00:00Z`),
+        previousAttempts: i,
+      })),
+      { id: "solo", userId: "u2", questId: "q1" },
+      { id: "other", userId: "u1", questId: "q2" },
     ]);
 
-    await migrate();
+    await applyMigration();
+
+    const rows = await survivors();
+    expect(rows.map((row) => row.id).sort()).toEqual(["dupe-27", "other", "solo"]);
+    expect(rows.find((row) => row.id === "dupe-27")?.previousAttempts).toBe(27);
+  });
+
+  it("adds the constraint so a second row for the same pair is rejected", async () => {
+    await insertQuestHistory([
+      { id: "a", userId: "u1", questId: "q1" },
+      { id: "b", userId: "u1", questId: "q1" },
+    ]);
+
+    await applyMigration();
+
+    // drizzle wraps driver errors, so read the cause for the reason the insert was refused.
+    const failure: unknown = await insertQuestHistory([
+      { id: "c", userId: "u1", questId: "q1" },
+    ]).catch((error: unknown) => error);
+    const cause = (failure as { cause?: { message?: string } })?.cause?.message;
+    expect(cause ?? String(failure)).toMatch(/Duplicate entry/i);
+    // The key the app's onDuplicateKeyUpdate relies on, by the name schema.ts declares.
+    expect(await indexColumns("QuestHistory", "uniqueUserIdQuestId")).toEqual({
+      columns: ["userId", "questId"],
+      unique: true,
+    });
+  });
+
+  it("is a no-op when the table already holds one row per pair", async () => {
+    await insertQuestHistory([
+      { id: "a", userId: "u1", questId: "q1" },
+      { id: "b", userId: "u2", questId: "q1" },
+    ]);
+
+    await applyMigration();
 
     expect((await survivors()).map((row) => row.id)).toEqual(["a", "b"]);
   });
-});
+})

--- a/app/tests/server/api/questHistory.uniqueMigration.test.ts
+++ b/app/tests/server/api/questHistory.uniqueMigration.test.ts
@@ -205,6 +205,33 @@ describe.skipIf(!enabled)("QuestHistory unique (userId, questId) migration", () 
     expect(indexes.every((row) => row.Non_unique === 0)).toBe(true);
   });
 
+  it("keeps a survivor whose id contains the characters used to build the sort key", async () => {
+    // id is varchar(191); a separator-based key would truncate here, match no row, and delete
+    // the entire group. The key is fixed width instead, so the id is recovered whole.
+    await seed([
+      {
+        id: "open|attempt 2026",
+        userId: "u1",
+        questId: "q1",
+        completed: 0,
+        endedAt: null,
+        startedAt: "2026-01-01 00:00:00.000",
+      },
+      {
+        id: "loser",
+        userId: "u1",
+        questId: "q1",
+        completed: 1,
+        endedAt: new Date("2026-05-02T00:00:00Z"),
+        startedAt: "2026-05-01 00:00:00.000",
+      },
+    ]);
+
+    await migrate();
+
+    expect((await survivors()).map((row) => row.id)).toEqual(["open|attempt 2026"]);
+  });
+
   it("is a no-op when the table already holds one row per pair", async () => {
     await seed([
       { id: "a", userId: "u1", questId: "q1", startedAt: "2026-01-01 00:00:00.000" },

--- a/app/tests/server/api/questHistory.uniqueMigration.test.ts
+++ b/app/tests/server/api/questHistory.uniqueMigration.test.ts
@@ -1,0 +1,218 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import mysql from "mysql2/promise";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+/**
+ * Runs migration 0039 — deduplicate QuestHistory, then add uniqueUserIdQuestId — against a real
+ * MySQL, so the winner it keeps and the counters it merges are checked rather than assumed.
+ *
+ * Set TEST_MYSQL_URL to a THROWAWAY database — this creates and drops `QuestHistory` in it:
+ *   TEST_MYSQL_URL='mysql://root:placeholder@127.0.0.1:3307/tnr_test' bun test
+ */
+const url = process.env.TEST_MYSQL_URL;
+const dbName = url ? new URL(url).pathname.replace(/^\//, "") : "";
+const enabled = !!url && /test/i.test(dbName);
+
+const statements = readFileSync(
+  join(
+    import.meta.dirname,
+    "../../../drizzle/migrations/0039_quest_history_unique_user_quest.sql",
+  ),
+  "utf8",
+)
+  .split("--> statement-breakpoint")
+  .map((statement) => statement.trim())
+  .filter(Boolean);
+
+let connection: mysql.Connection;
+
+type Row = {
+  id: string;
+  userId: string;
+  questId: string;
+  completed?: number;
+  endedAt?: Date | null;
+  startedAt: string;
+  previousCompletes?: number;
+  previousAttempts?: number;
+};
+
+const seed = async (rows: Row[]) => {
+  await connection.query(
+    "INSERT INTO QuestHistory (id, userId, questId, questType, completed, endedAt, startedAt, previousCompletes, previousAttempts) VALUES ?",
+    [
+      rows.map((row) => [
+        row.id,
+        row.userId,
+        row.questId,
+        "tier",
+        row.completed ?? 0,
+        row.endedAt ?? null,
+        row.startedAt,
+        row.previousCompletes ?? 0,
+        row.previousAttempts ?? 0,
+      ]),
+    ],
+  );
+};
+
+const migrate = async () => {
+  for (const statement of statements) {
+    await connection.query(statement);
+  }
+};
+
+const survivors = async () => {
+  const [rows] = await connection.query<mysql.RowDataPacket[]>(
+    "SELECT id, userId, questId, completed, endedAt, previousCompletes, previousAttempts FROM QuestHistory ORDER BY userId, questId",
+  );
+  return rows;
+};
+
+describe.skipIf(!enabled)("QuestHistory unique (userId, questId) migration", () => {
+  beforeAll(async () => {
+    connection = await mysql.createConnection({ uri: url, multipleStatements: true });
+    expect(statements).toHaveLength(3);
+  });
+
+  afterAll(async () => {
+    await connection?.query("DROP TABLE IF EXISTS QuestHistory");
+    await connection?.end();
+  });
+
+  beforeEach(async () => {
+    // Rebuilt per test so each run starts from the pre-migration shape: no unique key.
+    await connection.query(`
+      DROP TABLE IF EXISTS QuestHistory;
+      CREATE TABLE QuestHistory (
+        id varchar(191) NOT NULL PRIMARY KEY,
+        userId varchar(191) NOT NULL,
+        questId varchar(191) NOT NULL,
+        questType varchar(191) NOT NULL,
+        completed tinyint NOT NULL DEFAULT 0,
+        endedAt datetime(3) NULL,
+        startedAt datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+        previousCompletes int NOT NULL DEFAULT 0,
+        previousAttempts int NOT NULL DEFAULT 0,
+        periodCompletes int NOT NULL DEFAULT 0,
+        periodStartAt datetime(3) NULL
+      );
+    `);
+  });
+
+  it("keeps the open attempt and lifts the highest lifetime counters onto it", async () => {
+    await seed([
+      // Newer, but finished — losing to the open attempt is the point.
+      {
+        id: "closed",
+        userId: "u1",
+        questId: "q1",
+        completed: 1,
+        endedAt: new Date("2026-05-01T00:00:00Z"),
+        startedAt: "2026-05-01 00:00:00.000",
+        previousCompletes: 3,
+        previousAttempts: 9,
+      },
+      {
+        id: "open",
+        userId: "u1",
+        questId: "q1",
+        completed: 0,
+        endedAt: null,
+        startedAt: "2026-01-01 00:00:00.000",
+        previousCompletes: 1,
+        previousAttempts: 2,
+      },
+    ]);
+
+    await migrate();
+
+    const rows = await survivors();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe("open");
+    expect(rows[0]?.previousCompletes).toBe(3);
+    expect(rows[0]?.previousAttempts).toBe(9);
+  });
+
+  it("falls back to the most recently started attempt when none is open", async () => {
+    await seed([
+      {
+        id: "older",
+        userId: "u1",
+        questId: "q1",
+        completed: 1,
+        endedAt: new Date("2026-01-02T00:00:00Z"),
+        startedAt: "2026-01-01 00:00:00.000",
+      },
+      {
+        id: "newer",
+        userId: "u1",
+        questId: "q1",
+        completed: 1,
+        endedAt: new Date("2026-06-02T00:00:00Z"),
+        startedAt: "2026-06-01 00:00:00.000",
+      },
+    ]);
+
+    await migrate();
+
+    const rows = await survivors();
+    expect(rows.map((row) => row.id)).toEqual(["newer"]);
+  });
+
+  it("collapses a deep group and leaves unduplicated pairs untouched", async () => {
+    await seed([
+      ...Array.from({ length: 28 }, (_, i) => ({
+        id: `dupe-${i}`,
+        userId: "u1",
+        questId: "q1",
+        completed: 1,
+        endedAt: new Date("2026-01-02T00:00:00Z"),
+        startedAt: `2026-01-${String(i + 1).padStart(2, "0")} 00:00:00.000`,
+        previousAttempts: i,
+      })),
+      { id: "solo", userId: "u2", questId: "q1", startedAt: "2026-01-01 00:00:00.000" },
+      { id: "other", userId: "u1", questId: "q2", startedAt: "2026-01-01 00:00:00.000" },
+    ]);
+
+    await migrate();
+
+    const rows = await survivors();
+    expect(rows.map((row) => row.id).sort()).toEqual(["dupe-27", "other", "solo"].sort());
+    expect(rows.find((row) => row.id === "dupe-27")?.previousAttempts).toBe(27);
+  });
+
+  it("adds the constraint so a second row for the same pair is rejected", async () => {
+    await seed([
+      { id: "a", userId: "u1", questId: "q1", startedAt: "2026-01-01 00:00:00.000" },
+      { id: "b", userId: "u1", questId: "q1", startedAt: "2026-01-02 00:00:00.000" },
+    ]);
+
+    await migrate();
+
+    await expect(
+      seed([{ id: "c", userId: "u1", questId: "q1", startedAt: "2026-02-01 00:00:00.000" }]),
+    ).rejects.toThrow(/Duplicate entry/i);
+
+    // The key the app's onDuplicateKeyUpdate relies on, by the name schema.ts declares.
+    const [indexes] = await connection.query<mysql.RowDataPacket[]>(
+      "SHOW INDEX FROM QuestHistory WHERE Key_name = 'uniqueUserIdQuestId'",
+    );
+    expect(indexes.map((row) => row.Column_name)).toEqual(["userId", "questId"]);
+    expect(indexes.every((row) => row.Non_unique === 0)).toBe(true);
+  });
+
+  it("is a no-op when the table already holds one row per pair", async () => {
+    await seed([
+      { id: "a", userId: "u1", questId: "q1", startedAt: "2026-01-01 00:00:00.000" },
+      { id: "b", userId: "u2", questId: "q1", startedAt: "2026-01-01 00:00:00.000" },
+    ]);
+
+    await migrate();
+
+    expect((await survivors()).map((row) => row.id)).toEqual(["a", "b"]);
+  });
+});

--- a/app/tests/server/api/quests.assignment.test.ts
+++ b/app/tests/server/api/quests.assignment.test.ts
@@ -1,5 +1,7 @@
 // @vitest-environment node
 
+import type { SQL } from "drizzle-orm";
+import { MySqlDialect } from "drizzle-orm/mysql-core";
 import { describe, expect, it, vi } from "vitest";
 import {
   assignQuestToUser,
@@ -64,6 +66,50 @@ const makeClient = (assignedQuest: { questId: string } | null = { questId: quest
     update,
     insert,
     findFirst,
+  };
+};
+
+/**
+ * Renders a drizzle `sql` fragment to its statement + bound params. The bulk reset removes the
+ * tracker with raw JSON surgery, so asserting on the SET payload object alone cannot tell
+ * "drop this one tracker" apart from "wipe every tracker of every user the daily cron touches".
+ */
+const render = (fragment: unknown) => new MySqlDialect().sqlToQuery(fragment as SQL);
+
+/** Client for the bulk reset: one LEFT JOIN select, then insert + batched updates. */
+const makeBulkClient = (rows: { userId: string; historyId: string | null }[]) => {
+  const sets: Record<string, unknown>[] = [];
+  const wheres: unknown[] = [];
+  const update = vi.fn(() => ({
+    set: (value: Record<string, unknown>) => {
+      sets.push(value);
+      return {
+        where: vi.fn((condition: unknown) => {
+          wheres.push(condition);
+          return Promise.resolve({ rowsAffected: rows.length });
+        }),
+      };
+    },
+  }));
+  const onDuplicateKeyUpdate = vi.fn().mockResolvedValue(undefined);
+  const values = vi.fn((inserted: { userId: string }[]) => {
+    void inserted;
+    return { onDuplicateKeyUpdate };
+  });
+  const insert = vi.fn(() => ({ values }));
+  const select = vi.fn(() => ({
+    from: vi.fn(() => ({
+      leftJoin: vi.fn(() => ({ where: vi.fn().mockResolvedValue(rows) })),
+    })),
+  }));
+  return {
+    client: { select, update, insert } as never,
+    sets,
+    wheres,
+    update,
+    insert,
+    values,
+    select,
   };
 };
 
@@ -207,34 +253,49 @@ describe("assignQuestToUser compatibility", () => {
   });
 
   it("clears reused daily tracker progress during bulk reassignment", async () => {
-    const sets: Record<string, unknown>[] = [];
-    const update = vi.fn(() => ({
-      set: (value: Record<string, unknown>) => {
-        sets.push(value);
-        return { where: vi.fn().mockResolvedValue({ rowsAffected: 1 }) };
-      },
-    }));
-    const select = vi
-      .fn()
-      .mockReturnValueOnce({
-        from: vi.fn(() => ({
-          leftJoin: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })),
-        })),
-      })
-      .mockReturnValueOnce({
-        from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([{ userId: user.userId }]) })),
-      });
-    const client = { select, update } as never;
+    const daily = { ...quest, questType: "daily" };
+    const { client, sets, wheres, update, select, insert } = makeBulkClient([
+      { userId: user.userId, historyId: "history-1" },
+    ]);
 
-    await upsertQuestEntries(
-      client,
-      { ...quest, questType: "daily" } as never,
-      undefined as never,
-    );
+    await upsertQuestEntries(client, daily as never, undefined as never);
 
+    // Both branches share the one LEFT JOIN pass; nobody is missing a history row here.
+    expect(select).toHaveBeenCalledOnce();
+    expect(insert).not.toHaveBeenCalled();
     expect(update).toHaveBeenCalledTimes(2);
-    expect(sets[0]).toMatchObject({ completed: 0, endAt: null });
-    expect(sets[1]?.questData).toBeTruthy();
+
+    // The tracker must be gone before the quest reopens, or the window in between hands out a
+    // free daily: the quest is active while last run's fully-done tracker still reads resolved.
+    const removal = render(sets[0]?.questData);
+    expect(removal.sql).toContain("JSON_REMOVE");
+    // Scoped to this one tracker, not the whole document, and matched on the top-level id only.
+    expect(removal.sql).toContain("JSON_SEARCH");
+    expect(removal.sql).toContain("$[*].id");
+    expect(removal.params).toContain(daily.id);
+    // JSON_SEARCH matches with LIKE semantics and nanoid ids contain `_`, so the id has to be
+    // escaped or the reset drops some other quest's tracker.
+    expect(removal.sql).toContain("REPLACE(REPLACE(REPLACE(?, '#', '##'), '%', '#%'), '_', '#_')");
+    // Rows with no tracker for this quest are skipped rather than written with a NULL document.
+    expect(render(wheres[0]).sql).toContain("IS NOT NULL");
+
+    expect(sets[1]).toMatchObject({ completed: 0, endAt: null });
+  });
+
+  it("reuses one history row lookup and inserts only for users missing a row", async () => {
+    const daily = { ...quest, questType: "daily" };
+    const { client, select, insert, values } = makeBulkClient([
+      { userId: "user-1", historyId: "history-1" },
+      { userId: "user-2", historyId: null },
+    ]);
+
+    await upsertQuestEntries(client, daily as never, undefined as never);
+
+    expect(select).toHaveBeenCalledOnce();
+    expect(insert).toHaveBeenCalledOnce();
+    expect(values.mock.calls[0]?.[0]).toMatchObject([
+      { userId: "user-2", questId: daily.id, questType: "daily" },
+    ]);
   });
 
   it("resets stale tracker state when restarting an already-attempted quest", async () => {

--- a/app/tests/server/api/quests.assignment.test.ts
+++ b/app/tests/server/api/quests.assignment.test.ts
@@ -72,7 +72,7 @@ const makeClient = (assignedQuest: { questId: string } | null = { questId: quest
 /**
  * Renders a drizzle `sql` fragment to its statement + bound params. The bulk reset removes the
  * tracker with raw JSON surgery, so asserting on the SET payload object alone cannot tell
- * "drop this one tracker" apart from "wipe every tracker of every user the daily cron touches".
+ * "drop this one tracker" apart from "wipe every tracker this user has".
  */
 const render = (fragment: unknown) => new MySqlDialect().sqlToQuery(fragment as SQL);
 
@@ -295,8 +295,8 @@ describe("assignQuestToUser compatibility", () => {
   });
 
   it("repeats the removal until a pass finds no tracker left to drop", async () => {
-    // JSON_SEARCH 'one' drops a single tracker per statement, and production questData holds
-    // duplicate ids; stopping after one pass leaves the survivor for getNewTrackers to reuse.
+    // JSON_SEARCH 'one' drops a single tracker per statement; with duplicate ids in questData,
+    // stopping after one pass leaves the survivor for getNewTrackers to reuse.
     const { client, sets } = makeBulkClient(
       [{ userId: user.userId, historyId: "history-1" }],
       [1, 1, 0, 1],

--- a/app/tests/server/api/quests.assignment.test.ts
+++ b/app/tests/server/api/quests.assignment.test.ts
@@ -313,6 +313,26 @@ describe("assignQuestToUser compatibility", () => {
     expect(sets.slice(0, 3).every((set) => "questData" in set)).toBe(true);
   });
 
+  it("leaves the quest shut when the removal never finishes clearing a batch", async () => {
+    // questData has no length limit, so a batch can in principle outlast the pass cap. Reopening
+    // then would produce exactly what the removal prevents: an active quest whose tracker still
+    // reads complete.
+    const { client, sets, update } = makeBulkClient(
+      [{ userId: user.userId, historyId: "history-1" }],
+      Array.from({ length: 80 }, () => 1),
+    );
+
+    await upsertQuestEntries(
+      client,
+      { ...quest, questType: "daily" } as never,
+      undefined as never,
+    );
+
+    expect(sets.every((set) => "questData" in set)).toBe(true);
+    expect(sets.some((set) => "completed" in set)).toBe(false);
+    expect(update).toHaveBeenCalledTimes(50);
+  });
+
   it("batches distinct users when a quest has duplicate history rows", async () => {
     const daily = { ...quest, questType: "daily" };
     const { client, wheres } = makeBulkClient([

--- a/app/tests/server/api/quests.assignment.test.ts
+++ b/app/tests/server/api/quests.assignment.test.ts
@@ -344,6 +344,79 @@ describe("assignQuestToUser compatibility", () => {
     ]);
   });
 
+  it("keeps tracker progress when re-entering a quest attempt that is still open", async () => {
+    // A `start_quest` objective consequence can name a quest the player is already working
+    // through. Restart semantics would silently throw that progress away.
+    const objectiveQuest = {
+      ...quest,
+      content: {
+        objectives: [
+          {
+            id: "obj-1",
+            task: "items_crafted",
+            value: 2,
+            description: "",
+            successDescription: "",
+          },
+        ],
+        reward: {},
+        sceneBackground: "",
+        sceneCharacters: [],
+      },
+    };
+    const openTracker = {
+      id: objectiveQuest.id,
+      goals: [{ id: "obj-1", done: false, value: 1 }],
+      startAt: new Date().toISOString(),
+    };
+    const openEntry = {
+      id: "history-1",
+      userId: user.userId,
+      questId: objectiveQuest.id,
+      questType: objectiveQuest.questType,
+      completed: 0,
+      endAt: null,
+      previousAttempts: 1,
+    };
+
+    const sets: Record<string, unknown>[] = [];
+    const update = vi.fn(() => ({
+      set: (value: Record<string, unknown>) => {
+        sets.push(value);
+        return { where: vi.fn().mockResolvedValue({ rowsAffected: 1 }) };
+      },
+    }));
+    const client = {
+      update,
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({ onDuplicateKeyUpdate: vi.fn().mockResolvedValue(undefined) })),
+      })),
+      query: { questHistory: { findFirst: vi.fn().mockResolvedValue(openEntry) } },
+    } as never;
+
+    await upsertQuestEntry(
+      client,
+      {
+        ...user,
+        questData: [openTracker],
+        userQuests: [{ ...openEntry, quest: objectiveQuest }],
+      } as never,
+      objectiveQuest as never,
+      "quest_objective",
+      openEntry as never,
+    );
+
+    const questDataWrite = sets.find((set) => "questData" in set);
+    const trackers = (questDataWrite?.questData ?? []) as {
+      id: string;
+      goals: { id: string; value?: number }[];
+    }[];
+    const goal = trackers
+      .find((tracker) => tracker.id === objectiveQuest.id)
+      ?.goals.find((g) => g.id === "obj-1");
+    expect(goal?.value).toBe(1);
+  });
+
   it("resets stale tracker state when restarting an already-attempted quest", async () => {
     const objectiveQuest = {
       ...quest,

--- a/app/tests/server/api/quests.assignment.test.ts
+++ b/app/tests/server/api/quests.assignment.test.ts
@@ -76,17 +76,25 @@ const makeClient = (assignedQuest: { questId: string } | null = { questId: quest
  */
 const render = (fragment: unknown) => new MySqlDialect().sqlToQuery(fragment as SQL);
 
-/** Client for the bulk reset: one LEFT JOIN select, then insert + batched updates. */
-const makeBulkClient = (rows: { userId: string; historyId: string | null }[]) => {
+/**
+ * Client for the bulk reset: one LEFT JOIN select, then insert + batched updates.
+ * `rowsAffected` is consumed in statement order; the removal repeats while it stays non-zero,
+ * so the default models one removal, its terminating no-op pass, and the history reopen.
+ */
+const makeBulkClient = (
+  rows: { userId: string; historyId: string | null }[],
+  rowsAffected: number[] = [1, 0, 1],
+) => {
   const sets: Record<string, unknown>[] = [];
   const wheres: unknown[] = [];
   const update = vi.fn(() => ({
     set: (value: Record<string, unknown>) => {
+      const affected = rowsAffected[sets.length] ?? 0;
       sets.push(value);
       return {
         where: vi.fn((condition: unknown) => {
           wheres.push(condition);
-          return Promise.resolve({ rowsAffected: rows.length });
+          return Promise.resolve({ rowsAffected: affected });
         }),
       };
     },
@@ -263,10 +271,14 @@ describe("assignQuestToUser compatibility", () => {
     // Both branches share the one LEFT JOIN pass; nobody is missing a history row here.
     expect(select).toHaveBeenCalledOnce();
     expect(insert).not.toHaveBeenCalled();
-    expect(update).toHaveBeenCalledTimes(2);
 
     // The tracker must be gone before the quest reopens, or the window in between hands out a
     // free daily: the quest is active while last run's fully-done tracker still reads resolved.
+    const reopenIndex = sets.findIndex((set) => "completed" in set);
+    expect(reopenIndex).toBeGreaterThan(0);
+    expect(sets.slice(0, reopenIndex).every((set) => "questData" in set)).toBe(true);
+    expect(reopenIndex).toBe(sets.length - 1);
+
     const removal = render(sets[0]?.questData);
     expect(removal.sql).toContain("JSON_REMOVE");
     // Scoped to this one tracker, not the whole document, and matched on the top-level id only.
@@ -279,7 +291,41 @@ describe("assignQuestToUser compatibility", () => {
     // Rows with no tracker for this quest are skipped rather than written with a NULL document.
     expect(render(wheres[0]).sql).toContain("IS NOT NULL");
 
-    expect(sets[1]).toMatchObject({ completed: 0, endAt: null });
+    expect(sets[reopenIndex]).toMatchObject({ completed: 0, endAt: null });
+  });
+
+  it("repeats the removal until a pass finds no tracker left to drop", async () => {
+    // JSON_SEARCH 'one' drops a single tracker per statement, and production questData holds
+    // duplicate ids; stopping after one pass leaves the survivor for getNewTrackers to reuse.
+    const { client, sets } = makeBulkClient(
+      [{ userId: user.userId, historyId: "history-1" }],
+      [1, 1, 0, 1],
+    );
+
+    await upsertQuestEntries(
+      client,
+      { ...quest, questType: "daily" } as never,
+      undefined as never,
+    );
+
+    const reopenIndex = sets.findIndex((set) => "completed" in set);
+    expect(reopenIndex).toBe(3);
+    expect(sets.slice(0, 3).every((set) => "questData" in set)).toBe(true);
+  });
+
+  it("batches distinct users when a quest has duplicate history rows", async () => {
+    const daily = { ...quest, questType: "daily" };
+    const { client, wheres } = makeBulkClient([
+      { userId: "user-1", historyId: "history-1" },
+      { userId: "user-1", historyId: "history-2" },
+      { userId: "user-2", historyId: "history-3" },
+    ]);
+
+    await upsertQuestEntries(client, daily as never, undefined as never);
+
+    const params = render(wheres[0]).params;
+    expect(params.filter((param) => param === "user-1")).toHaveLength(1);
+    expect(params).toContain("user-2");
   });
 
   it("reuses one history row lookup and inserts only for users missing a row", async () => {

--- a/app/tests/server/api/quests.assignment.test.ts
+++ b/app/tests/server/api/quests.assignment.test.ts
@@ -205,4 +205,107 @@ describe("assignQuestToUser compatibility", () => {
     expect(insert).not.toHaveBeenCalled();
     expect(update).not.toHaveBeenCalled();
   });
+
+  it("clears reused daily tracker progress during bulk reassignment", async () => {
+    const sets: Record<string, unknown>[] = [];
+    const update = vi.fn(() => ({
+      set: (value: Record<string, unknown>) => {
+        sets.push(value);
+        return { where: vi.fn().mockResolvedValue({ rowsAffected: 1 }) };
+      },
+    }));
+    const select = vi
+      .fn()
+      .mockReturnValueOnce({
+        from: vi.fn(() => ({
+          leftJoin: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })),
+        })),
+      })
+      .mockReturnValueOnce({
+        from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([{ userId: user.userId }]) })),
+      });
+    const client = { select, update } as never;
+
+    await upsertQuestEntries(
+      client,
+      { ...quest, questType: "daily" } as never,
+      undefined as never,
+    );
+
+    expect(update).toHaveBeenCalledTimes(2);
+    expect(sets[0]).toMatchObject({ completed: 0, endAt: null });
+    expect(sets[1]?.questData).toBeTruthy();
+  });
+
+  it("resets stale tracker state when restarting an already-attempted quest", async () => {
+    const objectiveQuest = {
+      ...quest,
+      content: {
+        objectives: [
+          {
+            id: "obj-1",
+            task: "items_crafted",
+            value: 2,
+            description: "",
+            successDescription: "",
+          },
+        ],
+        reward: {},
+        sceneBackground: "",
+        sceneCharacters: [],
+      },
+    };
+    const staleTracker = {
+      id: objectiveQuest.id,
+      goals: [{ id: "obj-1", done: true, value: 2 }],
+      startAt: new Date().toISOString(),
+    };
+    const existingEntry = {
+      id: "history-1",
+      userId: user.userId,
+      questId: objectiveQuest.id,
+      questType: objectiveQuest.questType,
+      completed: 1,
+      endAt: new Date(),
+      previousAttempts: 1,
+    };
+
+    const sets: Record<string, unknown>[] = [];
+    const update = vi.fn(() => ({
+      set: (value: Record<string, unknown>) => {
+        sets.push(value);
+        return { where: vi.fn().mockResolvedValue({ rowsAffected: 1 }) };
+      },
+    }));
+    const client = {
+      update,
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({ onDuplicateKeyUpdate: vi.fn().mockResolvedValue(undefined) })),
+      })),
+      query: { questHistory: { findFirst: vi.fn().mockResolvedValue(existingEntry) } },
+    } as never;
+
+    await upsertQuestEntry(
+      client,
+      {
+        ...user,
+        questData: [staleTracker],
+        userQuests: [{ ...existingEntry, quest: objectiveQuest }],
+      } as never,
+      objectiveQuest as never,
+      "system",
+      existingEntry as never,
+    );
+
+    const questDataWrite = sets.find((set) => "questData" in set);
+    expect(questDataWrite).toBeTruthy();
+    const trackers = (questDataWrite?.questData ?? []) as {
+      id: string;
+      goals: { id: string; done?: boolean; value?: number }[];
+    }[];
+    const tracker = trackers.find((t) => t.id === objectiveQuest.id);
+    const goal = tracker?.goals.find((g) => g.id === "obj-1");
+    expect(goal?.done).toBe(false);
+    expect(goal?.value).toBe(0);
+  });
 });

--- a/app/tests/server/api/quests.rewardCommit.test.ts
+++ b/app/tests/server/api/quests.rewardCommit.test.ts
@@ -219,4 +219,35 @@ describe("commitQuestObjectiveRewards compatibility", () => {
     expect(deleteFrom).toHaveBeenCalledOnce();
     expect(deleteWhere).toHaveBeenCalledOnce();
   });
+
+  it("drops the resolved quest tracker so replayed assignments start with fresh objectives", async () => {
+    const { user, missionHistory } = makeUser();
+    const { client, sets } = makeClient([
+      { rowsAffected: 1 },
+      { rowsAffected: 1 },
+      { rowsAffected: 1 },
+    ]);
+    const trackerForResolvedQuest = {
+      id: missionHistory.questId,
+      goals: [{ id: "obj-1", done: true, value: 1 }],
+      startAt: new Date().toISOString(),
+    };
+
+    const result = await commitQuestObjectiveRewards({
+      client,
+      userId: user.userId,
+      user: user as never,
+      rewards: rewards(),
+      trackers: [trackerForResolvedQuest] as never,
+      userQuest: missionHistory as never,
+      resolved: true,
+      notifications: [],
+      consequences: [],
+      existingHistory: missionHistory,
+    });
+
+    expect(result.outcome).toBe("claimed");
+    expect(sets[1]).toMatchObject({ questData: [] });
+    expect(sets[2]).toMatchObject({ questData: [] });
+  });
 });

--- a/app/tests/server/api/quests.rewardCommit.test.ts
+++ b/app/tests/server/api/quests.rewardCommit.test.ts
@@ -1,10 +1,12 @@
 // @vitest-environment node
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { commitQuestObjectiveRewards } from "../../../src/server/api/routers/quests";
 import { PostProcessedRewardSchema } from "@/validators/rewards";
 
 const rewards = () => PostProcessedRewardSchema.parse({});
+
+afterEach(() => vi.restoreAllMocks());
 
 /** Builds the minimum hydrated user shape exercised by the shared reward commit path. */
 const makeUser = (retryDelay: "none" | "daily" = "none") => {
@@ -102,6 +104,38 @@ const makeClient = (
     },
   };
   return { client: client as never, sets, update, deleteFrom, deleteWhere };
+};
+
+/**
+ * Client for the gathering payout: updateRewards fetches gatherable items, then writes the
+ * dropped items and the userData row. Every other reward branch stays empty and issues no query.
+ */
+const makeGatheringClient = () => {
+  const sets: Record<string, unknown>[] = [];
+  const update = vi.fn(() => ({
+    set: (value: Record<string, unknown>) => {
+      sets.push(value);
+      return { where: vi.fn().mockResolvedValue({ rowsAffected: 1 }) };
+    },
+  }));
+  const select = vi.fn(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn().mockResolvedValue([{ id: "herb-1", name: "Herb", rarity: "COMMON" }]),
+    })),
+  }));
+  const insert = vi.fn(() => ({
+    values: vi.fn(() => ({ onDuplicateKeyUpdate: vi.fn().mockResolvedValue(undefined) })),
+  }));
+  return {
+    client: {
+      update,
+      select,
+      insert,
+      delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue({ rowsAffected: 0 }) })),
+      query: { questHistory: { findFirst: vi.fn().mockResolvedValue(null) } },
+    } as never,
+    sets,
+  };
 };
 
 describe("commitQuestObjectiveRewards compatibility", () => {
@@ -249,5 +283,36 @@ describe("commitQuestObjectiveRewards compatibility", () => {
     expect(result.outcome).toBe("claimed");
     expect(sets[1]).toMatchObject({ questData: [] });
     expect(sets[2]).toMatchObject({ questData: [] });
+  });
+
+  it("keeps the resolved tracker dropped when the payout also folds in gathering drops", async () => {
+    // The user snapshot still reads the quest as active (the completion CAS only touched the
+    // DB row), so updateRewards' herbs_gathered fold would otherwise rebuild the tracker that
+    // was just removed and hand the replayed quest a head start.
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const { user, missionHistory } = makeUser();
+    const { client, sets } = makeGatheringClient();
+
+    const result = await commitQuestObjectiveRewards({
+      client,
+      userId: user.userId,
+      user: { ...user, occupation: "GATHERING" } as never,
+      rewards: PostProcessedRewardSchema.parse({ reward_gathering_items: true }),
+      trackers: [
+        { id: missionHistory.questId, goals: [{ id: "obj-1", done: true, value: 1 }] },
+      ] as never,
+      userQuest: missionHistory as never,
+      resolved: true,
+      notifications: [],
+      consequences: [],
+      existingHistory: missionHistory,
+    });
+
+    expect(result.outcome).toBe("claimed");
+    // The fold still runs (the tier quest keeps its tracker) — only the finished quest is gone.
+    const payout = sets.find((set) => "money" in set);
+    const persisted = (payout?.questData ?? []) as { id: string }[];
+    expect(persisted.map((tracker) => tracker.id)).not.toContain(missionHistory.questId);
+    expect(persisted.length).toBeGreaterThan(0);
   });
 });

--- a/app/tests/server/api/quests.trackerSql.test.ts
+++ b/app/tests/server/api/quests.trackerSql.test.ts
@@ -1,147 +1,93 @@
 // @vitest-environment node
 
-import { inArray } from "drizzle-orm";
-import { drizzle } from "drizzle-orm/mysql2";
-import mysql from "mysql2/promise";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { beforeEach, expect, it } from "vitest";
 import { questHistory, userData } from "@/drizzle/schema";
+import { QuestTracker } from "@/validators/objectives";
 import { upsertQuestEntries } from "../../../src/server/api/routers/quests";
+import { insertUsers } from "../../setup/factories";
+import { describeWithDatabase, getTestDatabase, resetTables } from "../../setup/testDatabase";
 
 /**
  * The bulk daily reset clears a tracker with raw JSON surgery (JSON_SEARCH + JSON_REMOVE). The
- * other suites assert the statement drizzle renders; these run it on a real MySQL, because the
- * rendered string says nothing about whether the engine drops the element you meant.
- *
- * Set TEST_MYSQL_URL to a THROWAWAY database — this creates and drops `UserData` and
- * `QuestHistory` in it. CI provides one; locally the dev stack's MySQL works:
- *   TEST_MYSQL_URL='mysql://root:placeholder@127.0.0.1:3307/tnr_test' bun test
+ * other quest suites assert the statement drizzle renders; these run it on a real MySQL, because
+ * the rendered string says nothing about whether the engine drops the element you meant.
  */
-const url = process.env.TEST_MYSQL_URL;
-const dbName = url ? new URL(url).pathname.replace(/^\//, "") : "";
-// Refuse a database whose name does not look disposable: the setup drops real table names.
-const enabled = !!url && /test/i.test(dbName);
+/** Parsed through the validator so a stored tracker always matches the shape the app writes. */
+const tracker = (id: string, done: boolean, goalId = "o1") =>
+  QuestTracker.parse({
+    id,
+    startAt: "2026-01-01T00:00:00.000Z",
+    goals: [{ id: goalId, done, value: 1 }],
+  });
 
-let connection: mysql.Connection;
-let client: Parameters<typeof upsertQuestEntries>[0];
-
-const tracker = (id: string, done: boolean) =>
-  ({ id, startAt: "2026-01-01T00:00:00.000Z", goals: [{ id: "o1", done, value: 1 }] }) as const;
-
-const questDataOf = async (userId: string) => {
-  const [rows] = await connection.query<mysql.RowDataPacket[]>(
-    "SELECT questData FROM UserData WHERE userId = ?",
-    [userId],
-  );
-  const value = rows[0]?.questData;
-  return (typeof value === "string" ? JSON.parse(value) : value) as { id: string }[] | null;
+const trackersOf = async (userId: string) => {
+  const database = await getTestDatabase();
+  const [row] = await database
+    .select({ questData: userData.questData })
+    .from(userData)
+    .where(eq(userData.userId, userId));
+  return row?.questData ?? null;
 };
 
 const trackerIds = async (userId: string) =>
-  ((await questDataOf(userId)) ?? []).map((entry) => entry.id);
+  ((await trackersOf(userId)) ?? []).map((entry) => entry.id);
 
-describe.skipIf(!enabled)("bulk daily reset against a real MySQL", () => {
-  beforeAll(async () => {
-    connection = await mysql.createConnection({ uri: url, multipleStatements: true });
-    // Mirrors production, which has no unique key on (userId, questId).
-    await connection.query(`
-      DROP TABLE IF EXISTS UserData;
-      DROP TABLE IF EXISTS QuestHistory;
-      CREATE TABLE UserData (userId varchar(191) NOT NULL PRIMARY KEY, questData json);
-      CREATE TABLE QuestHistory (
-        id varchar(191) NOT NULL PRIMARY KEY,
-        userId varchar(191) NOT NULL,
-        questId varchar(191) NOT NULL,
-        questType varchar(191) NOT NULL,
-        completed tinyint NOT NULL DEFAULT 0,
-        endedAt datetime(3) NULL,
-        startedAt datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-        previousCompletes int NOT NULL DEFAULT 0,
-        previousAttempts int NOT NULL DEFAULT 0,
-        periodCompletes int NOT NULL DEFAULT 0,
-        periodStartAt datetime(3) NULL
-      );
-    `);
-    const db = drizzle(connection);
-    // upsertQuestEntries reads rowsAffected to decide whether another removal pass is needed;
-    // the mysql2 driver reports it as [ResultSetHeader], so normalise it here only.
-    client = {
-      select: db.select.bind(db),
-      insert: db.insert.bind(db),
-      update: (table: Parameters<typeof db.update>[0]) => {
-        const builder = db.update(table);
-        return {
-          set: (values: Record<string, unknown>) => {
-            const withValues = builder.set(values);
-            return {
-              where: async (condition: Parameters<typeof withValues.where>[0]) => {
-                const result = await withValues.where(condition);
-                const header = Array.isArray(result) ? result[0] : result;
-                return { rowsAffected: header.affectedRows ?? 0 };
-              },
-            };
-          },
-        };
-      },
-    } as unknown as Parameters<typeof upsertQuestEntries>[0];
-  });
-
-  afterAll(async () => {
-    await connection?.query("DROP TABLE IF EXISTS UserData; DROP TABLE IF EXISTS QuestHistory;");
-    await connection?.end();
-  });
-
+describeWithDatabase("bulk daily reset against a real MySQL", () => {
   beforeEach(async () => {
-    await connection.query("DELETE FROM UserData; DELETE FROM QuestHistory;");
+    await resetTables(questHistory, userData);
   });
 
   const reset = async (questId: string, userIds: string[]) =>
     upsertQuestEntries(
-      client,
+      await getTestDatabase(),
       { id: questId, questType: "daily" } as never,
       inArray(userData.userId, userIds) as never,
     );
 
-  it("drops only the reassigned quest's tracker, across every production questData shape", async () => {
-    // `q_b` vs `qxb`: nanoid ids contain `_`, which is a LIKE wildcard inside JSON_SEARCH.
-    await connection.query(
-      "INSERT INTO UserData (userId, questData) VALUES (?,?),(?,?),(?,?),(?,?),(?,?),(?,?)",
-      [
-        "mixed", JSON.stringify([tracker("q_a", true), tracker("q_b", true)]),
-        "wildcard", JSON.stringify([tracker("qxb", false)]),
-        "empty", JSON.stringify([]),
-        "sqlnull", null,
-        "deep", JSON.stringify([
+  it("drops only the reassigned quest's tracker, across every stored questData shape", async () => {
+    await insertUsers([
+      { userId: "mixed", questData: [tracker("q_a", true), tracker("q_b", true)] },
+      // nanoid ids contain `_`, which is a LIKE wildcard inside JSON_SEARCH.
+      { userId: "wildcard", questData: [tracker("qxb", false)] },
+      { userId: "empty", questData: [] },
+      { userId: "sqlnull", questData: null },
+      {
+        userId: "deep",
+        questData: [
           ...Array.from({ length: 11 }, (_, i) => tracker(`pad-${i}`, false)),
           tracker("q_b", true),
-        ]),
-        // An objective id that collides with the quest id must not be mistaken for a tracker:
-        // the search is scoped to `$[*].id`, so a recursive path would delete this goal instead.
-        "goalcollision", JSON.stringify([
-          { id: "other", startAt: "2026-01-01T00:00:00.000Z", goals: [{ id: "q_b", done: false }] },
-        ]),
-      ],
-    );
+        ],
+      },
+      // An objective id colliding with the quest id must not be mistaken for a tracker: the
+      // search is scoped to `$[*].id`, so a recursive path would delete this goal instead.
+      { userId: "goalcollision", questData: [tracker("other", false, "q_b")] },
+    ]);
 
     await reset("q_b", ["mixed", "wildcard", "empty", "sqlnull", "deep", "goalcollision"]);
 
     expect(await trackerIds("mixed")).toEqual(["q_a"]);
     expect(await trackerIds("wildcard")).toEqual(["qxb"]);
     expect(await trackerIds("empty")).toEqual([]);
-    expect(await questDataOf("sqlnull")).toBeNull();
+    expect(await trackersOf("sqlnull")).toBeNull();
     // A two-digit array index still trims to `$[11]`, not `$[1]`.
     expect(await trackerIds("deep")).not.toContain("q_b");
     expect(await trackerIds("deep")).toHaveLength(11);
-    expect(await questDataOf("goalcollision")).toEqual([
-      { id: "other", startAt: "2026-01-01T00:00:00.000Z", goals: [{ id: "q_b", done: false }] },
-    ]);
+    expect(await trackersOf("goalcollision")).toEqual([tracker("other", false, "q_b")]);
   });
 
   it("clears every copy when questData holds duplicate tracker ids", async () => {
     // One pass would promote the survivor to the tracker getNewTrackers reads, and the daily
     // would still open completed.
-    await connection.query("INSERT INTO UserData (userId, questData) VALUES (?,?),(?,?)", [
-      "twice", JSON.stringify([tracker("q_a", false), tracker("q_b", true), tracker("q_b", true)]),
-      "thrice", JSON.stringify([tracker("q_b", true), tracker("q_b", true), tracker("q_b", true)]),
+    await insertUsers([
+      {
+        userId: "twice",
+        questData: [tracker("q_a", false), tracker("q_b", true), tracker("q_b", true)],
+      },
+      {
+        userId: "thrice",
+        questData: [tracker("q_b", true), tracker("q_b", true), tracker("q_b", true)],
+      },
     ]);
 
     await reset("q_b", ["twice", "thrice"]);
@@ -151,41 +97,30 @@ describe.skipIf(!enabled)("bulk daily reset against a real MySQL", () => {
   });
 
   it("reopens history rows and inserts one only for users who had none", async () => {
-    await connection.query("INSERT INTO UserData (userId, questData) VALUES (?,?),(?,?)", [
-      "hasrow", JSON.stringify([tracker("q_b", true)]),
-      "norow", JSON.stringify([]),
+    const database = await getTestDatabase();
+    await insertUsers([
+      { userId: "hasrow", questData: [tracker("q_b", true)] },
+      { userId: "norow", questData: [] },
     ]);
-    await connection.query(
-      "INSERT INTO QuestHistory (id, userId, questId, questType, completed, endedAt) VALUES (?,?,?,?,?,?)",
-      ["h1", "hasrow", "q_b", "daily", 1, new Date()],
-    );
+    await database
+      .insert(questHistory)
+      .values({
+        id: "h1",
+        userId: "hasrow",
+        questId: "q_b",
+        questType: "daily",
+        completed: 1,
+        endAt: new Date(),
+      } as never);
 
     await reset("q_b", ["hasrow", "norow"]);
 
-    const [rows] = await connection.query<mysql.RowDataPacket[]>(
-      "SELECT userId, completed, endedAt FROM QuestHistory WHERE questId = 'q_b' ORDER BY userId",
-    );
+    const rows = await database
+      .select({ userId: questHistory.userId, completed: questHistory.completed, endAt: questHistory.endAt })
+      .from(questHistory)
+      .where(eq(questHistory.questId, "q_b"))
+      .orderBy(questHistory.userId);
     expect(rows.map((row) => row.userId)).toEqual(["hasrow", "norow"]);
-    expect(rows.every((row) => row.completed === 0 && row.endedAt === null)).toBe(true);
+    expect(rows.every((row) => row.completed === 0 && row.endAt === null)).toBe(true);
   });
-
-  it("reopens every duplicate history row without inserting another", async () => {
-    // Rows that predate the uniqueUserIdQuestId constraint can still pair up this way.
-    await connection.query("INSERT INTO UserData (userId, questData) VALUES (?,?)", [
-      "dupe", JSON.stringify([tracker("q_b", true)]),
-    ]);
-    await connection.query(
-      "INSERT INTO QuestHistory (id, userId, questId, questType, completed, endedAt) VALUES (?,?,?,?,?,?),(?,?,?,?,?,?)",
-      ["h1", "dupe", "q_b", "daily", 1, new Date(), "h2", "dupe", "q_b", "daily", 1, new Date()],
-    );
-
-    await reset("q_b", ["dupe"]);
-
-    expect(await trackerIds("dupe")).toEqual([]);
-    const [rows] = await connection.query<mysql.RowDataPacket[]>(
-      "SELECT COUNT(*) AS n FROM QuestHistory WHERE userId = 'dupe' AND completed = 0 AND endedAt IS NULL",
-    );
-    // Both existing rows reopen; the LEFT JOIN fan-out must not add a third.
-    expect(Number(rows[0]?.n)).toBe(2);
-  });
-});
+})

--- a/app/tests/server/api/quests.trackerSql.test.ts
+++ b/app/tests/server/api/quests.trackerSql.test.ts
@@ -8,11 +8,11 @@ import { questHistory, userData } from "@/drizzle/schema";
 import { upsertQuestEntries } from "../../../src/server/api/routers/quests";
 
 /**
- * The bulk daily reset clears a tracker with raw JSON surgery (JSON_SEARCH + JSON_REMOVE).
- * Every other test asserts the statement drizzle renders; these run it on a real MySQL, because
- * the rendered string tells you nothing about whether the engine drops the element you meant.
+ * The bulk daily reset clears a tracker with raw JSON surgery (JSON_SEARCH + JSON_REMOVE). The
+ * other suites assert the statement drizzle renders; these run it on a real MySQL, because the
+ * rendered string says nothing about whether the engine drops the element you meant.
  *
- * Set TEST_MYSQL_URL to a THROWAWAY database — this creates and drops `UserData` /
+ * Set TEST_MYSQL_URL to a THROWAWAY database — this creates and drops `UserData` and
  * `QuestHistory` in it. CI provides one; locally the dev stack's MySQL works:
  *   TEST_MYSQL_URL='mysql://root:placeholder@127.0.0.1:3307/tnr_test' bun test
  */
@@ -137,8 +137,8 @@ describe.skipIf(!enabled)("bulk daily reset against a real MySQL", () => {
   });
 
   it("clears every copy when questData holds duplicate tracker ids", async () => {
-    // 181 production users carry two copies of the same daily tracker; one pass would promote
-    // the survivor to the one getNewTrackers reads and the daily would still open completed.
+    // One pass would promote the survivor to the tracker getNewTrackers reads, and the daily
+    // would still open completed.
     await connection.query("INSERT INTO UserData (userId, questData) VALUES (?,?),(?,?)", [
       "twice", JSON.stringify([tracker("q_a", false), tracker("q_b", true), tracker("q_b", true)]),
       "thrice", JSON.stringify([tracker("q_b", true), tracker("q_b", true), tracker("q_b", true)]),
@@ -170,7 +170,7 @@ describe.skipIf(!enabled)("bulk daily reset against a real MySQL", () => {
   });
 
   it("reopens every duplicate history row without inserting another", async () => {
-    // Production has 593 duplicate (userId, questId) pairs because there is no unique key.
+    // Rows that predate the uniqueUserIdQuestId constraint can still pair up this way.
     await connection.query("INSERT INTO UserData (userId, questData) VALUES (?,?)", [
       "dupe", JSON.stringify([tracker("q_b", true)]),
     ]);

--- a/app/tests/server/api/quests.trackerSql.test.ts
+++ b/app/tests/server/api/quests.trackerSql.test.ts
@@ -1,0 +1,191 @@
+// @vitest-environment node
+
+import { inArray } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/mysql2";
+import mysql from "mysql2/promise";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { questHistory, userData } from "@/drizzle/schema";
+import { upsertQuestEntries } from "../../../src/server/api/routers/quests";
+
+/**
+ * The bulk daily reset clears a tracker with raw JSON surgery (JSON_SEARCH + JSON_REMOVE).
+ * Every other test asserts the statement drizzle renders; these run it on a real MySQL, because
+ * the rendered string tells you nothing about whether the engine drops the element you meant.
+ *
+ * Set TEST_MYSQL_URL to a THROWAWAY database — this creates and drops `UserData` /
+ * `QuestHistory` in it. CI provides one; locally the dev stack's MySQL works:
+ *   TEST_MYSQL_URL='mysql://root:placeholder@127.0.0.1:3307/tnr_test' bun test
+ */
+const url = process.env.TEST_MYSQL_URL;
+const dbName = url ? new URL(url).pathname.replace(/^\//, "") : "";
+// Refuse a database whose name does not look disposable: the setup drops real table names.
+const enabled = !!url && /test/i.test(dbName);
+
+let connection: mysql.Connection;
+let client: Parameters<typeof upsertQuestEntries>[0];
+
+const tracker = (id: string, done: boolean) =>
+  ({ id, startAt: "2026-01-01T00:00:00.000Z", goals: [{ id: "o1", done, value: 1 }] }) as const;
+
+const questDataOf = async (userId: string) => {
+  const [rows] = await connection.query<mysql.RowDataPacket[]>(
+    "SELECT questData FROM UserData WHERE userId = ?",
+    [userId],
+  );
+  const value = rows[0]?.questData;
+  return (typeof value === "string" ? JSON.parse(value) : value) as { id: string }[] | null;
+};
+
+const trackerIds = async (userId: string) =>
+  ((await questDataOf(userId)) ?? []).map((entry) => entry.id);
+
+describe.skipIf(!enabled)("bulk daily reset against a real MySQL", () => {
+  beforeAll(async () => {
+    connection = await mysql.createConnection({ uri: url, multipleStatements: true });
+    // Mirrors production, which has no unique key on (userId, questId).
+    await connection.query(`
+      DROP TABLE IF EXISTS UserData;
+      DROP TABLE IF EXISTS QuestHistory;
+      CREATE TABLE UserData (userId varchar(191) NOT NULL PRIMARY KEY, questData json);
+      CREATE TABLE QuestHistory (
+        id varchar(191) NOT NULL PRIMARY KEY,
+        userId varchar(191) NOT NULL,
+        questId varchar(191) NOT NULL,
+        questType varchar(191) NOT NULL,
+        completed tinyint NOT NULL DEFAULT 0,
+        endedAt datetime(3) NULL,
+        startedAt datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+        previousCompletes int NOT NULL DEFAULT 0,
+        previousAttempts int NOT NULL DEFAULT 0,
+        periodCompletes int NOT NULL DEFAULT 0,
+        periodStartAt datetime(3) NULL
+      );
+    `);
+    const db = drizzle(connection);
+    // upsertQuestEntries reads rowsAffected to decide whether another removal pass is needed;
+    // the mysql2 driver reports it as [ResultSetHeader], so normalise it here only.
+    client = {
+      select: db.select.bind(db),
+      insert: db.insert.bind(db),
+      update: (table: Parameters<typeof db.update>[0]) => {
+        const builder = db.update(table);
+        return {
+          set: (values: Record<string, unknown>) => {
+            const withValues = builder.set(values);
+            return {
+              where: async (condition: Parameters<typeof withValues.where>[0]) => {
+                const result = await withValues.where(condition);
+                const header = Array.isArray(result) ? result[0] : result;
+                return { rowsAffected: header.affectedRows ?? 0 };
+              },
+            };
+          },
+        };
+      },
+    } as unknown as Parameters<typeof upsertQuestEntries>[0];
+  });
+
+  afterAll(async () => {
+    await connection?.query("DROP TABLE IF EXISTS UserData; DROP TABLE IF EXISTS QuestHistory;");
+    await connection?.end();
+  });
+
+  beforeEach(async () => {
+    await connection.query("DELETE FROM UserData; DELETE FROM QuestHistory;");
+  });
+
+  const reset = async (questId: string, userIds: string[]) =>
+    upsertQuestEntries(
+      client,
+      { id: questId, questType: "daily" } as never,
+      inArray(userData.userId, userIds) as never,
+    );
+
+  it("drops only the reassigned quest's tracker, across every production questData shape", async () => {
+    // `q_b` vs `qxb`: nanoid ids contain `_`, which is a LIKE wildcard inside JSON_SEARCH.
+    await connection.query(
+      "INSERT INTO UserData (userId, questData) VALUES (?,?),(?,?),(?,?),(?,?),(?,?),(?,?)",
+      [
+        "mixed", JSON.stringify([tracker("q_a", true), tracker("q_b", true)]),
+        "wildcard", JSON.stringify([tracker("qxb", false)]),
+        "empty", JSON.stringify([]),
+        "sqlnull", null,
+        "deep", JSON.stringify([
+          ...Array.from({ length: 11 }, (_, i) => tracker(`pad-${i}`, false)),
+          tracker("q_b", true),
+        ]),
+        // An objective id that collides with the quest id must not be mistaken for a tracker:
+        // the search is scoped to `$[*].id`, so a recursive path would delete this goal instead.
+        "goalcollision", JSON.stringify([
+          { id: "other", startAt: "2026-01-01T00:00:00.000Z", goals: [{ id: "q_b", done: false }] },
+        ]),
+      ],
+    );
+
+    await reset("q_b", ["mixed", "wildcard", "empty", "sqlnull", "deep", "goalcollision"]);
+
+    expect(await trackerIds("mixed")).toEqual(["q_a"]);
+    expect(await trackerIds("wildcard")).toEqual(["qxb"]);
+    expect(await trackerIds("empty")).toEqual([]);
+    expect(await questDataOf("sqlnull")).toBeNull();
+    // A two-digit array index still trims to `$[11]`, not `$[1]`.
+    expect(await trackerIds("deep")).not.toContain("q_b");
+    expect(await trackerIds("deep")).toHaveLength(11);
+    expect(await questDataOf("goalcollision")).toEqual([
+      { id: "other", startAt: "2026-01-01T00:00:00.000Z", goals: [{ id: "q_b", done: false }] },
+    ]);
+  });
+
+  it("clears every copy when questData holds duplicate tracker ids", async () => {
+    // 181 production users carry two copies of the same daily tracker; one pass would promote
+    // the survivor to the one getNewTrackers reads and the daily would still open completed.
+    await connection.query("INSERT INTO UserData (userId, questData) VALUES (?,?),(?,?)", [
+      "twice", JSON.stringify([tracker("q_a", false), tracker("q_b", true), tracker("q_b", true)]),
+      "thrice", JSON.stringify([tracker("q_b", true), tracker("q_b", true), tracker("q_b", true)]),
+    ]);
+
+    await reset("q_b", ["twice", "thrice"]);
+
+    expect(await trackerIds("twice")).toEqual(["q_a"]);
+    expect(await trackerIds("thrice")).toEqual([]);
+  });
+
+  it("reopens history rows and inserts one only for users who had none", async () => {
+    await connection.query("INSERT INTO UserData (userId, questData) VALUES (?,?),(?,?)", [
+      "hasrow", JSON.stringify([tracker("q_b", true)]),
+      "norow", JSON.stringify([]),
+    ]);
+    await connection.query(
+      "INSERT INTO QuestHistory (id, userId, questId, questType, completed, endedAt) VALUES (?,?,?,?,?,?)",
+      ["h1", "hasrow", "q_b", "daily", 1, new Date()],
+    );
+
+    await reset("q_b", ["hasrow", "norow"]);
+
+    const [rows] = await connection.query<mysql.RowDataPacket[]>(
+      "SELECT userId, completed, endedAt FROM QuestHistory WHERE questId = 'q_b' ORDER BY userId",
+    );
+    expect(rows.map((row) => row.userId)).toEqual(["hasrow", "norow"]);
+    expect(rows.every((row) => row.completed === 0 && row.endedAt === null)).toBe(true);
+  });
+
+  it("reopens every duplicate history row without inserting another", async () => {
+    // Production has 593 duplicate (userId, questId) pairs because there is no unique key.
+    await connection.query("INSERT INTO UserData (userId, questData) VALUES (?,?)", [
+      "dupe", JSON.stringify([tracker("q_b", true)]),
+    ]);
+    await connection.query(
+      "INSERT INTO QuestHistory (id, userId, questId, questType, completed, endedAt) VALUES (?,?,?,?,?,?),(?,?,?,?,?,?)",
+      ["h1", "dupe", "q_b", "daily", 1, new Date(), "h2", "dupe", "q_b", "daily", 1, new Date()],
+    );
+
+    await reset("q_b", ["dupe"]);
+
+    expect(await trackerIds("dupe")).toEqual([]);
+    const [rows] = await connection.query<mysql.RowDataPacket[]>(
+      "SELECT COUNT(*) AS n FROM QuestHistory WHERE userId = 'dupe' AND completed = 0 AND endedAt IS NULL",
+    );
+    // Both existing rows reopen; the LEFT JOIN fan-out must not add a third.
+    expect(Number(rows[0]?.n)).toBe(2);
+  });
+});

--- a/app/tests/setup/factories.ts
+++ b/app/tests/setup/factories.ts
@@ -1,0 +1,50 @@
+/**
+ * Row builders for the shared test database. Each fills the columns the schema requires and
+ * leaves the rest to their defaults, so a test only states the fields it is actually about.
+ */
+import { nanoid } from "nanoid";
+import { quest, questHistory, userData } from "@/drizzle/schema";
+import { getTestDatabase } from "./testDatabase";
+
+type Insert<T> = Partial<T> & Record<string, unknown>;
+
+export const insertUsers = async (users: Insert<typeof userData.$inferInsert>[]) => {
+  const database = await getTestDatabase();
+  const rows = users.map((user, index) => ({
+    userId: `user-${index}`,
+    username: `user-${index}`,
+    gender: "Male",
+    streak: 0,
+    ...user,
+  }));
+  await database.insert(userData).values(rows as never);
+  return rows;
+};
+
+export const insertQuests = async (quests: Insert<typeof quest.$inferInsert>[]) => {
+  const database = await getTestDatabase();
+  const rows = quests.map((entry) => ({
+    id: nanoid(),
+    name: "Test quest",
+    questType: "daily",
+    content: { objectives: [], reward: {}, sceneBackground: "", sceneCharacters: [] },
+    ...entry,
+  }));
+  await database.insert(quest).values(rows as never);
+  return rows;
+};
+
+export const insertQuestHistory = async (
+  entries: Insert<typeof questHistory.$inferInsert>[],
+) => {
+  const database = await getTestDatabase();
+  const rows = entries.map((entry) => ({
+    id: nanoid(),
+    userId: "user-0",
+    questId: "quest-0",
+    questType: "daily",
+    ...entry,
+  }));
+  await database.insert(questHistory).values(rows as never);
+  return rows;
+};

--- a/app/tests/setup/preload.ts
+++ b/app/tests/setup/preload.ts
@@ -1,0 +1,21 @@
+/**
+ * Registered via bunfig.toml: brings the shared test database up once per `bun test` run.
+ * No-ops when TEST_MYSQL_URL is unset.
+ *
+ * The schema is left in place afterwards. `prepareTestDatabase` reconciles it on the next run
+ * and truncates every table, so a leftover database makes the next run cheaper without letting
+ * its rows leak into it.
+ */
+import { afterAll, beforeAll } from "vitest";
+import { closeTestDatabase, hasTestDatabase, prepareTestDatabase } from "./testDatabase";
+
+if (hasTestDatabase) {
+  // Reconciling the schema is slower than a unit test's default budget.
+  beforeAll(async () => {
+    await prepareTestDatabase();
+  }, 180_000);
+
+  afterAll(async () => {
+    await closeTestDatabase();
+  }, 60_000);
+}

--- a/app/tests/setup/testDatabase.ts
+++ b/app/tests/setup/testDatabase.ts
@@ -3,11 +3,12 @@
  *
  * The schema is pushed straight from `drizzle/schema.ts`, so tests run against the same tables,
  * types, indexes and constraints as production instead of a hand-rolled subset that drifts.
- * Setup and teardown happen once per `bun test` run; suites only reset the tables they touch.
+ * Setup happens once per `bun test` run; suites only reset the tables they touch.
  *
- * Point TEST_MYSQL_URL at a database you are happy to lose — setup drops every table in it:
+ * Every table in the target database is truncated, so both variables are required:
+ *   TEST_MYSQL_ALLOW_DESTRUCTIVE=1 \
  *   TEST_MYSQL_URL='mysql://root:placeholder@127.0.0.1:3307/tnr_test' bun test
- * Without it, `describeWithDatabase` skips and nothing here connects.
+ * With neither set, `describeWithDatabase` skips and nothing here connects.
  */
 import { execFileSync } from "node:child_process";
 import { drizzle } from "drizzle-orm/mysql2";
@@ -17,13 +18,22 @@ import type { DrizzleClient } from "@/server/db";
 import * as schema from "@/drizzle/schema";
 
 const url = process.env.TEST_MYSQL_URL;
-const databaseName = url ? new URL(url).pathname.replace(/^\//, "") : "";
+const allowDestructive = process.env.TEST_MYSQL_ALLOW_DESTRUCTIVE === "1";
 
 /**
- * Setup drops every table, so refuse anything whose name does not read as disposable. A typo
- * pointing this at a real database would otherwise be unrecoverable.
+ * Setup truncates every table in the target database, so the caller has to say out loud that it
+ * is disposable. Naming heuristics were not enough: `production_test` and `contest` both read as
+ * test databases. Configuring a URL without the opt-in is a mistake worth surfacing rather than
+ * silently skipping, so it throws.
  */
-export const hasTestDatabase = !!url && /test/i.test(databaseName);
+if (url && !allowDestructive) {
+  throw new Error(
+    "TEST_MYSQL_URL is set but TEST_MYSQL_ALLOW_DESTRUCTIVE is not '1'. Every table in that " +
+      "database will be truncated, so opt in explicitly and only for a database you can lose.",
+  );
+}
+
+export const hasTestDatabase = !!url && allowDestructive;
 
 /** `describe` that skips wholesale when no test database is configured. */
 export const describeWithDatabase = hasTestDatabase ? describe : describe.skip;

--- a/app/tests/setup/testDatabase.ts
+++ b/app/tests/setup/testDatabase.ts
@@ -1,0 +1,156 @@
+/**
+ * Shared throwaway MySQL for suites that need to execute real SQL.
+ *
+ * The schema is pushed straight from `drizzle/schema.ts`, so tests run against the same tables,
+ * types, indexes and constraints as production instead of a hand-rolled subset that drifts.
+ * Setup and teardown happen once per `bun test` run; suites only reset the tables they touch.
+ *
+ * Point TEST_MYSQL_URL at a database you are happy to lose — setup drops every table in it:
+ *   TEST_MYSQL_URL='mysql://root:placeholder@127.0.0.1:3307/tnr_test' bun test
+ * Without it, `describeWithDatabase` skips and nothing here connects.
+ */
+import { execFileSync } from "node:child_process";
+import { drizzle } from "drizzle-orm/mysql2";
+import mysql from "mysql2/promise";
+import { describe } from "vitest";
+import type { DrizzleClient } from "@/server/db";
+import * as schema from "@/drizzle/schema";
+
+const url = process.env.TEST_MYSQL_URL;
+const databaseName = url ? new URL(url).pathname.replace(/^\//, "") : "";
+
+/**
+ * Setup drops every table, so refuse anything whose name does not read as disposable. A typo
+ * pointing this at a real database would otherwise be unrecoverable.
+ */
+export const hasTestDatabase = !!url && /test/i.test(databaseName);
+
+/** `describe` that skips wholesale when no test database is configured. */
+export const describeWithDatabase = hasTestDatabase ? describe : describe.skip;
+
+let connection: mysql.Connection | undefined;
+let client: DrizzleClient | undefined;
+
+/**
+ * mysql2 reports writes as `[ResultSetHeader]`; the PlanetScale driver the app is built on
+ * reports `{ rowsAffected }`, and server code branches on it. Normalise writes so the code under
+ * test behaves as it does in production. Reads pass through untouched.
+ */
+const normalize = (result: unknown) => {
+  const header = Array.isArray(result) ? result[0] : result;
+  if (header && typeof header === "object" && "affectedRows" in header) {
+    const typed = header as { affectedRows: number; insertId?: number };
+    return { rowsAffected: typed.affectedRows, insertId: String(typed.insertId ?? 0) };
+  }
+  return result;
+};
+
+const wrapWriteBuilder = <T extends object>(builder: T): T =>
+  new Proxy(builder, {
+    get(target, property, receiver) {
+      if (property === "then") {
+        return (onFulfilled?: (value: unknown) => unknown, onRejected?: () => unknown) =>
+          Promise.resolve(target as PromiseLike<unknown>).then(
+            (value) => onFulfilled?.(normalize(value)),
+            onRejected,
+          );
+      }
+      const value = Reflect.get(target, property, receiver);
+      if (typeof value !== "function") return value;
+      return (...args: unknown[]) => {
+        const next = (value as (...a: unknown[]) => unknown).apply(target, args);
+        return next && typeof next === "object" ? wrapWriteBuilder(next as object) : next;
+      };
+    },
+  });
+
+/**
+ * Bring the database in line with `drizzle/schema.ts`. `push` diffs against what is already
+ * there, so a database left over from a previous run costs a diff rather than 130 CREATE TABLEs,
+ * and a schema change since that run is applied (including dropped columns).
+ */
+export const prepareTestDatabase = async () => {
+  if (!hasTestDatabase) return;
+  execFileSync(
+    "bunx",
+    [
+      "drizzle-kit",
+      "push",
+      "--dialect=mysql",
+      "--schema=./drizzle/schema.ts",
+      `--url=${url}`,
+      "--force",
+    ],
+    { stdio: "pipe" },
+  );
+  // Rows a previous run left behind would leak into any suite that does not reset that table.
+  await truncateEveryTable();
+};
+
+const truncateEveryTable = async () => {
+  const active = await mysql.createConnection({ uri: url, multipleStatements: true });
+  try {
+    const [tables] = await active.query<mysql.RowDataPacket[]>(
+      "SELECT table_name AS name FROM information_schema.tables WHERE table_schema = DATABASE()",
+    );
+    if (tables.length === 0) return;
+    const truncations = tables.map((row) => `TRUNCATE TABLE \`${row.name}\`;`).join(" ");
+    await active.query(
+      `SET FOREIGN_KEY_CHECKS = 0; ${truncations} SET FOREIGN_KEY_CHECKS = 1;`,
+    );
+  } finally {
+    await active.end();
+  }
+};
+
+/**
+ * Drizzle client against the shared test database, shaped like the app's `DrizzleClient` so
+ * server functions can be called directly. The schema is pushed on first use.
+ */
+export const getTestDatabase = async (): Promise<DrizzleClient> => {
+  if (!client) {
+    connection = await mysql.createConnection({ uri: url, multipleStatements: true });
+    const database = drizzle(connection, { schema, mode: "default" });
+    client = new Proxy(database, {
+      get(target, property, receiver) {
+        if (property === "insert" || property === "update" || property === "delete") {
+          const method = Reflect.get(target, property, receiver) as (
+            ...args: unknown[]
+          ) => object;
+          return (...args: unknown[]) => wrapWriteBuilder(method.apply(target, args));
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    }) as unknown as DrizzleClient;
+  }
+  return client;
+};
+
+/** Empty the given tables. Call in `beforeEach` for the tables a suite writes. */
+export const resetTables = async (...tables: { _: { name: string } }[]) => {
+  const database = await getTestDatabase();
+  await Promise.all(tables.map((table) => database.delete(table as never)));
+};
+
+/** Run one raw statement, for the few cases that need DDL (applying a migration, for example). */
+export const runRawSql = async (statement: string) => {
+  await getTestDatabase();
+  await connection?.query(statement);
+};
+
+/** Current index columns for a table, so a suite can assert on constraints. */
+export const indexColumns = async (table: string, keyName: string) => {
+  await getTestDatabase();
+  const [rows] = (await connection?.query(
+    "SELECT COLUMN_NAME AS col, NON_UNIQUE AS nonUnique FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ? ORDER BY SEQ_IN_INDEX",
+    [table, keyName],
+  )) as [{ col: string; nonUnique: number }[], unknown];
+  return { columns: rows.map((row) => row.col), unique: rows.every((row) => !row.nonUnique) };
+};
+
+/** Release the shared connection. Registered once by the test preload. */
+export const closeTestDatabase = async () => {
+  await connection?.end();
+  connection = undefined;
+  client = undefined;
+};


### PR DESCRIPTION
# Pull Request Closes #1299



## Summary

- Removed completed quest trackers after rewards are committed.
- Cleared stale tracker progress when replayable quests restart.
- Cleared reused daily trackers during bulk reassignment.
- Removed only the matching tracker atomically, preserving progress for unrelated quests.
- Added regression coverage for completion, restart, and bulk daily reassignment.

I tested locally and was able to verify that the tracker progress was being reset for dailies 


## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed quest tracker progress persisting incorrectly when quests are reassigned, restarted, or completed.
  * Replayed quests now begin with fresh objectives instead of inheriting previously completed goals.
  * Resolved quest trackers are cleared after rewards are claimed.
  * Improved handling of duplicate quest history records during bulk assignment and migration.

* **Performance**
  * Improved the efficiency of daily quest resets.

* **Tests**
  * Added coverage for quest reassignment, objective restarts, reward completion, daily resets, tracker cleanup, and history migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->