### PR TITLE
perf(bundle): load the emoji set, WebGL stack and chart.js on demand

### DIFF
--- a/app/bun.lock
+++ b/app/bun.lock
@@ -61,7 +61,6 @@
         "@vercel/mcp-adapter": "^1.0.0",
         "@vercel/og": "^1.0.1",
         "@vercel/speed-insights": "^2.0.0",
-        "abstract-astar": "0.2.0",
         "ai": "^7.0.77",
         "alea": "1.0.1",
         "babel-plugin-react-compiler": "^1.0.0",
@@ -1126,8 +1125,6 @@
     "@xtuc/long": ["@xtuc/long@4.2.2", "", {}, "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
-
-    "abstract-astar": ["abstract-astar@0.2.0", "", {}, "sha512-gtpsiAQu7CF+VfCFKkOEtgB8C8WN5U0TTokFn66aNg0vd0ahBd9kJ5fn8xLnSxm2g+kE/LwUzsMeIryONTf7oQ=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 

--- a/app/package.json
+++ b/app/package.json
@@ -87,7 +87,6 @@
     "@vercel/mcp-adapter": "^1.0.0",
     "@vercel/og": "^1.0.1",
     "@vercel/speed-insights": "^2.0.0",
-    "abstract-astar": "0.2.0",
     "ai": "^7.0.77",
     "alea": "1.0.1",
     "babel-plugin-react-compiler": "^1.0.0",

--- a/app/src/layout/EmojiPicker.tsx
+++ b/app/src/layout/EmojiPicker.tsx
@@ -14,6 +14,8 @@ export interface AppEmojiPickerProps {
 const DEFAULT_PER_LINE = 9;
 const DEFAULT_EMOJI_SIZE = 24;
 const DEFAULT_EMOJI_BUTTON_SIZE = 36;
+/** What emoji-mart's own grid comes out at; only used to reserve the space. */
+const PICKER_HEIGHT = 435;
 
 /**
  * The picker and its dataset load together, behind this one boundary.
@@ -39,15 +41,14 @@ const EmojiMartPicker = dynamic(
   },
   {
     ssr: false,
-    // Holds the popover's shape for the one fetch it now takes to open. Sized from the defaults
-    // below, since next/dynamic gives the placeholder no props to read the overrides from.
+    // Reserves the popover's shape for the one fetch it now takes to open. Width comes
+    // from the container rather than from perLine, because dynamicWidth makes the picker
+    // itself 100% wide and derive perLine from the measured width — so a perLine-based
+    // guess would simply be a different number, not a better one.
     loading: () => (
       <div
-        className="rounded-lg border border-border bg-popover"
-        style={{
-          width: DEFAULT_PER_LINE * DEFAULT_EMOJI_BUTTON_SIZE,
-          height: DEFAULT_PER_LINE * DEFAULT_EMOJI_BUTTON_SIZE * 1.35,
-        }}
+        className="w-full rounded-lg border border-border bg-popover"
+        style={{ height: PICKER_HEIGHT }}
       />
     ),
   },

--- a/app/src/layout/EmojiPicker.tsx
+++ b/app/src/layout/EmojiPicker.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import data from "@emoji-mart/data";
 import dynamic from "next/dynamic";
 import type React from "react";
 
@@ -12,16 +11,55 @@ export interface AppEmojiPickerProps {
   emojiButtonSize?: number;
 }
 
-const EmojiMartPicker = dynamic(() => import("@emoji-mart/react"), { ssr: false });
+const DEFAULT_PER_LINE = 9;
+const DEFAULT_EMOJI_SIZE = 24;
+const DEFAULT_EMOJI_BUTTON_SIZE = 36;
+
+/**
+ * The picker and its dataset load together, behind this one boundary.
+ *
+ * `@emoji-mart/data` is a 432 KB JSON module whose default export is consumed whole, so nothing
+ * can tree-shake it: it lands in whatever chunk imports it. Importing it at the top of this file
+ * put it in the root layout's graph — Comment and RichInput both reach it — so every signed-in
+ * page downloaded and parsed the entire emoji set for a popover most players never open.
+ */
+const EmojiMartPicker = dynamic(
+  async () => {
+    const [picker, emojiData] = await Promise.all([
+      import("@emoji-mart/react"),
+      import("@emoji-mart/data"),
+    ]);
+    const Picker = picker.default;
+    // The picker wants the parsed dataset, not the module namespace around it
+    const data = emojiData.default;
+    const WithData = (props: Record<string, unknown>) => (
+      <Picker {...props} data={data} />
+    );
+    return { default: WithData };
+  },
+  {
+    ssr: false,
+    // Holds the popover's shape for the one fetch it now takes to open. Sized from the defaults
+    // below, since next/dynamic gives the placeholder no props to read the overrides from.
+    loading: () => (
+      <div
+        className="rounded-lg border border-border bg-popover"
+        style={{
+          width: DEFAULT_PER_LINE * DEFAULT_EMOJI_BUTTON_SIZE,
+          height: DEFAULT_PER_LINE * DEFAULT_EMOJI_BUTTON_SIZE * 1.35,
+        }}
+      />
+    ),
+  },
+);
 
 export const EmojiPicker: React.FC<AppEmojiPickerProps> = (props) => {
-  const perLine = props.perLine ?? 9;
-  const emojiSize = props.emojiSize ?? 24;
-  const emojiButtonSize = props.emojiButtonSize ?? 36;
+  const perLine = props.perLine ?? DEFAULT_PER_LINE;
+  const emojiSize = props.emojiSize ?? DEFAULT_EMOJI_SIZE;
+  const emojiButtonSize = props.emojiButtonSize ?? DEFAULT_EMOJI_BUTTON_SIZE;
 
   return (
     <EmojiMartPicker
-      data={data}
       perLine={perLine}
       emojiSize={emojiSize}
       emojiButtonSize={emojiButtonSize}

--- a/app/src/layout/EmojiPicker.tsx
+++ b/app/src/layout/EmojiPicker.tsx
@@ -14,7 +14,13 @@ export interface AppEmojiPickerProps {
 const DEFAULT_PER_LINE = 9;
 const DEFAULT_EMOJI_SIZE = 24;
 const DEFAULT_EMOJI_BUTTON_SIZE = 36;
-/** What emoji-mart's own grid comes out at; only used to reserve the space. */
+/**
+ * What emoji-mart's own grid measures once it renders, used only to reserve the space. Both
+ * are observed rather than derived: under `dynamicWidth` the picker sizes itself and works out
+ * perLine from the result, so neither perLine nor the container gives the number away — the
+ * popovers this sits in are absolutely positioned and have no width of their own to inherit.
+ */
+const PICKER_WIDTH = 300;
 const PICKER_HEIGHT = 435;
 
 /**
@@ -41,14 +47,11 @@ const EmojiMartPicker = dynamic(
   },
   {
     ssr: false,
-    // Reserves the popover's shape for the one fetch it now takes to open. Width comes
-    // from the container rather than from perLine, because dynamicWidth makes the picker
-    // itself 100% wide and derive perLine from the measured width — so a perLine-based
-    // guess would simply be a different number, not a better one.
+    // Reserves the popover's shape for the one fetch it now takes to open
     loading: () => (
       <div
-        className="w-full rounded-lg border border-border bg-popover"
-        style={{ height: PICKER_HEIGHT }}
+        className="rounded-lg border border-border bg-popover"
+        style={{ width: PICKER_WIDTH, height: PICKER_HEIGHT }}
       />
     ),
   },

--- a/app/src/layout/GraphBankLedger.tsx
+++ b/app/src/layout/GraphBankLedger.tsx
@@ -1,8 +1,18 @@
+import dynamic from "next/dynamic";
 import type React from "react";
 import { api } from "@/app/_trpc/client";
-import GraphUsersGeneric from "@/layout/GraphUsersGeneric";
 import Loader from "@/layout/Loader";
 import { getUnique } from "@/utils/grouping";
+
+/**
+ * cytoscape and its edge-handles plugin are over a megabyte of source for a graph that only
+ * appears once someone asks for it, so the boundary sits here rather than at the page: this
+ * wrapper's whole job is to feed GraphUsersGeneric, and every consumer gets the deferral.
+ */
+const GraphUsersGeneric = dynamic(() => import("@/layout/GraphUsersGeneric"), {
+  ssr: false,
+  loading: () => <Loader explanation="Loading graph" />,
+});
 
 const GraphBankLedger: React.FC = () => {
   // Queries

--- a/app/src/layout/GraphBlackmarketLedger.tsx
+++ b/app/src/layout/GraphBlackmarketLedger.tsx
@@ -1,8 +1,18 @@
+import dynamic from "next/dynamic";
 import type React from "react";
 import { api } from "@/app/_trpc/client";
-import GraphUsersGeneric from "@/layout/GraphUsersGeneric";
 import Loader from "@/layout/Loader";
 import { getUnique } from "@/utils/grouping";
+
+/**
+ * cytoscape and its edge-handles plugin are over a megabyte of source for a graph that only
+ * appears once someone asks for it, so the boundary sits here rather than at the page: this
+ * wrapper's whole job is to feed GraphUsersGeneric, and every consumer gets the deferral.
+ */
+const GraphUsersGeneric = dynamic(() => import("@/layout/GraphUsersGeneric"), {
+  ssr: false,
+  loading: () => <Loader explanation="Loading graph" />,
+});
 
 const GraphBlackmarketLedger: React.FC = () => {
   // Queries

--- a/app/src/layout/GraphCombatLog.tsx
+++ b/app/src/layout/GraphCombatLog.tsx
@@ -1,12 +1,22 @@
+import dynamic from "next/dynamic";
 import type React from "react";
 import { api } from "@/app/_trpc/client";
-import GraphUsersGeneric from "@/layout/GraphUsersGeneric";
 import Loader from "@/layout/Loader";
 import { getUnique } from "@/utils/grouping";
 
 interface GraphCombatLogProps {
   userId: string;
 }
+/**
+ * cytoscape and its edge-handles plugin are over a megabyte of source for a graph that only
+ * appears once someone asks for it, so the boundary sits here rather than at the page: this
+ * wrapper's whole job is to feed GraphUsersGeneric, and every consumer gets the deferral.
+ */
+const GraphUsersGeneric = dynamic(() => import("@/layout/GraphUsersGeneric"), {
+  ssr: false,
+  loading: () => <Loader explanation="Loading graph" />,
+});
+
 const GraphCombatLog: React.FC<GraphCombatLogProps> = (props) => {
   // Queries
   const { data, isPending } = api.combat.getGraph.useQuery(

--- a/app/src/layout/ItemWithEffects.tsx
+++ b/app/src/layout/ItemWithEffects.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { BarChartBig, Box, Copy, SquarePen, Trash2 } from "lucide-react";
 import dynamic from "next/dynamic";
 import Link from "next/link";

--- a/app/src/layout/ItemWithEffects.tsx
+++ b/app/src/layout/ItemWithEffects.tsx
@@ -1,4 +1,5 @@
 import { BarChartBig, Box, Copy, SquarePen, Trash2 } from "lucide-react";
+import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import type React from "react";
@@ -16,7 +17,7 @@ import Confirm2 from "@/layout/Confirm2";
 import ContentImage from "@/layout/ContentImage";
 import DurabilityBar from "@/layout/DurabilityBar";
 import ElementImage from "@/layout/ElementImage";
-import Model3d from "@/layout/Model3d";
+import Loader from "@/layout/Loader";
 import { getPreventTypeName } from "@/libs/combat/util";
 import { getFarmPlantExperience } from "@/libs/farming";
 import { getRewardArray } from "@/libs/objectives";
@@ -92,6 +93,17 @@ export interface ItemWithEffectsProps {
   onDelete?: (id: string) => void;
   folderName?: string;
 }
+
+/**
+ * three.js and the @react-three stack are ~296 KB gzip, and this dialog is the only thing that
+ * renders them - behind a click, on content that has a 3D model at all. Statically imported here
+ * they reached the root layout's chunk, so every visitor downloaded and parsed a WebGL engine
+ * that almost none of them would ever run.
+ */
+const Model3d = dynamic(() => import("@/layout/Model3d"), {
+  ssr: false,
+  loading: () => <Loader explanation="Loading 3D model" />,
+});
 
 const ItemWithEffects: React.FC<ItemWithEffectsProps> = (props) => {
   const {

--- a/app/src/layout/ModerationSummary.tsx
+++ b/app/src/layout/ModerationSummary.tsx
@@ -30,6 +30,8 @@ export const ModerationSummary: React.FC<ModerationSummaryProps> = ({
   trigger,
 }) => {
   const [open, setOpen] = React.useState(false);
+  /** A deferred chunk can 404 after a deploy; the summary above it still stands. */
+  const [chartFailed, setChartFailed] = React.useState(false);
   const { data, isLoading } = api.reports.getUserModerationSummary.useQuery(
     { userId },
     { enabled: open },
@@ -55,6 +57,23 @@ export const ModerationSummary: React.FC<ModerationSummaryProps> = ({
         .sort((a, b) => b.count - a.count)
     : [];
 
+  /**
+   * Loads the charting library once and remembers it. Hands back the constructor rather than a
+   * flag so the caller holds a non-null value, and so the eager warm-up and the draw path share
+   * one failure route.
+   */
+  const ensureChart = async () => {
+    if (chartCtorRef.current) return chartCtorRef.current;
+    try {
+      chartCtorRef.current = (await import("chart.js/auto")).Chart;
+      return chartCtorRef.current;
+    } catch (error) {
+      console.error("Could not load the charting library", error);
+      setChartFailed(true);
+      return null;
+    }
+  };
+
   // Function to create or update the chart
   const createOrUpdateChart = async () => {
     if (!data || !categoryChartRef.current || categoryChartData.length === 0) return;
@@ -63,9 +82,8 @@ export const ModerationSummary: React.FC<ModerationSummaryProps> = ({
     // reachable from the root layout, so ~72 KB gzip rode along on every page for a panel
     // opened on demand. Fetched on first draw instead, then kept for redraws.
     const run = ++chartRunRef.current;
-    if (!chartCtorRef.current) {
-      chartCtorRef.current = (await import("chart.js/auto")).Chart;
-    }
+    const Chart = await ensureChart();
+    if (!Chart) return;
     // The dialog can close, or the whole component unmount, while that import is in flight
     const canvas = categoryChartRef.current;
     if (run !== chartRunRef.current || !canvas) return;
@@ -78,7 +96,7 @@ export const ModerationSummary: React.FC<ModerationSummaryProps> = ({
 
     const ctx = canvas.getContext("2d");
     if (ctx) {
-      chartInstanceRef.current = new chartCtorRef.current(ctx, {
+      chartInstanceRef.current = new Chart(ctx, {
         type: "bar",
         data: {
           labels: categoryChartData.map((item) => item.category),
@@ -138,6 +156,9 @@ export const ModerationSummary: React.FC<ModerationSummaryProps> = ({
   // Effect to handle dialog open/close
   useEffect(() => {
     if (open) {
+      // Fetch the library alongside the query rather than after it: the draw below waits
+      // for data, and queueing the chunk behind that round-trip is a needless waterfall
+      void ensureChart();
       // When dialog opens, ensure chart is created if we have data
       const timeoutId = setTimeout(() => {
         void createOrUpdateChart();
@@ -209,7 +230,13 @@ export const ModerationSummary: React.FC<ModerationSummaryProps> = ({
               <CardContent>
                 {categoryChartData.length > 0 ? (
                   <div className="h-80">
-                    <canvas ref={categoryChartRef} />
+                    {chartFailed ? (
+                      <p className="py-4 text-center text-muted-foreground text-sm">
+                        The chart could not be loaded. The counts above are unaffected.
+                      </p>
+                    ) : (
+                      <canvas ref={categoryChartRef} />
+                    )}
                   </div>
                 ) : (
                   <p className="py-8 text-center text-gray-500">

--- a/app/src/layout/ModerationSummary.tsx
+++ b/app/src/layout/ModerationSummary.tsx
@@ -1,5 +1,4 @@
-import type { ChartTypeRegistry, TooltipItem } from "chart.js/auto";
-import { Chart as ChartJS } from "chart.js/auto";
+import type { Chart as ChartJS, ChartTypeRegistry, TooltipItem } from "chart.js/auto";
 import { AlertTriangle } from "lucide-react";
 import React, { useEffect, useRef } from "react";
 import { api } from "@/app/_trpc/client";
@@ -41,6 +40,9 @@ export const ModerationSummary: React.FC<ModerationSummaryProps> = ({
 
   // Chart instance for cleanup
   const chartInstanceRef = useRef<ChartJS<keyof ChartTypeRegistry> | null>(null);
+  const chartCtorRef = useRef<typeof import("chart.js/auto").Chart | null>(null);
+  /** Bumped per draw so an import that resolves late cannot overwrite a newer chart. */
+  const chartRunRef = useRef(0);
 
   // Format data for category chart - filter out totalEntries and only include categories with values > 0
   const categoryChartData = data
@@ -54,8 +56,19 @@ export const ModerationSummary: React.FC<ModerationSummaryProps> = ({
     : [];
 
   // Function to create or update the chart
-  const createOrUpdateChart = () => {
+  const createOrUpdateChart = async () => {
     if (!data || !categoryChartRef.current || categoryChartData.length === 0) return;
+
+    // chart.js/auto registers every controller so nothing tree-shakes, and this dialog was
+    // reachable from the root layout, so ~72 KB gzip rode along on every page for a panel
+    // opened on demand. Fetched on first draw instead, then kept for redraws.
+    const run = ++chartRunRef.current;
+    if (!chartCtorRef.current) {
+      chartCtorRef.current = (await import("chart.js/auto")).Chart;
+    }
+    // The dialog can close, or the whole component unmount, while that import is in flight
+    const canvas = categoryChartRef.current;
+    if (run !== chartRunRef.current || !canvas) return;
 
     // Clean up previous chart instance
     if (chartInstanceRef.current) {
@@ -63,9 +76,9 @@ export const ModerationSummary: React.FC<ModerationSummaryProps> = ({
       chartInstanceRef.current = null;
     }
 
-    const ctx = categoryChartRef.current.getContext("2d");
+    const ctx = canvas.getContext("2d");
     if (ctx) {
-      chartInstanceRef.current = new ChartJS(ctx, {
+      chartInstanceRef.current = new chartCtorRef.current(ctx, {
         type: "bar",
         data: {
           labels: categoryChartData.map((item) => item.category),
@@ -110,7 +123,7 @@ export const ModerationSummary: React.FC<ModerationSummaryProps> = ({
   useEffect(() => {
     if (data) {
       // We'll create the chart when data is available, but only render it when dialog is open
-      createOrUpdateChart();
+      void createOrUpdateChart();
     }
 
     // Cleanup function
@@ -127,7 +140,7 @@ export const ModerationSummary: React.FC<ModerationSummaryProps> = ({
     if (open) {
       // When dialog opens, ensure chart is created if we have data
       const timeoutId = setTimeout(() => {
-        createOrUpdateChart();
+        void createOrUpdateChart();
       }, 100); // Small delay to ensure the canvas is visible
       return () => clearTimeout(timeoutId);
     }

--- a/app/src/layout/ModerationSummary.tsx
+++ b/app/src/layout/ModerationSummary.tsx
@@ -105,44 +105,51 @@ export const ModerationSummary: React.FC<ModerationSummaryProps> = ({
 
     const ctx = canvas.getContext("2d");
     if (ctx) {
-      chartInstanceRef.current = new Chart(ctx, {
-        type: "bar",
-        data: {
-          labels: categoryChartData.map((item) => item.category),
-          datasets: [
-            {
-              label: "Count",
-              data: categoryChartData.map((item) => item.count),
-              backgroundColor: "rgba(234, 88, 12, 0.7)",
-              borderColor: "rgba(234, 88, 12, 1)",
-              borderWidth: 1,
+      try {
+        chartInstanceRef.current = new Chart(ctx, {
+          type: "bar",
+          data: {
+            labels: categoryChartData.map((item) => item.category),
+            datasets: [
+              {
+                label: "Count",
+                data: categoryChartData.map((item) => item.count),
+                backgroundColor: "rgba(234, 88, 12, 0.7)",
+                borderColor: "rgba(234, 88, 12, 1)",
+                borderWidth: 1,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: {
+                display: false,
+              },
+              tooltip: {
+                callbacks: {
+                  label: (tooltipItem: TooltipItem<"bar">) =>
+                    `Count: ${tooltipItem.formattedValue}`,
+                },
+              },
             },
-          ],
-        },
-        options: {
-          responsive: true,
-          maintainAspectRatio: false,
-          plugins: {
-            legend: {
-              display: false,
-            },
-            tooltip: {
-              callbacks: {
-                label: (tooltipItem: TooltipItem<"bar">) =>
-                  `Count: ${tooltipItem.formattedValue}`,
+            scales: {
+              y: {
+                beginAtZero: true,
+                ticks: {
+                  precision: 0,
+                },
               },
             },
           },
-          scales: {
-            y: {
-              beginAtZero: true,
-              ticks: {
-                precision: 0,
-              },
-            },
-          },
-        },
-      });
+        });
+      } catch (error) {
+        console.error("Could not draw the moderation chart", error);
+        // Only if this draw is still the current one, so a superseded run cannot
+        // report a failure the live chart has already recovered from
+        if (run === chartRunRef.current) setChartFailed(true);
+      }
     }
   };
 

--- a/app/src/layout/ModerationSummary.tsx
+++ b/app/src/layout/ModerationSummary.tsx
@@ -46,16 +46,25 @@ export const ModerationSummary: React.FC<ModerationSummaryProps> = ({
   /** Bumped per draw so an import that resolves late cannot overwrite a newer chart. */
   const chartRunRef = useRef(0);
 
-  // Format data for category chart - filter out totalEntries and only include categories with values > 0
-  const categoryChartData = data
-    ? Object.entries(data[0] || {})
-        .filter(([key, value]) => key !== "totalEntries" && Number(value) > 0)
-        .map(([category, count]) => ({
-          category: formatCategoryName(category),
-          count: Number(count),
-        }))
-        .sort((a, b) => b.count - a.count)
-    : [];
+  /**
+   * Format data for category chart - filter out totalEntries and only include categories with
+   * values > 0. Memoized because it is a dependency of the draw effect below: rebuilt on every
+   * render it would tear the chart down and start a fresh async draw each time, and the canvas
+   * ends up blank whenever a cleanup lands after the draw it was meant to precede.
+   */
+  const categoryChartData = React.useMemo(
+    () =>
+      data
+        ? Object.entries(data[0] || {})
+            .filter(([key, value]) => key !== "totalEntries" && Number(value) > 0)
+            .map(([category, count]) => ({
+              category: formatCategoryName(category),
+              count: Number(count),
+            }))
+            .sort((a, b) => b.count - a.count)
+        : [],
+    [data],
+  );
 
   /**
    * Loads the charting library once and remembers it. Hands back the constructor rather than a

--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -1689,6 +1689,8 @@ const UserTrainingLog: React.FC<TrainingStatsComponentProps> = ({
   // State
   const chartRef = useRef<HTMLCanvasElement>(null);
   const activeLayout = useActiveLayout();
+  /** A deferred chunk can 404 after a deploy, and an empty box explains nothing. */
+  const [chartFailed, setChartFailed] = useState(false);
 
   // Query
   const { data: logEntries } = api.train.getTrainingLog.useQuery(
@@ -1735,7 +1737,14 @@ const UserTrainingLog: React.FC<TrainingStatsComponentProps> = ({
       let chart: { destroy: () => void } | undefined;
       let cancelled = false;
       void (async () => {
-        const { Chart } = await import("chart.js/auto");
+        let Chart: typeof import("chart.js/auto").Chart;
+        try {
+          Chart = (await import("chart.js/auto")).Chart;
+        } catch (error) {
+          console.error("Could not load the charting library", error);
+          if (!cancelled) setChartFailed(true);
+          return;
+        }
         // The tab can close, or the theme change, while the import is in flight
         if (cancelled) return;
         // Update stats chart
@@ -1817,7 +1826,13 @@ const UserTrainingLog: React.FC<TrainingStatsComponentProps> = ({
       initialBreak={true}
     >
       <div className="relative w-[99%] p-3">
-        <canvas ref={chartRef} id="chart"></canvas>
+        {chartFailed ? (
+          <p className="py-4 text-center text-muted-foreground text-sm">
+            The training chart could not be loaded.
+          </p>
+        ) : (
+          <canvas ref={chartRef} id="chart"></canvas>
+        )}
       </div>
     </ContentBox>
   );

--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -26,7 +26,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import type React from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { UseFormReturn } from "react-hook-form";
 import { useForm, useWatch } from "react-hook-form";
 import type { z } from "zod";
@@ -1682,6 +1682,9 @@ interface TrainingStatsComponentProps {
   isActive: boolean;
 }
 
+/** The x axis of the training log: one point per hour of the day. */
+const HOURS_OF_DAY = [...Array(24).keys()];
+
 const UserTrainingLog: React.FC<TrainingStatsComponentProps> = ({
   userId,
   isActive,
@@ -1698,11 +1701,14 @@ const UserTrainingLog: React.FC<TrainingStatsComponentProps> = ({
     { enabled: isActive },
   );
 
-  // Create dataset for each training speed
-  const x = [...Array(24).keys()];
-  const datasets =
-    logEntries &&
-    TrainingSpeeds.map((speed) => {
+  /**
+   * Create dataset for each training speed. Memoized because the draw effect below depends on
+   * it: rebuilt on every render it would destroy the chart and start a fresh async draw each
+   * time, and the canvas is left blank whenever a cleanup lands after the draw it preceded.
+   */
+  const datasets = useMemo(() => {
+    if (!logEntries) return undefined;
+    return TrainingSpeeds.map((speed) => {
       const hourlyEvents = groupBy(
         logEntries
           .filter((e) => e.speed === speed)
@@ -1714,7 +1720,7 @@ const UserTrainingLog: React.FC<TrainingStatsComponentProps> = ({
       );
       return {
         label: speed,
-        data: x.map((i) => {
+        data: HOURS_OF_DAY.map((i) => {
           const entries = hourlyEvents.get(i) || [];
           return {
             x: i,
@@ -1724,6 +1730,7 @@ const UserTrainingLog: React.FC<TrainingStatsComponentProps> = ({
         }),
       };
     });
+  }, [logEntries]);
 
   // Create chart
   useEffect(() => {
@@ -1805,7 +1812,7 @@ const UserTrainingLog: React.FC<TrainingStatsComponentProps> = ({
             },
           },
           data: {
-            labels: x,
+            labels: HOURS_OF_DAY,
             datasets: datasets,
           },
         });

--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -7,7 +7,6 @@
  */
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Chart as ChartJS } from "chart.js/auto";
 import {
   Award,
   BarChart2,
@@ -1728,72 +1727,85 @@ const UserTrainingLog: React.FC<TrainingStatsComponentProps> = ({
   useEffect(() => {
     const ctx = chartRef?.current?.getContext("2d");
     if (ctx && datasets) {
-      // Update stats chart
-      const chartTextColor = getEffectiveThemeTextColor(activeLayout);
-      ChartJS.defaults.color = chartTextColor;
-      const myChart = new ChartJS(ctx, {
-        type: "bar",
-        options: {
-          maintainAspectRatio: false,
-          responsive: true,
-          aspectRatio: 1.1,
-          scales: {
-            y: {
-              beginAtZero: true,
-              grid: { color: "rgba(148, 163, 184, 0.16)" },
-              ticks: {
-                color: chartTextColor,
-                stepSize: 1,
+      // chart.js/auto registers every controller so nothing tree-shakes it, and this is one
+      // tab among several on a page most visitors land on. Fetched when the log is actually
+      // drawn instead of with the page.
+      // Only destroy() is ever called on it, and chart.js's own generics do not accept the
+      // custom {x, y, entries} points this dataset uses
+      let chart: { destroy: () => void } | undefined;
+      let cancelled = false;
+      void (async () => {
+        const { Chart } = await import("chart.js/auto");
+        // The tab can close, or the theme change, while the import is in flight
+        if (cancelled) return;
+        // Update stats chart
+        const chartTextColor = getEffectiveThemeTextColor(activeLayout);
+        Chart.defaults.color = chartTextColor;
+        chart = new Chart(ctx, {
+          type: "bar",
+          options: {
+            maintainAspectRatio: false,
+            responsive: true,
+            aspectRatio: 1.1,
+            scales: {
+              y: {
+                beginAtZero: true,
+                grid: { color: "rgba(148, 163, 184, 0.16)" },
+                ticks: {
+                  color: chartTextColor,
+                  stepSize: 1,
+                },
+                title: {
+                  display: false,
+                  text: "#Events",
+                },
+                stacked: true,
               },
-              title: {
-                display: false,
-                text: "#Events",
+              x: {
+                grid: { color: "rgba(148, 163, 184, 0.16)" },
+                stacked: true,
+                ticks: { color: chartTextColor },
+                title: {
+                  display: true,
+                  color: chartTextColor,
+                  text: "Hour of Day",
+                },
               },
-              stacked: true,
             },
-            x: {
-              grid: { color: "rgba(148, 163, 184, 0.16)" },
-              stacked: true,
-              ticks: { color: chartTextColor },
-              title: {
+            plugins: {
+              legend: {
+                position: "bottom",
                 display: true,
-                color: chartTextColor,
-                text: "Hour of Day",
               },
-            },
-          },
-          plugins: {
-            legend: {
-              position: "bottom",
-              display: true,
-            },
-            tooltip: {
-              callbacks: {
-                title: (tooltipItems) =>
-                  `Training at hour ${tooltipItems?.[0]?.label || "unknown"}`,
-                label: (tooltipItems) => {
-                  const raw = tooltipItems?.raw as {
-                    entries: { trainingFinishedAt: string }[];
-                  };
-                  return (
-                    raw.entries?.map((e) =>
-                      new Date(e.trainingFinishedAt).toLocaleString(),
-                    ) || []
-                  );
+              tooltip: {
+                callbacks: {
+                  title: (tooltipItems) =>
+                    `Training at hour ${tooltipItems?.[0]?.label || "unknown"}`,
+                  label: (tooltipItems) => {
+                    const raw = tooltipItems?.raw as {
+                      entries: { trainingFinishedAt: string }[];
+                    };
+                    return (
+                      raw.entries?.map((e) =>
+                        new Date(e.trainingFinishedAt).toLocaleString(),
+                      ) || []
+                    );
+                  },
                 },
               },
             },
           },
-        },
-        data: {
-          labels: x,
-          datasets: datasets,
-        },
-      });
+          data: {
+            labels: x,
+            datasets: datasets,
+          },
+        });
+      })();
 
       // Remove on unmount
       return () => {
-        myChart.destroy();
+        cancelled = true;
+        chart?.destroy();
       };
     }
   }, [activeLayout, datasets]);

--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -1757,65 +1757,70 @@ const UserTrainingLog: React.FC<TrainingStatsComponentProps> = ({
         // Update stats chart
         const chartTextColor = getEffectiveThemeTextColor(activeLayout);
         Chart.defaults.color = chartTextColor;
-        chart = new Chart(ctx, {
-          type: "bar",
-          options: {
-            maintainAspectRatio: false,
-            responsive: true,
-            aspectRatio: 1.1,
-            scales: {
-              y: {
-                beginAtZero: true,
-                grid: { color: "rgba(148, 163, 184, 0.16)" },
-                ticks: {
-                  color: chartTextColor,
-                  stepSize: 1,
+        try {
+          chart = new Chart(ctx, {
+            type: "bar",
+            options: {
+              maintainAspectRatio: false,
+              responsive: true,
+              aspectRatio: 1.1,
+              scales: {
+                y: {
+                  beginAtZero: true,
+                  grid: { color: "rgba(148, 163, 184, 0.16)" },
+                  ticks: {
+                    color: chartTextColor,
+                    stepSize: 1,
+                  },
+                  title: {
+                    display: false,
+                    text: "#Events",
+                  },
+                  stacked: true,
                 },
-                title: {
-                  display: false,
-                  text: "#Events",
+                x: {
+                  grid: { color: "rgba(148, 163, 184, 0.16)" },
+                  stacked: true,
+                  ticks: { color: chartTextColor },
+                  title: {
+                    display: true,
+                    color: chartTextColor,
+                    text: "Hour of Day",
+                  },
                 },
-                stacked: true,
               },
-              x: {
-                grid: { color: "rgba(148, 163, 184, 0.16)" },
-                stacked: true,
-                ticks: { color: chartTextColor },
-                title: {
+              plugins: {
+                legend: {
+                  position: "bottom",
                   display: true,
-                  color: chartTextColor,
-                  text: "Hour of Day",
                 },
-              },
-            },
-            plugins: {
-              legend: {
-                position: "bottom",
-                display: true,
-              },
-              tooltip: {
-                callbacks: {
-                  title: (tooltipItems) =>
-                    `Training at hour ${tooltipItems?.[0]?.label || "unknown"}`,
-                  label: (tooltipItems) => {
-                    const raw = tooltipItems?.raw as {
-                      entries: { trainingFinishedAt: string }[];
-                    };
-                    return (
-                      raw.entries?.map((e) =>
-                        new Date(e.trainingFinishedAt).toLocaleString(),
-                      ) || []
-                    );
+                tooltip: {
+                  callbacks: {
+                    title: (tooltipItems) =>
+                      `Training at hour ${tooltipItems?.[0]?.label || "unknown"}`,
+                    label: (tooltipItems) => {
+                      const raw = tooltipItems?.raw as {
+                        entries: { trainingFinishedAt: string }[];
+                      };
+                      return (
+                        raw.entries?.map((e) =>
+                          new Date(e.trainingFinishedAt).toLocaleString(),
+                        ) || []
+                      );
+                    },
                   },
                 },
               },
             },
-          },
-          data: {
-            labels: HOURS_OF_DAY,
-            datasets: datasets,
-          },
-        });
+            data: {
+              labels: HOURS_OF_DAY,
+              datasets: datasets,
+            },
+          });
+        } catch (error) {
+          console.error("Could not draw the training chart", error);
+          if (!cancelled) setChartFailed(true);
+        }
       })();
 
       // Remove on unmount

--- a/app/tests/app/lockfile.test.ts
+++ b/app/tests/app/lockfile.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * `package.json` pins bun via `packageManager`, but nothing enforces it, and an older bun does
+ * not refuse to work here — it silently rewrites `bun.lock` in the format it does understand.
+ * That rewrite is not a formatting difference: it re-resolves every floating version and drops
+ * the nested `overrides` that older versions cannot express, so a lockfile that arrives this way
+ * quietly moves transitive dependencies for everyone. It is easy to sweep into a commit by
+ * accident and nearly invisible in review, hence a test rather than a convention.
+ */
+const APP_ROOT = join(import.meta.dirname, "../..");
+
+const readLockfile = () => readFileSync(join(APP_ROOT, "bun.lock"), "utf8");
+
+/** bun.lock is JSONC — trailing commas make JSON.parse useless, so read the one field directly. */
+const lockfileVersion = (source: string) => {
+  const match = source.match(/"lockfileVersion"\s*:\s*(\d+)/);
+  return match?.[1] === undefined ? undefined : Number(match[1]);
+};
+
+const packageManager = () => {
+  const manifest = JSON.parse(readFileSync(join(APP_ROOT, "package.json"), "utf8")) as {
+    packageManager?: string;
+  };
+  return manifest.packageManager;
+};
+
+describe("bun.lock", () => {
+  it("has not been downgraded by an older bun", () => {
+    expect(
+      lockfileVersion(readLockfile()),
+      "bun.lock was written by a bun older than the one package.json pins. Install the pinned " +
+        "version and re-run `bun install`, or restore the file with `git checkout -- app/bun.lock`.",
+    ).toBeGreaterThanOrEqual(3);
+  });
+
+  it("still carries the nested overrides an older bun would have dropped", () => {
+    // Scoped to the overrides block on purpose: both names also appear in the packages list, so
+    // searching the whole file passes even on a lockfile that has lost them
+    const source = readLockfile();
+    const overrides = source.match(/"overrides":\s*\{([\s\S]*?)\n {2}\},/)?.[1] ?? "";
+    expect(overrides).toContain("@types/cytoscape-edgehandles");
+    expect(overrides).toContain("@types/react-cytoscapejs");
+  });
+
+  it("pins a package manager for everyone to match", () => {
+    expect(packageManager()).toMatch(/^bun@\d+\.\d+\.\d+$/);
+  });
+});

--- a/app/tests/app/lockfile.test.ts
+++ b/app/tests/app/lockfile.test.ts
@@ -20,12 +20,23 @@ const lockfileVersion = (source: string) => {
   return match?.[1] === undefined ? undefined : Number(match[1]);
 };
 
-const packageManager = () => {
-  const manifest = JSON.parse(readFileSync(join(APP_ROOT, "package.json"), "utf8")) as {
+const manifest = () =>
+  JSON.parse(readFileSync(join(APP_ROOT, "package.json"), "utf8")) as {
     packageManager?: string;
+    overrides?: Record<string, unknown>;
   };
-  return manifest.packageManager;
-};
+
+/**
+ * The object-valued overrides, which are the ones an older bun cannot express and silently drops
+ * ("Bun currently does not support nested overrides"). Read from package.json rather than listed
+ * here, so an override added later is covered without anyone remembering to update this. The
+ * string-valued ones are deliberately not checked: they survive the downgrade, so they would
+ * report nothing about it.
+ */
+const nestedOverrideNames = () =>
+  Object.entries(manifest().overrides ?? {})
+    .filter(([, value]) => typeof value === "object" && value !== null)
+    .map(([name]) => name);
 
 describe("bun.lock", () => {
   it("has not been downgraded by an older bun", () => {
@@ -37,15 +48,16 @@ describe("bun.lock", () => {
   });
 
   it("still carries the nested overrides an older bun would have dropped", () => {
-    // Scoped to the overrides block on purpose: both names also appear in the packages list, so
+    // Scoped to the overrides block on purpose: the names also appear in the packages list, so
     // searching the whole file passes even on a lockfile that has lost them
-    const source = readLockfile();
-    const overrides = source.match(/"overrides":\s*\{([\s\S]*?)\n {2}\},/)?.[1] ?? "";
-    expect(overrides).toContain("@types/cytoscape-edgehandles");
-    expect(overrides).toContain("@types/react-cytoscapejs");
+    const overrides = readLockfile().match(/"overrides":\s*\{([\s\S]*?)\n {2}\},/)?.[1] ?? "";
+    const nested = nestedOverrideNames();
+    // Without one of these the assertion below is vacuous and the canary watches nothing
+    expect(nested.length).toBeGreaterThan(0);
+    for (const name of nested) expect(overrides).toContain(name);
   });
 
   it("pins a package manager for everyone to match", () => {
-    expect(packageManager()).toMatch(/^bun@\d+\.\d+\.\d+$/);
+    expect(manifest().packageManager).toMatch(/^bun@\d+\.\d+\.\d+$/);
   });
 });


### PR DESCRIPTION
Three libraries sat in the root layout's eager module graph, so every visitor downloaded and parsed them before the shell was interactive — whether or not they ever opened the thing that uses them. Audit findings F43, F68 and F69.

| | what it is | why it could not be tree-shaken |
|---|---|---|
| `@emoji-mart/data` | 432 KB JSON emoji set | consumed as one default export, so no bundler can drop part of it |
| three + drei + fiber + three-stdlib + hls.js | the WebGL stack behind `Model3d` | a static import for a dialog that opens on a click, on content that has a 3D model at all |
| `chart.js/auto` | charting | the `/auto` build registers every controller by design, precisely so that nothing shakes out |

## What changed

- **`EmojiPicker.tsx`** — the dataset moves inside the `next/dynamic` boundary the picker already had, so both arrive together on first open. A `loading` skeleton holds the popover's shape for that one fetch.
- **`ItemWithEffects.tsx`** — `Model3d` becomes a `next/dynamic` import with `ssr: false` and a `Loader` fallback. It renders a WebGL canvas inside an already-open Radix dialog, so there was no SSR output to lose.
- **`ModerationSummary.tsx`** — `chart.js/auto` becomes an `await import()` inside the draw function, cached in a ref. Deferring the library rather than the component keeps the trigger icon statically rendered, so no icon pops in, and it covers every consumer of the dialog at once.
- **`PublicUser.tsx`** — the same, for the training-log chart. See below.

## The plan was wrong about one thing

It said deferring chart.js inside `ModerationSummary` would fix `PublicUser` too. It does not — `PublicUser` imports chart.js on its own line for a different chart, so `/userid`, `/username`, `/townhall` and `/traininggrounds` would have kept shipping the whole library. Confirmed in the browser before fixing it: the profile page fetched `node_modules_chart` at **108 KB transferred / 604 KB decoded** before any click. It is fixed in the second commit, and afterwards that request is gone.

## Measurement

Sizes are measured on the **module graph**, walking static import edges from the root layout's client entry and stopping at every `import()`. Chunk sizes are a poor proxy here — a bundler can put a lazily-needed module in a statically-loaded chunk and vice versa, and doing it that way first gave me a result that said this change made things *worse*.

```
components/layout/core4_beta   (the root layout's client entry)
  eager modules   6833 -> 6283
  eager source   27.2 MB -> 16.4 MB
```

`three`, `three-stdlib`, `@react-three/fiber`, `hls.js`, `chart.js` and the emoji JSON all leave that set. Minified transfer of what moved behind a boundary, from this repo's own `node_modules`:

| | raw | gzip |
|---|---|---|
| emoji dataset | 423 KB | 79 KB |
| emoji-mart | 159 KB | 38 KB |
| chart.js | 204 KB | 69 KB |
| three | 357 KB | 85 KB |
| drei | 365 KB | 119 KB |
| hls.js (pulled in by drei) | 604 KB | 184 KB |

## Verified in the browser

Against the local dev stack, signed in as a provisioned test user:

- **Emoji picker** — end to end. `/tavern` loads 115 resources with **zero** emoji chunks; clicking the trigger fetches `@emoji-mart/data/sets/15/native.json`, the picker renders **163 grid buttons** with real category labels, and picking one inserts 👍 into the textarea. That also settles the ESM interop question, since a wrong `.default` would render an empty grid.
- **The placeholder** — measured, after getting it wrong twice. `perLine * emojiButtonSize` gave 324px against a real 300px; `w-full` then measured **2px**, because the popovers are absolutely positioned and a percentage had nothing to resolve against. It now measures **300×435 against the picker's 300×435**, so the popover does not change size when the chunk lands.
- **chart.js** — the profile page went from fetching 108 KB of chart.js on load to **0**, and the moderation dialog still opens and renders.
- **Nothing eager** — `/items`, which renders `ItemWithEffects`, loads 110 resources / 156 KB with zero three.js, chart.js or emoji chunks.

- **The moderation chart** — with four seeded flags, opening the dialog fetches a 111 KB chunk that was not there on page load, and the canvas comes back **500×240 with 51% of its pixels painted**, bars matching the underlying counts.
- **The 3D dialog** — the AI manual page loads 141 resources with **zero** three.js. Clicking the model icon pulls **7 chunks / 648 KB** (`three.core`, `three.module`, `three-stdlib`, fiber, drei) and renders the model in a WebGL canvas.

Fixtures for the last two were seeded in the dev database and removed again afterwards; it is back to zero moderation rows, no `avatar3d`, and the test account at its original role.

### One regression this caught

The chart built and then came out **blank** — visible only by reading the canvas pixels, since the dialog looked right. Both draw effects depend on a dataset rebuilt inline every render, so they re-run constantly. Harmless while the draw was synchronous, because each cleanup's `destroy()` was immediately followed by a create in the same effect body; with the library deferred the create became asynchronous, so a cleanup could land *after* the create it was meant to precede and tear the chart down moments after it appeared. Fixed by memoizing both datasets (last commit).

## Risk

- Opening the emoji picker, the moderation chart or the 3D dialog now costs one extra chunk fetch, each covered by a loading state.
- `ssr: false` on `Model3d` is safe: every importer chain reaches `ItemWithEffects` as client code, and the component renders a WebGL canvas inside an already-open dialog.
- The two chart call sites are async now, so both guard against the dialog closing or the component unmounting while the import is in flight — a run token in `ModerationSummary`, a `cancelled` flag in `PublicUser`.
- `cytoscape` gets the same treatment (see below), so nothing of this class is left in these graphs.

## Three loose ends, cleaned up here

- **`cytoscape` (1083 KB source)** was eager for a graph behind a button, on the profile page, the bank and the black market. Deferred in the three thin wrappers that feed `GraphUsersGeneric`, so every consumer inherits it. `PublicUser`'s eager graph goes 10143 → **9014 KB**; across this PR it is 10648 → 9014.
- **`abstract-astar` is gone.** PR #1488 replaced its A* and left the package declared, with nothing importing it. Its two lockfile lines were removed by hand — see below for why — and it has no dependencies of its own, so there was nothing else to unwind.
- **A guard for the lockfile.** `package.json` pins `bun@1.4.0`, but nothing enforces it, and an older bun does not refuse to work: it silently rewrites `bun.lock` in the format it understands, re-resolving floating versions and dropping the nested `overrides` it cannot express. That rewrite nearly rode into an earlier PR in this series. `app/tests/app/lockfile.test.ts` now catches it.

  The overrides assertion there is scoped to the `overrides` block deliberately — both package names also appear in the `packages` list, so my first version passed on a lockfile that had genuinely lost them. Verified the way that mistake deserves: let the old bun rewrite the file, watch both assertions fail, restore, watch them pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance and bundle-boundary changes with loading fallbacks and async chart lifecycle guards; no auth, payments, or data-model changes.
> 
> **Overview**
> **Moves heavy client libraries out of the root layout’s eager graph** so signed-in pages no longer download emoji JSON (~432 KB), the three.js stack, `chart.js/auto`, or cytoscape until a user actually opens the picker, 3D dialog, charts, or ledger graphs.
> 
> **Emoji picker** — `@emoji-mart/data` is loaded inside the existing `next/dynamic` boundary with the React picker; a fixed-size loading skeleton reserves popover space.
> 
> **3D models** — `Model3d` in `ItemWithEffects` is dynamically imported with `ssr: false` and a loader fallback.
> 
> **Charts** — `ModerationSummary` and the training log in `PublicUser` use `await import("chart.js/auto")` on first draw (with caching, run/cancel guards, and user-visible failure text). Chart datasets are **memoized** so async draws are not torn down by effect cleanups that used to run synchronously.
> 
> **Graph views** — `GraphUsersGeneric` (cytoscape) is dynamically loaded in the bank, black market, and combat log wrappers so all consumers defer the graph chunk.
> 
> **Cleanup** — Removes unused `abstract-astar` from dependencies. Adds **`lockfile.test.ts`** to catch `bun.lock` downgrades and dropped nested overrides when an older Bun rewrites the lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c40a97f18a706aadec35ade8e32ae274185da586. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved loading performance by loading emoji pickers, 3D content, charts, and ledger graphs only when needed.
  * Added loading indicators while interactive content initializes.

* **Bug Fixes**
  * Added clearer fallback messages when chart libraries or visualizations fail.
  * Prevented outdated chart updates during rapid navigation or loading changes.
  * Preserved moderation counts even when chart visualization is unavailable.
  * Improved reliability when initializing training and moderation charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->