### PR TITLE
perf(travel): make the pathfinding A* actually search towards the goal

### DIFF
--- a/app/src/libs/hexgrid.ts
+++ b/app/src/libs/hexgrid.ts
@@ -1,4 +1,3 @@
-import { aStar } from "abstract-astar";
 import type {
   BoundingBox,
   Ellipse,
@@ -157,10 +156,28 @@ export const getPossibleActionTiles = (
 export class PathCalculator {
   cache: Map<string, TerrainHex[] | undefined>;
   grid: Grid<TerrainHex>;
+  /**
+   * Lower bound on what a single step can cost, so the heuristic below can be scaled by it and
+   * still never overestimate. A step costs `to.cost + from.cost`, so it is at least twice the
+   * cheapest passable tile on this grid — 2 where combat sets every tile to 1, 4 on sector and
+   * window grids where a tile costs `walkCost + 1`. It has to be read off the grid rather than
+   * hardcoded because this class serves both. Snapshotted here like the path cache, which
+   * already assumes tile cost and blocked state hold still for this instance.
+   */
+  minStepCost: number;
 
   constructor(grid: Grid<TerrainHex>) {
     this.cache = new Map<string, TerrainHex[] | undefined>();
     this.grid = grid;
+    let cheapest = Number.POSITIVE_INFINITY;
+    grid.forEach((tile) => {
+      if (!tile.blocked && Number.isFinite(tile.cost) && tile.cost < cheapest) {
+        cheapest = tile.cost;
+      }
+    });
+    // A grid with no passable tile, or one whose tiles are free, leaves the heuristic at zero,
+    // which is a plain Dijkstra search: slower, but still correct
+    this.minStepCost = cheapest > 0 && Number.isFinite(cheapest) ? 2 * cheapest : 0;
   }
 
   /**
@@ -176,20 +193,115 @@ export class PathCalculator {
     if (this.cache.has(key)) {
       return this.cache.get(key);
     }
-    const shortestPath = aStar<TerrainHex>({
+    const shortestPath = findShortestPath({
       start: origin,
       goal: target,
-      estimateFromNodeToGoal: (tile) => this.grid.distance(tile, origin),
-      neighborsAdjacentToNode: (center) =>
+      estimate: (tile) => this.minStepCost * this.grid.distance(tile, target),
+      neighbors: (center) =>
         this.grid
           .traverse(ring({ radius: 1, center }))
           .toArray()
           .filter((tile) => !tile.blocked),
-      actualCostToMove: (_, from, to) => {
-        return to.cost + from.cost;
-      },
+      stepCost: (from, to) => to.cost + from.cost,
     });
     this.cache.set(key, shortestPath);
     return shortestPath;
   };
 }
+
+/**
+ * A* with a lazy-deletion binary heap.
+ *
+ * Finding a cheaper route to a tile pushes a second entry rather than moving the existing one,
+ * and whichever entry surfaces after the tile is settled is skipped. That is what replaced
+ * `abstract-astar`: its MinHeap sifts DOWN when a key decreases (a decrease has to sift up) and
+ * `removeMinimum` leaves the moved item's stale index behind in its index map, so once the
+ * heuristic actually reorders the frontier the pop order is wrong and the path it returns is not
+ * always the shortest — measured at 4 of 68 paths on a sector-sized grid with mixed terrain
+ * costs. Never decreasing a key sidesteps both.
+ *
+ * `estimate` must not overestimate the remaining cost or the result is not the shortest path;
+ * `PathCalculator.minStepCost` is what keeps the caller's estimate under that bound.
+ */
+const findShortestPath = ({
+  start,
+  goal,
+  estimate,
+  neighbors,
+  stepCost,
+}: {
+  start: TerrainHex;
+  goal: TerrainHex;
+  estimate: (tile: TerrainHex) => number;
+  neighbors: (tile: TerrainHex) => TerrainHex[];
+  stepCost: (from: TerrainHex, to: TerrainHex) => number;
+}) => {
+  const cheapestTo = new Map<TerrainHex, number>([[start, 0]]);
+  const cameFrom = new Map<TerrainHex, TerrainHex>();
+  const settled = new Set<TerrainHex>();
+  const frontier: { tile: TerrainHex; score: number }[] = [
+    { tile: start, score: estimate(start) },
+  ];
+  const scoreAt = (index: number) => frontier[index]?.score ?? Number.POSITIVE_INFINITY;
+  const swap = (a: number, b: number) => {
+    const first = frontier[a];
+    const second = frontier[b];
+    if (first === undefined || second === undefined) return;
+    frontier[a] = second;
+    frontier[b] = first;
+  };
+  const siftUp = (index: number) => {
+    while (index > 0) {
+      const parent = (index - 1) >> 1;
+      if (scoreAt(parent) <= scoreAt(index)) return;
+      swap(index, parent);
+      index = parent;
+    }
+  };
+  const siftDown = (index: number) => {
+    for (;;) {
+      const left = index * 2 + 1;
+      const right = left + 1;
+      let smallest = index;
+      if (left < frontier.length && scoreAt(left) < scoreAt(smallest)) smallest = left;
+      if (right < frontier.length && scoreAt(right) < scoreAt(smallest))
+        smallest = right;
+      if (smallest === index) return;
+      swap(index, smallest);
+      index = smallest;
+    }
+  };
+  while (frontier.length > 0) {
+    const top = frontier[0];
+    const last = frontier.pop();
+    if (top === undefined || last === undefined) break;
+    if (frontier.length > 0) {
+      frontier[0] = last;
+      siftDown(0);
+    }
+    const current = top.tile;
+    if (current === goal) {
+      const path = [current];
+      let step = current;
+      for (;;) {
+        const previous = cameFrom.get(step);
+        if (previous === undefined) return path.reverse();
+        path.push(previous);
+        step = previous;
+      }
+    }
+    if (settled.has(current)) continue;
+    settled.add(current);
+    const costToCurrent = cheapestTo.get(current) ?? Number.POSITIVE_INFINITY;
+    for (const next of neighbors(current)) {
+      const candidate = costToCurrent + stepCost(current, next);
+      if (candidate < (cheapestTo.get(next) ?? Number.POSITIVE_INFINITY)) {
+        cheapestTo.set(next, candidate);
+        cameFrom.set(next, current);
+        frontier.push({ tile: next, score: candidate + estimate(next) });
+        siftUp(frontier.length - 1);
+      }
+    }
+  }
+  return undefined;
+};

--- a/app/src/libs/hexgrid.ts
+++ b/app/src/libs/hexgrid.ts
@@ -152,6 +152,11 @@ export const getPossibleActionTiles = (
 
 /**
  * Uses A* algorithm to calculate the shortest path between two hexes.
+ *
+ * Only the COST of the returned path is defined. A grid usually holds many equally cheap routes
+ * between two tiles and which one comes back depends on the search order, so callers must not
+ * treat the specific tiles as stable — `getBarriersBetween` reads them to decide which barriers
+ * absorb an attack, and that answer moves whenever the search does.
  */
 export class PathCalculator {
   cache: Map<string, TerrainHex[] | undefined>;
@@ -161,8 +166,13 @@ export class PathCalculator {
    * still never overestimate. A step costs `to.cost + from.cost`, so it is at least twice the
    * cheapest passable tile on this grid — 2 where combat sets every tile to 1, 4 on sector and
    * window grids where a tile costs `walkCost + 1`. It has to be read off the grid rather than
-   * hardcoded because this class serves both. Snapshotted here like the path cache, which
-   * already assumes tile cost and blocked state hold still for this instance.
+   * hardcoded because this class serves both.
+   *
+   * Snapshotted, and it bites harder than the path cache does: a stale cache still answers a
+   * miss correctly, whereas a bound taken before a tile got CHEAPER overestimates, and then even
+   * a miss comes back with a path that is not the shortest. Lowering any tile's cost means
+   * building a new calculator, not just clearing the cache. Every site does that today — each
+   * one constructs after its mutations — which is why this is a note rather than a guard.
    */
   minStepCost: number;
 

--- a/app/tests/libs/hexgrid.astar.test.ts
+++ b/app/tests/libs/hexgrid.astar.test.ts
@@ -161,6 +161,25 @@ describe("PathCalculator.getShortestPath", () => {
     expect(path).not.toContain(at(grid, 3, 1));
   });
 
+  /**
+   * A tripwire, not a contract. Many routes tie on cost and this is merely the one today's search
+   * order produces — but `getBarriersBetween` turns the route into which barriers absorb an
+   * attack, so a change here is a change to combat damage. Landing that deliberately is fine;
+   * landing it without noticing is not. Re-record the expectation when you mean to move it.
+   */
+  it("takes a stable route among the equally cheap ones", () => {
+    const grid = makeGrid(6, 6, () => 1);
+    const path = found(
+      new PathCalculator(grid).getShortestPath(at(grid, 0, 0), at(grid, 3, 0)),
+    );
+    expect(path.map((tile) => `${tile.col},${tile.row}`)).toEqual([
+      "0,0",
+      "1,0",
+      "2,1",
+      "3,0",
+    ]);
+  });
+
   it.each([
     ["combat, every tile cost 1", 13, "combat", 0.15],
     ["sector, every tile cost 2", 26, "sector", 0.15],

--- a/app/tests/libs/hexgrid.astar.test.ts
+++ b/app/tests/libs/hexgrid.astar.test.ts
@@ -70,6 +70,15 @@ const optimalCost = (grid: Grid<TerrainHex>, start: TerrainHex, goal: TerrainHex
   return Number.POSITIVE_INFINITY;
 };
 
+/**
+ * Narrows away the `undefined` a missing path would return, so the assertions that follow are
+ * reached rather than skipped — a loop over an absent path passes without checking anything.
+ */
+const found = (path: TerrainHex[] | undefined) => {
+  expect(path).toBeDefined();
+  return path as TerrainHex[];
+};
+
 /** Fixed seed: a failure has to be reproducible to be worth anything. */
 const randomiser = (seed: number): (() => number) => () =>
   ((seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff);
@@ -113,10 +122,12 @@ describe("PathCalculator.minStepCost", () => {
 describe("PathCalculator.getShortestPath", () => {
   it("returns a contiguous path from origin to target", () => {
     const grid = makeGrid(9, 9, () => 2);
-    const path = new PathCalculator(grid).getShortestPath(at(grid, 0, 0), at(grid, 8, 8));
-    expect(path?.[0]).toBe(at(grid, 0, 0));
-    expect(path?.[path.length - 1]).toBe(at(grid, 8, 8));
-    path?.slice(1).forEach((tile, index) => {
+    const path = found(
+      new PathCalculator(grid).getShortestPath(at(grid, 0, 0), at(grid, 8, 8)),
+    );
+    expect(path[0]).toBe(at(grid, 0, 0));
+    expect(path[path.length - 1]).toBe(at(grid, 8, 8));
+    path.slice(1).forEach((tile, index) => {
       expect(grid.distance(path[index] as TerrainHex, tile)).toBe(1);
     });
   });
@@ -144,8 +155,9 @@ describe("PathCalculator.getShortestPath", () => {
   it("walks around a costly tile rather than through it", () => {
     // ai_v2 marks tiles holding a user or a barrier as cost 100 instead of blocking them
     const grid = makeGrid(7, 3, (col, row) => (col === 3 && row === 1 ? 100 : 1));
-    const path = new PathCalculator(grid).getShortestPath(at(grid, 0, 1), at(grid, 6, 1));
-    expect(path).toBeDefined();
+    const path = found(
+      new PathCalculator(grid).getShortestPath(at(grid, 0, 1), at(grid, 6, 1)),
+    );
     expect(path).not.toContain(at(grid, 3, 1));
   });
 

--- a/app/tests/libs/hexgrid.astar.test.ts
+++ b/app/tests/libs/hexgrid.astar.test.ts
@@ -1,0 +1,196 @@
+import { defineHex, Grid, Orientation, rectangle, ring } from "honeycomb-grid";
+import { describe, expect, it } from "vitest";
+import { PathCalculator, type TerrainHex } from "@/libs/hexgrid";
+
+/**
+ * The heuristic is only allowed to guide the search, never to change what it finds, so the tests
+ * that matter here compare against an independent Dijkstra rather than against a stored path.
+ */
+const makeGrid = (
+  width: number,
+  height: number,
+  costOf: (col: number, row: number) => number,
+  blockedOf: (col: number, row: number) => boolean = () => false,
+) => {
+  const Tile = defineHex({
+    dimensions: { width: 10, height: 10 },
+    origin: { x: -5, y: -5 },
+    orientation: Orientation.FLAT,
+  });
+  return new Grid(Tile, rectangle({ width, height })).map((tile) => {
+    const hex = tile as unknown as TerrainHex;
+    hex.cost = costOf(tile.col, tile.row);
+    hex.blocked = blockedOf(tile.col, tile.row);
+    return tile;
+  }) as unknown as Grid<TerrainHex>;
+};
+
+const at = (grid: Grid<TerrainHex>, col: number, row: number) =>
+  grid.getHex({ col, row }) as TerrainHex;
+
+const neighbours = (grid: Grid<TerrainHex>, center: TerrainHex) =>
+  grid
+    .traverse(ring({ radius: 1, center }))
+    .toArray()
+    .filter((tile) => !tile.blocked);
+
+const stepCost = (from: TerrainHex, to: TerrainHex) => to.cost + from.cost;
+
+const pathCost = (path: TerrainHex[] | undefined) =>
+  path === undefined
+    ? Number.POSITIVE_INFINITY
+    : path
+        .slice(1)
+        .reduce((total, tile, index) => total + stepCost(path[index] as TerrainHex, tile), 0);
+
+/** Deliberately naive and heuristic-free, so it agrees with A* only if A* is right. */
+const optimalCost = (grid: Grid<TerrainHex>, start: TerrainHex, goal: TerrainHex) => {
+  const best = new Map<TerrainHex, number>([[start, 0]]);
+  const settled = new Set<TerrainHex>();
+  const frontier: TerrainHex[] = [start];
+  while (frontier.length > 0) {
+    frontier.sort(
+      (a, b) =>
+        (best.get(a) ?? Number.POSITIVE_INFINITY) -
+        (best.get(b) ?? Number.POSITIVE_INFINITY),
+    );
+    const current = frontier.shift() as TerrainHex;
+    if (current === goal) return best.get(goal) ?? Number.POSITIVE_INFINITY;
+    if (settled.has(current)) continue;
+    settled.add(current);
+    for (const next of neighbours(grid, current)) {
+      const candidate =
+        (best.get(current) ?? Number.POSITIVE_INFINITY) + stepCost(current, next);
+      if (candidate < (best.get(next) ?? Number.POSITIVE_INFINITY)) {
+        best.set(next, candidate);
+        frontier.push(next);
+      }
+    }
+  }
+  return Number.POSITIVE_INFINITY;
+};
+
+/** Fixed seed: a failure has to be reproducible to be worth anything. */
+const randomiser = (seed: number): (() => number) => () =>
+  ((seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff);
+
+describe("PathCalculator.minStepCost", () => {
+  it("is twice the tile cost on a combat grid", () => {
+    expect(new PathCalculator(makeGrid(5, 5, () => 1)).minStepCost).toBe(2);
+  });
+
+  it("is twice the cheapest tile on a sector grid", () => {
+    expect(new PathCalculator(makeGrid(5, 5, () => 2)).minStepCost).toBe(4);
+  });
+
+  it("follows the cheapest passable tile when terrain is mixed", () => {
+    const grid = makeGrid(5, 5, (col) => (col === 0 ? 2 : 5));
+    expect(new PathCalculator(grid).minStepCost).toBe(4);
+  });
+
+  it("ignores blocked tiles, however cheap they claim to be", () => {
+    // A wall carries cost 9999 in the window grid, but a cheap blocked tile would be worse:
+    // it would drag the bound down and cost the search its guidance
+    const grid = makeGrid(
+      5,
+      5,
+      (col) => (col === 0 ? 1 : 3),
+      (col) => col === 0,
+    );
+    expect(new PathCalculator(grid).minStepCost).toBe(6);
+  });
+
+  it("falls back to zero — a plain Dijkstra — when no tile is passable", () => {
+    expect(new PathCalculator(makeGrid(4, 4, () => 2, () => true)).minStepCost).toBe(0);
+  });
+
+  it("falls back to zero rather than trusting a nonsense cost", () => {
+    expect(new PathCalculator(makeGrid(4, 4, () => Number.NaN)).minStepCost).toBe(0);
+    expect(new PathCalculator(makeGrid(4, 4, () => 0)).minStepCost).toBe(0);
+  });
+});
+
+describe("PathCalculator.getShortestPath", () => {
+  it("returns a contiguous path from origin to target", () => {
+    const grid = makeGrid(9, 9, () => 2);
+    const path = new PathCalculator(grid).getShortestPath(at(grid, 0, 0), at(grid, 8, 8));
+    expect(path?.[0]).toBe(at(grid, 0, 0));
+    expect(path?.[path.length - 1]).toBe(at(grid, 8, 8));
+    path?.slice(1).forEach((tile, index) => {
+      expect(grid.distance(path[index] as TerrainHex, tile)).toBe(1);
+    });
+  });
+
+  it("gives up when the origin or the target is blocked", () => {
+    const grid = makeGrid(5, 5, () => 1, (col, row) => col === 4 && row === 4);
+    const finder = new PathCalculator(grid);
+    expect(finder.getShortestPath(at(grid, 0, 0), at(grid, 4, 4))).toBeUndefined();
+    expect(finder.getShortestPath(at(grid, 4, 4), at(grid, 0, 0))).toBeUndefined();
+  });
+
+  it("gives up when a wall separates the two tiles", () => {
+    const grid = makeGrid(9, 9, () => 1, (col) => col === 4);
+    const path = new PathCalculator(grid).getShortestPath(at(grid, 0, 0), at(grid, 8, 8));
+    expect(path).toBeUndefined();
+  });
+
+  it("answers a repeated query from the cache", () => {
+    const grid = makeGrid(6, 6, () => 2);
+    const finder = new PathCalculator(grid);
+    const first = finder.getShortestPath(at(grid, 0, 0), at(grid, 5, 5));
+    expect(finder.getShortestPath(at(grid, 0, 0), at(grid, 5, 5))).toBe(first);
+  });
+
+  it("walks around a costly tile rather than through it", () => {
+    // ai_v2 marks tiles holding a user or a barrier as cost 100 instead of blocking them
+    const grid = makeGrid(7, 3, (col, row) => (col === 3 && row === 1 ? 100 : 1));
+    const path = new PathCalculator(grid).getShortestPath(at(grid, 0, 1), at(grid, 6, 1));
+    expect(path).toBeDefined();
+    expect(path).not.toContain(at(grid, 3, 1));
+  });
+
+  it.each([
+    ["combat, every tile cost 1", 13, "combat", 0.15],
+    ["sector, every tile cost 2", 26, "sector", 0.15],
+    ["window, mixed terrain cost", 40, "window", 0.12],
+  ] as const)(
+    "matches Dijkstra's cost on every reachable pair (%s)",
+    (_shape, size, terrain, blockRate) => {
+      const random = randomiser(size * 7919);
+      const costs = new Map<string, number>();
+      const blocked = new Map<string, boolean>();
+      for (let col = 0; col < size; col++) {
+        for (let row = 0; row < size; row++) {
+          costs.set(`${col},${row}`, 2 + Math.floor(random() * 3));
+          blocked.set(`${col},${row}`, random() < blockRate);
+        }
+      }
+      const grid = makeGrid(
+        size,
+        size,
+        (col, row) => {
+          if (terrain === "combat") return 1;
+          if (terrain === "sector") return 2;
+          return costs.get(`${col},${row}`) ?? 2;
+        },
+        (col, row) => blocked.get(`${col},${row}`) ?? false,
+      );
+      const finder = new PathCalculator(grid);
+      let compared = 0;
+      for (let attempt = 0; attempt < 60; attempt++) {
+        const start = at(grid, ~~(random() * size), ~~(random() * size));
+        const goal = at(grid, ~~(random() * size), ~~(random() * size));
+        if (!start || !goal || start.blocked || goal.blocked || start === goal) continue;
+        const want = optimalCost(grid, start, goal);
+        const path = finder.getShortestPath(start, goal);
+        if (want === Number.POSITIVE_INFINITY) {
+          expect(path).toBeUndefined();
+          continue;
+        }
+        compared++;
+        expect(pathCost(path)).toBe(want);
+      }
+      expect(compared).toBeGreaterThan(20);
+    },
+  );
+});


### PR DESCRIPTION
The travel map's A* was not doing any A*. Its heuristic measured how far a tile is from where the walk **started**:

```ts
estimateFromNodeToGoal: (tile) => this.grid.distance(tile, origin),
```

`h(n)` therefore grew in step with `g(n)` instead of shrinking towards the target, `f = g + h` stayed monotonic in `g`, and the search flooded outwards in every direction — every reachable tile inside the goal's cost radius, each expansion allocating a Grid, an array and a filtered array. It was *worse than passing no heuristic at all*: identical search work, plus a `distance()` call per relaxed node.

## Aiming it at the goal

The scale matters as much as the direction. A step costs `to.cost + from.cost`, so it is never cheaper than twice the cheapest passable tile on that grid — and this one class serves grids with different floors: combat sets every tile to `1` (min step 2), sector and window grids use `walkCost + 1` (min step 4). A hardcoded factor cannot serve both: `2` is a no-op on the travel grids, and `4` overestimates in combat, which would bend AI movement and barrier lookups. So the bound is read off the grid once, in the constructor, alongside the path cache that already assumes tile state holds still.

## Why the search itself was replaced — in the same commit

Fixing the heuristic made it actually reorder the frontier — which turned a latent bug in `abstract-astar` into wrong answers. Its `MinHeap` sifts **down** when a key decreases (a decrease has to sift **up**), and `removeMinimum` leaves the moved item's stale index behind in its index map. Both corrupt the pop order, so a tile gets settled before its cheapest route is known:

> 4 of 68 paths on a sector-sized grid with mixed terrain costs came back ~1% longer than optimal.

That is not just a longer walk. `getBarriersBetween` derives *which barriers sit between attacker and target* from this path, so a different route is different damage absorbed.

The replacement is A* over a lazy-deletion heap: a cheaper route pushes a second entry rather than moving the existing one, and whichever entry surfaces after a tile is settled is skipped. Never decreasing a key sidesteps both bugs. It is also slightly faster than the library, so the correctness costs nothing.

These started as two commits and were squashed into one, because the heuristic fix *without* the new search is worse than either side of it — 15 of 1150 paths wrong on a 26×26 grid, 54 of 2814 on a 40×40 one, worst case 8.3% longer, where the code before the branch was 0 for 0. This repo rebase-merges, so splitting them would leave that state in `main` for anyone bisecting through it.

## Measured

This repo's own grid shapes, the same origin/target pairs throughout, a fresh calculator each run so the cache never answers:

| | before | heuristic fixed | + own search |
|---|---|---|---|
| 78×78 window, mixed terrain, 12% blocked | 6.33 ms | 1.62 ms | **1.49 ms** |
| 13×13 combat arena | 0.223 ms | 0.044 ms | **0.044 ms** |

Per path, averaged over 20 random reachable pairs.

Two things about where this actually lands, since the finding that prompted the PR overstates them and I would rather the record be right:

**It is not in a render loop.** All four `getShortestPath` call sites in `Sector.tsx` are event handlers — the click-to-move handler, the post-move remainder walk, the border-crossing walk, and the websocket handler for other players' movement. `Sector.tsx:1638` is a scene-disposal `useEffect` cleanup, and `libs/threejs/sector.ts` never calls it at all. So this is not dropped frames while panning; it is latency on an interaction.

**A busy sector was never the tens-of-milliseconds case.** Every other player's step does cost a fresh search — the cache is keyed on origin+target, so it never hits — but a step is one tile, and even an uninformed Dijkstra stops as soon as it pops an adjacent target. Measured on the 78×78 window grid:

| distance | before | after |
|---|---|---|
| 1 tile (a broadcast step) | 0.098 ms | 0.029 ms |
| 2 tiles | 0.104 ms | 0.026 ms |
| 5 tiles | 0.581 ms | 0.120 ms |
| 10 tiles | 1.565 ms | 0.456 ms |

So the busy-sector case gets ~3.4× cheaper but was already sub-millisecond. The tens of milliseconds were only ever in the long queries — clicking a far tile, or the cross-border nav on the unified window grid — which is exactly where this pays off.

**313 random pairs** across combat, window and maze-shaped grids: every path matches an independent Dijkstra's cost exactly.

## Tests

`app/tests/libs/hexgrid.astar.test.ts` compares against a deliberately naive Dijkstra written in the test rather than against stored paths, so it fails on any heuristic that overestimates. Verified it has teeth: forcing the scale from 2 to 4 fails five of them, including a concrete 109-vs-107 path cost.

It also pins the parts that are easy to get subtly wrong later — that the bound follows the cheapest *passable* tile (a cheap blocked tile must not drag it down), that a grid with no passable tile or a nonsense cost falls back to a plain Dijkstra rather than to a broken heuristic, and that a costly-but-passable tile (`ai_v2` marks occupied tiles cost 100) is walked around rather than through.

## The behaviour change worth knowing about

A search that is actually guided picks a **different one of the equally cheap routes**. Not a longer one — the same cost, and on a uniform grid the same tile count — but different tiles. On the 12×10 battle grid, across all 14,280 ordered pairs:

| | |
|---|---|
| routes that differ | **9,844 (68.9%)** |
| paths whose cost differs | 0 |
| paths whose tile count differs | 0 |

Two consumers read the route rather than its cost, and both are server-side combat:

- `getBarriersBetween` derives *which barriers sit between attacker and target*, so a barrier on a given tile changes its verdict for **4.52%** of (pair, tile) combinations.
- `ai_v2`'s `move_towards_opponent` steps onto `path[1]`, which differs for **19%** of pairs — so an AI's first step changes that often.

Battles are persisted, so this lands inside fights that are already running. `mapDistancesToTarget` is unaffected: it keys on `path.length`, which does not move on the combat grid (0 of 14,280 pairs).

It is not a regression — the old route was itself an arbitrary pick among ties, whatever Dijkstra's pop order happened to yield, and there is no way to speed the search up without moving that choice. But it is a real, live change to combat damage and it should be a deliberate merge rather than a surprise.

`app/tests/libs/hexgrid.astar.test.ts` now pins one route as a tripwire, since cost-only assertions cannot see this: reversing the neighbour order keeps every path optimal, moves 77.5% of routes, and leaves the suite green.

## Risk

- The route change above.
- `abstract-astar` is now unused by this file but stays in `package.json` — dropping it means a lockfile change, and the local bun rewrites that file wholesale (it cannot parse `lockfileVersion: 3`), so it belongs in its own PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Correctness improves for path cost, but many tie-breaking routes change and can alter live combat barrier/damage via `getBarriersBetween`; `minStepCost` must be rebuilt if tile costs decrease after construction.
> 
> **Overview**
> **Fixes sector/travel pathfinding** by pointing A* at the goal and swapping out the `abstract-astar` dependency for an in-house lazy-deletion heap implementation.
> 
> `PathCalculator` no longer uses `distance(tile, origin)` as the heuristic (which behaved like uninformed search). It snapshots **`minStepCost`** from the cheapest passable tile and uses `minStepCost * distance(tile, target)` so combat and sector/window grids both get a valid, non-overestimating estimate. **`findShortestPath`** implements A* with push-on-decrease heap entries to avoid `abstract-astar` MinHeap bugs that could return ~1% longer routes once the heuristic actually reordered the frontier.
> 
> Docs and tests call out that **only path cost is guaranteed**—among equal-cost routes, which tiles are returned can change and affects **`getBarriersBetween`** (combat barrier absorption). New **`hexgrid.astar.test.ts`** compares costs to a naive Dijkstra, covers `minStepCost` edge cases, and pins one tie-break route as a deliberate tripwire.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c2a0aa538bfe11bd8143f235c023fe669ddfda6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->