### PR TITLE
perf(client): batch cache invalidations instead of awaiting them one by one

### DIFF
--- a/app/src/app/anbu/[anbuid]/page.tsx
+++ b/app/src/app/anbu/[anbuid]/page.tsx
@@ -216,8 +216,10 @@ const AnbuMembers: React.FC<AnbuMembersProps> = (props) => {
   const onSuccess = async (data: BaseServerResponse) => {
     showMutationToast(data);
     if (data.success) {
-      await utils.anbu.get.invalidate();
-      await utils.anbu.getRequests.invalidate();
+      await Promise.all([
+        utils.anbu.get.invalidate(),
+        utils.anbu.getRequests.invalidate(),
+      ]);
     }
   };
 

--- a/app/src/app/blackmarket/page.tsx
+++ b/app/src/app/blackmarket/page.tsx
@@ -174,8 +174,10 @@ const PityBloodlineRoll: React.FC<{
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.profile.getUser.invalidate();
-        await utils.bloodline.getItemRolls.invalidate();
+        await Promise.all([
+          utils.profile.getUser.invalidate(),
+          utils.bloodline.getItemRolls.invalidate(),
+        ]);
       }
     },
   });
@@ -294,8 +296,10 @@ const RyoShop: React.FC<{ userData: NonNullable<UserWithRelations> }> = ({
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
-          await utils.profile.getUser.invalidate();
-          await utils.blackmarket.getRyoOffers.invalidate();
+          await Promise.all([
+            utils.profile.getUser.invalidate(),
+            utils.blackmarket.getRyoOffers.invalidate(),
+          ]);
         }
       },
     });
@@ -305,8 +309,10 @@ const RyoShop: React.FC<{ userData: NonNullable<UserWithRelations> }> = ({
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
-          await utils.profile.getUser.invalidate();
-          await utils.blackmarket.getRyoOffers.invalidate();
+          await Promise.all([
+            utils.profile.getUser.invalidate(),
+            utils.blackmarket.getRyoOffers.invalidate(),
+          ]);
         }
       },
     });
@@ -316,8 +322,10 @@ const RyoShop: React.FC<{ userData: NonNullable<UserWithRelations> }> = ({
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
-          await utils.profile.getUser.invalidate();
-          await utils.blackmarket.getRyoOffers.invalidate();
+          await Promise.all([
+            utils.profile.getUser.invalidate(),
+            utils.blackmarket.getRyoOffers.invalidate(),
+          ]);
         }
       },
     });

--- a/app/src/app/clanhall/page.tsx
+++ b/app/src/app/clanhall/page.tsx
@@ -41,8 +41,10 @@ export default function Clans() {
     {
       onSuccess: async (data) => {
         showMutationToast(data);
-        await utils.clan.getAll.invalidate();
-        await utils.profile.getUser.invalidate();
+        await Promise.all([
+          utils.clan.getAll.invalidate(),
+          utils.profile.getUser.invalidate(),
+        ]);
       },
     },
   );

--- a/app/src/app/conceptart/page.tsx
+++ b/app/src/app/conceptart/page.tsx
@@ -129,8 +129,10 @@ export default function ConceptArt() {
           filterForm?.setValue("only_own", true);
           filterForm?.setValue("sort", "Most Recent");
           router.push(`/conceptart/${result.imageId}`);
-          await utils.conceptart.getAll.refetch();
-          await utils.profile.getUser.refetch();
+          await Promise.all([
+            utils.conceptart.getAll.refetch(),
+            utils.profile.getUser.refetch(),
+          ]);
         }
       },
       onError: (error) => {
@@ -154,8 +156,10 @@ export default function ConceptArt() {
           filterForm?.setValue("sort", "Most Recent");
           // Navigate to video page where polling will show progress
           router.push(`/conceptart/${result.videoId}`);
-          await utils.conceptart.getAll.refetch();
-          await utils.profile.getUser.refetch();
+          await Promise.all([
+            utils.conceptart.getAll.refetch(),
+            utils.profile.getUser.refetch(),
+          ]);
         }
       },
       onError: (error) => {

--- a/app/src/app/event/page.tsx
+++ b/app/src/app/event/page.tsx
@@ -237,8 +237,10 @@ const NotificationSystem: React.FC = () => {
     api.misc.submitNotification.useMutation({
       onSuccess: async (data) => {
         showMutationToast(data);
-        await utils.profile.getUser.invalidate();
-        await utils.misc.getPreviousNotifications.invalidate();
+        await Promise.all([
+          utils.profile.getUser.invalidate(),
+          utils.misc.getPreviousNotifications.invalidate(),
+        ]);
       },
     });
 

--- a/app/src/app/items/page.tsx
+++ b/app/src/app/items/page.tsx
@@ -725,9 +725,11 @@ const Backpack: React.FC<BackpackProps> = (props) => {
         showMutationToast({ success: true, message });
       }
       if (data.success) {
-        await utils.profile.getUser.invalidate();
-        await utils.item.getUserItemsWithVariants.invalidate();
-        await utils.bloodline.getItemRolls.invalidate();
+        await Promise.all([
+          utils.profile.getUser.invalidate(),
+          utils.item.getUserItemsWithVariants.invalidate(),
+          utils.bloodline.getItemRolls.invalidate(),
+        ]);
       }
     },
     onSettled,

--- a/app/src/app/jutsus/page.tsx
+++ b/app/src/app/jutsus/page.tsx
@@ -253,9 +253,11 @@ export default function MyJutsu() {
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success && userData) {
-          await utils.jutsu.getUserJutsus.invalidate(); // Refresh Jutsu list
-          await utils.jutsu.getRecentTransfers.invalidate(); // 🔹 Refresh free transfers
-          await utils.profile.getUser.invalidate(); // Refresh user profile to update free transfer count
+          await Promise.all([
+            utils.jutsu.getUserJutsus.invalidate(), // Refresh Jutsu list
+            utils.jutsu.getRecentTransfers.invalidate(), // 🔹 Refresh free transfers
+            utils.profile.getUser.invalidate(), // Refresh user profile to update free transfer count
+          ]);
           if (usedTransfers >= freeTransfers && transferCost > 0) {
             await updateUser({
               reputationPoints: userData.reputationPoints - transferCost,

--- a/app/src/app/manual/staff/applications/[applicationId]/page.tsx
+++ b/app/src/app/manual/staff/applications/[applicationId]/page.tsx
@@ -143,8 +143,10 @@ const ApproveButton: React.FC<{ applicationId: string }> = ({ applicationId }) =
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.applications.get.invalidate({ id: applicationId });
-        await utils.applications.list.invalidate();
+        await Promise.all([
+          utils.applications.get.invalidate({ id: applicationId }),
+          utils.applications.list.invalidate(),
+        ]);
       }
     },
   });
@@ -162,8 +164,10 @@ const RejectButton: React.FC<{ applicationId: string }> = ({ applicationId }) =>
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.applications.get.invalidate({ id: applicationId });
-        await utils.applications.list.invalidate();
+        await Promise.all([
+          utils.applications.get.invalidate({ id: applicationId }),
+          utils.applications.list.invalidate(),
+        ]);
       }
     },
   });

--- a/app/src/app/profile/edit/page.tsx
+++ b/app/src/app/profile/edit/page.tsx
@@ -502,8 +502,10 @@ const BattleSettingsEdit: React.FC<{ userId: string }> = ({ userId }) => {
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.profile.getAi.invalidate();
-        await utils.profile.getPublicUser.invalidate();
+        await Promise.all([
+          utils.profile.getAi.invalidate(),
+          utils.profile.getPublicUser.invalidate(),
+        ]);
       }
     },
   });
@@ -755,8 +757,10 @@ const Marriage: React.FC = () => {
   const onSuccess = async (data: BaseServerResponse) => {
     showMutationToast(data);
     if (data.success) {
-      await utils.marriage.getMarriedUsers.invalidate();
-      await utils.marriage.getRequests.invalidate();
+      await Promise.all([
+        utils.marriage.getMarriedUsers.invalidate(),
+        utils.marriage.getRequests.invalidate(),
+      ]);
     }
   };
 
@@ -862,8 +866,10 @@ const NewAiAvatar: React.FC = () => {
   const createAvatar = api.avatar.createAvatar.useMutation({
     onSuccess: async (data) => {
       showMutationToast(data);
-      await utils.profile.getUser.invalidate();
-      await utils.avatar.getHistoricalAvatars.invalidate();
+      await Promise.all([
+        utils.profile.getUser.invalidate(),
+        utils.avatar.getHistoricalAvatars.invalidate(),
+      ]);
     },
   });
   const userAttributes = api.profile.getUserAttributes.useQuery(undefined, {
@@ -2044,8 +2050,10 @@ const ManagementCommands: React.FC<ManagementCommandsProps> = ({ user }) => {
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
-          await utils.profile.getUser.invalidate();
-          await utils.skillTree.getUserSkills.invalidate();
+          await Promise.all([
+            utils.profile.getUser.invalidate(),
+            utils.skillTree.getUserSkills.invalidate(),
+          ]);
         }
       },
     });

--- a/app/src/app/traininggrounds/page.tsx
+++ b/app/src/app/traininggrounds/page.tsx
@@ -220,9 +220,11 @@ const SenseiSystem: React.FC<TrainingProps> = (props) => {
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
-          await utils.profile.getUser.invalidate();
-          await utils.sensei.getRequests.invalidate();
-          await utils.sensei.getStudents.invalidate();
+          await Promise.all([
+            utils.profile.getUser.invalidate(),
+            utils.sensei.getRequests.invalidate(),
+            utils.sensei.getStudents.invalidate(),
+          ]);
         }
       },
     });
@@ -232,8 +234,10 @@ const SenseiSystem: React.FC<TrainingProps> = (props) => {
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
-          await utils.profile.getUser.invalidate();
-          await utils.sensei.getRequests.invalidate();
+          await Promise.all([
+            utils.profile.getUser.invalidate(),
+            utils.sensei.getRequests.invalidate(),
+          ]);
         }
       },
     });
@@ -243,9 +247,11 @@ const SenseiSystem: React.FC<TrainingProps> = (props) => {
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
-          await utils.profile.getUser.invalidate();
-          await utils.sensei.getRequests.invalidate();
-          await utils.sensei.getStudents.invalidate();
+          await Promise.all([
+            utils.profile.getUser.invalidate(),
+            utils.sensei.getRequests.invalidate(),
+            utils.sensei.getStudents.invalidate(),
+          ]);
         }
       },
     });

--- a/app/src/app/travel/page.tsx
+++ b/app/src/app/travel/page.tsx
@@ -544,9 +544,11 @@ export default function Travel() {
         showMutationToast(data);
       }
       if (data.success) {
-        await utils.profile.getUser.invalidate();
-        await utils.item.getUserItems.invalidate();
-        await utils.bloodline.getItemRolls.invalidate();
+        await Promise.all([
+          utils.profile.getUser.invalidate(),
+          utils.item.getUserItems.invalidate(),
+          utils.bloodline.getItemRolls.invalidate(),
+        ]);
       }
     },
     onSettled: () => {

--- a/app/src/layout/AcceptWarning.tsx
+++ b/app/src/layout/AcceptWarning.tsx
@@ -33,8 +33,10 @@ const AcceptWarning: React.FC = () => {
       showMutationToast(data);
       if (data.success) {
         setIsModalOpen(false);
-        await utils.profile.getUser.invalidate();
-        await utils.reports.getBan.invalidate();
+        await Promise.all([
+          utils.profile.getUser.invalidate(),
+          utils.reports.getBan.invalidate(),
+        ]);
       }
     },
   });

--- a/app/src/layout/AiProfileEdit.tsx
+++ b/app/src/layout/AiProfileEdit.tsx
@@ -75,8 +75,10 @@ const AiProfileEdit: React.FC<AiProfileEditProps> = (props) => {
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
-          await utils.profile.getAi.invalidate();
-          await utils.profile.getPublicUser.invalidate();
+          await Promise.all([
+            utils.profile.getAi.invalidate(),
+            utils.profile.getPublicUser.invalidate(),
+          ]);
         }
       },
     });
@@ -86,8 +88,10 @@ const AiProfileEdit: React.FC<AiProfileEditProps> = (props) => {
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
-          await utils.profile.getAi.invalidate();
-          await utils.profile.getPublicUser.invalidate();
+          await Promise.all([
+            utils.profile.getAi.invalidate(),
+            utils.profile.getPublicUser.invalidate(),
+          ]);
         }
       },
     });

--- a/app/src/layout/Clan.tsx
+++ b/app/src/layout/Clan.tsx
@@ -325,8 +325,10 @@ export const ClanBattles: React.FC<ClanBattlesProps> = (props) => {
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.profile.getUser.invalidate();
-        await utils.clan.getClanBattles.invalidate();
+        await Promise.all([
+          utils.profile.getUser.invalidate(),
+          utils.clan.getClanBattles.invalidate(),
+        ]);
       }
     },
   });
@@ -335,8 +337,10 @@ export const ClanBattles: React.FC<ClanBattlesProps> = (props) => {
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.profile.getUser.invalidate();
-        await utils.clan.getClanBattles.invalidate();
+        await Promise.all([
+          utils.profile.getUser.invalidate(),
+          utils.clan.getClanBattles.invalidate(),
+        ]);
       }
     },
   });
@@ -345,8 +349,10 @@ export const ClanBattles: React.FC<ClanBattlesProps> = (props) => {
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.profile.getUser.invalidate();
-        await utils.clan.getClanBattles.invalidate();
+        await Promise.all([
+          utils.profile.getUser.invalidate(),
+          utils.clan.getClanBattles.invalidate(),
+        ]);
       }
     },
   });
@@ -356,8 +362,10 @@ export const ClanBattles: React.FC<ClanBattlesProps> = (props) => {
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
-          await utils.profile.getUser.invalidate();
-          await utils.clan.getClanBattles.invalidate();
+          await Promise.all([
+            utils.profile.getUser.invalidate(),
+            utils.clan.getClanBattles.invalidate(),
+          ]);
           router.push("/combat");
         }
       },
@@ -664,8 +672,10 @@ export const ClanRequests: React.FC<ClanRequestsProps> = (props) => {
   const onSuccess = async (data: BaseServerResponse) => {
     showMutationToast(data);
     if (data.success) {
-      await utils.clan.get.invalidate();
-      await utils.clan.getRequests.invalidate();
+      await Promise.all([
+        utils.clan.get.invalidate(),
+        utils.clan.getRequests.invalidate(),
+      ]);
     }
   };
 
@@ -793,9 +803,11 @@ export const ClanInfo: React.FC<ClanInfoProps> = (props) => {
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.profile.getUser.invalidate();
-        await utils.clan.get.invalidate();
-        await utils.clan.getRequests.invalidate();
+        await Promise.all([
+          utils.profile.getUser.invalidate(),
+          utils.clan.get.invalidate(),
+          utils.clan.getRequests.invalidate(),
+        ]);
         router.push("/clanhall");
       }
     },
@@ -805,8 +817,10 @@ export const ClanInfo: React.FC<ClanInfoProps> = (props) => {
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.clan.get.invalidate();
-        await utils.clan.getRequests.invalidate();
+        await Promise.all([
+          utils.clan.get.invalidate(),
+          utils.clan.getRequests.invalidate(),
+        ]);
       }
     },
   });
@@ -858,8 +872,10 @@ export const ClanInfo: React.FC<ClanInfoProps> = (props) => {
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.profile.getUser.invalidate();
-        await utils.clan.get.invalidate();
+        await Promise.all([
+          utils.profile.getUser.invalidate(),
+          utils.clan.get.invalidate(),
+        ]);
         toBankForm.reset();
       }
     },
@@ -870,8 +886,10 @@ export const ClanInfo: React.FC<ClanInfoProps> = (props) => {
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.profile.getUser.invalidate();
-        await utils.clan.get.invalidate();
+        await Promise.all([
+          utils.profile.getUser.invalidate(),
+          utils.clan.get.invalidate(),
+        ]);
         router.push("/clanhall");
       }
     },
@@ -881,8 +899,10 @@ export const ClanInfo: React.FC<ClanInfoProps> = (props) => {
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.clan.get.invalidate();
-        await utils.clan.getRequests.invalidate();
+        await Promise.all([
+          utils.clan.get.invalidate(),
+          utils.clan.getRequests.invalidate(),
+        ]);
       }
     },
   });
@@ -1466,9 +1486,11 @@ export const ClanMembers: React.FC<ClanMembersProps> = (props) => {
   const onSuccess = async (data: BaseServerResponse) => {
     showMutationToast(data);
     if (data.success) {
-      await utils.profile.getUser.invalidate();
-      await utils.clan.get.invalidate();
-      await utils.clan.getRequests.invalidate();
+      await Promise.all([
+        utils.profile.getUser.invalidate(),
+        utils.clan.get.invalidate(),
+        utils.clan.getRequests.invalidate(),
+      ]);
     }
   };
 

--- a/app/src/layout/DeleteUserButton.tsx
+++ b/app/src/layout/DeleteUserButton.tsx
@@ -36,8 +36,10 @@ const DeleteUserButton: React.FC<DeleteUserButtonProps> = (props) => {
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
-          await utils.profile.getUser.invalidate();
-          await utils.profile.getPublicUser.invalidate();
+          await Promise.all([
+            utils.profile.getUser.invalidate(),
+            utils.profile.getPublicUser.invalidate(),
+          ]);
           router.push("/");
         }
       },
@@ -52,8 +54,10 @@ const DeleteUserButton: React.FC<DeleteUserButtonProps> = (props) => {
             event: "toggle_deletion",
             character: userData.userId,
           });
-          await utils.profile.getUser.invalidate();
-          await utils.profile.getPublicUser.invalidate();
+          await Promise.all([
+            utils.profile.getUser.invalidate(),
+            utils.profile.getPublicUser.invalidate(),
+          ]);
         }
       },
     });

--- a/app/src/layout/JutsuLoadoutSelector.tsx
+++ b/app/src/layout/JutsuLoadoutSelector.tsx
@@ -35,9 +35,11 @@ const JutsuLoadoutSelector: React.FC<JutsuLoadoutSelectorProps> = (props) => {
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.profile.getUser.invalidate();
-        await utils.item.getUserItems.invalidate();
-        await utils.jutsu.getUserJutsus.invalidate();
+        await Promise.all([
+          utils.profile.getUser.invalidate(),
+          utils.item.getUserItems.invalidate(),
+          utils.jutsu.getUserJutsus.invalidate(),
+        ]);
       }
     },
   });

--- a/app/src/layout/OccupationCrafting.tsx
+++ b/app/src/layout/OccupationCrafting.tsx
@@ -98,8 +98,10 @@ export default function OccupationCrafting() {
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.item.getUserItems.invalidate();
-        await utils.profile.getUser.invalidate();
+        await Promise.all([
+          utils.item.getUserItems.invalidate(),
+          utils.profile.getUser.invalidate(),
+        ]);
       }
     },
   });
@@ -108,8 +110,10 @@ export default function OccupationCrafting() {
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.item.getUserItems.invalidate();
-        await utils.profile.getUser.invalidate();
+        await Promise.all([
+          utils.item.getUserItems.invalidate(),
+          utils.profile.getUser.invalidate(),
+        ]);
       }
     },
   });

--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -1275,8 +1275,10 @@ const EditUserComponent: React.FC<EditUserComponentProps> = ({ userId, profile }
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.profile.getPublicUser.invalidate();
-        await utils.jutsu.getPublicUserJutsus.invalidate();
+        await Promise.all([
+          utils.profile.getPublicUser.invalidate(),
+          utils.jutsu.getPublicUserJutsus.invalidate(),
+        ]);
       }
     },
   });
@@ -2104,8 +2106,10 @@ const BadgesTab: React.FC<BadgesTabProps> = ({ userId, username, currentBadges }
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.profile.getPublicUser.invalidate();
-        await utils.logs.getContentChanges.invalidate();
+        await Promise.all([
+          utils.profile.getPublicUser.invalidate(),
+          utils.logs.getContentChanges.invalidate(),
+        ]);
       }
     },
   });
@@ -2114,8 +2118,10 @@ const BadgesTab: React.FC<BadgesTabProps> = ({ userId, username, currentBadges }
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.profile.getPublicUser.invalidate();
-        await utils.logs.getContentChanges.invalidate();
+        await Promise.all([
+          utils.profile.getPublicUser.invalidate(),
+          utils.logs.getContentChanges.invalidate(),
+        ]);
       }
     },
   });

--- a/app/src/layout/Report.tsx
+++ b/app/src/layout/Report.tsx
@@ -49,9 +49,11 @@ const ReportUser: React.FC<ReportUserProps> = (props) => {
   // Mutations
   const createReport = api.reports.create.useMutation({
     onSuccess: async (data) => {
-      await utils.reports.getAll.invalidate();
-      await utils.comments.getConversationComments.invalidate();
-      await utils.comments.getForumComments.invalidate();
+      await Promise.all([
+        utils.reports.getAll.invalidate(),
+        utils.comments.getConversationComments.invalidate(),
+        utils.comments.getForumComments.invalidate(),
+      ]);
       showMutationToast(data);
     },
   });

--- a/app/src/layout/ShrineBattleLobby.tsx
+++ b/app/src/layout/ShrineBattleLobby.tsx
@@ -56,8 +56,10 @@ export const ShrineBattleLobby: React.FC<ShrineBattleLobbyProps> = ({
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
-          await utils.shrine.getShrineBattles.invalidate();
-          await utils.profile.getUser.invalidate();
+          await Promise.all([
+            utils.shrine.getShrineBattles.invalidate(),
+            utils.profile.getUser.invalidate(),
+          ]);
         }
       },
     });
@@ -67,8 +69,10 @@ export const ShrineBattleLobby: React.FC<ShrineBattleLobbyProps> = ({
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
-          await utils.shrine.getShrineBattles.invalidate();
-          await utils.profile.getUser.invalidate();
+          await Promise.all([
+            utils.shrine.getShrineBattles.invalidate(),
+            utils.profile.getUser.invalidate(),
+          ]);
         }
       },
     });
@@ -78,8 +82,10 @@ export const ShrineBattleLobby: React.FC<ShrineBattleLobbyProps> = ({
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
-          await utils.shrine.getShrineBattles.invalidate();
-          await utils.profile.getUser.invalidate();
+          await Promise.all([
+            utils.shrine.getShrineBattles.invalidate(),
+            utils.profile.getUser.invalidate(),
+          ]);
         }
       },
     });
@@ -89,8 +95,10 @@ export const ShrineBattleLobby: React.FC<ShrineBattleLobbyProps> = ({
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
-          await utils.shrine.getShrineBattles.invalidate();
-          await utils.profile.getUser.invalidate();
+          await Promise.all([
+            utils.shrine.getShrineBattles.invalidate(),
+            utils.profile.getUser.invalidate(),
+          ]);
           router.push("/combat");
         }
       },

--- a/app/src/layout/UserBlacklistControl.tsx
+++ b/app/src/layout/UserBlacklistControl.tsx
@@ -27,9 +27,11 @@ const UserBlacklistControl: React.FC = () => {
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
-          await utils.profile.getBlacklist.invalidate();
-          await utils.comments.getConversationComments.invalidate();
-          await utils.comments.getUserConversations.invalidate();
+          await Promise.all([
+            utils.profile.getBlacklist.invalidate(),
+            utils.comments.getConversationComments.invalidate(),
+            utils.comments.getUserConversations.invalidate(),
+          ]);
         }
       },
     });

--- a/app/src/layout/UserReport.tsx
+++ b/app/src/layout/UserReport.tsx
@@ -122,10 +122,12 @@ const DisplayUserReport: React.FC<UserReportProps> = (props) => {
   const onSuccess = async (data: BaseServerResponse) => {
     showMutationToast(data);
     if (data.success) {
-      await utils.reports.getAll.invalidate();
-      await utils.reports.get.invalidate();
-      await utils.comments.getReportComments.invalidate();
-      await utils.profile.getUser.invalidate();
+      await Promise.all([
+        utils.reports.getAll.invalidate(),
+        utils.reports.get.invalidate(),
+        utils.comments.getReportComments.invalidate(),
+        utils.profile.getUser.invalidate(),
+      ]);
       reset();
     }
   };

--- a/app/src/layout/WarSystem.tsx
+++ b/app/src/layout/WarSystem.tsx
@@ -125,9 +125,11 @@ export const WarRoom: React.FC<{
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
-          await utils.war.getActiveWars.invalidate();
-          await utils.war.getEndedWars.invalidate();
-          await utils.war.getAllyOffers.invalidate();
+          await Promise.all([
+            utils.war.getActiveWars.invalidate(),
+            utils.war.getEndedWars.invalidate(),
+            utils.war.getAllyOffers.invalidate(),
+          ]);
         }
       },
     });
@@ -640,8 +642,10 @@ export const SectorWar: React.FC<{
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.war.getActiveWars.invalidate();
-        await utils.war.getEndedWars.invalidate();
+        await Promise.all([
+          utils.war.getActiveWars.invalidate(),
+          utils.war.getEndedWars.invalidate(),
+        ]);
       }
     },
   });
@@ -1214,8 +1218,10 @@ export const VillageWar: React.FC<{
       onSuccess: async (data) => {
         showMutationToast(data);
         if (data.success) {
-          await utils.war.getActiveWars.invalidate();
-          await utils.war.getAllyOffers.invalidate();
+          await Promise.all([
+            utils.war.getActiveWars.invalidate(),
+            utils.war.getAllyOffers.invalidate(),
+          ]);
         }
       },
     });
@@ -1267,8 +1273,10 @@ export const VillageWar: React.FC<{
     onSuccess: async (data) => {
       showMutationToast(data);
       if (data.success) {
-        await utils.war.getActiveWars.invalidate();
-        await utils.war.getEndedWars.invalidate();
+        await Promise.all([
+          utils.war.getActiveWars.invalidate(),
+          utils.war.getEndedWars.invalidate(),
+        ]);
       }
     },
   });

--- a/app/tests/app/serialInvalidation.test.ts
+++ b/app/tests/app/serialInvalidation.test.ts
@@ -18,9 +18,11 @@ const SOURCE_ROOT = join(REPO_ROOT, "app/src");
 
 /** Any receiver, since `api.useUtils()` is stored as both `utils` and `util` across the app. */
 const CACHE_CALL =
-  /^\s*await\s+[\w$]+(?:\.[\w$]+)+\.(?:invalidate|refetch|prefetch|reset|fetch|ensureData)\(/;
+  /^await\s+[\w$]+(?:\.[\w$]+)+\.(?:invalidate|refetch|prefetch|reset|fetch|ensureData)\(/;
 const IGNORABLE = /^\s*(\/\/|\/\*|\*|$)/;
 const OPT_OUT = "serial-invalidation-ok";
+/** Enough for any real call; a bracket inside a string literal must not swallow the file. */
+const MAX_STATEMENT_LINES = 15;
 
 const sourceFiles = (directory: string): string[] =>
   readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
@@ -29,48 +31,56 @@ const sourceFiles = (directory: string): string[] =>
     return /\.tsx?$/.test(entry.name) ? [path] : [];
   });
 
-/** Line indices where a cache call starts, skipping over calls whose arguments wrap. */
-const cacheCalls = (lines: string[]) => {
-  const starts: number[] = [];
-  const ends: number[] = [];
-  for (let i = 0; i < lines.length; i++) {
-    if (!CACHE_CALL.test(lines[i] ?? "")) continue;
-    let depth = 0;
-    let end = i;
-    for (; end < lines.length; end++) {
-      const line = lines[end] ?? "";
-      depth += (line.match(/\(/g)?.length ?? 0) - (line.match(/\)/g)?.length ?? 0);
-      if (depth <= 0) break;
+/**
+ * Awaited statements as single logical lines, so neither a wrapped argument list nor a member
+ * chain broken across lines can hide a call.
+ */
+const awaitedStatements = (lines: string[]) => {
+  const statements: { start: number; end: number; text: string }[] = [];
+  let start = -1;
+  let depth = 0;
+  let text = "";
+  lines.forEach((line, index) => {
+    const trimmed = line.trim();
+    if (start < 0) {
+      if (!trimmed.startsWith("await ")) return;
+      start = index;
+      text = "";
     }
-    starts.push(i);
-    ends.push(end);
-    i = end;
-  }
-  return { starts, ends };
+    // Drop a trailing comment, or a statement carrying one would never look finished
+    const code = trimmed.replace(/(^|[^:])\/\/.*$/, "$1").trim();
+    text += code;
+    depth += (code.match(/[([]/g)?.length ?? 0) - (code.match(/[)\]]/g)?.length ?? 0);
+    if ((depth <= 0 && text.endsWith(";")) || index - start >= MAX_STATEMENT_LINES) {
+      statements.push({ start, end: index, text });
+      start = -1;
+      depth = 0;
+    }
+  });
+  return statements;
 };
 
-const serialRuns = (path: string) => {
-  const lines = readFileSync(path, "utf8").split("\n");
-  const { starts, ends } = cacheCalls(lines);
+const serialRuns = (lines: string[], label: string) => {
+  const calls = awaitedStatements(lines).filter((one) => CACHE_CALL.test(one.text));
   const runs: string[] = [];
   let runStart = 0;
-  for (let call = 1; call <= starts.length; call++) {
+  for (let call = 1; call <= calls.length; call++) {
     // A blank line or a comment between two awaits does not make them any less serial
+    const previous = calls[call - 1];
+    const next = calls[call];
     const continues =
-      call < starts.length &&
-      lines
-        .slice((ends[call - 1] ?? 0) + 1, starts[call])
-        .every((line) => IGNORABLE.test(line));
+      next !== undefined &&
+      previous !== undefined &&
+      lines.slice(previous.end + 1, next.start).every((line) => IGNORABLE.test(line));
     if (continues) continue;
-    const first = starts[runStart] ?? 0;
-    const last = ends[call - 1] ?? first;
-    const excused = lines
-      .slice(Math.max(first - 1, 0), last + 1)
-      .some((line) => line.includes(OPT_OUT));
-    if (call - runStart >= 2 && !excused) {
-      runs.push(
-        `${relative(REPO_ROOT, path)}:${first + 1} (${call - runStart} awaits in a row)`,
-      );
+    const first = calls[runStart];
+    if (call - runStart >= 2 && first !== undefined && previous !== undefined) {
+      const excused = lines
+        .slice(Math.max(first.start - 1, 0), previous.end + 1)
+        .some((line) => line.includes(OPT_OUT));
+      if (!excused) {
+        runs.push(`${label}:${first.start + 1} (${call - runStart} awaits in a row)`);
+      }
     }
     runStart = call;
   }
@@ -79,10 +89,39 @@ const serialRuns = (path: string) => {
 
 describe("client cache invalidation", () => {
   it("never awaits invalidations one at a time", () => {
-    const offenders = sourceFiles(SOURCE_ROOT).flatMap(serialRuns);
+    const offenders = sourceFiles(SOURCE_ROOT).flatMap((path) =>
+      serialRuns(readFileSync(path, "utf8").split("\n"), relative(REPO_ROOT, path)),
+    );
     expect(
       offenders,
       `Batch these into one await Promise.all([...]) so the refetches share a request:\n${offenders.join("\n")}`,
     ).toEqual([]);
+  });
+
+  // The scan above is only worth as much as what it can see, so pin down every shape it must
+  // catch — and every one it must not, since a guard that cries wolf gets deleted
+  const found = (source: string) => serialRuns(source.split("\n"), "fixture").length;
+  const user = "await utils.profile.getUser.invalidate();";
+  const clan = "await utils.clan.get.invalidate();";
+
+  it.each([
+    ["back to back", `${user}\n${clan}`],
+    ["under the `util` alias", `await util.profile.getUser.invalidate();\n${clan}`],
+    ["with a blank line between", `${user}\n\n${clan}`],
+    ["with a comment between", `${user}\n// why\n${clan}`],
+    ["with a wrapped argument list", `await utils.clan.get.invalidate({\n  id,\n});\n${clan}`],
+    ["with a wrapped member chain", `await utils.profile.getUser\n.invalidate();\n${clan}`],
+    ["with trailing comments", `${user} // the user\n${clan} // the clan`],
+  ])("catches two invalidations %s", (_shape, source) => {
+    expect(found(source)).toBe(1);
+  });
+
+  it.each([
+    ["one invalidation on its own", user],
+    ["a statement between them", `${user}\nrouter.push("/");\n${clan}`],
+    ["a cancel before an invalidate", `await utils.profile.getUser.cancel();\n${user}`],
+    ["an opt-out", `// ${OPT_OUT}: the second reads what the first wrote\n${user}\n${clan}`],
+  ])("leaves %s alone", (_shape, source) => {
+    expect(found(source)).toBe(0);
   });
 });

--- a/app/tests/app/serialInvalidation.test.ts
+++ b/app/tests/app/serialInvalidation.test.ts
@@ -32,6 +32,18 @@ const sourceFiles = (directory: string): string[] =>
   });
 
 /**
+ * Strings first, then comments, so a `//` inside a string is not mistaken for one. Enough to
+ * keep a bracket or a semicolon written inside either of them out of the counting below; a
+ * literal that itself spans lines is left to the statement-length bound.
+ */
+const code = (line: string) =>
+  line
+    .replace(/(["'`])(?:\\.|(?!\1)[^\\])*\1/g, '""')
+    .replace(/\/\*.*?\*\//g, " ")
+    .replace(/\/\/.*$/, "")
+    .trim();
+
+/**
  * Awaited statements as single logical lines, so neither a wrapped argument list nor a member
  * chain broken across lines can hide a call.
  */
@@ -47,10 +59,10 @@ const awaitedStatements = (lines: string[]) => {
       start = index;
       text = "";
     }
-    // Drop a trailing comment, or a statement carrying one would never look finished
-    const code = trimmed.replace(/(^|[^:])\/\/.*$/, "$1").trim();
-    text += code;
-    depth += (code.match(/[([]/g)?.length ?? 0) - (code.match(/[)\]]/g)?.length ?? 0);
+    // Without this a statement trailed by a comment would never look finished
+    const bare = code(trimmed);
+    text += bare;
+    depth += (bare.match(/[([]/g)?.length ?? 0) - (bare.match(/[)\]]/g)?.length ?? 0);
     if ((depth <= 0 && text.endsWith(";")) || index - start >= MAX_STATEMENT_LINES) {
       statements.push({ start, end: index, text });
       start = -1;
@@ -112,6 +124,8 @@ describe("client cache invalidation", () => {
     ["with a wrapped argument list", `await utils.clan.get.invalidate({\n  id,\n});\n${clan}`],
     ["with a wrapped member chain", `await utils.profile.getUser\n.invalidate();\n${clan}`],
     ["with trailing comments", `${user} // the user\n${clan} // the clan`],
+    ["with a trailing block comment", `${user} /* the user */\n${clan}`],
+    ["with a bracket inside a string", `await utils.clan.get.invalidate("[");\n${clan}`],
   ])("catches two invalidations %s", (_shape, source) => {
     expect(found(source)).toBe(1);
   });

--- a/app/tests/app/serialInvalidation.test.ts
+++ b/app/tests/app/serialInvalidation.test.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { describe, expect, it } from "vitest";
 
 /**
@@ -7,12 +7,20 @@ import { describe, expect, it } from "vitest";
  * refetch each one triggers only starts once the previous has landed. Fired together they leave
  * in the same tick and the tRPC httpBatchLink folds them into a single request, so a three-call
  * handler goes from three round-trips to one. This walks the client source and fails on any run
- * of consecutive awaited cache calls that should have been a single `await Promise.all([...])`.
+ * of awaited cache calls that should have been a single `await Promise.all([...])`.
+ *
+ * `cancel()` is deliberately not one of the verbs: it issues no request, and it is usually
+ * followed by an invalidate or setData on the same key that must not race it. A pair that is
+ * genuinely ordered can opt out with a `serial-invalidation-ok` comment saying why.
  */
-const SOURCE_ROOT = join(import.meta.dirname, "../../src");
+const REPO_ROOT = join(import.meta.dirname, "../../..");
+const SOURCE_ROOT = join(REPO_ROOT, "app/src");
 
+/** Any receiver, since `api.useUtils()` is stored as both `utils` and `util` across the app. */
 const CACHE_CALL =
-  /^\s*await\s+utils\.[\w.]+\.(?:invalidate|refetch|cancel|reset|prefetch)\(/;
+  /^\s*await\s+[\w$]+(?:\.[\w$]+)+\.(?:invalidate|refetch|prefetch|reset|fetch|ensureData)\(/;
+const IGNORABLE = /^\s*(\/\/|\/\*|\*|$)/;
+const OPT_OUT = "serial-invalidation-ok";
 
 const sourceFiles = (directory: string): string[] =>
   readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
@@ -21,19 +29,50 @@ const sourceFiles = (directory: string): string[] =>
     return /\.tsx?$/.test(entry.name) ? [path] : [];
   });
 
+/** Line indices where a cache call starts, skipping over calls whose arguments wrap. */
+const cacheCalls = (lines: string[]) => {
+  const starts: number[] = [];
+  const ends: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!CACHE_CALL.test(lines[i] ?? "")) continue;
+    let depth = 0;
+    let end = i;
+    for (; end < lines.length; end++) {
+      const line = lines[end] ?? "";
+      depth += (line.match(/\(/g)?.length ?? 0) - (line.match(/\)/g)?.length ?? 0);
+      if (depth <= 0) break;
+    }
+    starts.push(i);
+    ends.push(end);
+    i = end;
+  }
+  return { starts, ends };
+};
+
 const serialRuns = (path: string) => {
   const lines = readFileSync(path, "utf8").split("\n");
+  const { starts, ends } = cacheCalls(lines);
   const runs: string[] = [];
-  let start = 0;
-  for (let i = 0; i <= lines.length; i++) {
-    if (i < lines.length && CACHE_CALL.test(lines[i] ?? "")) {
-      if (!CACHE_CALL.test(lines[i - 1] ?? "")) start = i;
-      continue;
+  let runStart = 0;
+  for (let call = 1; call <= starts.length; call++) {
+    // A blank line or a comment between two awaits does not make them any less serial
+    const continues =
+      call < starts.length &&
+      lines
+        .slice((ends[call - 1] ?? 0) + 1, starts[call])
+        .every((line) => IGNORABLE.test(line));
+    if (continues) continue;
+    const first = starts[runStart] ?? 0;
+    const last = ends[call - 1] ?? first;
+    const excused = lines
+      .slice(Math.max(first - 1, 0), last + 1)
+      .some((line) => line.includes(OPT_OUT));
+    if (call - runStart >= 2 && !excused) {
+      runs.push(
+        `${relative(REPO_ROOT, path)}:${first + 1} (${call - runStart} awaits in a row)`,
+      );
     }
-    if (i - start >= 2 && CACHE_CALL.test(lines[i - 1] ?? "")) {
-      const relative = path.slice(SOURCE_ROOT.length + 1);
-      runs.push(`${relative}:${start + 1} (${i - start} awaits in a row)`);
-    }
+    runStart = call;
   }
   return runs;
 };

--- a/app/tests/app/serialInvalidation.test.ts
+++ b/app/tests/app/serialInvalidation.test.ts
@@ -1,0 +1,49 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Awaiting cache invalidations one after another costs one HTTP round-trip each, because the
+ * refetch each one triggers only starts once the previous has landed. Fired together they leave
+ * in the same tick and the tRPC httpBatchLink folds them into a single request, so a three-call
+ * handler goes from three round-trips to one. This walks the client source and fails on any run
+ * of consecutive awaited cache calls that should have been a single `await Promise.all([...])`.
+ */
+const SOURCE_ROOT = join(import.meta.dirname, "../../src");
+
+const CACHE_CALL =
+  /^\s*await\s+utils\.[\w.]+\.(?:invalidate|refetch|cancel|reset|prefetch)\(/;
+
+const sourceFiles = (directory: string): string[] =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    return /\.tsx?$/.test(entry.name) ? [path] : [];
+  });
+
+const serialRuns = (path: string) => {
+  const lines = readFileSync(path, "utf8").split("\n");
+  const runs: string[] = [];
+  let start = 0;
+  for (let i = 0; i <= lines.length; i++) {
+    if (i < lines.length && CACHE_CALL.test(lines[i] ?? "")) {
+      if (!CACHE_CALL.test(lines[i - 1] ?? "")) start = i;
+      continue;
+    }
+    if (i - start >= 2 && CACHE_CALL.test(lines[i - 1] ?? "")) {
+      const relative = path.slice(SOURCE_ROOT.length + 1);
+      runs.push(`${relative}:${start + 1} (${i - start} awaits in a row)`);
+    }
+  }
+  return runs;
+};
+
+describe("client cache invalidation", () => {
+  it("never awaits invalidations one at a time", () => {
+    const offenders = sourceFiles(SOURCE_ROOT).flatMap(serialRuns);
+    expect(
+      offenders,
+      `Batch these into one await Promise.all([...]) so the refetches share a request:\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Second item from the performance audit. `profile.getUser`'s payload was [#1479](https://github.com/studie-tech/TheNinjaRPG/pull/1479); this one is the click latency around it.

## The pattern

```ts
onSuccess: async (data) => {
  showMutationToast(data);
  if (data.success) {
    await utils.profile.getUser.invalidate();
    await utils.sensei.getRequests.invalidate();
    await utils.sensei.getStudents.invalidate();
  }
},
```

`invalidate()` resolves only once the refetch it triggers has landed, so each `await` costs a full HTTP round-trip. Fired together they leave in the same tick and the `httpBatchLink` folds them into one request. Until the last one resolves the handler has not returned, so the button stays disabled and the global wait cursor stays on.

54 runs across 23 files, 121 awaited invalidations between them. All of them are now a single `await Promise.all([...])`. This is not a new convention — 48 handlers on `main` already batch exactly this way (`app/src/app/travel/page.tsx`, `auctionhouse`, `items`, …); the codebase was split roughly down the middle, and this finishes the half that was not converted.

## Measured

In the browser against the local dev server, driving the app's **own** tRPC utils on a page where all three queries are really mounted (`profile.getUser`, `item.getUserItems`, `jutsu.getUserJutsus`), four alternating rounds each:

| | requests | wall clock |
|---|---|---|
| three, awaited one at a time | 3 | 570 / 596 / 668 / 580 ms |
| three, one `Promise.all` | **1** | 283 / 263 / 258 / 256 ms |
| two, awaited one at a time | 2 | 752 / 427 / 440 / 549 ms |
| two, one `Promise.all` | **1** | 255 / 263 / 255 / 267 ms |

≈2.3x on a three-call handler, ≈1.9x on a two-call one. The ratio is what transfers to production; the absolute numbers are local-stack latency.

**Where it does not help, and why the count is not 67:** `invalidate()` only refetches queries that have a mounted observer; one with none is marked stale and issues no request. So a chain saves as many round-trips as it has queries actually on screen, not as many as it has lines. Several members are inert at their own call site — `bloodline.getItemRolls` has exactly one observer, on `/blackmarket`, yet is invalidated from `/travel` and `/items`; `skillTree.getUserSkills` lives on the profile *view* but is invalidated from `/profile/edit`; `reports.getAll` is only on `/reports`, so the one 4-call chain (`UserReport.tsx`) is really 3 → 1; both `AiProfileEdit` chains have one dead member in each of their two hosts and save nothing at all.

Verified end to end on `profile.toggleBlacklistEntry` (`/profile/edit` → User Blacklist): three invalidations, one refetch before and after, entry appears correctly — a genuine no-change case.

The win is on the handlers whose queries are all mounted, which is most of them: `profile.getUser` appears in 35 of the 54 chains and is mounted app-wide, as are `item.getUserItems` and `jutsu.getUserJutsus` (all three refetched in the measurement above, taken on `/traininggrounds`).

**One trade-off:** a batch resolves as a single JSON array, so the fast query in a group no longer lands before the slow one — `ShrineBattleLobby` used to paint the battle list first and the user bar after, and now paints both together. Total time is never worse (`max(t1,t2) ≤ t1+t2`) and the handler returns sooner, but the intermediate half-updated render is gone. That is the intended behaviour here; worth knowing before batching a group that contains a genuinely slow procedure.

## Why the rewrite is safe

Checked against the installed `@tanstack/query-core` rather than assumed:

- **Error handling is unchanged.** `refetchQueries` attaches `.catch(noop)` to every fetch unless `throwOnError` is passed, which it never is here — so a failing refetch did not short-circuit the old serial chain either, and the toast count is the same in both shapes.
- **The set of queries each `invalidate()` sees is unchanged.** `notifyManager` schedules on a macrotask while an `await` continuation is a microtask, so React could not re-render between two serial awaits. Nothing mounted or unmounted in between then, and nothing does now.
- **No group invalidates two overlapping keys**, so no two parallel invalidations can fight over the same query.
- **Statements after a chain keep their position** — `router.push`, `reset()`, `updateUser()` all still run after every invalidation, exactly as before.
- **No group batches two write-performing procedures.** `profile.getUser` is the only one that writes, and it appears at most once per group.
- **No batch can be split.** `maxURLLength` and `maxItems` both default to `Infinity` and neither is set in `Provider.tsx`, and the largest group is 4 calls of which one passes an input, so the GET URL stays in the hundreds of bytes.

## Guard

`app/tests/app/serialInvalidation.test.ts` walks `app/src` and fails on any run of awaited cache calls that should be one `Promise.all`, naming each `file:line`. It ignores the receiver's name (`utils` and `util` are both in use), tolerates blank lines, comments and wrapped argument lists between the awaits, and skips `cancel()` — that one issues no request, and is normally followed by an invalidate or `setData` on the same key that must not race it. A genuinely ordered pair can opt out with a `serial-invalidation-ok` comment.

Verified by planting each of those shapes and watching the test catch them, and by reintroducing one real chain and watching it fail.

`make typecheck`, `make lint` and 1331 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving client cache refresh pattern with no server or auth changes; only trade-off is parallel refetches instead of staggered UI updates for mixed fast/slow queries.
> 
> **Overview**
> Mutation **onSuccess** handlers across pages and layout components no longer **await** each tRPC/React Query `invalidate` or `refetch` in sequence. They now use **`await Promise.all([...])`** so independent refetches can be folded into a **single batched HTTP request** via `httpBatchLink`, cutting round-trips after user actions and letting handlers return sooner (buttons re-enable faster).
> 
> **Coverage** spans ANBU, blackmarket, clan hall, concept art, events, items, jutsus, profile edit, training grounds, travel, reports, clan UI, shrine battles, war system, and similar flows—same cache keys invalidated as before; code after the batch (`router.push`, `reset`, etc.) still runs afterward.
> 
> A new **`serialInvalidation.test.ts`** scans `app/src` and fails on consecutive awaited cache calls that should be batched, with opt-out via `serial-invalidation-ok` for genuinely ordered pairs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d55bb06165aee40fb4910e7f77892214fbed9763. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved refresh speed after actions across profiles, inventories, clans, battles, reports, offers, and other game features.
  * Updated data refreshes to complete concurrently, helping changes appear more quickly and consistently throughout the app.

* **Tests**
  * Expanded coverage to detect delayed or incomplete data refresh patterns, including multiline cases and complex formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->