### PR TITLE
perf(profile): read global game state once per request, not once per procedure

### DIFF
--- a/app/src/app/api/trpc/[trpc]/route.ts
+++ b/app/src/app/api/trpc/[trpc]/route.ts
@@ -4,6 +4,7 @@ import { cookies, headers } from "next/headers";
 import type { NextRequest } from "next/server";
 import { appRouter } from "@/api/root";
 import { createAppTRPCContext } from "@/api/trpc";
+import { withRequestScope } from "@/server/requestScope";
 
 export const runtime = "nodejs";
 export const maxDuration = 90;
@@ -14,45 +15,51 @@ const handler = async (req: NextRequest) => {
 
   let shouldFlush = false;
 
-  const response = await fetchRequestHandler({
-    endpoint: "/api/trpc",
-    req,
-    router: appRouter,
-    createContext() {
-      return createAppTRPCContext({ req, readHeaders, readCookies });
-    },
-    onError: ({ error, path, input, ctx }) => {
-      // tRPC rejects a GET against a mutation path with METHOD_NOT_SUPPORTED before any
-      // resolver runs, and only crawlers reach it: httpBatchLink always POSTs mutations,
-      // so an anonymous caller is a bot ignoring the /api/ disallow in robots.ts and there
-      // is no user-facing failure to surface. An authenticated caller would mean genuine
-      // client/server skew, so those keep reporting here, and the client still surfaces
-      // them through the global error toast in _trpc/Provider.tsx.
-      const isCrawlerMethodRejection =
-        error.code === "METHOD_NOT_SUPPORTED" && !ctx?.userId;
-      // A Clerk session with no UserData row of its OWN: character creation was never
-      // finished, or the character was deleted while the tab stayed open. The client
-      // forwards to /register off profile.getUser's undefined user, so the guard firing
-      // elsewhere in the same request is expected. fetchUser raises the identical message
-      // for a missing *target* user, so match the session id rather than the shape.
-      const isUnregisteredUser =
-        error.code === "NOT_FOUND" &&
-        !!ctx?.userId &&
-        error.message === `User not found: ${ctx.userId}. Please complete registration.`;
-      if (
-        !isCrawlerMethodRejection &&
-        !isUnregisteredUser &&
-        !["UNAUTHORIZED", "TOO_MANY_REQUESTS"].includes(error.code)
-      ) {
-        logError(
-          error,
-          `❌ tRPC failed with ${error.code} on ${path ?? "<no-path>"}. Message: ${error.message}. Input: ${JSON.stringify(input)}. Stack: ${error.stack}`,
-          { input, path, error, ctx },
-        );
-        shouldFlush = true;
-      }
-    },
-  });
+  // One memo per HTTP request, shared by every procedure in the batch: httpBatchLink
+  // packs a page's whole mount into a single POST, and the shared helpers those
+  // procedures call would otherwise re-read the same global rows once per procedure.
+  const response = await withRequestScope(() =>
+    fetchRequestHandler({
+      endpoint: "/api/trpc",
+      req,
+      router: appRouter,
+      createContext() {
+        return createAppTRPCContext({ req, readHeaders, readCookies });
+      },
+      onError: ({ error, path, input, ctx }) => {
+        // tRPC rejects a GET against a mutation path with METHOD_NOT_SUPPORTED before any
+        // resolver runs, and only crawlers reach it: httpBatchLink always POSTs mutations,
+        // so an anonymous caller is a bot ignoring the /api/ disallow in robots.ts and there
+        // is no user-facing failure to surface. An authenticated caller would mean genuine
+        // client/server skew, so those keep reporting here, and the client still surfaces
+        // them through the global error toast in _trpc/Provider.tsx.
+        const isCrawlerMethodRejection =
+          error.code === "METHOD_NOT_SUPPORTED" && !ctx?.userId;
+        // A Clerk session with no UserData row of its OWN: character creation was never
+        // finished, or the character was deleted while the tab stayed open. The client
+        // forwards to /register off profile.getUser's undefined user, so the guard firing
+        // elsewhere in the same request is expected. fetchUser raises the identical message
+        // for a missing *target* user, so match the session id rather than the shape.
+        const isUnregisteredUser =
+          error.code === "NOT_FOUND" &&
+          !!ctx?.userId &&
+          error.message ===
+            `User not found: ${ctx.userId}. Please complete registration.`;
+        if (
+          !isCrawlerMethodRejection &&
+          !isUnregisteredUser &&
+          !["UNAUTHORIZED", "TOO_MANY_REQUESTS"].includes(error.code)
+        ) {
+          logError(
+            error,
+            `❌ tRPC failed with ${error.code} on ${path ?? "<no-path>"}. Message: ${error.message}. Input: ${JSON.stringify(input)}. Stack: ${error.stack}`,
+            { input, path, error, ctx },
+          );
+          shouldFlush = true;
+        }
+      },
+    }),
+  );
   if (shouldFlush) {
     console.error("Error Detected. Flushing Sentry");
     await flushSafe();

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -125,6 +125,7 @@ import { handleQuestConsequences, insertNextQuest } from "@/routers/quests";
 import { fetchVillage } from "@/routers/village";
 import { deleteUser } from "@/server/api/routers/staff";
 import type { DrizzleClient } from "@/server/db";
+import { scopedRead } from "@/server/requestScope";
 import { adjustSeichiSilverAtomically } from "@/server/utils/concurrency";
 import { buildDerivedUserRegenUpdate } from "@/server/utils/profileRegen";
 import { getRandomElement } from "@/utils/array";
@@ -2414,6 +2415,98 @@ export const updateUserContent = async (props: {
 };
 
 /**
+ * Global game state that `fetchUpdatedUser` needs on every call, memoized for the
+ * duration of one HTTP request by {@link scopedRead}.
+ *
+ * None of these predicates mention a user, so a tRPC batch used to re-read the same
+ * rows once per procedure - and `fetchUpdatedUser` is called by nearly every
+ * procedure the busy pages mount. Sharing them collapses that fan-out to one read
+ * each without changing what any caller sees: `scopedRead` hands out clones, so the
+ * per-user rewriting that happens downstream (hiding quest locations, attaching the
+ * user's own subset of wars/raids/lobbies) still operates on private copies.
+ *
+ * The lobby and raid cutoffs are evaluated against the first caller's `now`. Later
+ * callers in the same request therefore inherit a cutoff that is milliseconds old,
+ * which is well inside the minute-scale windows both filters describe.
+ */
+const fetchAchievementCatalogue = (client: DrizzleClient) =>
+  scopedRead("achievements", () =>
+    client
+      .select()
+      .from(quest)
+      .where(and(eq(quest.questType, "achievement"), eq(quest.hidden, false))),
+  );
+
+const fetchAllGameSettings = (client: DrizzleClient) =>
+  scopedRead("gameSettings", () => client.select().from(gameSetting));
+
+const fetchHasUnvotedPolls = (client: DrizzleClient, userId: string, now: Date) =>
+  scopedRead(`unvotedPolls:${userId}`, () =>
+    client
+      .select({ id: poll.id })
+      .from(poll)
+      .leftJoin(
+        userPollVote,
+        and(eq(userPollVote.pollId, poll.id), eq(userPollVote.userId, userId)),
+      )
+      .where(
+        and(
+          eq(poll.isActive, true),
+          // Either endDate is null or endDate is in the future
+          or(isNull(poll.endDate), sql`${poll.endDate} > ${now}`),
+          // User hasn't voted on this poll
+          isNull(userPollVote.id),
+        ),
+      )
+      .limit(1),
+  );
+
+/** All active wars, for enemy_village sector type resolution. */
+const fetchAllActiveWars = (client: DrizzleClient) =>
+  scopedRead("allActiveWars", () =>
+    client.query.war.findMany({
+      where: isNull(war.endedAt),
+      columns: {
+        id: true,
+        type: true,
+        attackerVillageId: true,
+        defenderVillageId: true,
+        sector: true,
+      },
+      with: {
+        attackerVillage: { columns: { id: true, name: true, sector: true } },
+        defenderVillage: { columns: { id: true, name: true, sector: true } },
+        warAllies: true,
+      },
+    }),
+  );
+
+/** Shrine battle lobbies whose battle has not started and that are not yet stale. */
+const fetchActiveShrineLobbies = (client: DrizzleClient, staleBefore: Date) =>
+  scopedRead("activeShrineLobbies", () =>
+    client.query.mpvpBattleQueue.findMany({
+      where: and(
+        eq(mpvpBattleQueue.battleType, "SHRINE_BATTLE"),
+        isNull(mpvpBattleQueue.battleId),
+        gt(mpvpBattleQueue.createdAt, staleBefore),
+      ),
+    }),
+  );
+
+/** All raids whose boss is still standing and whose window has not closed. */
+const fetchActiveRaids = (client: DrizzleClient, now: Date) =>
+  scopedRead("activeRaids", () =>
+    client.query.quest.findMany({
+      where: and(
+        eq(quest.questType, "raid"),
+        eq(quest.hidden, false),
+        gte(quest.raidBossCurrentHealth, 1),
+        or(isNull(quest.raidEndsAt), gte(quest.raidEndsAt, now)),
+      ),
+    }),
+  );
+
+/**
  * Fetch user with bloodline & village relations. Occasionally updates the user with regeneration
  * of pools, or optionally forces regeneration with forceRegen=true
  */
@@ -2445,11 +2538,8 @@ export const fetchUpdatedUser = async (props: {
     activeShrineBattles,
     activeRaids,
   ] = await Promise.all([
-    client
-      .select()
-      .from(quest)
-      .where(and(eq(quest.questType, "achievement"), eq(quest.hidden, false))),
-    client.select().from(gameSetting),
+    fetchAchievementCatalogue(client),
+    fetchAllGameSettings(client),
     client.query.userData.findFirst({
       where: eq(userData.userId, userId),
       with: {
@@ -2497,59 +2587,10 @@ export const fetchUpdatedUser = async (props: {
         votes: true,
       },
     }),
-    client
-      .select({ id: poll.id })
-      .from(poll)
-      .leftJoin(
-        userPollVote,
-        and(eq(userPollVote.pollId, poll.id), eq(userPollVote.userId, userId)),
-      )
-      .where(
-        and(
-          eq(poll.isActive, true),
-          // Either endDate is null or endDate is in the future
-          or(isNull(poll.endDate), sql`${poll.endDate} > ${now}`),
-          // User hasn't voted on this poll
-          isNull(userPollVote.id),
-        ),
-      )
-      .limit(1),
-    // Fetch all active wars for enemy_village sector type resolution
-    client.query.war.findMany({
-      where: isNull(war.endedAt),
-      columns: {
-        id: true,
-        type: true,
-        attackerVillageId: true,
-        defenderVillageId: true,
-        sector: true,
-      },
-      with: {
-        attackerVillage: { columns: { id: true, name: true, sector: true } },
-        defenderVillage: { columns: { id: true, name: true, sector: true } },
-        warAllies: true,
-      },
-    }),
-    // Fetch all active shrine battles (only those where battle hasn't started
-    // yet AND the lobby hasn't aged past its natural lifetime — stale rows
-    // are cleaned up by the shrine-maintenance cron but we filter here too so
-    // notifications clear immediately rather than waiting on the next tick.
-    client.query.mpvpBattleQueue.findMany({
-      where: and(
-        eq(mpvpBattleQueue.battleType, "SHRINE_BATTLE"),
-        isNull(mpvpBattleQueue.battleId),
-        gt(mpvpBattleQueue.createdAt, shrineLobbyStaleBefore),
-      ),
-    }),
-    // Fetch all active raids (boss not defeated, not ended)
-    client.query.quest.findMany({
-      where: and(
-        eq(quest.questType, "raid"),
-        eq(quest.hidden, false),
-        gte(quest.raidBossCurrentHealth, 1),
-        or(isNull(quest.raidEndsAt), gte(quest.raidEndsAt, now)),
-      ),
-    }),
+    fetchHasUnvotedPolls(client, userId, now),
+    fetchAllActiveWars(client),
+    fetchActiveShrineLobbies(client, shrineLobbyStaleBefore),
+    fetchActiveRaids(client, now),
   ]);
 
   // Reskin bloodline if needed

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -2415,98 +2415,6 @@ export const updateUserContent = async (props: {
 };
 
 /**
- * Global game state that `fetchUpdatedUser` needs on every call, memoized for the
- * duration of one HTTP request by {@link scopedRead}.
- *
- * None of these predicates mention a user, so a tRPC batch used to re-read the same
- * rows once per procedure - and `fetchUpdatedUser` is called by nearly every
- * procedure the busy pages mount. Sharing them collapses that fan-out to one read
- * each without changing what any caller sees: `scopedRead` hands out clones, so the
- * per-user rewriting that happens downstream (hiding quest locations, attaching the
- * user's own subset of wars/raids/lobbies) still operates on private copies.
- *
- * The lobby and raid cutoffs are evaluated against the first caller's `now`. Later
- * callers in the same request therefore inherit a cutoff that is milliseconds old,
- * which is well inside the minute-scale windows both filters describe.
- */
-const fetchAchievementCatalogue = (client: DrizzleClient) =>
-  scopedRead("achievements", () =>
-    client
-      .select()
-      .from(quest)
-      .where(and(eq(quest.questType, "achievement"), eq(quest.hidden, false))),
-  );
-
-const fetchAllGameSettings = (client: DrizzleClient) =>
-  scopedRead("gameSettings", () => client.select().from(gameSetting));
-
-const fetchHasUnvotedPolls = (client: DrizzleClient, userId: string, now: Date) =>
-  scopedRead(`unvotedPolls:${userId}`, () =>
-    client
-      .select({ id: poll.id })
-      .from(poll)
-      .leftJoin(
-        userPollVote,
-        and(eq(userPollVote.pollId, poll.id), eq(userPollVote.userId, userId)),
-      )
-      .where(
-        and(
-          eq(poll.isActive, true),
-          // Either endDate is null or endDate is in the future
-          or(isNull(poll.endDate), sql`${poll.endDate} > ${now}`),
-          // User hasn't voted on this poll
-          isNull(userPollVote.id),
-        ),
-      )
-      .limit(1),
-  );
-
-/** All active wars, for enemy_village sector type resolution. */
-const fetchAllActiveWars = (client: DrizzleClient) =>
-  scopedRead("allActiveWars", () =>
-    client.query.war.findMany({
-      where: isNull(war.endedAt),
-      columns: {
-        id: true,
-        type: true,
-        attackerVillageId: true,
-        defenderVillageId: true,
-        sector: true,
-      },
-      with: {
-        attackerVillage: { columns: { id: true, name: true, sector: true } },
-        defenderVillage: { columns: { id: true, name: true, sector: true } },
-        warAllies: true,
-      },
-    }),
-  );
-
-/** Shrine battle lobbies whose battle has not started and that are not yet stale. */
-const fetchActiveShrineLobbies = (client: DrizzleClient, staleBefore: Date) =>
-  scopedRead("activeShrineLobbies", () =>
-    client.query.mpvpBattleQueue.findMany({
-      where: and(
-        eq(mpvpBattleQueue.battleType, "SHRINE_BATTLE"),
-        isNull(mpvpBattleQueue.battleId),
-        gt(mpvpBattleQueue.createdAt, staleBefore),
-      ),
-    }),
-  );
-
-/** All raids whose boss is still standing and whose window has not closed. */
-const fetchActiveRaids = (client: DrizzleClient, now: Date) =>
-  scopedRead("activeRaids", () =>
-    client.query.quest.findMany({
-      where: and(
-        eq(quest.questType, "raid"),
-        eq(quest.hidden, false),
-        gte(quest.raidBossCurrentHealth, 1),
-        or(isNull(quest.raidEndsAt), gte(quest.raidEndsAt, now)),
-      ),
-    }),
-  );
-
-/**
  * Fetch user with bloodline & village relations. Occasionally updates the user with regeneration
  * of pools, or optionally forces regeneration with forceRegen=true
  */
@@ -2952,6 +2860,98 @@ const persistPassiveRegenToDb = async ({
     .set(derivedUserUpdate)
     .where(eq(userData.userId, userId));
 };
+
+/**
+ * Global game state that `fetchUpdatedUser` needs on every call, memoized for the
+ * duration of one HTTP request by {@link scopedRead}.
+ *
+ * None of these predicates mention a user, so a tRPC batch used to re-read the same
+ * rows once per procedure - and `fetchUpdatedUser` is called by nearly every
+ * procedure the busy pages mount. Sharing them collapses that fan-out to one read
+ * each without changing what any caller sees: `scopedRead` hands out clones, so the
+ * per-user rewriting that happens downstream (hiding quest locations, attaching the
+ * user's own subset of wars/raids/lobbies) still operates on private copies.
+ *
+ * The lobby and raid cutoffs are evaluated against the first caller's `now`. Later
+ * callers in the same request therefore inherit a cutoff that is milliseconds old,
+ * which is well inside the minute-scale windows both filters describe.
+ */
+const fetchAchievementCatalogue = (client: DrizzleClient) =>
+  scopedRead("achievements", () =>
+    client
+      .select()
+      .from(quest)
+      .where(and(eq(quest.questType, "achievement"), eq(quest.hidden, false))),
+  );
+
+const fetchAllGameSettings = (client: DrizzleClient) =>
+  scopedRead("gameSettings", () => client.select().from(gameSetting));
+
+const fetchHasUnvotedPolls = (client: DrizzleClient, userId: string, now: Date) =>
+  scopedRead(`unvotedPolls:${userId}`, () =>
+    client
+      .select({ id: poll.id })
+      .from(poll)
+      .leftJoin(
+        userPollVote,
+        and(eq(userPollVote.pollId, poll.id), eq(userPollVote.userId, userId)),
+      )
+      .where(
+        and(
+          eq(poll.isActive, true),
+          // Either endDate is null or endDate is in the future
+          or(isNull(poll.endDate), sql`${poll.endDate} > ${now}`),
+          // User hasn't voted on this poll
+          isNull(userPollVote.id),
+        ),
+      )
+      .limit(1),
+  );
+
+/** All active wars, for enemy_village sector type resolution. */
+const fetchAllActiveWars = (client: DrizzleClient) =>
+  scopedRead("allActiveWars", () =>
+    client.query.war.findMany({
+      where: isNull(war.endedAt),
+      columns: {
+        id: true,
+        type: true,
+        attackerVillageId: true,
+        defenderVillageId: true,
+        sector: true,
+      },
+      with: {
+        attackerVillage: { columns: { id: true, name: true, sector: true } },
+        defenderVillage: { columns: { id: true, name: true, sector: true } },
+        warAllies: true,
+      },
+    }),
+  );
+
+/** Shrine battle lobbies whose battle has not started and that are not yet stale. */
+const fetchActiveShrineLobbies = (client: DrizzleClient, staleBefore: Date) =>
+  scopedRead("activeShrineLobbies", () =>
+    client.query.mpvpBattleQueue.findMany({
+      where: and(
+        eq(mpvpBattleQueue.battleType, "SHRINE_BATTLE"),
+        isNull(mpvpBattleQueue.battleId),
+        gt(mpvpBattleQueue.createdAt, staleBefore),
+      ),
+    }),
+  );
+
+/** All raids whose boss is still standing and whose window has not closed. */
+const fetchActiveRaids = (client: DrizzleClient, now: Date) =>
+  scopedRead("activeRaids", () =>
+    client.query.quest.findMany({
+      where: and(
+        eq(quest.questType, "raid"),
+        eq(quest.hidden, false),
+        gte(quest.raidBossCurrentHealth, 1),
+        or(isNull(quest.raidEndsAt), gte(quest.raidEndsAt, now)),
+      ),
+    }),
+  );
 
 export const fetchPublicUsers = async (info: {
   client: DrizzleClient;

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -3086,10 +3086,14 @@ export const fetchPublicUsers = async (info: {
       limit: input.limit,
       orderBy: getOrder(),
     }),
+    // Only the caller's role is read, to decide whether IPs may be seen. This runs
+    // on most page loads (the online-players sidebar), so it selects that one column
+    // rather than the whole ~90-column row.
     ...(userId
       ? [
           client.query.userData.findFirst({
             where: eq(userData.userId, userId),
+            columns: { role: true },
           }),
         ]
       : [null]),

--- a/app/src/server/requestScope.ts
+++ b/app/src/server/requestScope.ts
@@ -1,0 +1,66 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * Per-request memo for reads that every procedure in an HTTP request repeats.
+ *
+ * The tRPC client batches whatever a page mounts into a single POST, and tRPC
+ * resolves those procedures concurrently. Any read that a shared helper performs
+ * - the achievement catalogue and game settings that `fetchUpdatedUser` needs, for
+ * instance - therefore hits PlanetScale once per procedure rather than once per
+ * page load, which is the dominant source of duplicate queries on the busy pages.
+ *
+ * Only reads that satisfy all three of the following belong here:
+ *
+ *  1. The predicate is fully determined by the key, so two callers in the same
+ *     request cannot legitimately want different rows back.
+ *  2. Nothing the request itself writes is expected to be visible to a later read
+ *     in the same request. A memoized read returns the snapshot the first caller
+ *     took, so a write landing in between is observed on the next request instead.
+ *  3. The rows carry no per-caller state. `userData` is deliberately excluded: it
+ *     is the row every mutation reads, mutates in memory and writes back.
+ */
+type RequestScope = Map<string, Promise<unknown>>;
+
+const storage = new AsyncLocalStorage<RequestScope>();
+
+/**
+ * Run `fn` with a fresh memo. Call this once per HTTP request, at the outermost
+ * point of the handler, so every procedure in a batch shares one store.
+ */
+export const withRequestScope = <T>(fn: () => T): T => storage.run(new Map(), fn);
+
+/**
+ * Read `load()` at most once per request, keyed by `key`.
+ *
+ * Outside a request scope (crons, scripts, tests) this is a plain pass-through, so
+ * callers behave exactly as they did before.
+ *
+ * Every caller - including the first - receives a structured clone rather than the
+ * memoized value. Callers routinely mutate what they read back: quest objectives
+ * are rewritten in place to hide locations from players who are not in the right
+ * sector, for example, and that rewrite is user-specific. Handing out the memoized
+ * object itself would let one caller's edits leak into the next caller's copy.
+ */
+export const scopedRead = async <T>(
+  key: string,
+  load: () => Promise<T>,
+): Promise<T> => {
+  const scope = storage.getStore();
+  if (!scope) return load();
+  let pending = scope.get(key) as Promise<T> | undefined;
+  if (!pending) {
+    // `load()` is awaited into a real promise before it is memoized. A Drizzle
+    // query builder is a thenable that re-runs `execute()` on every `then`, so
+    // memoizing the builder itself would cache the intent to query rather than
+    // its result and every reader would still hit the database.
+    pending = (async () => load())();
+    scope.set(key, pending);
+    // A dropped connection on the first caller must not fail every later one too;
+    // evict the rejected read so the next caller re-issues it. The catch also keeps
+    // the memoized promise from ever counting as an unhandled rejection.
+    void pending.catch(() => {
+      if (scope.get(key) === pending) scope.delete(key);
+    });
+  }
+  return structuredClone(await pending);
+};

--- a/app/tests/server/api/profile.publicUserIps.test.ts
+++ b/app/tests/server/api/profile.publicUserIps.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+
+import { beforeEach, expect, it } from "vitest";
+import { userData } from "@/drizzle/schema";
+import type { GetPublicUsersSchema } from "@/validators/user";
+import { fetchPublicUsers } from "../../../src/server/api/routers/profile";
+import { insertUsers } from "../../setup/factories";
+import { describeWithDatabase, getTestDatabase, resetTables } from "../../setup/testDatabase";
+
+/**
+ * `fetchPublicUsers` decides whether to reveal players' IPs from the caller's own role, which it
+ * reads back from the database. It selects only the `role` column to do so - this suite runs the
+ * guard against a real MySQL, so a projection that stopped carrying the field, or stopped
+ * matching the caller's row at all, shows up as staff losing IPs rather than as a green build.
+ */
+const listing: GetPublicUsersSchema = {
+  limit: 10,
+  isAi: false,
+  orderBy: "Strongest",
+};
+
+const lastIpsSeenBy = async (userId: string | undefined) => {
+  const result = await fetchPublicUsers({
+    client: await getTestDatabase(),
+    input: listing,
+    userId,
+  });
+  return result.data.map((u) => u.lastIp);
+};
+
+describeWithDatabase("fetchPublicUsers IP visibility", () => {
+  beforeEach(async () => {
+    await resetTables(userData);
+    await insertUsers([
+      { userId: "staff", username: "staff", role: "OWNER", lastIp: "10.0.0.1" },
+      { userId: "player", username: "player", role: "USER", lastIp: "10.0.0.2" },
+      { userId: "proxied", username: "proxied", role: "USER", lastIp: null },
+    ]);
+  });
+
+  it("shows real IPs to a role that may see them", async () => {
+    expect((await lastIpsSeenBy("staff")).sort()).toEqual([
+      "10.0.0.1",
+      "10.0.0.2",
+      "Proxied",
+    ]);
+  });
+
+  it("hides every IP from an ordinary player", async () => {
+    expect(await lastIpsSeenBy("player")).toEqual(["hidden", "hidden", "hidden"]);
+  });
+
+  it("hides every IP from a signed-out caller", async () => {
+    expect(await lastIpsSeenBy(undefined)).toEqual(["hidden", "hidden", "hidden"]);
+  });
+
+  it("refuses an IP search from a role that may not see IPs", async () => {
+    await expect(
+      fetchPublicUsers({
+        client: await getTestDatabase(),
+        input: { ...listing, ip: "10.0.0.1" },
+        userId: "player",
+      }),
+    ).rejects.toThrow(/not allowed to search IPs/);
+  });
+
+  it("allows an IP search from a role that may see them", async () => {
+    const result = await fetchPublicUsers({
+      client: await getTestDatabase(),
+      input: { ...listing, ip: "10.0.0.1" },
+      userId: "staff",
+    });
+    expect(result.data.map((u) => u.username)).toEqual(["staff"]);
+  });
+});

--- a/app/tests/server/requestScope.test.ts
+++ b/app/tests/server/requestScope.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { scopedRead, withRequestScope } from "@/server/requestScope";
+
+/** A loader that records how many times it actually ran. */
+const counted = <T>(value: () => T) => {
+  const state = { calls: 0 };
+  const load = () => {
+    state.calls++;
+    return Promise.resolve(value());
+  };
+  return { state, load };
+};
+
+describe("scopedRead", () => {
+  it("is a pass-through outside a request scope", async () => {
+    const { state, load } = counted(() => ({ n: 1 }));
+    await scopedRead("k", load);
+    await scopedRead("k", load);
+    expect(state.calls).toBe(2);
+  });
+
+  it("reads once per key within a request scope", async () => {
+    const { state, load } = counted(() => ({ n: 1 }));
+    await withRequestScope(async () => {
+      await scopedRead("k", load);
+      await scopedRead("k", load);
+      await scopedRead("k", load);
+    });
+    expect(state.calls).toBe(1);
+  });
+
+  it("collapses concurrent readers onto one in-flight read", async () => {
+    const { state, load } = counted(() => ({ n: 1 }));
+    await withRequestScope(async () => {
+      await Promise.all([
+        scopedRead("k", load),
+        scopedRead("k", load),
+        scopedRead("k", load),
+      ]);
+    });
+    expect(state.calls).toBe(1);
+  });
+
+  it("keeps separate keys separate", async () => {
+    const { state, load } = counted(() => ({ n: 1 }));
+    await withRequestScope(async () => {
+      await scopedRead("a", load);
+      await scopedRead("b", load);
+    });
+    expect(state.calls).toBe(2);
+  });
+
+  it("does not share the memo between two requests", async () => {
+    const { state, load } = counted(() => ({ n: 1 }));
+    await withRequestScope(() => scopedRead("k", load));
+    await withRequestScope(() => scopedRead("k", load));
+    expect(state.calls).toBe(2);
+  });
+
+  it("hands every reader its own copy, including the first", async () => {
+    const source = { nested: { list: [1, 2, 3] } };
+    const { load } = counted(() => source);
+    await withRequestScope(async () => {
+      const first = await scopedRead("k", load);
+      const second = await scopedRead("k", load);
+      expect(first).toEqual(source);
+      expect(first).not.toBe(second);
+      expect(first.nested).not.toBe(second.nested);
+      // The memoized value itself must stay pristine for later readers.
+      first.nested.list.push(4);
+      const third = await scopedRead("k", load);
+      expect(third.nested.list).toEqual([1, 2, 3]);
+      expect(source.nested.list).toEqual([1, 2, 3]);
+    });
+  });
+
+  it("preserves dates through the copy", async () => {
+    const at = new Date("2024-01-02T03:04:05.000Z");
+    await withRequestScope(async () => {
+      const read = await scopedRead("k", () => Promise.resolve({ at }));
+      expect(read.at).toBeInstanceOf(Date);
+      expect(read.at.getTime()).toBe(at.getTime());
+    });
+  });
+
+  it("memoizes the result of a thenable, not the thenable itself", async () => {
+    // A Drizzle query builder is a thenable that runs the statement afresh on every
+    // `then`. Memoizing the builder would look like a cache hit while still hitting
+    // the database for every reader, which is exactly the bug this guards.
+    let executions = 0;
+    const builder = {
+      then(resolve: (value: { n: number }) => void) {
+        executions++;
+        resolve({ n: executions });
+      },
+    };
+    await withRequestScope(async () => {
+      const first = await scopedRead("k", () => builder as unknown as Promise<{ n: number }>);
+      const second = await scopedRead("k", () => builder as unknown as Promise<{ n: number }>);
+      expect(first).toEqual({ n: 1 });
+      expect(second).toEqual({ n: 1 });
+    });
+    expect(executions).toBe(1);
+  });
+
+  it("rejects every waiter but evicts the failed read so the next one retries", async () => {
+    let attempt = 0;
+    const load = () => {
+      attempt++;
+      return attempt === 1
+        ? Promise.reject(new Error("connection reset by peer"))
+        : Promise.resolve({ n: attempt });
+    };
+    await withRequestScope(async () => {
+      const [a, b] = await Promise.allSettled([
+        scopedRead("k", load),
+        scopedRead("k", load),
+      ]);
+      expect(a.status).toBe("rejected");
+      expect(b.status).toBe("rejected");
+      expect(await scopedRead("k", load)).toEqual({ n: 2 });
+    });
+    expect(attempt).toBe(2);
+  });
+});


### PR DESCRIPTION
First fix out of the performance audit: the top-ranked finding, `fetchUpdatedUser` being re-run in full by every procedure in a tRPC batch.

## The problem

`fetchUpdatedUser` opens with a seven-way `Promise.all`. Six of those seven reads are the same for every caller in a request:

| read | predicate mentions the user? | mutated by callers? |
|---|---|---|
| achievement catalogue | no | yes — quest objectives are rewritten per user |
| game settings | no | no |
| unvoted-poll probe | yes, but read-only | no |
| all active wars | no | no |
| active shrine lobbies | no | no |
| active raids | no | no |
| **`userData` + relations** | **yes** | **yes — every mutation writes it back** |

`httpBatchLink` packs a page's whole mount into one POST and tRPC resolves those procedures concurrently, so a page load paid for all six once *per procedure*.

## The fix

A request-scoped memo (`AsyncLocalStorage`, entered once in the tRPC route handler), with the six qualifying reads routed through it. `src/server/requestScope.ts` documents the three conditions a read has to meet to belong there.

The `userData` row is deliberately **not** memoized. It is the row every mutation reads, mutates in memory and writes back, and it gates what actions a player is allowed to take — it stays a private per-caller read, exactly as before.

Two details that matter:

- **Every caller gets a `structuredClone`, the first one included.** Callers mutate what they read back: `controlShownQuestLocationInformation` rewrites quest objectives in place to hide locations from players outside the right sector, and that rewrite is per-user. Handing out the memoized object would leak one player's view into the next caller's copy — and `hospital.userHeal` really does call `fetchUpdatedUser` for two different users in one request.
- **`load()` is awaited into a real promise before it is memoized.** A Drizzle query builder is a thenable that re-runs `execute()` on every `then`, so memoizing the builder caches the *intent* to query, not its result — a cache that looks like it hits while every reader still goes to the database. This one actually bit during validation; there is a regression test for it.

Outside a request scope — crons, scripts, tests — `scopedRead` is a plain pass-through, so nothing off the tRPC path changes behaviour.

## Validation

Measured against a local dev server with a provisioned level-50 test account, instrumenting the PlanetScale driver's `fetch` and attributing every query to its request through the same `AsyncLocalStorage`. The workload is one batch of the five no-input query procedures that call `fetchUpdatedUser`: `profile.getUser`, `home.getUserHome`, `home.getAvailableUpgrades`, `bloodline.getSwapInfo`, `skillTree.getResetInfo`. The memo was toggled with an env flag so both builds ran identical instrumentation.

| | before | after |
|---|---|---|
| DB round-trips per batch | **37** | **13** |
| median batch latency (15 samples) | 299 ms | 286 ms |
| max latency | 331 ms | 328 ms |
| clone overhead | — | 1.4 ms/request, all six keys |

Per-shape, before → after: achievement catalogue 5→1, game settings 5→1, poll probe 5→1, active wars 5→1, shrine lobbies 5→1, active raids 5→1, `userData` 5→5 (unchanged by design).

Local wall-clock barely moves because the seven reads already run in parallel against a Docker MySQL on loopback. The win is the 24 fewer HTTPS round-trips to PlanetScale per page load, which is what costs money and queues under contention in production.

**Functional equivalence:** the full batch response was captured under both builds and diffed after normalising timestamps — 5147 lines of JSON, differing on a single line, the throwaway test account's username.

## Ordering safety

A memoized read returns the snapshot the first caller took, so a write landing mid-request is observed on the next request. I scanned every procedure that calls `fetchUpdatedUser` for a write to one of the six tables followed by a later `fetchUpdatedUser` in the same procedure: zero hits. Two procedures call `fetchUpdatedUser` twice, both concurrently at the top (`hospital.userHeal`, for two different users), never write-then-read.

## Checks

- `make typecheck` clean (with `tsconfig.tsbuildinfo` removed first)
- `make test` — 1300 pass, 0 fail, including 9 new tests for `scopedRead`
- `make lint` — no new diagnostics in the changed files



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot `fetchUpdatedUser` path with memo snapshot semantics and cloning; behavior is documented as equivalent but regressions would affect most page loads.
> 
> **Overview**
> Adds **request-scoped read deduplication** so batched tRPC page loads stop repeating the same global DB queries once per procedure.
> 
> The tRPC route handler now runs inside `withRequestScope` (`AsyncLocalStorage`). In `fetchUpdatedUser`, six shared reads—achievements, game settings, active wars, shrine lobbies, raids, and the unvoted-poll probe—go through `scopedRead` helpers so a batch pays **one round-trip each** instead of one per procedure. Per-user `userData` stays a fresh read every time.
> 
> `scopedRead` **clones results** with `structuredClone` so downstream per-user quest/war/raid rewriting cannot leak between concurrent callers, memoizes **resolved promises** (not Drizzle thenables), and **evicts failed reads** so a later caller can retry. Off the tRPC path it is a no-op.
> 
> Separately, `fetchPublicUsers` loads the caller with **`columns: { role: true }`** only for the IP visibility guard, plus new tests for `scopedRead` and public-user IP rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8e8a0144479d291becf821dd4981aeb159755b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved request handling by reusing repeated data lookups within a single request.
  * Reduced duplicate work for profile-related achievements, settings, polls, wars, shrines, and raids.

* **Reliability**
  * Ensured failed lookups can be retried without affecting later requests.
  * Preserved data isolation and safe results when the same information is requested concurrently.

* **Tests**
  * Added coverage for request isolation, concurrent reads, result copying, date handling, and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up in this PR

**Helpers moved below `fetchUpdatedUser`.** They were below the router but in front of the function they serve; the file already puts that function's other private helper (`persistPassiveRegenToDb`) after it. Pure move.

**`fetchPublicUsers` selects `role` instead of the whole row.** It re-reads the caller's own `UserData` row to decide whether the listing may show IPs, and was selecting ~90 columns (including the `effects` JSON) to use exactly one field at the two `canSeeIps` guards. `profile.getPublicUsers` backs the online-players sidebar and appeared in **14 of 40** tRPC batches across a ~20-page browse, so it rides along on most page loads. Bandwidth only — the query still runs.

Because that touches a permission guard, it comes with a DB-backed suite (`app/tests/server/api/profile.publicUserIps.test.ts`) that runs `fetchPublicUsers` against a real MySQL for a staff role, an ordinary player, and a signed-out caller, in both the listing and IP-search directions. Verified it has teeth: swapping the projection to one that drops `role` fails two of its five cases rather than silently hiding IPs from staff.

## Why nothing else got the memo treatment

I re-instrumented and browsed ~20 pages as a logged-in level-50 account — 40 tRPC batches, 297 queries — counting identical statements repeated inside one request. **7 duplicates out of 297 (2%)**, and 4 of those are the `userData`-with-relations read that this PR deliberately excludes (3× on `/home`: `getUserHome` + `getAvailableUpgrades` + `getUser`). The other 3 are one-offs on `/users`.

Memoizing the user row would be the only remaining win, and it is not free: it changes when `persistPassiveRegenToDb`'s write becomes visible, so a procedure that today reads `updatedAt = now` and skips its own persist would always re-persist. Not worth it to save 2 reads on one page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
