### PR TITLE
perf(profile): stop asking the database for quests that cannot exist

### DIFF
--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -2596,6 +2596,45 @@ export const updateUserContent = async (props: {
   return { jutsuChanges: changes.jutsuChanges, itemChanges: changes.itemChanges };
 };
 
+/** The quest types fetchUpdatedUser tries to start a user on when they hold none. */
+const BOOTSTRAP_QUEST_TYPES = ["tier", "exam"] as const;
+
+/**
+ * What the tier/exam bootstrap needs to know before it can decide whether starting a quest is
+ * even possible: which quests of those types exist, and which ones this user already has a
+ * history row for. `QuestHistory.completed` is `NOT NULL`, so fetchUncompletedQuests' own
+ * `isNull(completed)` on a left join matches exactly the quests with no history row — which is
+ * what `startedIds` inverts.
+ *
+ * Both reads depend only on `userId`, so they belong in fetchUpdatedUser's opening batch rather
+ * than costing round-trips of their own. `QuestHistory.questType` is denormalised from the quest,
+ * so a retyped quest could leave a history row out of `startedIds`; that can only make the guard
+ * pass where it might have skipped, never the reverse.
+ */
+export const fetchQuestBootstrap = async (client: DrizzleClient, userId: string) => {
+  const [candidates, started] = await Promise.all([
+    client
+      .select({
+        id: quest.id,
+        questType: quest.questType,
+        requiredLevel: quest.requiredLevel,
+        maxLevel: quest.maxLevel,
+      })
+      .from(quest)
+      .where(inArray(quest.questType, [...BOOTSTRAP_QUEST_TYPES])),
+    client
+      .select({ questId: questHistory.questId })
+      .from(questHistory)
+      .where(
+        and(
+          eq(questHistory.userId, userId),
+          inArray(questHistory.questType, [...BOOTSTRAP_QUEST_TYPES]),
+        ),
+      ),
+  ]);
+  return { candidates, startedIds: new Set(started.map((row) => row.questId)) };
+};
+
 /**
  * Fetch user with bloodline & village relations. Occasionally updates the user with regeneration
  * of pools, or optionally forces regeneration with forceRegen=true
@@ -2627,6 +2666,7 @@ export const fetchUpdatedUser = async (props: {
     allActiveWars,
     activeShrineBattles,
     activeRaids,
+    questBootstrap,
   ] = await Promise.all([
     fetchAchievementCatalogue(client),
     fetchAllGameSettings(client),
@@ -2681,6 +2721,7 @@ export const fetchUpdatedUser = async (props: {
     fetchAllActiveWars(client),
     fetchActiveShrineLobbies(client, shrineLobbyStaleBefore),
     fetchActiveRaids(client, now),
+    fetchQuestBootstrap(client, userId),
   ]);
 
   // Reskin bloodline if needed
@@ -2857,8 +2898,20 @@ export const fetchUpdatedUser = async (props: {
   // They run in sequence, not in parallel: insertNextQuest mutates user.userQuests and
   // persists its own questData snapshot, so concurrent inserts overwrite each other.
   if (user) {
-    for (const questType of ["tier", "exam"] as const) {
+    for (const questType of BOOTSTRAP_QUEST_TYPES) {
       if (user.userQuests?.some((q) => q.quest.questType === questType)) continue;
+      // A strict subset of fetchUncompletedQuests' own filters. Clearing none of them means that
+      // query is guaranteed to come back empty, and the round-trip buys nothing; anything that
+      // does clear them still goes through insertNextQuest, which stays the authority on whether
+      // a quest is actually startable.
+      const possible = questBootstrap.candidates.some(
+        (candidate) =>
+          candidate.questType === questType &&
+          !questBootstrap.startedIds.has(candidate.id) &&
+          candidate.requiredLevel <= user.level &&
+          candidate.maxLevel >= user.level,
+      );
+      if (!possible) continue;
       try {
         if (await insertNextQuest(client, user, questType)) {
           forceRegen = true;

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -3174,61 +3174,55 @@ export type AchievementProgress = Omit<UserQuest, "quest">;
 const BOOTSTRAP_QUEST_TYPES = ["tier", "exam"] as const;
 
 /**
- * What the tier/exam bootstrap needs to know before it can decide whether starting a quest is
- * even possible: which quests of those types exist, and which ones this user already has a
- * history row for. `QuestHistory.completed` is `NOT NULL`, so fetchUncompletedQuests' own
- * `isNull(completed)` on a left join matches exactly the quests with no history row — which is
- * what `startedIds` inverts.
+ * What the tier/exam bootstrap needs before it can tell whether starting a quest is even
+ * possible: every quest of those types, each carrying whether this user has a history row for it.
  *
- * Both reads depend only on `userId`, so they belong in fetchUpdatedUser's opening batch rather
- * than costing round-trips of their own. `QuestHistory.questType` is denormalised from the quest,
- * so a retyped quest could leave a history row out of `startedIds`; that can only make the guard
- * pass where it might have skipped, never the reverse.
+ * Deliberately the same left join fetchUncompletedQuests itself performs — on questId and userId,
+ * with `completed` selected — so the guard below can test `completed === null` and be reading the
+ * identical condition rather than an argument that resembles it. Joining rather than reading the
+ * two tables separately also keeps `QuestHistory.questType` out of it, which is denormalised from
+ * the quest and can drift.
+ *
+ * It depends only on `userId`, so it belongs in fetchUpdatedUser's opening batch rather than
+ * costing a round-trip of its own.
  */
 export const fetchQuestBootstrap = (client: DrizzleClient, userId: string) =>
-  scopedRead(`questBootstrap:${userId}`, async () => {
-    const [candidates, started] = await Promise.all([
-      client
-        .select({
-          id: quest.id,
-          questType: quest.questType,
-          requiredLevel: quest.requiredLevel,
-          maxLevel: quest.maxLevel,
-        })
-        .from(quest)
-        .where(inArray(quest.questType, [...BOOTSTRAP_QUEST_TYPES])),
-      client
-        .select({ questId: questHistory.questId })
-        .from(questHistory)
-        .where(
-          and(
-            eq(questHistory.userId, userId),
-            inArray(questHistory.questType, [...BOOTSTRAP_QUEST_TYPES]),
-          ),
-        ),
-    ]);
-    return { candidates, startedIds: new Set(started.map((row) => row.questId)) };
-  });
+  scopedRead(`questBootstrap:${userId}`, () =>
+    client
+      .select({
+        id: quest.id,
+        questType: quest.questType,
+        requiredLevel: quest.requiredLevel,
+        maxLevel: quest.maxLevel,
+        completed: questHistory.completed,
+      })
+      .from(quest)
+      .leftJoin(
+        questHistory,
+        and(eq(questHistory.questId, quest.id), eq(questHistory.userId, userId)),
+      )
+      .where(inArray(quest.questType, [...BOOTSTRAP_QUEST_TYPES])),
+  );
 
 /**
  * Whether starting a quest of this type is even possible, from what fetchQuestBootstrap read.
  *
- * A strict subset of fetchUncompletedQuests' filters — quest type, level band, and no existing
- * history row — so a `false` means that query is guaranteed to return nothing and the round-trip
- * buys nothing. Everything else it filters on (farming level, the date window, quest rank,
- * village, bloodline, sage requirements, hidden) is deliberately not checked here: leaving a
- * filter out can only let a call through that would have been skipped, never the reverse. A
- * `true` still goes to insertNextQuest, which remains the authority.
+ * A strict subset of fetchUncompletedQuests' filters — quest type, level band, and that same
+ * `isNull(completed)` on the join — so a `false` means that query is guaranteed to return nothing
+ * and the round-trip buys nothing. Everything else it filters on (farming level, the date window,
+ * quest rank, village, bloodline, sage requirements, hidden) is deliberately not checked here:
+ * leaving a filter out can only let a call through that would have been skipped, never the
+ * reverse. A `true` still goes to insertNextQuest, which remains the authority.
  */
 export const canBootstrapQuestType = (
-  bootstrap: Awaited<ReturnType<typeof fetchQuestBootstrap>>,
+  candidates: Awaited<ReturnType<typeof fetchQuestBootstrap>>,
   questType: (typeof BOOTSTRAP_QUEST_TYPES)[number],
   level: number,
 ) =>
-  bootstrap.candidates.some(
+  candidates.some(
     (candidate) =>
       candidate.questType === questType &&
-      !bootstrap.startedIds.has(candidate.id) &&
+      candidate.completed === null &&
       candidate.requiredLevel <= level &&
       candidate.maxLevel >= level,
   );

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -2596,45 +2596,6 @@ export const updateUserContent = async (props: {
   return { jutsuChanges: changes.jutsuChanges, itemChanges: changes.itemChanges };
 };
 
-/** The quest types fetchUpdatedUser tries to start a user on when they hold none. */
-const BOOTSTRAP_QUEST_TYPES = ["tier", "exam"] as const;
-
-/**
- * What the tier/exam bootstrap needs to know before it can decide whether starting a quest is
- * even possible: which quests of those types exist, and which ones this user already has a
- * history row for. `QuestHistory.completed` is `NOT NULL`, so fetchUncompletedQuests' own
- * `isNull(completed)` on a left join matches exactly the quests with no history row — which is
- * what `startedIds` inverts.
- *
- * Both reads depend only on `userId`, so they belong in fetchUpdatedUser's opening batch rather
- * than costing round-trips of their own. `QuestHistory.questType` is denormalised from the quest,
- * so a retyped quest could leave a history row out of `startedIds`; that can only make the guard
- * pass where it might have skipped, never the reverse.
- */
-export const fetchQuestBootstrap = async (client: DrizzleClient, userId: string) => {
-  const [candidates, started] = await Promise.all([
-    client
-      .select({
-        id: quest.id,
-        questType: quest.questType,
-        requiredLevel: quest.requiredLevel,
-        maxLevel: quest.maxLevel,
-      })
-      .from(quest)
-      .where(inArray(quest.questType, [...BOOTSTRAP_QUEST_TYPES])),
-    client
-      .select({ questId: questHistory.questId })
-      .from(questHistory)
-      .where(
-        and(
-          eq(questHistory.userId, userId),
-          inArray(questHistory.questType, [...BOOTSTRAP_QUEST_TYPES]),
-        ),
-      ),
-  ]);
-  return { candidates, startedIds: new Set(started.map((row) => row.questId)) };
-};
-
 /**
  * Fetch user with bloodline & village relations. Occasionally updates the user with regeneration
  * of pools, or optionally forces regeneration with forceRegen=true
@@ -3219,6 +3180,45 @@ const fetchActiveRaids = (client: DrizzleClient, now: Date) =>
 
 /** A user's progress on one quest, without the static definition it belongs to. */
 export type AchievementProgress = Omit<UserQuest, "quest">;
+
+/** The quest types fetchUpdatedUser tries to start a user on when they hold none. */
+const BOOTSTRAP_QUEST_TYPES = ["tier", "exam"] as const;
+
+/**
+ * What the tier/exam bootstrap needs to know before it can decide whether starting a quest is
+ * even possible: which quests of those types exist, and which ones this user already has a
+ * history row for. `QuestHistory.completed` is `NOT NULL`, so fetchUncompletedQuests' own
+ * `isNull(completed)` on a left join matches exactly the quests with no history row — which is
+ * what `startedIds` inverts.
+ *
+ * Both reads depend only on `userId`, so they belong in fetchUpdatedUser's opening batch rather
+ * than costing round-trips of their own. `QuestHistory.questType` is denormalised from the quest,
+ * so a retyped quest could leave a history row out of `startedIds`; that can only make the guard
+ * pass where it might have skipped, never the reverse.
+ */
+export const fetchQuestBootstrap = async (client: DrizzleClient, userId: string) => {
+  const [candidates, started] = await Promise.all([
+    client
+      .select({
+        id: quest.id,
+        questType: quest.questType,
+        requiredLevel: quest.requiredLevel,
+        maxLevel: quest.maxLevel,
+      })
+      .from(quest)
+      .where(inArray(quest.questType, [...BOOTSTRAP_QUEST_TYPES])),
+    client
+      .select({ questId: questHistory.questId })
+      .from(questHistory)
+      .where(
+        and(
+          eq(questHistory.userId, userId),
+          inArray(questHistory.questType, [...BOOTSTRAP_QUEST_TYPES]),
+        ),
+      ),
+  ]);
+  return { candidates, startedIds: new Set(started.map((row) => row.questId)) };
+};
 
 /**
  * Move a user's achievement rows out of `user.userQuests` and return them without their `quest`.

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -2861,18 +2861,7 @@ export const fetchUpdatedUser = async (props: {
   if (user) {
     for (const questType of BOOTSTRAP_QUEST_TYPES) {
       if (user.userQuests?.some((q) => q.quest.questType === questType)) continue;
-      // A strict subset of fetchUncompletedQuests' own filters. Clearing none of them means that
-      // query is guaranteed to come back empty, and the round-trip buys nothing; anything that
-      // does clear them still goes through insertNextQuest, which stays the authority on whether
-      // a quest is actually startable.
-      const possible = questBootstrap.candidates.some(
-        (candidate) =>
-          candidate.questType === questType &&
-          !questBootstrap.startedIds.has(candidate.id) &&
-          candidate.requiredLevel <= user.level &&
-          candidate.maxLevel >= user.level,
-      );
-      if (!possible) continue;
+      if (!canBootstrapQuestType(questBootstrap, questType, user.level)) continue;
       try {
         if (await insertNextQuest(client, user, questType)) {
           forceRegen = true;
@@ -3196,29 +3185,53 @@ const BOOTSTRAP_QUEST_TYPES = ["tier", "exam"] as const;
  * so a retyped quest could leave a history row out of `startedIds`; that can only make the guard
  * pass where it might have skipped, never the reverse.
  */
-export const fetchQuestBootstrap = async (client: DrizzleClient, userId: string) => {
-  const [candidates, started] = await Promise.all([
-    client
-      .select({
-        id: quest.id,
-        questType: quest.questType,
-        requiredLevel: quest.requiredLevel,
-        maxLevel: quest.maxLevel,
-      })
-      .from(quest)
-      .where(inArray(quest.questType, [...BOOTSTRAP_QUEST_TYPES])),
-    client
-      .select({ questId: questHistory.questId })
-      .from(questHistory)
-      .where(
-        and(
-          eq(questHistory.userId, userId),
-          inArray(questHistory.questType, [...BOOTSTRAP_QUEST_TYPES]),
+export const fetchQuestBootstrap = (client: DrizzleClient, userId: string) =>
+  scopedRead(`questBootstrap:${userId}`, async () => {
+    const [candidates, started] = await Promise.all([
+      client
+        .select({
+          id: quest.id,
+          questType: quest.questType,
+          requiredLevel: quest.requiredLevel,
+          maxLevel: quest.maxLevel,
+        })
+        .from(quest)
+        .where(inArray(quest.questType, [...BOOTSTRAP_QUEST_TYPES])),
+      client
+        .select({ questId: questHistory.questId })
+        .from(questHistory)
+        .where(
+          and(
+            eq(questHistory.userId, userId),
+            inArray(questHistory.questType, [...BOOTSTRAP_QUEST_TYPES]),
+          ),
         ),
-      ),
-  ]);
-  return { candidates, startedIds: new Set(started.map((row) => row.questId)) };
-};
+    ]);
+    return { candidates, startedIds: new Set(started.map((row) => row.questId)) };
+  });
+
+/**
+ * Whether starting a quest of this type is even possible, from what fetchQuestBootstrap read.
+ *
+ * A strict subset of fetchUncompletedQuests' filters — quest type, level band, and no existing
+ * history row — so a `false` means that query is guaranteed to return nothing and the round-trip
+ * buys nothing. Everything else it filters on (farming level, the date window, quest rank,
+ * village, bloodline, sage requirements, hidden) is deliberately not checked here: leaving a
+ * filter out can only let a call through that would have been skipped, never the reverse. A
+ * `true` still goes to insertNextQuest, which remains the authority.
+ */
+export const canBootstrapQuestType = (
+  bootstrap: Awaited<ReturnType<typeof fetchQuestBootstrap>>,
+  questType: (typeof BOOTSTRAP_QUEST_TYPES)[number],
+  level: number,
+) =>
+  bootstrap.candidates.some(
+    (candidate) =>
+      candidate.questType === questType &&
+      !bootstrap.startedIds.has(candidate.id) &&
+      candidate.requiredLevel <= level &&
+      candidate.maxLevel >= level,
+  );
 
 /**
  * Move a user's achievement rows out of `user.userQuests` and return them without their `quest`.

--- a/app/tests/server/api/profile.questBootstrap.test.ts
+++ b/app/tests/server/api/profile.questBootstrap.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { quest, questHistory, type UserData } from "@/drizzle/schema";
+import { fetchQuestBootstrap } from "../../../src/server/api/routers/profile";
+import { fetchUncompletedQuests } from "../../../src/server/api/routers/quests";
+import { insertQuestHistory, insertQuests } from "../../setup/factories";
+import {
+  describeWithDatabase,
+  getTestDatabase,
+  resetTables,
+} from "../../setup/testDatabase";
+
+/**
+ * `fetchUpdatedUser` used to call `insertNextQuest` for "tier" and "exam" on every request, and
+ * that always begins with a `fetchUncompletedQuests` round-trip — which comes back empty for the
+ * overwhelming majority of players. A JS guard now skips the call when nothing could possibly
+ * match.
+ *
+ * The guard is only safe while it stays a strict SUBSET of that query's filters, so what matters
+ * is one direction: whenever the guard says "impossible", the real query must genuinely return
+ * nothing. These tests assert that against a real database rather than a mock, so the day someone
+ * adds a filter to `fetchUncompletedQuests` and the two drift apart, this is what notices.
+ */
+const BAND = { requiredLevel: 10, maxLevel: 50 } as const;
+
+/** Mirrors the guard in fetchUpdatedUser. Kept here in full so a change there fails this file. */
+const guardSaysPossible = (
+  bootstrap: Awaited<ReturnType<typeof fetchQuestBootstrap>>,
+  questType: "tier" | "exam",
+  level: number,
+) =>
+  bootstrap.candidates.some(
+    (candidate) =>
+      candidate.questType === questType &&
+      !bootstrap.startedIds.has(candidate.id) &&
+      candidate.requiredLevel <= level &&
+      candidate.maxLevel >= level,
+  );
+
+const asUser = (level: number) =>
+  ({
+    userId: "user-guard",
+    role: "USER",
+    rank: "JONIN",
+    level,
+    villageId: null,
+    isOutlaw: false,
+    bloodlineId: null,
+    farmingExperience: 0,
+    questData: [],
+  }) as unknown as UserData;
+
+describeWithDatabase("quest bootstrap guard", () => {
+  beforeEach(async () => {
+    await resetTables(questHistory, quest);
+  });
+
+  it("agrees with the real query across the level range", async () => {
+    const [tier] = await insertQuests([
+      { id: "tier-1", questType: "tier", questRank: "D", tierLevel: 1, ...BAND },
+    ]);
+    expect(tier).toBeDefined();
+
+    const database = await getTestDatabase();
+    let sawPossible = false;
+    let sawImpossible = false;
+
+    // Around, on, and well outside the quest's band
+    for (const level of [1, 9, 10, 11, 30, 49, 50, 51, 80]) {
+      const bootstrap = await fetchQuestBootstrap(database, "user-guard");
+      const possible = guardSaysPossible(bootstrap, "tier", level);
+      const rows = await fetchUncompletedQuests(database, asUser(level), "tier");
+      if (possible) sawPossible = true;
+      else {
+        sawImpossible = true;
+        // The direction that matters: skipping must never lose a startable quest
+        expect(rows, `level ${level}: guard skipped a non-empty query`).toHaveLength(0);
+      }
+      // And when it does let the call through, the query really has something for it
+      if (possible) {
+        expect(rows.length, `level ${level}: guard passed on an empty query`).toBeGreaterThan(0);
+      }
+    }
+
+    // Neither branch may be vacuous, or the loop above proves nothing
+    expect(sawPossible).toBe(true);
+    expect(sawImpossible).toBe(true);
+  });
+
+  it("skips once every quest of the type has been started", async () => {
+    await insertQuests([
+      { id: "tier-1", questType: "tier", questRank: "D", tierLevel: 1, ...BAND },
+      { id: "tier-2", questType: "tier", questRank: "D", tierLevel: 2, ...BAND },
+    ]);
+    const database = await getTestDatabase();
+
+    // In-band with nothing started: the call has to go through
+    expect(
+      guardSaysPossible(await fetchQuestBootstrap(database, "user-guard"), "tier", 30),
+    ).toBe(true);
+
+    // A history row exists even when the quest was never finished, and
+    // QuestHistory.completed is NOT NULL, so the real query's isNull(completed) on the left
+    // join excludes it either way — which is exactly what startedIds reproduces
+    await insertQuestHistory([
+      { userId: "user-guard", questId: "tier-1", questType: "tier", completed: 0 },
+      { userId: "user-guard", questId: "tier-2", questType: "tier", completed: 1 },
+    ]);
+
+    const bootstrap = await fetchQuestBootstrap(database, "user-guard");
+    expect(guardSaysPossible(bootstrap, "tier", 30)).toBe(false);
+    expect(await fetchUncompletedQuests(database, asUser(30), "tier")).toHaveLength(0);
+  });
+
+  it("skips a type that has no quests at all, which is exam in production today", async () => {
+    await insertQuests([
+      { id: "tier-1", questType: "tier", questRank: "D", tierLevel: 1, ...BAND },
+    ]);
+    const database = await getTestDatabase();
+    const bootstrap = await fetchQuestBootstrap(database, "user-guard");
+
+    expect(bootstrap.candidates.some((c) => c.questType === "exam")).toBe(false);
+    expect(guardSaysPossible(bootstrap, "exam", 30)).toBe(false);
+    expect(await fetchUncompletedQuests(database, asUser(30), "exam")).toHaveLength(0);
+  });
+
+  it("only reads the two quest types it is responsible for", async () => {
+    await insertQuests([
+      { id: "tier-1", questType: "tier", questRank: "D", tierLevel: 1, ...BAND },
+      { id: "daily-1", questType: "daily", questRank: "D", ...BAND },
+      { id: "mission-1", questType: "mission", questRank: "D", ...BAND },
+    ]);
+    const database = await getTestDatabase();
+    const bootstrap = await fetchQuestBootstrap(database, "user-guard");
+
+    expect(bootstrap.candidates.map((c) => c.questType).sort()).toEqual(["tier"]);
+  });
+});

--- a/app/tests/server/api/profile.questBootstrap.test.ts
+++ b/app/tests/server/api/profile.questBootstrap.test.ts
@@ -2,7 +2,10 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import { quest, questHistory, type UserData } from "@/drizzle/schema";
-import { fetchQuestBootstrap } from "../../../src/server/api/routers/profile";
+import {
+  canBootstrapQuestType,
+  fetchQuestBootstrap,
+} from "../../../src/server/api/routers/profile";
 import { fetchUncompletedQuests } from "../../../src/server/api/routers/quests";
 import { insertQuestHistory, insertQuests } from "../../setup/factories";
 import {
@@ -17,26 +20,21 @@ import {
  * overwhelming majority of players. A JS guard now skips the call when nothing could possibly
  * match.
  *
- * The guard is only safe while it stays a strict SUBSET of that query's filters, so what matters
- * is one direction: whenever the guard says "impossible", the real query must genuinely return
- * nothing. These tests assert that against a real database rather than a mock, so the day someone
- * adds a filter to `fetchUncompletedQuests` and the two drift apart, this is what notices.
+ * The guard is only safe while it stays a strict SUBSET of that query's filters, so one direction
+ * is what matters: whenever it says "impossible", the real query must genuinely return nothing.
+ * These tests assert that against a real database rather than a mock.
+ *
+ * They call the shipped `canBootstrapQuestType`, deliberately. An earlier version of this file
+ * re-implemented the predicate locally, which meant it went on passing while the real guard was
+ * broken — tightening its level check to `>` would have denied every level-50 player their tier
+ * quest with the suite still green.
+ *
+ * Note which direction each assertion protects. A filter added to `fetchUncompletedQuests` makes
+ * the query stricter, which keeps the guard a subset and is always safe. A filter added to the
+ * GUARD is what can start skipping real work, and that is what the skip-implies-empty assertion
+ * below is for.
  */
 const BAND = { requiredLevel: 10, maxLevel: 50 } as const;
-
-/** Mirrors the guard in fetchUpdatedUser. Kept here in full so a change there fails this file. */
-const guardSaysPossible = (
-  bootstrap: Awaited<ReturnType<typeof fetchQuestBootstrap>>,
-  questType: "tier" | "exam",
-  level: number,
-) =>
-  bootstrap.candidates.some(
-    (candidate) =>
-      candidate.questType === questType &&
-      !bootstrap.startedIds.has(candidate.id) &&
-      candidate.requiredLevel <= level &&
-      candidate.maxLevel >= level,
-  );
 
 const asUser = (level: number) =>
   ({
@@ -69,21 +67,22 @@ describeWithDatabase("quest bootstrap guard", () => {
     // Around, on, and well outside the quest's band
     for (const level of [1, 9, 10, 11, 30, 49, 50, 51, 80]) {
       const bootstrap = await fetchQuestBootstrap(database, "user-guard");
-      const possible = guardSaysPossible(bootstrap, "tier", level);
+      const possible = canBootstrapQuestType(bootstrap, "tier", level);
       const rows = await fetchUncompletedQuests(database, asUser(level), "tier");
-      if (possible) sawPossible = true;
-      else {
+      if (possible) {
+        sawPossible = true;
+        // Only sound because this fixture clears the filters the guard does not look at; a new
+        // filter on the query would legitimately break this without breaking the guard
+        expect(rows.length, `level ${level}: guard passed on an empty query`).toBeGreaterThan(0);
+      } else {
         sawImpossible = true;
         // The direction that matters: skipping must never lose a startable quest
         expect(rows, `level ${level}: guard skipped a non-empty query`).toHaveLength(0);
       }
-      // And when it does let the call through, the query really has something for it
-      if (possible) {
-        expect(rows.length, `level ${level}: guard passed on an empty query`).toBeGreaterThan(0);
-      }
     }
 
-    // Neither branch may be vacuous, or the loop above proves nothing
+    // Neither branch may be vacuous, or the loop above proves nothing — and a guard stuck at
+    // `true` (safe but useless) or `false` (silently skipping everyone) fails right here
     expect(sawPossible).toBe(true);
     expect(sawImpossible).toBe(true);
   });
@@ -97,7 +96,7 @@ describeWithDatabase("quest bootstrap guard", () => {
 
     // In-band with nothing started: the call has to go through
     expect(
-      guardSaysPossible(await fetchQuestBootstrap(database, "user-guard"), "tier", 30),
+      canBootstrapQuestType(await fetchQuestBootstrap(database, "user-guard"), "tier", 30),
     ).toBe(true);
 
     // A history row exists even when the quest was never finished, and
@@ -109,7 +108,7 @@ describeWithDatabase("quest bootstrap guard", () => {
     ]);
 
     const bootstrap = await fetchQuestBootstrap(database, "user-guard");
-    expect(guardSaysPossible(bootstrap, "tier", 30)).toBe(false);
+    expect(canBootstrapQuestType(bootstrap, "tier", 30)).toBe(false);
     expect(await fetchUncompletedQuests(database, asUser(30), "tier")).toHaveLength(0);
   });
 
@@ -121,7 +120,7 @@ describeWithDatabase("quest bootstrap guard", () => {
     const bootstrap = await fetchQuestBootstrap(database, "user-guard");
 
     expect(bootstrap.candidates.some((c) => c.questType === "exam")).toBe(false);
-    expect(guardSaysPossible(bootstrap, "exam", 30)).toBe(false);
+    expect(canBootstrapQuestType(bootstrap, "exam", 30)).toBe(false);
     expect(await fetchUncompletedQuests(database, asUser(30), "exam")).toHaveLength(0);
   });
 

--- a/app/tests/server/api/profile.questBootstrap.test.ts
+++ b/app/tests/server/api/profile.questBootstrap.test.ts
@@ -119,7 +119,7 @@ describeWithDatabase("quest bootstrap guard", () => {
     const database = await getTestDatabase();
     const bootstrap = await fetchQuestBootstrap(database, "user-guard");
 
-    expect(bootstrap.candidates.some((c) => c.questType === "exam")).toBe(false);
+    expect(bootstrap.some((c) => c.questType === "exam")).toBe(false);
     expect(canBootstrapQuestType(bootstrap, "exam", 30)).toBe(false);
     expect(await fetchUncompletedQuests(database, asUser(30), "exam")).toHaveLength(0);
   });
@@ -133,6 +133,6 @@ describeWithDatabase("quest bootstrap guard", () => {
     const database = await getTestDatabase();
     const bootstrap = await fetchQuestBootstrap(database, "user-guard");
 
-    expect(bootstrap.candidates.map((c) => c.questType).sort()).toEqual(["tier"]);
+    expect(bootstrap.map((c) => c.questType).sort()).toEqual(["tier"]);
   });
 });


### PR DESCRIPTION
Audit finding **F06**. `fetchUpdatedUser` tries to start every user on a tier and an exam quest, and `insertNextQuest` always opens with a `fetchUncompletedQuests` round-trip. Both run **serially, after the opening `Promise.all`**, on the response critical path — and `fetchUpdatedUser` backs `profile.getUser`, which every signed-in client polls every five minutes, on top of every page load and every mutation that calls it.

Almost none of those queries can return anything.

## The production numbers

Measured against `main-1` today, users active in the last 7 days:

| | |
|---|---|
| active human users | 2,831 |
| **`exam`** quests that exist | **0** — that lookup has never been able to insert anything |
| **`tier`** quests | 4, all `requiredLevel` 10 / `maxLevel` 50 |
| below level 10 | 2,046 |
| above level 50 | 390 |
| in band but already holding all four | 121 |
| **could ever match** | **274 of 2,831 (9.7%)** |

So for ~90% of active players both lookups are dead code executed against the database, twice, on every request that touches `fetchUpdatedUser`.

## The fix

One read tells us everything needed to rule the calls out: every tier/exam quest, each carrying whether this user already has a `QuestHistory` row for it. It depends only on `userId`, so it joins the **existing** opening `Promise.all` and adds no latency of its own, and like every one of its six siblings in that batch it is wrapped in `scopedRead`, so it is issued once per tRPC batch rather than once per procedure. That matters on `/home`, which mounts two procedures calling `fetchUpdatedUser` alongside the `getUser` poll in a single POST.

It is deliberately the **same left join `fetchUncompletedQuests` itself performs** — on `questId` and `userId`, with `completed` selected. `EXPLAIN` on production: `range` on `Quest_questType_idx` (5 rows), then `eq_ref` on `uniqueUserIdQuestId`, 1 row, `Using index` — fully covered, no table lookup.

The loop then skips `insertNextQuest` when nothing could match.

## Why the guard cannot lose a quest

It checks a **strict subset** of `fetchUncompletedQuests`' own filters — quest type, level band, and no prior history row. It ignores farming level, the `startsAt`/`endsAt` window, quest rank, village, bloodline, sage requirements and the `hidden` filter entirely. Ignoring a filter can only make the guard pass *more* often than the query returns rows, never less, so a skip always means the query was guaranteed empty. When the guard passes, unmodified `insertNextQuest` runs and stays the authority.

The one part that has to be exact rather than conservative is the history check, and using the same join makes it exact by construction: the guard tests `completed === null`, which is literally `fetchUncompletedQuests`' own `isNull(questHistory.completed)`, rather than something that has to be argued equivalent to it.

An earlier revision read the two tables separately and filtered history by `QuestHistory.questType` — a column denormalised from the quest at insert and never refreshed, so it could drift. The join never consults it.

## Tests

`app/tests/server/api/profile.questBootstrap.test.ts` asserts the guard against a **real database** rather than a mock. It walks levels either side of the band and asserts that a skip implies the query is empty, with explicit checks that neither branch went unexercised, so the loop cannot pass vacuously and a guard stuck at `true` or `false` fails outright.

Worth being precise about which direction is protected, since I had this backwards in an earlier draft: a filter added to `fetchUncompletedQuests` makes the *query* stricter, which keeps the guard a subset and is always safe. The dangerous change is a filter added to the *guard* — that is what skip-implies-empty catches.

CI runs it: `.github/workflows/test_build.yml` sets `TEST_MYSQL_URL` and `TEST_MYSQL_ALLOW_DESTRUCTIVE`, so this is not one of the suites that silently skips.

The test calls the **shipped** predicate rather than a copy of it, and that distinction was earned: an earlier version of this file re-implemented the guard locally, and adversarial review showed the suite stayed green while the real guard was broken — tightening its level check to `>` denies every level-50 player their tier quest, since all four production tier quests have `maxLevel` 50. With the predicate exported and both callers sharing it, that same edit now fails the suite on `guard skipped a non-empty query`.

## Risk

- The guard's snapshot is taken slightly earlier in the request than the old inline query. A quest created in that window is picked up on the next request rather than this one; nothing is lost, and quest bootstrap already runs on every request.
- No writes, no ordering, no CAS: the change only decides whether to *ask*, never what to store.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved quest setup when user profiles are updated.
  * Quest recommendations now account for the user’s level, quest type, and previously started quests.
  * Quest options include completion status and relevant tier or exam information.

* **Bug Fixes**
  * Prevented invalid or duplicate quests from being added during quest initialization.
  * Improved handling for quest types with no available candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->