### PR TITLE
perf(profile): send achievement progress, not the achievement catalogue

### DIFF
--- a/app/src/hooks/quest.ts
+++ b/app/src/hooks/quest.ts
@@ -87,10 +87,14 @@ export const useQuestEditForm = (quest: Quest, refetch: () => void) => {
     api.sageMode.getAllNames.useQuery(undefined);
 
   // Mutation for updating item
+  const utils = api.useUtils();
   const { mutate: updateQuest } = api.quests.update.useMutation({
     onSuccess: (data) => {
       showMutationToast(data);
       refetch();
+      // Players hold the achievement definitions for the whole session, so an edit to one has
+      // to drop that cache or it keeps rendering the version staff just replaced.
+      void utils.quests.getAchievementCatalogue.invalidate();
     },
   });
 

--- a/app/src/layout/Logbook.tsx
+++ b/app/src/layout/Logbook.tsx
@@ -41,6 +41,9 @@ import Post from "./Post";
 const tabs = ["Active", "History", "Battles", "Achievements"] as const;
 type tabType = (typeof tabs)[number];
 
+/** Matches the interval `profile.getUser` refreshes its own achievement progress on. */
+const CATALOGUE_REFRESH_MS = 5 * 60 * 1000;
+
 const Logbook: React.FC = () => {
   // State
   const [tab, setTab] = useState<tabType | null>(null);
@@ -79,11 +82,19 @@ const LogbookAchievements: React.FC = () => {
   const [activeElement, setActiveElement] = useState<string>("");
 
   // Achievement definitions are the same for every player and change only when staff edit
-  // content, so profile.getUser sends progress alone and they are fetched here instead. The
-  // staleTime overrides the app-wide Infinity so an edit to an existing achievement is picked up
-  // the next time this remounts or the window regains focus; it does not schedule a fetch of its
-  // own, which is what the unresolved-row effect below is for. isLoading rather than isPending: a
-  // disabled query never stops being pending, which would leave the tab on its spinner forever.
+  // content, so profile.getUser sends progress alone and they are fetched here instead.
+  //
+  // The refresh knobs together cover the three ways the cache can fall behind. An achievement
+  // published or hidden since the last fetch shows up as a progress row with no definition, which
+  // the effect below reacts to at once. An edit to an existing one changes no ids and so is
+  // invisible to that check, which is what refetchInterval is for; staleTime covers the same case
+  // on remount and refocus, since an interval only runs while this is mounted and focused.
+  //
+  // Polling this costs less than the code it replaces rather than eating into the saving: it runs
+  // only while the Achievements tab is open, on the same cadence profile.getUser already polls at
+  // (UserContext), and that poll used to carry these very definitions for every player on every
+  // page. isLoading rather than isPending: a disabled query never stops being pending, which would
+  // leave the tab on its spinner forever.
   const {
     data: catalogue,
     isFetched,
@@ -92,7 +103,8 @@ const LogbookAchievements: React.FC = () => {
     refetch,
   } = api.quests.getAchievementCatalogue.useQuery(undefined, {
     enabled: !!userData,
-    staleTime: 5 * 60 * 1000,
+    staleTime: CATALOGUE_REFRESH_MS,
+    refetchInterval: CATALOGUE_REFRESH_MS,
   });
 
   const definitions = useMemo(

--- a/app/src/layout/Logbook.tsx
+++ b/app/src/layout/Logbook.tsx
@@ -84,10 +84,20 @@ const LogbookAchievements: React.FC = () => {
   // refetch, and a definition that stayed cached past that point would leave a freshly published
   // achievement rendering nothing. isLoading rather than isPending: a disabled query never stops
   // being pending, which would leave the tab on its spinner forever.
-  const { data: catalogue, isLoading } = api.quests.getAchievementCatalogue.useQuery(
-    undefined,
-    { enabled: !!userData, staleTime: 5 * 60 * 1000 },
-  );
+  const {
+    data: catalogue,
+    isLoading,
+    refetch,
+  } = api.quests.getAchievementCatalogue.useQuery(undefined, {
+    enabled: !!userData,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  // Progress rows arrived but their definitions did not, so the list below is missing entries.
+  // Keyed on the data itself rather than on `isError`, which flickers false between the query's
+  // retries: what matters to the player is whether anything is missing, not how it went wrong.
+  const missingDefinitions =
+    !isLoading && !catalogue && (achievementProgress?.length ?? 0) > 0;
 
   const quests = useMemo(() => {
     const definitions = new Map(catalogue?.map((q) => [q.id, q]));
@@ -118,6 +128,18 @@ const LogbookAchievements: React.FC = () => {
 
   return (
     <div className="">
+      {/* Say so, and keep whatever did arrive on screen: a list that looks complete but is not
+          hides achievements, and one that never renders never auto-claims either. */}
+      {missingDefinitions && (
+        <div className="flex flex-row items-center gap-3 p-3">
+          <span className="text-muted-foreground text-sm">
+            Could not load the achievement list. Your progress is safe.
+          </span>
+          <Button type="button" variant="info" onClick={() => void refetch()}>
+            Retry
+          </Button>
+        </div>
+      )}
       {quests
         .filter((uq) => uq.completed === 0)
         .map((uq) => {

--- a/app/src/layout/Logbook.tsx
+++ b/app/src/layout/Logbook.tsx
@@ -80,40 +80,61 @@ const LogbookAchievements: React.FC = () => {
 
   // Achievement definitions are the same for every player and change only when staff edit
   // content, so profile.getUser sends progress alone and they are fetched here instead. The
-  // staleTime overrides the app-wide Infinity: progress arrives on getUser's own five-minute
-  // refetch, and a definition that stayed cached past that point would leave a freshly published
-  // achievement rendering nothing. isLoading rather than isPending: a disabled query never stops
-  // being pending, which would leave the tab on its spinner forever.
+  // staleTime overrides the app-wide Infinity so an edit to an existing achievement is picked up
+  // the next time this remounts or the window regains focus; it does not schedule a fetch of its
+  // own, which is what the unresolved-row effect below is for. isLoading rather than isPending: a
+  // disabled query never stops being pending, which would leave the tab on its spinner forever.
   const {
     data: catalogue,
     isLoading,
+    isFetching,
     refetch,
   } = api.quests.getAchievementCatalogue.useQuery(undefined, {
     enabled: !!userData,
     staleTime: 5 * 60 * 1000,
   });
 
-  // Progress rows arrived but their definitions did not, so the list below is missing entries.
-  // Keyed on the data itself rather than on `isError`, which flickers false between the query's
-  // retries: what matters to the player is whether anything is missing, not how it went wrong.
-  const missingDefinitions =
-    !isLoading && !catalogue && (achievementProgress?.length ?? 0) > 0;
+  const definitions = useMemo(
+    () => new Map(catalogue?.map((q) => [q.id, q])),
+    [catalogue],
+  );
+
+  // Progress rows the cached catalogue cannot resolve, which the join below would otherwise drop
+  // in silence. Checked per row rather than as "did the catalogue arrive at all": one fetched
+  // before staff published an achievement is present but short, and a failed refresh keeps
+  // serving the older rows. Keyed on the data for the same reason `isError` is not used here - it
+  // reads false across the query's retry backoff, so a guard on it renders nothing.
+  const unresolvedIds = useMemo(
+    () =>
+      (achievementProgress ?? [])
+        .filter((progress) => !definitions.has(progress.questId))
+        .map((progress) => progress.questId)
+        .join(","),
+    [achievementProgress, definitions],
+  );
+
+  // Staleness alone never refetches a query that stays mounted, so a definition published after
+  // this was cached would otherwise never arrive. Pull again as soon as a row cannot be resolved,
+  // keyed on the ids themselves: a refetch that comes back with the same rows leaves the key
+  // unchanged and does not fire a second time.
+  useEffect(() => {
+    if (unresolvedIds) void refetch();
+  }, [unresolvedIds, refetch]);
 
   const quests = useMemo(() => {
-    const definitions = new Map(catalogue?.map((q) => [q.id, q]));
     return [
       // Tier quests, plus any achievement whose objectives kept it on the user object.
       ...(userData?.userQuests?.filter((uq) =>
         ["tier", "achievement"].includes(uq.quest.questType),
       ) ?? []),
-      // A progress row whose definition is missing - staff hid or deleted the achievement
-      // between the two queries - renders nothing rather than throwing on `uq.quest`.
+      // A progress row whose definition is missing renders nothing rather than throwing on
+      // `uq.quest`; the banner below tells the player the list is short.
       ...(achievementProgress ?? []).flatMap((progress) => {
         const quest = definitions.get(progress.questId);
         return quest ? [{ ...progress, quest }] : [];
       }),
     ];
-  }, [userData?.userQuests, achievementProgress, catalogue]);
+  }, [userData?.userQuests, achievementProgress, definitions]);
 
   useEffect(() => {
     if (quests.length > 0 && !activeElement) {
@@ -129,11 +150,12 @@ const LogbookAchievements: React.FC = () => {
   return (
     <div className="">
       {/* Say so, and keep whatever did arrive on screen: a list that looks complete but is not
-          hides achievements, and one that never renders never auto-claims either. */}
-      {missingDefinitions && (
+          hides achievements, and one that never renders never auto-claims either. Held back while
+          a fetch is in flight so the refetch above can fix it without the banner flashing. */}
+      {!isFetching && unresolvedIds && (
         <div className="flex flex-row items-center gap-3 p-3">
           <span className="text-muted-foreground text-sm">
-            Could not load the achievement list. Your progress is safe.
+            Could not load every achievement. Your progress is safe.
           </span>
           <Button type="button" variant="info" onClick={() => void refetch()}>
             Retry

--- a/app/src/layout/Logbook.tsx
+++ b/app/src/layout/Logbook.tsx
@@ -86,8 +86,9 @@ const LogbookAchievements: React.FC = () => {
   // disabled query never stops being pending, which would leave the tab on its spinner forever.
   const {
     data: catalogue,
-    isLoading,
+    isFetched,
     isFetching,
+    isLoading,
     refetch,
   } = api.quests.getAchievementCatalogue.useQuery(undefined, {
     enabled: !!userData,
@@ -116,9 +117,11 @@ const LogbookAchievements: React.FC = () => {
   // Staleness alone never refetches a query that stays mounted, so a definition published after
   // this was cached would otherwise never arrive. Pull again as soon as a row cannot be resolved,
   // keyed on the ids themselves: a refetch that comes back with the same rows leaves the key
-  // unchanged and does not fire a second time.
+  // unchanged and does not fire a second time. `cancelRefetch: false` because progress can land
+  // before the first catalogue fetch does, and the default would abort that request and reissue
+  // it; joining it instead keeps a healthy mount at a single round-trip.
   useEffect(() => {
-    if (unresolvedIds) void refetch();
+    if (unresolvedIds) void refetch({ cancelRefetch: false });
   }, [unresolvedIds, refetch]);
 
   const quests = useMemo(() => {
@@ -151,8 +154,9 @@ const LogbookAchievements: React.FC = () => {
     <div className="">
       {/* Say so, and keep whatever did arrive on screen: a list that looks complete but is not
           hides achievements, and one that never renders never auto-claims either. Held back while
-          a fetch is in flight so the refetch above can fix it without the banner flashing. */}
-      {!isFetching && unresolvedIds && (
+          fetch is in flight, or has yet to happen at all, so the refetch above can fix it
+          without the banner flashing in between. */}
+      {isFetched && !isFetching && unresolvedIds && (
         <div className="flex flex-row items-center gap-3 p-3">
           <span className="text-muted-foreground text-sm">
             Could not load every achievement. Your progress is safe.

--- a/app/src/layout/Logbook.tsx
+++ b/app/src/layout/Logbook.tsx
@@ -1,6 +1,6 @@
 import { Loader2, Sparkles, X } from "lucide-react";
 import type React from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { api } from "@/app/_trpc/client";
 import { Button } from "@/components/ui/button";
 import {
@@ -75,14 +75,36 @@ const Logbook: React.FC = () => {
  * ```
  */
 const LogbookAchievements: React.FC = () => {
-  const { data: userData } = useRequiredUserData();
+  const { data: userData, achievementProgress } = useRequiredUserData();
   const [activeElement, setActiveElement] = useState<string>("");
-  const quests = userData?.userQuests?.filter((uq) =>
-    ["tier", "achievement"].includes(uq.quest.questType),
+
+  // Achievement definitions are the same for every player and change only when staff edit
+  // content, so profile.getUser sends progress alone and they are fetched once here instead -
+  // the query client keeps them for the session. isLoading rather than isPending: a disabled
+  // query never stops being pending, which would leave the tab on its spinner forever.
+  const { data: catalogue, isLoading } = api.quests.getAchievementCatalogue.useQuery(
+    undefined,
+    { enabled: !!userData },
   );
 
+  const quests = useMemo(() => {
+    const definitions = new Map(catalogue?.map((q) => [q.id, q]));
+    return [
+      // Tier quests, plus any achievement whose objectives kept it on the user object.
+      ...(userData?.userQuests?.filter((uq) =>
+        ["tier", "achievement"].includes(uq.quest.questType),
+      ) ?? []),
+      // A progress row whose definition is missing - staff hid or deleted the achievement
+      // between the two queries - renders nothing rather than throwing on `uq.quest`.
+      ...(achievementProgress ?? []).flatMap((progress) => {
+        const quest = definitions.get(progress.questId);
+        return quest ? [{ ...progress, quest }] : [];
+      }),
+    ];
+  }, [userData?.userQuests, achievementProgress, catalogue]);
+
   useEffect(() => {
-    if (quests && quests.length > 0 && !activeElement) {
+    if (quests.length > 0 && !activeElement) {
       const firstAchievement = quests[0];
       if (firstAchievement) {
         setActiveElement(firstAchievement.quest.name);
@@ -90,12 +112,13 @@ const LogbookAchievements: React.FC = () => {
     }
   }, [quests, activeElement]);
 
+  if (isLoading) return <Loader explanation="Loading achievements..." />;
+
   return (
     <div className="">
-      {userData?.userQuests
-        ?.filter((uq) => ["tier", "achievement"].includes(uq.quest.questType))
+      {quests
         .filter((uq) => uq.completed === 0)
-        ?.map((uq) => {
+        .map((uq) => {
           const tracker = userData?.questData?.find((q) => q.id === uq.questId);
 
           return (

--- a/app/src/layout/Logbook.tsx
+++ b/app/src/layout/Logbook.tsx
@@ -79,12 +79,14 @@ const LogbookAchievements: React.FC = () => {
   const [activeElement, setActiveElement] = useState<string>("");
 
   // Achievement definitions are the same for every player and change only when staff edit
-  // content, so profile.getUser sends progress alone and they are fetched once here instead -
-  // the query client keeps them for the session. isLoading rather than isPending: a disabled
-  // query never stops being pending, which would leave the tab on its spinner forever.
+  // content, so profile.getUser sends progress alone and they are fetched here instead. The
+  // staleTime overrides the app-wide Infinity: progress arrives on getUser's own five-minute
+  // refetch, and a definition that stayed cached past that point would leave a freshly published
+  // achievement rendering nothing. isLoading rather than isPending: a disabled query never stops
+  // being pending, which would leave the tab on its spinner forever.
   const { data: catalogue, isLoading } = api.quests.getAchievementCatalogue.useQuery(
     undefined,
-    { enabled: !!userData },
+    { enabled: !!userData, staleTime: 5 * 60 * 1000 },
   );
 
   const quests = useMemo(() => {

--- a/app/src/libs/quest.ts
+++ b/app/src/libs/quest.ts
@@ -1549,6 +1549,28 @@ export const mockAchievementHistoryEntries = (
 };
 
 /**
+ * Whether any of a quest's objectives is something the overworld has to draw or act on: a map
+ * location, an ambush, a bound NPC placement, or a dialog. The sector and world-map views scan
+ * `userQuests[].quest.content.objectives` for exactly these.
+ *
+ * Achievements are lifetime counters and normally carry none of it, which is what lets
+ * `profile.getUser` ship them as progress rows plus a cached catalogue. An authored exception
+ * keeps its full `Quest` row on the user object instead, since a catalogue shared by every
+ * player cannot carry the per-user location state `controlShownQuestLocationInformation` applies.
+ */
+export const questHasOverworldObjectives = (quest: Quest) =>
+  quest.content.objectives.some(
+    (objective) =>
+      ("sector" in objective && !!objective.sector) ||
+      ("longitude" in objective && !!objective.longitude) ||
+      ("latitude" in objective && !!objective.latitude) ||
+      ("attackers" in objective && (objective.attackers?.length ?? 0) > 0) ||
+      ("overworldPlacementId" in objective && !!objective.overworldPlacementId) ||
+      ("hideLocation" in objective && !!objective.hideLocation) ||
+      objective.task === "dialog",
+  );
+
+/**
  * Hides the location information of quest objectives if certain conditions are met.
  *
  * @param quest - The quest object containing objectives.

--- a/app/src/libs/quest.ts
+++ b/app/src/libs/quest.ts
@@ -1550,23 +1550,30 @@ export const mockAchievementHistoryEntries = (
 
 /**
  * Whether any of a quest's objectives is something the overworld has to draw or act on: a map
- * location, an ambush, a bound NPC placement, or a dialog. The sector and world-map views scan
- * `userQuests[].quest.content.objectives` for exactly these.
+ * location, an ambush, a bound NPC placement, or a dialog. The sector view, the world map and
+ * `getActiveObjectives` scan `userQuests[].quest.content.objectives` for exactly these.
  *
  * Achievements are lifetime counters and normally carry none of it, which is what lets
- * `profile.getUser` ship them as progress rows plus a cached catalogue. An authored exception
- * keeps its full `Quest` row on the user object instead, since a catalogue shared by every
- * player cannot carry the per-user location state `controlShownQuestLocationInformation` applies.
+ * `quests.getAchievementCatalogue` publish them for the client to cache instead of `getUser`
+ * re-sending them. An authored exception is withheld from the catalogue and keeps travelling on
+ * the user object, so the overworld still sees it.
+ *
+ * A stored coordinate counts even when it is zero. Sector 0 is a real sector
+ * (`MAP_SECTOR_ID_MIN`) and (0, 0) is a real tile, so the test is whether the objective carries
+ * the field at all - a counter objective has no coordinate keys whatsoever. `attackers` and
+ * `opponentAIs` are the other way round: nearly every objective serialises them as empty arrays,
+ * so only a populated one means anything.
  */
 export const questHasOverworldObjectives = (quest: Quest) =>
   quest.content.objectives.some(
     (objective) =>
-      ("sector" in objective && !!objective.sector) ||
-      ("longitude" in objective && !!objective.longitude) ||
-      ("latitude" in objective && !!objective.latitude) ||
-      ("attackers" in objective && (objective.attackers?.length ?? 0) > 0) ||
+      "sector" in objective ||
+      "longitude" in objective ||
+      "latitude" in objective ||
+      "hideLocation" in objective ||
       ("overworldPlacementId" in objective && !!objective.overworldPlacementId) ||
-      ("hideLocation" in objective && !!objective.hideLocation) ||
+      ("attackers" in objective && (objective.attackers?.length ?? 0) > 0) ||
+      ("opponentAIs" in objective && (objective.opponentAIs?.length ?? 0) > 0) ||
       objective.task === "dialog",
   );
 

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -481,7 +481,9 @@ export const profileRouter = createTRPCRouter({
         },
       );
       // Ship achievement progress on its own; the definitions come from the catalogue query
-      const achievementProgress = user ? splitAchievementProgress(user) : [];
+      const achievementProgress = user
+        ? splitAchievementProgress(user, await fetchPublishedAchievements(ctx.drizzle))
+        : [];
       // Figure out notifications
       const notifications: NavBarDropdownLink[] = [];
 
@@ -2888,6 +2890,24 @@ export const fetchAchievementCatalogue = (client: DrizzleClient) =>
       .where(and(eq(quest.questType, "achievement"), eq(quest.hidden, false))),
   );
 
+/**
+ * The achievements whose definitions `quests.getAchievementCatalogue` publishes for the client to
+ * cache, and therefore exactly the ones `profile.getUser` may send as progress alone.
+ *
+ * Both sides read this one list rather than re-deciding with a predicate: by the time `getUser`
+ * runs, `fetchUpdatedUser` has rewritten the objectives on its own copy of these quests - trackers
+ * write resolved coordinates back onto them, and location hiding rewrites them again - so a
+ * predicate applied there and a predicate applied to the raw row can disagree, and a progress row
+ * whose definition the catalogue withholds renders nothing at all.
+ *
+ * Inside a request scope the underlying read is memoized, so a caller that has already gone
+ * through `fetchUpdatedUser` pays nothing for this.
+ */
+export const fetchPublishedAchievements = async (client: DrizzleClient) =>
+  (await fetchAchievementCatalogue(client)).filter(
+    (achievement) => !questHasOverworldObjectives(achievement),
+  );
+
 const fetchAllGameSettings = (client: DrizzleClient) =>
   scopedRead("gameSettings", () => client.select().from(gameSetting));
 
@@ -2970,23 +2990,19 @@ export type AchievementProgress = Omit<UserQuest, "quest">;
  * of kilobytes of unchanging catalogue JSON on every page load. The client joins the returned
  * progress against `quests.getAchievementCatalogue`, which it holds for the session.
  *
- * A row is only moved when the catalogue is certain to carry its definition, since the client
- * renders nothing for a progress row it cannot resolve. That rules out two cases, both of which
- * keep travelling on the user object: a hidden achievement, which the catalogue does not publish
- * and only content staff can see at all, and one whose objectives reach into the overworld - the
- * sector and world-map views read those straight off `userQuests`, and a catalogue shared by every
- * player cannot carry the per-user location state they depend on.
+ * A row moves exactly when `published` carries its definition, which makes the two halves a
+ * partition by construction: nothing is sent twice, and nothing is stranded as a progress row the
+ * client cannot resolve. Everything else - a hidden achievement, one the overworld still needs,
+ * an orphaned row whose quest was deleted - stays on the user object untouched.
  */
-export const splitAchievementProgress = (user: NonNullable<UserWithRelations>) => {
+export const splitAchievementProgress = (
+  user: NonNullable<UserWithRelations>,
+  published: Quest[],
+) => {
+  const publishedIds = new Set(published.map((achievement) => achievement.id));
   const progress: AchievementProgress[] = [];
   user.userQuests = user.userQuests.filter((userQuest) => {
-    if (
-      userQuest.quest?.questType !== "achievement" ||
-      userQuest.quest.hidden ||
-      questHasOverworldObjectives(userQuest.quest)
-    ) {
-      return true;
-    }
+    if (!publishedIds.has(userQuest.questId)) return true;
     const { quest: _definition, ...rest } = userQuest;
     progress.push(rest);
     return false;

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -113,6 +113,7 @@ import {
   getNewTrackers,
   isAvailableUserQuests,
   mockAchievementHistoryEntries,
+  questHasOverworldObjectives,
 } from "@/libs/quest";
 import { getRaidObjectiveData } from "@/libs/raids";
 import { createThumbnail } from "@/libs/replicate";
@@ -479,6 +480,8 @@ export const profileRouter = createTRPCRouter({
           // forceRegen: true, // This should be disabled in prod to save on DB calls
         },
       );
+      // Ship achievement progress on its own; the definitions come from the catalogue query
+      const achievementProgress = user ? splitAchievementProgress(user) : [];
       // Figure out notifications
       const notifications: NavBarDropdownLink[] = [];
 
@@ -969,6 +972,7 @@ export const profileRouter = createTRPCRouter({
       }
       return {
         userData: user,
+        achievementProgress: achievementProgress,
         notifications: notifications,
         serverTime: Date.now(),
         userAgent: ctx.userAgent,
@@ -2876,7 +2880,7 @@ const persistPassiveRegenToDb = async ({
  * callers in the same request therefore inherit a cutoff that is milliseconds old,
  * which is well inside the minute-scale windows both filters describe.
  */
-const fetchAchievementCatalogue = (client: DrizzleClient) =>
+export const fetchAchievementCatalogue = (client: DrizzleClient) =>
   scopedRead("achievements", () =>
     client
       .select()
@@ -2952,6 +2956,43 @@ const fetchActiveRaids = (client: DrizzleClient, now: Date) =>
       ),
     }),
   );
+
+/** A user's progress on one quest, without the static definition it belongs to. */
+export type AchievementProgress = Omit<UserQuest, "quest">;
+
+/**
+ * Move a user's achievement rows out of `user.userQuests` and return them without their `quest`.
+ *
+ * Achievements are global static content: every player is handed the same definitions, and
+ * `mockAchievementHistoryEntries` attaches the whole `Quest` row - every objective with its
+ * description, scene assets and reward spec - to a progress row that is otherwise a handful of
+ * counters. Sending that from `profile.getUser` re-serialised, re-transferred and re-parsed tens
+ * of kilobytes of unchanging catalogue JSON on every page load. The client joins the returned
+ * progress against `quests.getAchievementCatalogue`, which it holds for the session.
+ *
+ * A row is only moved when the catalogue is certain to carry its definition, since the client
+ * renders nothing for a progress row it cannot resolve. That rules out two cases, both of which
+ * keep travelling on the user object: a hidden achievement, which the catalogue does not publish
+ * and only content staff can see at all, and one whose objectives reach into the overworld - the
+ * sector and world-map views read those straight off `userQuests`, and a catalogue shared by every
+ * player cannot carry the per-user location state they depend on.
+ */
+export const splitAchievementProgress = (user: NonNullable<UserWithRelations>) => {
+  const progress: AchievementProgress[] = [];
+  user.userQuests = user.userQuests.filter((userQuest) => {
+    if (
+      userQuest.quest?.questType !== "achievement" ||
+      userQuest.quest.hidden ||
+      questHasOverworldObjectives(userQuest.quest)
+    ) {
+      return true;
+    }
+    const { quest: _definition, ...rest } = userQuest;
+    progress.push(rest);
+    return false;
+  });
+  return progress;
+};
 
 export const fetchPublicUsers = async (info: {
   client: DrizzleClient;

--- a/app/src/server/api/routers/quests.ts
+++ b/app/src/server/api/routers/quests.ts
@@ -83,6 +83,7 @@ import {
   getReward,
   getUserQuests,
   isAvailableUserQuests,
+  questHasOverworldObjectives,
   verifyQuestContentForSave,
 } from "@/libs/quest";
 import { sageQuestFilters } from "@/libs/sageMode";
@@ -92,7 +93,11 @@ import { extendWarParticipantSql } from "@/libs/war";
 import { initiateBattle } from "@/routers/combat";
 import { fetchUserItems } from "@/routers/item";
 import type { UserWithRelations } from "@/routers/profile";
-import { fetchUpdatedUser, fetchUser } from "@/routers/profile";
+import {
+  fetchAchievementCatalogue,
+  fetchUpdatedUser,
+  fetchUser,
+} from "@/routers/profile";
 import { deleteRequests } from "@/routers/sensei";
 import { fetchSectorVillage } from "@/routers/village";
 import { fetchActiveWars } from "@/routers/war";
@@ -191,6 +196,18 @@ export const questsRouter = createTRPCRouter({
         data: hideNpcOnlyQuestsFrom(viewerRole, results),
         nextCursor: nextCursor,
       };
+    }),
+  getAchievementCatalogue: protectedProcedure
+    .meta({
+      mcp: { enabled: true, description: "Get the static achievement definitions" },
+    })
+    .query(async ({ ctx }) => {
+      // Achievement definitions are the same for every player and change only when staff edit
+      // content, so `profile.getUser` sends progress alone and the client holds these instead of
+      // re-downloading them on every page load. The overworld exception is withheld here for the
+      // same reason it stays on the user object: its locations are resolved per player.
+      const achievements = await fetchAchievementCatalogue(ctx.drizzle);
+      return achievements.filter((a) => !questHasOverworldObjectives(a));
     }),
   get: publicProcedure
     .meta({ mcp: { enabled: true, description: "Get a single quest by ID" } })

--- a/app/src/server/api/routers/quests.ts
+++ b/app/src/server/api/routers/quests.ts
@@ -83,7 +83,6 @@ import {
   getReward,
   getUserQuests,
   isAvailableUserQuests,
-  questHasOverworldObjectives,
   verifyQuestContentForSave,
 } from "@/libs/quest";
 import { sageQuestFilters } from "@/libs/sageMode";
@@ -94,7 +93,7 @@ import { initiateBattle } from "@/routers/combat";
 import { fetchUserItems } from "@/routers/item";
 import type { UserWithRelations } from "@/routers/profile";
 import {
-  fetchAchievementCatalogue,
+  fetchPublishedAchievements,
   fetchUpdatedUser,
   fetchUser,
 } from "@/routers/profile";
@@ -204,10 +203,8 @@ export const questsRouter = createTRPCRouter({
     .query(async ({ ctx }) => {
       // Achievement definitions are the same for every player and change only when staff edit
       // content, so `profile.getUser` sends progress alone and the client holds these instead of
-      // re-downloading them on every page load. The overworld exception is withheld here for the
-      // same reason it stays on the user object: its locations are resolved per player.
-      const achievements = await fetchAchievementCatalogue(ctx.drizzle);
-      return achievements.filter((a) => !questHasOverworldObjectives(a));
+      // re-downloading them on every page load.
+      return await fetchPublishedAchievements(ctx.drizzle);
     }),
   get: publicProcedure
     .meta({ mcp: { enabled: true, description: "Get a single quest by ID" } })

--- a/app/src/utils/UserContext.tsx
+++ b/app/src/utils/UserContext.tsx
@@ -7,7 +7,7 @@ import { useRouter } from "next/navigation";
 import type Pusher from "pusher-js";
 import type React from "react";
 import { createContext, useContext, useEffect, useState } from "react";
-import type { UserWithRelations } from "@/api/routers/profile";
+import type { AchievementProgress, UserWithRelations } from "@/api/routers/profile";
 import { api } from "@/app/_trpc/client";
 import type { StructureRoute } from "@/drizzle/constants";
 import { usePusherHandler } from "@/layout/PusherHandler";
@@ -41,6 +41,12 @@ export const blockingPopupOpenAtom = atom<boolean>(false);
  */
 export const UserContext = createContext<{
   data: UserWithRelations;
+  /**
+   * Achievement progress, carried beside `data` rather than inside `data.userQuests`: the
+   * definitions these rows belong to are static and are fetched once from
+   * `quests.getAchievementCatalogue`. The logbook joins the two.
+   */
+  achievementProgress: AchievementProgress[] | undefined;
   notifications: NavBarDropdownLink[] | undefined;
   userAgent: string | undefined;
   status: string;
@@ -54,6 +60,7 @@ export const UserContext = createContext<{
   ) => Promise<void>;
 }>({
   data: undefined,
+  achievementProgress: undefined,
   notifications: undefined,
   userAgent: undefined,
   status: "unknown",
@@ -166,6 +173,7 @@ export function UserContextProvider(props: { children: React.ReactNode }) {
     <UserContext
       value={{
         data: data?.userData,
+        achievementProgress: data?.achievementProgress,
         notifications: data?.notifications,
         userAgent: data?.userAgent,
         pusher: pusher,
@@ -230,9 +238,9 @@ export const useRequireInVillage = (structureRoute?: StructureRoute) => {
   // would keep the access check below from ever running.
   const { data: sectorVillage, isLoading: isLoadingSector } =
     api.travel.getVillageInSector.useQuery(
-    { sector: userData?.sector ?? -1, isOutlaw: userData?.isOutlaw ?? false },
-    { enabled: userData?.sector != null },
-  );
+      { sector: userData?.sector ?? -1, isOutlaw: userData?.isOutlaw ?? false },
+      { enabled: userData?.sector != null },
+    );
   const ownVillage = userData?.village?.sector === sectorVillage?.sector;
   const router = useRouter();
   useEffect(() => {

--- a/app/tests/server/api/profile.achievementSplit.test.ts
+++ b/app/tests/server/api/profile.achievementSplit.test.ts
@@ -1,15 +1,25 @@
 // @vitest-environment node
 
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import { quest } from "@/drizzle/schema";
 import { questHasOverworldObjectives } from "@/libs/quest";
 import type { UserWithRelations } from "../../../src/server/api/routers/profile";
-import { splitAchievementProgress } from "../../../src/server/api/routers/profile";
+import {
+  fetchPublishedAchievements,
+  splitAchievementProgress,
+} from "../../../src/server/api/routers/profile";
+import { insertQuests } from "../../setup/factories";
+import {
+  describeWithDatabase,
+  getTestDatabase,
+  resetTables,
+} from "../../setup/testDatabase";
 
 /**
  * `profile.getUser` stops shipping achievement definitions and sends progress rows instead; the
- * logbook joins them against the catalogue `quests.getAchievementCatalogue` serves. The two sides
- * have to partition the same way, or an achievement either arrives twice or not at all - which is
- * what these cover, along with the counters the progress row still has to carry.
+ * logbook joins them against the catalogue `quests.getAchievementCatalogue` serves. Both halves
+ * are cut from `fetchPublishedAchievements`, so this suite covers that one list deciding the
+ * partition, the counters a progress row still has to carry, and the predicate behind the list.
  */
 const asObjective = (fields: Record<string, unknown>) =>
   ({ id: "obj-1", task: "pvp_kills", value: 10, ...fields }) as never;
@@ -29,13 +39,13 @@ const asQuest = (
   }) as never;
 
 const asUserQuest = (
-  quest: { id: string; questType: string },
+  definition: { id: string; questType: string },
   extra: Record<string, unknown> = {},
 ) => ({
-  id: quest.id,
+  id: definition.id,
   userId: "u1",
-  questId: quest.id,
-  questType: quest.questType,
+  questId: definition.id,
+  questType: definition.questType,
   completed: 0,
   previousCompletes: 0,
   previousAttempts: 0,
@@ -43,7 +53,7 @@ const asUserQuest = (
   periodStartAt: null,
   endAt: null,
   startedAt: new Date("2020-01-01"),
-  quest,
+  quest: definition,
   ...extra,
 });
 
@@ -56,12 +66,15 @@ const counterAchievement = asQuest("ach-counter", "achievement", [
 const dailyQuest = asQuest("daily-1", "daily", [
   asObjective({ task: "collect_item", sector: 12 }),
 ]);
+const published = [counterAchievement] as unknown as Parameters<
+  typeof splitAchievementProgress
+>[1];
 
 describe("splitAchievementProgress", () => {
-  it("moves counter achievements out of userQuests and drops their definition", () => {
+  it("moves the rows the catalogue publishes and drops their definition", () => {
     const user = asUser([asUserQuest(counterAchievement), asUserQuest(dailyQuest)]);
 
-    const progress = splitAchievementProgress(user);
+    const progress = splitAchievementProgress(user, published);
 
     expect(user.userQuests.map((uq) => uq.questId)).toEqual(["daily-1"]);
     expect(progress).toHaveLength(1);
@@ -79,7 +92,7 @@ describe("splitAchievementProgress", () => {
       }),
     ]);
 
-    const progress = splitAchievementProgress(user);
+    const progress = splitAchievementProgress(user, published);
 
     expect(progress[0]).toMatchObject({
       id: "real-history-row",
@@ -91,47 +104,48 @@ describe("splitAchievementProgress", () => {
     });
   });
 
-  it("keeps an achievement that reaches into the overworld on the user object", () => {
-    // The sector and world-map views read these objectives straight off userQuests, and the
-    // shared catalogue withholds the same quest - so it must not be moved out here either.
-    const placed = asQuest("ach-placed", "achievement", [
+  it("keeps every row the catalogue does not publish", () => {
+    // Hidden achievements, ones the overworld still needs, and rows orphaned by a deleted quest
+    // are all the same rule here: no published definition, so the client could not resolve them.
+    const hidden = asQuest("ach-hidden", "achievement", [asObjective({})], true);
+    const overworld = asQuest("ach-placed", "achievement", [
       asObjective({ task: "defeat_opponents", sector: 42 }),
     ]);
-    const user = asUser([asUserQuest(placed), asUserQuest(counterAchievement)]);
-
-    const progress = splitAchievementProgress(user);
-
-    expect(user.userQuests.map((uq) => uq.questId)).toEqual(["ach-placed"]);
-    expect(progress.map((p) => p.questId)).toEqual(["ach-counter"]);
-  });
-
-  it("keeps a hidden achievement on the user object", () => {
-    // The catalogue publishes non-hidden achievements only, so moving this one would strand a
-    // progress row the client cannot resolve - and staff would stop seeing it in the logbook.
-    const secret = asQuest("ach-hidden", "achievement", [asObjective({})], true);
-    const user = asUser([asUserQuest(secret), asUserQuest(counterAchievement)]);
-
-    const progress = splitAchievementProgress(user);
-
-    expect(user.userQuests.map((uq) => uq.questId)).toEqual(["ach-hidden"]);
-    expect(progress.map((p) => p.questId)).toEqual(["ach-counter"]);
-  });
-
-  it("tolerates an orphaned row whose quest was deleted", () => {
     const user = asUser([
+      asUserQuest(hidden),
+      asUserQuest(overworld),
       { ...asUserQuest(counterAchievement), questId: "orphan", quest: null },
       asUserQuest(counterAchievement),
     ]);
 
-    const progress = splitAchievementProgress(user);
+    const progress = splitAchievementProgress(user, published);
 
-    expect(user.userQuests.map((uq) => uq.questId)).toEqual(["orphan"]);
+    expect(user.userQuests.map((uq) => uq.questId)).toEqual([
+      "ach-hidden",
+      "ach-placed",
+      "orphan",
+    ]);
     expect(progress.map((p) => p.questId)).toEqual(["ach-counter"]);
   });
 
-  it("leaves a user with no achievements untouched", () => {
+  it("decides on the published ids, not on the quest object it was handed", () => {
+    // fetchUpdatedUser rewrites objectives on its own copy of a quest before this runs - trackers
+    // write resolved coordinates back onto them - so re-deciding here could disagree with the
+    // catalogue and strand a progress row that then renders as nothing.
+    const rewritten = asQuest("ach-counter", "achievement", [
+      asObjective({ sector: 7, longitude: 3, latitude: 4 }),
+    ]);
+    const user = asUser([asUserQuest(rewritten)]);
+
+    expect(splitAchievementProgress(user, published).map((p) => p.questId)).toEqual([
+      "ach-counter",
+    ]);
+    expect(user.userQuests).toHaveLength(0);
+  });
+
+  it("leaves a user with no published achievements untouched", () => {
     const user = asUser([asUserQuest(dailyQuest)]);
-    expect(splitAchievementProgress(user)).toEqual([]);
+    expect(splitAchievementProgress(user, published)).toEqual([]);
     expect(user.userQuests).toHaveLength(1);
   });
 });
@@ -141,21 +155,28 @@ describe("questHasOverworldObjectives", () => {
     expect(questHasOverworldObjectives(counterAchievement)).toBe(false);
   });
 
-  it("ignores the zero coordinates every objective carries by default", () => {
-    // Every authored objective serialises sector/longitude/latitude, and an achievement that
-    // never set them stores zeros. Treating those as a location would keep the whole catalogue
-    // inline and undo the split.
-    const zeroed = asQuest("ach-zeroed", "achievement", [
-      asObjective({ sector: 0, longitude: 0, latitude: 0, attackers: [] }),
+  it("counts a stored zero coordinate as a location", () => {
+    // Sector 0 is a real sector and (0, 0) is a real tile, so carrying the field is what matters
+    // - a counter objective has no coordinate keys at all.
+    const atOrigin = asQuest("ach-origin", "achievement", [
+      asObjective({ sector: 0, longitude: 0, latitude: 0 }),
     ]);
-    expect(questHasOverworldObjectives(zeroed)).toBe(false);
+    expect(questHasOverworldObjectives(atOrigin)).toBe(true);
+  });
+
+  it("ignores the empty attacker lists nearly every objective serialises", () => {
+    const noAmbush = asQuest("ach-no-ambush", "achievement", [
+      asObjective({ attackers: [], opponentAIs: [], attackers_max_per_battle: 1 }),
+    ]);
+    expect(questHasOverworldObjectives(noAmbush)).toBe(false);
   });
 
   it.each([
     ["a map location", { sector: 7, longitude: 3, latitude: 4 }],
     ["an ambush", { attackers: ["ai-1"] }],
+    ["named opponents", { opponentAIs: [{ ids: ["ai-1"], number: 1 }] }],
     ["a bound NPC placement", { overworldPlacementId: "placement-1" }],
-    ["a hidden location", { hideLocation: true }],
+    ["a hidden location", { hideLocation: false }],
     ["a dialog", { task: "dialog" }],
   ])("is true for %s", (_label, fields) => {
     expect(
@@ -163,5 +184,49 @@ describe("questHasOverworldObjectives", () => {
         asQuest("ach-overworld", "achievement", [asObjective(fields)]),
       ),
     ).toBe(true);
+  });
+});
+
+/**
+ * The published list is the single source of truth for the split, so it is worth running against
+ * a real MySQL: the `hidden` filter lives in SQL and the overworld filter in TypeScript, and only
+ * both together keep `getUser` and `getAchievementCatalogue` cutting at the same place.
+ */
+describeWithDatabase("fetchPublishedAchievements", () => {
+  const content = (objectives: unknown[]) => ({
+    objectives,
+    reward: {},
+    sceneBackground: "",
+    sceneCharacters: [],
+  }) as never;
+
+  beforeEach(async () => {
+    await resetTables(quest);
+    await insertQuests([
+      {
+        id: "pub-counter",
+        questType: "achievement",
+        content: content([{ id: "o1", task: "pvp_kills", value: 5 }]),
+      },
+      {
+        id: "pub-hidden",
+        questType: "achievement",
+        hidden: true,
+        content: content([{ id: "o1", task: "pvp_kills", value: 5 }]),
+      },
+      {
+        id: "pub-overworld",
+        questType: "achievement",
+        content: content([
+          { id: "o1", task: "defeat_opponents", sector: 0, longitude: 0, latitude: 0 },
+        ]),
+      },
+      { id: "pub-daily", questType: "daily" },
+    ]);
+  });
+
+  it("publishes only the non-hidden achievements the overworld does not need", async () => {
+    const result = await fetchPublishedAchievements(await getTestDatabase());
+    expect(result.map((q) => q.id)).toEqual(["pub-counter"]);
   });
 });

--- a/app/tests/server/api/profile.achievementSplit.test.ts
+++ b/app/tests/server/api/profile.achievementSplit.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { questHasOverworldObjectives } from "@/libs/quest";
+import type { UserWithRelations } from "../../../src/server/api/routers/profile";
+import { splitAchievementProgress } from "../../../src/server/api/routers/profile";
+
+/**
+ * `profile.getUser` stops shipping achievement definitions and sends progress rows instead; the
+ * logbook joins them against the catalogue `quests.getAchievementCatalogue` serves. The two sides
+ * have to partition the same way, or an achievement either arrives twice or not at all - which is
+ * what these cover, along with the counters the progress row still has to carry.
+ */
+const asObjective = (fields: Record<string, unknown>) =>
+  ({ id: "obj-1", task: "pvp_kills", value: 10, ...fields }) as never;
+
+const asQuest = (
+  id: string,
+  questType: string,
+  objectives: unknown[],
+  hidden = false,
+) =>
+  ({
+    id,
+    name: `quest ${id}`,
+    questType,
+    hidden,
+    content: { objectives, reward: {} },
+  }) as never;
+
+const asUserQuest = (
+  quest: { id: string; questType: string },
+  extra: Record<string, unknown> = {},
+) => ({
+  id: quest.id,
+  userId: "u1",
+  questId: quest.id,
+  questType: quest.questType,
+  completed: 0,
+  previousCompletes: 0,
+  previousAttempts: 0,
+  periodCompletes: 0,
+  periodStartAt: null,
+  endAt: null,
+  startedAt: new Date("2020-01-01"),
+  quest,
+  ...extra,
+});
+
+const asUser = (userQuests: unknown[]) =>
+  ({ userQuests }) as unknown as NonNullable<UserWithRelations>;
+
+const counterAchievement = asQuest("ach-counter", "achievement", [
+  asObjective({ task: "pvp_kills", value: 100 }),
+]);
+const dailyQuest = asQuest("daily-1", "daily", [
+  asObjective({ task: "collect_item", sector: 12 }),
+]);
+
+describe("splitAchievementProgress", () => {
+  it("moves counter achievements out of userQuests and drops their definition", () => {
+    const user = asUser([asUserQuest(counterAchievement), asUserQuest(dailyQuest)]);
+
+    const progress = splitAchievementProgress(user);
+
+    expect(user.userQuests.map((uq) => uq.questId)).toEqual(["daily-1"]);
+    expect(progress).toHaveLength(1);
+    expect(progress[0]?.questId).toBe("ach-counter");
+    expect(progress[0]).not.toHaveProperty("quest");
+  });
+
+  it("carries the progress counters the logbook renders", () => {
+    const user = asUser([
+      asUserQuest(counterAchievement, {
+        id: "real-history-row",
+        completed: 1,
+        previousCompletes: 3,
+        previousAttempts: 4,
+      }),
+    ]);
+
+    const progress = splitAchievementProgress(user);
+
+    expect(progress[0]).toMatchObject({
+      id: "real-history-row",
+      questId: "ach-counter",
+      questType: "achievement",
+      completed: 1,
+      previousCompletes: 3,
+      previousAttempts: 4,
+    });
+  });
+
+  it("keeps an achievement that reaches into the overworld on the user object", () => {
+    // The sector and world-map views read these objectives straight off userQuests, and the
+    // shared catalogue withholds the same quest - so it must not be moved out here either.
+    const placed = asQuest("ach-placed", "achievement", [
+      asObjective({ task: "defeat_opponents", sector: 42 }),
+    ]);
+    const user = asUser([asUserQuest(placed), asUserQuest(counterAchievement)]);
+
+    const progress = splitAchievementProgress(user);
+
+    expect(user.userQuests.map((uq) => uq.questId)).toEqual(["ach-placed"]);
+    expect(progress.map((p) => p.questId)).toEqual(["ach-counter"]);
+  });
+
+  it("keeps a hidden achievement on the user object", () => {
+    // The catalogue publishes non-hidden achievements only, so moving this one would strand a
+    // progress row the client cannot resolve - and staff would stop seeing it in the logbook.
+    const secret = asQuest("ach-hidden", "achievement", [asObjective({})], true);
+    const user = asUser([asUserQuest(secret), asUserQuest(counterAchievement)]);
+
+    const progress = splitAchievementProgress(user);
+
+    expect(user.userQuests.map((uq) => uq.questId)).toEqual(["ach-hidden"]);
+    expect(progress.map((p) => p.questId)).toEqual(["ach-counter"]);
+  });
+
+  it("tolerates an orphaned row whose quest was deleted", () => {
+    const user = asUser([
+      { ...asUserQuest(counterAchievement), questId: "orphan", quest: null },
+      asUserQuest(counterAchievement),
+    ]);
+
+    const progress = splitAchievementProgress(user);
+
+    expect(user.userQuests.map((uq) => uq.questId)).toEqual(["orphan"]);
+    expect(progress.map((p) => p.questId)).toEqual(["ach-counter"]);
+  });
+
+  it("leaves a user with no achievements untouched", () => {
+    const user = asUser([asUserQuest(dailyQuest)]);
+    expect(splitAchievementProgress(user)).toEqual([]);
+    expect(user.userQuests).toHaveLength(1);
+  });
+});
+
+describe("questHasOverworldObjectives", () => {
+  it("is false for a quest whose objectives are pure counters", () => {
+    expect(questHasOverworldObjectives(counterAchievement)).toBe(false);
+  });
+
+  it("ignores the zero coordinates every objective carries by default", () => {
+    // Every authored objective serialises sector/longitude/latitude, and an achievement that
+    // never set them stores zeros. Treating those as a location would keep the whole catalogue
+    // inline and undo the split.
+    const zeroed = asQuest("ach-zeroed", "achievement", [
+      asObjective({ sector: 0, longitude: 0, latitude: 0, attackers: [] }),
+    ]);
+    expect(questHasOverworldObjectives(zeroed)).toBe(false);
+  });
+
+  it.each([
+    ["a map location", { sector: 7, longitude: 3, latitude: 4 }],
+    ["an ambush", { attackers: ["ai-1"] }],
+    ["a bound NPC placement", { overworldPlacementId: "placement-1" }],
+    ["a hidden location", { hideLocation: true }],
+    ["a dialog", { task: "dialog" }],
+  ])("is true for %s", (_label, fields) => {
+    expect(
+      questHasOverworldObjectives(
+        asQuest("ach-overworld", "achievement", [asObjective(fields)]),
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Second fix out of the performance audit: `profile.getUser` shipping the whole achievement catalogue on every call.

## The problem

`fetchUpdatedUser` synthesises a `QuestHistory`-shaped entry for every achievement in the game (`mockAchievementHistoryEntries`) and attaches the **full `Quest` row** to each one — every objective with its description, scene assets and reward spec. Achievements are global static content, identical for every player and unchanged unless staff edit them, but they were re-serialised, re-transferred and re-parsed on every `getUser` call, and `getUser` runs on every page load.

Measured through the local test-user broker on a freshly provisioned level-50 account with an empty inventory and no learned jutsu — the floor, not a heavy account:

```
total response              116,417 bytes raw / 15,494 gzip
userData.userQuests          90,265 bytes  (26 entries, 24 of them achievements)
```

## The fix

Split the static catalogue from the per-user progress.

- `profile.getUser` moves achievement rows out of `userData.userQuests` into a new top-level `achievementProgress` field, carrying the progress counters alone.
- A new `quests.getAchievementCatalogue` query serves the definitions, fetched only when the logbook's Achievements tab is open — the one place in the client that renders achievements.
- `LogbookAchievements` joins progress + catalogue + the `questData` trackers it already used.

Both halves are cut from **one list**, `fetchPublishedAchievements`, rather than each re-deciding with a predicate. That matters: by the time `getUser` runs, `fetchUpdatedUser` has rewritten those quests' objectives in place — trackers write resolved coordinates back onto them, and `controlShownQuestLocationInformation` rewrites them again — so a predicate applied there and the same predicate applied to the raw database row can disagree. Cutting both sides from the same list makes the split a partition by construction: nothing is sent twice, and no progress row arrives whose definition the client cannot resolve. It also subsumes the hidden, orphaned and changed-`questType` cases without enumerating them — anything the catalogue does not publish simply keeps travelling on the user object, exactly as before.

An achievement whose objectives **reach into the overworld** is withheld from the catalogue and stays inline, because the sector view, the world map and `getActiveObjectives` read `userQuests[].quest.content.objectives` directly. In current content that is one quest ("Kill the Creator"); the other 29 move.

The list costs no round-trip: the underlying read is request-scoped-memoized (#1478) and `fetchUpdatedUser` has already taken it.

Only `profile.getUser` is affected. `fetchUpdatedUser` itself is untouched, so combat, quest tracking, reward checks and every other server caller still see the full achievement list.

## Validation

Same account, same broker, before/after on one local server:

| | before | after |
|---|---|---|
| `profile.getUser` response | **116,417 raw / 15,494 gzip** | **60,181 raw / 12,001 gzip** |
| `userData.userQuests` | 90,265 B (26 entries) | 26,970 B (3 entries) |
| `achievementProgress` | — | 7,061 B (23 entries) |

**−56 KB raw (−48%) and −3.5 KB gzip (−22%) on every page load.** The raw number is the one that matters most: this is main-thread `JSON.parse` + superjson-deserialize time on the critical path of every navigation and every post-action refresh. Gzip already ate most of the wire cost, because the catalogue is 30 near-identical reward blocks — the win here is CPU, not bandwidth.

Checked independently against production content: 30 non-hidden achievements, 71 KB of `Quest` JSON, and — weighting the per-village variation across the 5,227 accounts active in the last 30 days — a mean of **~49 KB raw removed per `getUser` call** in production, which lands within 2.3% of the broker measurement per entry. Production has **zero** orphaned achievement `QuestHistory` rows and **zero** rows whose `questType` disagrees with their quest, so no progress row can arrive without a resolvable definition.

The counter-cost is one catalogue fetch per session — 76,393 raw / 5,682 gzip — and only for players who open the Achievements tab. Net positive for any session past its second page load. When the Achievements tab is the persisted one, the query batches into the page's existing tRPC request, so it is not even a separate round-trip.

Verified in the browser against a real signed-in account: the Achievements tab renders the same 25 entries as before, with rewards, descriptions, objectives and progress counters intact, and nothing duplicated. `/travel` and `/missionhall` — the other pages that read `userQuests` — show no quest-related console errors.

Also verified against a catalogue that loads but is **short** by two definitions (the endpoint returning `.slice(0, -2)`, standing in for one fetched before staff published an achievement): the banner appears, the list renders 24 entries instead of 25, exactly one automatic refetch goes out — the id-keyed effect does not re-fire when the refetch returns the same rows — and Retry restores all 25 with the banner gone.

And against a forced 500 on the catalogue endpoint: the tab shows a "could not load" banner with a Retry that re-issues the query, and keeps the entries that did arrive on screen rather than replacing them. Worth noting because the obvious guard, `isError`, does **not** work — it reads false through the query's retry backoff, so the first attempt at this rendered nothing and the tab still silently showed a short list. The banner keys on the data instead: definitions absent while progress rows exist.

`make typecheck`, `make lint` and `make test` all pass; 15 new tests cover the partition, the counters, the divergence guard, the overworld predicate and, against a real MySQL, the published list itself.

## Behaviour changes worth knowing

- Completing an achievement mid-combat no longer pops the logbook modal (`Combat.tsx` / `Sector.tsx` look the quest up in `userData.userQuests`). That modal exists to show the *next* objective of a consecutive quest; every achievement in production has exactly one objective, so there was never a next one to show. The achievement still appears — and still auto-claims — in the logbook.
- Content changes still reach players on `getUser`'s own cadence, by three complementary routes: an achievement published or hidden since the last fetch appears as a progress row with no definition and triggers an immediate refetch; an edit to an existing one changes no ids, so a 5-minute `refetchInterval` covers it; and `staleTime` covers remount and refocus, which an interval cannot reach while unmounted. A staff quest edit also invalidates the cache outright.
- The interval is not a tax on the saving: the query is mounted only while the Achievements tab is open, and it polls on the same cadence `getUser` already uses — a poll that previously carried these very definitions to every player on every page. It also pauses while the tab is backgrounded (verified: unchanged across four intervals with the document hidden).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an achievement catalogue showing published, non-overworld achievements.
  * Achievement progress is now tracked and displayed separately from catalogue definitions.
  * Added automatic catalogue refreshes and retry messaging when achievement definitions are unavailable.
  * Quest updates now refresh achievement progress and catalogue data.

* **Bug Fixes**
  * Improved handling of missing, unpublished, or outdated achievement definitions while preserving progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->