### PR TITLE
perf(images): let catalog tiles load when they are scrolled to

### DIFF
--- a/app/src/app/combat/page.tsx
+++ b/app/src/app/combat/page.tsx
@@ -266,6 +266,7 @@ export default function CombatPage() {
           currentRound={battle.round}
           className="p-1"
           showBgColor={true}
+          eagerImages={true}
           showLabels={showActionLabels}
           selectedId={actionId}
           combatMode={true}

--- a/app/src/layout/CombatActions.tsx
+++ b/app/src/layout/CombatActions.tsx
@@ -62,6 +62,12 @@ interface ActionSelectorSettingsProps {
   lastElement?: HTMLDivElement | null;
   setLastElement?: (el: HTMLDivElement | null) => void;
   showInfoIcon?: boolean;
+  /**
+   * Load every tile's art immediately. Only the combat action bar sets it: it is on screen the
+   * moment combat opens and holds a handful of actions, unlike the catalogs which are long and
+   * mostly below the fold.
+   */
+  eagerImages?: boolean;
   combatMode?: boolean;
   userActionPoints?: number;
   battle?: ReturnedBattle | null;
@@ -315,6 +321,7 @@ export const ActionOption: React.FC<ActionOptionProps> = (props) => {
             hideBorder={settings.hideBorder}
             frames={frames}
             speed={speed}
+            eager={settings.eagerImages}
             onClick={handleClick}
           />
         )}

--- a/app/src/layout/ContentImage.tsx
+++ b/app/src/layout/ContentImage.tsx
@@ -21,6 +21,15 @@ interface ContentImageProps {
   className: string;
   roundFull?: boolean;
   hideBorder?: boolean;
+  /**
+   * Load this tile immediately instead of when it scrolls into view. Only for grids that are
+   * above the fold on arrival — everything else is a catalog the player may never scroll, and
+   * eager tiles there compete with the images they can actually see.
+   *
+   * `loading` rather than `preload`: next/image's own guidance is to preload only a single LCP
+   * candidate, and every consumer of this is a grid of many equal images.
+   */
+  eager?: boolean;
   onClick?: () => void;
 }
 
@@ -100,7 +109,7 @@ const ContentImage: React.FC<ContentImageProps> = (props) => {
           alt={props.alt}
           width={125}
           height={125}
-          priority={true}
+          loading={props.eager ? "eager" : "lazy"}
           onClick={props.onClick}
         />
       );
@@ -127,7 +136,7 @@ const ContentImage: React.FC<ContentImageProps> = (props) => {
             alt={props.alt}
             width={125}
             height={125}
-            priority={true}
+            loading={props.eager ? "eager" : "lazy"}
             onClick={props.onClick}
           />
         </div>


### PR DESCRIPTION
Audit finding **F41**. `ContentImage` hardcoded `priority` on **both** images it can draw — the tile art and the rarity frame — with no way to turn it off. It is the tile renderer for every catalog in the game: the village shop, the crafting catalogs, the item and jutsu manuals, `ItemWithEffects` lists, the combat action bar and the combat timeline. Nothing was ever lazy, anywhere.

In Next 16 `priority` is deprecated, and what it actually produces here is a `<link rel="preload" as="image">` in the document head. So the tiles were not merely fetched eagerly — they were queued in the head alongside the wallpaper's genuine LCP request.

## What changed

Tiles are lazy by default, with an opt-in (`eager`) for grids that really are on screen on arrival. **Only the combat action bar takes it.**

The opt-in sets `loading="eager"`, not `preload`, following next/image's own guidance — preload is for a single LCP candidate, and *"when not to use it: when you have multiple images that could be considered the LCP element depending on the viewport"*, which is precisely a grid of equal tiles. That keeps the head clear even where tiles are eager.

Both images inside a tile take the same value, so art can never paint without its frame.

## Measured in the browser

Same pages, same 1280×800 viewport, dev server, before/after by swapping only these files:

| | images fetched on arrival | `<link rel=preload as=image>` | lazy `<img>` tags |
|---|---|---|---|
| `/manual/item` before | 53 | 23 | 45 |
| `/manual/item` **after** | **13** | **11** | **85** |
| `/manual/jutsu` before | 67 | 14 | 54 |
| `/manual/jutsu` **after** | **55** | **11** | **74** |

`/manual/item` is 4240px tall with 43 tiles below the fold on arrival, so three quarters of what it used to fetch was for tiles nobody had scrolled to yet.

## And nothing visible changed

The number that mattered more than the savings: at four scroll positions on `/manual/item` (0, 1200, 2400, 3400), **every in-viewport image is painted in both versions** — 34/34, 13/13, 7/7, 5/7 — including the same two already-broken assets that fail on `main` too. Lazy tiles render as they are reached; nothing is left blank.

In combat, the action bar still renders 12 eager tags and paints 9/9 of its visible icons.

## Risk

- The rarity frame becomes lazy alongside the art. Safe because both carry the same value, and the frames are four static URLs that hit the HTTP cache after the first tile.
- Deliberately **not** done, per the finding's own warning: opting `ItemWithEffects` in wholesale (112 call sites, mostly list rows) would reintroduce the defect at a larger scale, and re-paginating `Shop.tsx` is a separate change with its own risks — its expiry filter runs client-side after the page returns.
- Request counts in dev mode are noisy across runs because of compile-on-demand and HTTP cache state; the figures above are DOM-derived (`<img>` load state and head links), which is why they reproduce.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is limited to when off-screen catalog images fetch; combat UI keeps eager loading, and art/frame share the same loading mode.
> 
> **Overview**
> **Catalog tile images no longer preload everything on page load.** `ContentImage` drops hardcoded Next.js `priority` (which emitted many `<link rel="preload">` entries) in favor of **`loading="lazy"` by default**, with an optional **`eager`** flag that sets `loading="eager"` instead—without using preload, since these are grids of many equal-sized tiles.
> 
> **`ActionSelector` gains `eagerImages`**, wired through to `ContentImage` for both the art and the rarity frame so they stay in sync. **Only the combat page** passes `eagerImages={true}` for the on-screen action bar; long manuals, shops, and other catalogs inherit lazy loading with no call-site changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ad816dd2bf3cadc591590b4ac02386b07bf2b86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->