### PR TITLE
Optimize app-wide sidebar timer queries

### DIFF
--- a/app/src/app/traininggrounds/page.tsx
+++ b/app/src/app/traininggrounds/page.tsx
@@ -751,7 +751,10 @@ const JutsuTraining: React.FC<TrainingProps> = (props) => {
             handleNextStep();
           }
         }
-        await utils.jutsu.getUserJutsus.invalidate();
+        await Promise.all([
+          utils.jutsu.getUserJutsus.invalidate(),
+          utils.profile.getSidebarTimers.invalidate(),
+        ]);
       },
       onSettled: () => {
         document.body.style.cursor = "default";
@@ -764,7 +767,10 @@ const JutsuTraining: React.FC<TrainingProps> = (props) => {
     api.jutsu.stopTraining.useMutation({
       onSuccess: async (data) => {
         showMutationToast(data);
-        await utils.jutsu.getUserJutsus.invalidate();
+        await Promise.all([
+          utils.jutsu.getUserJutsus.invalidate(),
+          utils.profile.getSidebarTimers.invalidate(),
+        ]);
       },
       onSettled: () => {
         document.body.style.cursor = "default";

--- a/app/src/layout/CraftingCatalog.tsx
+++ b/app/src/layout/CraftingCatalog.tsx
@@ -103,7 +103,10 @@ export const CraftingCatalog: React.FC<CraftingCatalogProps> = ({
       if (data.success) {
         setSelectedItem(null);
         setCraftQuantity(1);
-        await utils.item.getUserItems.invalidate();
+        await Promise.all([
+          utils.item.getUserItems.invalidate(),
+          utils.profile.getSidebarTimers.invalidate(),
+        ]);
       }
     },
   });

--- a/app/src/layout/MenuBoxProfile.tsx
+++ b/app/src/layout/MenuBoxProfile.tsx
@@ -55,7 +55,6 @@ import AvatarImage from "@/layout/Avatar";
 import Countdown from "@/layout/Countdown";
 import ElementImage from "@/layout/ElementImage";
 import Image from "@/layout/Image";
-import { getFilter, useFiltering } from "@/layout/JutsuFiltering";
 import LevelUpBtn from "@/layout/LevelUpBtn";
 import StatusBar from "@/layout/StatusBar";
 import { sealCheck } from "@/libs/combat/tags";
@@ -117,18 +116,11 @@ const MenuBoxProfile: React.FC = () => {
   const [, setState] = useState<number>(0);
   const battle = useAtomValue(userBattleAtom);
   const utils = api.useUtils();
-  const state = useFiltering();
 
-  // Get user's jutsus
-  const { data: userJutsus } = api.jutsu.getUserJutsus.useQuery(getFilter(state), {
+  const { data: sidebarTimers } = api.profile.getSidebarTimers.useQuery(undefined, {
     enabled: !!userData,
   });
-  const { data: userItems } = api.item.getUserItems.useQuery(undefined, {
-    enabled: !!userData,
-  });
-  const trainingJutsu = userJutsus?.find(
-    (j) => j.finishTraining && j.finishTraining > new Date(),
-  );
+  const trainingJutsu = sidebarTimers?.jutsuTraining;
 
   /** Finish time for stealth or sensory training at the training grounds */
   const covertTrainingFinishAt = useMemo(() => {
@@ -143,41 +135,8 @@ const MenuBoxProfile: React.FC = () => {
     userData?.covertTrainingMinutes,
   ]);
 
-  const activeItemCraftingTimer = useMemo(() => {
-    if (!userItems?.length) return null;
-    const now = Date.now();
-    let best: { finish: Date; tooltip: string } | null = null;
-    for (const ui of userItems) {
-      if (!ui.craftingFinishedAt) continue;
-      const finish = new Date(ui.craftingFinishedAt);
-      if (finish.getTime() <= now) continue;
-      const entry = {
-        finish,
-        tooltip: `Crafting ${ui.item.name}`,
-      };
-      if (!best || finish < best.finish) best = entry;
-    }
-    return best;
-  }, [userItems]);
-
-  const activeImbuementTimer = useMemo(() => {
-    if (!userItems?.length) return null;
-    const now = Date.now();
-    let best: { finish: Date; tooltip: string } | null = null;
-    for (const ui of userItems) {
-      for (const imb of ui.imbuements ?? []) {
-        if (!imb.craftingFinishedAt) continue;
-        const finish = new Date(imb.craftingFinishedAt);
-        if (finish.getTime() <= now) continue;
-        const entry = {
-          finish,
-          tooltip: `Imbuing ${imb.item.name} onto ${ui.item.name}`,
-        };
-        if (!best || finish < best.finish) best = entry;
-      }
-    }
-    return best;
-  }, [userItems]);
+  const activeItemCraftingTimer = sidebarTimers?.crafting;
+  const activeImbuementTimer = sidebarTimers?.imbuement;
 
   // Get location of user
   const { location } = useGameMenu(userData);
@@ -485,17 +444,20 @@ const MenuBoxProfile: React.FC = () => {
                     <Atom className="mr-2 h-6 w-6" />
                     <Link href="/traininggrounds">
                       <Countdown
-                        targetDate={trainingJutsu.finishTraining || new Date()}
+                        targetDate={trainingJutsu.finishTraining}
                         timeDiff={timeDiff}
                         onFinish={async () => {
-                          await utils.jutsu.getUserJutsus.invalidate();
+                          await Promise.all([
+                            utils.jutsu.getUserJutsus.invalidate(),
+                            utils.profile.getSidebarTimers.invalidate(),
+                          ]);
                         }}
                       />
                     </Link>
                   </div>
                 </TooltipTrigger>
                 <TooltipContent>
-                  Training {trainingJutsu.jutsu?.name} to level {trainingJutsu.level}
+                  Training {trainingJutsu.name} to level {trainingJutsu.level}
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
@@ -537,16 +499,21 @@ const MenuBoxProfile: React.FC = () => {
                     <Hammer className="mr-2 h-6 w-6" />
                     <Link href="/occupation">
                       <Countdown
-                        targetDate={activeItemCraftingTimer.finish}
+                        targetDate={activeItemCraftingTimer.craftingFinishedAt}
                         timeDiff={timeDiff}
                         onFinish={async () => {
-                          await utils.item.getUserItems.invalidate();
+                          await Promise.all([
+                            utils.item.getUserItems.invalidate(),
+                            utils.profile.getSidebarTimers.invalidate(),
+                          ]);
                         }}
                       />
                     </Link>
                   </div>
                 </TooltipTrigger>
-                <TooltipContent>{activeItemCraftingTimer.tooltip}</TooltipContent>
+                <TooltipContent>
+                  Crafting {activeItemCraftingTimer.itemName}
+                </TooltipContent>
               </Tooltip>
             </TooltipProvider>
           )}
@@ -558,16 +525,22 @@ const MenuBoxProfile: React.FC = () => {
                     <Gem className="mr-2 h-6 w-6" />
                     <Link href="/occupation">
                       <Countdown
-                        targetDate={activeImbuementTimer.finish}
+                        targetDate={activeImbuementTimer.craftingFinishedAt}
                         timeDiff={timeDiff}
                         onFinish={async () => {
-                          await utils.item.getUserItems.invalidate();
+                          await Promise.all([
+                            utils.item.getUserItems.invalidate(),
+                            utils.profile.getSidebarTimers.invalidate(),
+                          ]);
                         }}
                       />
                     </Link>
                   </div>
                 </TooltipTrigger>
-                <TooltipContent>{activeImbuementTimer.tooltip}</TooltipContent>
+                <TooltipContent>
+                  Imbuing {activeImbuementTimer.imbuedName} onto{" "}
+                  {activeImbuementTimer.targetName}
+                </TooltipContent>
               </Tooltip>
             </TooltipProvider>
           )}

--- a/app/src/layout/OccupationCrafting.tsx
+++ b/app/src/layout/OccupationCrafting.tsx
@@ -67,7 +67,14 @@ export default function OccupationCrafting() {
       setIsImbueModalOpen(false);
       setSelectedImbuableItem(undefined);
       setSelectedCrystalUserItem(undefined);
-      await utils.item.getUserItems.invalidate();
+      if (data.success) {
+        await Promise.all([
+          utils.item.getUserItems.invalidate(),
+          utils.profile.getSidebarTimers.invalidate(),
+        ]);
+      } else {
+        await utils.item.getUserItems.invalidate();
+      }
     },
   });
 
@@ -75,7 +82,10 @@ export default function OccupationCrafting() {
     api.occupation.finishCraftingImmediately.useMutation({
       onSuccess: async (data) => {
         showMutationToast(data);
-        await utils.item.getUserItems.invalidate();
+        await Promise.all([
+          utils.item.getUserItems.invalidate(),
+          utils.profile.getSidebarTimers.invalidate(),
+        ]);
       },
     });
 
@@ -83,7 +93,10 @@ export default function OccupationCrafting() {
     api.occupation.finishImbuingImmediately.useMutation({
       onSuccess: async (data) => {
         showMutationToast(data);
-        await utils.item.getUserItems.invalidate();
+        await Promise.all([
+          utils.item.getUserItems.invalidate(),
+          utils.profile.getSidebarTimers.invalidate(),
+        ]);
       },
     });
 

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -18,6 +18,7 @@ import {
   or,
   sql,
 } from "drizzle-orm";
+import { alias } from "drizzle-orm/mysql-core";
 import { customAlphabet, nanoid } from "nanoid";
 import { z } from "zod";
 import {
@@ -85,6 +86,7 @@ import {
   userBlackList,
   userData,
   userItem,
+  userItemImbuement,
   userJutsu,
   userNindo,
   userPollVote,
@@ -198,6 +200,67 @@ import {
 const pusher = getServerPusher();
 
 export const profileRouter = createTRPCRouter({
+  getSidebarTimers: protectedProcedure.query(async ({ ctx }) => {
+    const now = sql`NOW()`;
+    const imbuedItem = alias(item, "imbuedItem");
+
+    const [jutsuTrainingRows, craftingRows, imbuementRows] = await Promise.all([
+      ctx.drizzle
+        .select({
+          name: jutsu.name,
+          level: userJutsu.level,
+          finishTraining: userJutsu.finishTraining,
+        })
+        .from(userJutsu)
+        .innerJoin(jutsu, eq(userJutsu.jutsuId, jutsu.id))
+        .where(and(eq(userJutsu.userId, ctx.userId), gt(userJutsu.finishTraining, now)))
+        .orderBy(asc(userJutsu.finishTraining))
+        .limit(1),
+      ctx.drizzle
+        .select({
+          itemName: item.name,
+          craftingFinishedAt: userItem.craftingFinishedAt,
+        })
+        .from(userItem)
+        .innerJoin(item, eq(userItem.itemId, item.id))
+        .where(
+          and(eq(userItem.userId, ctx.userId), gt(userItem.craftingFinishedAt, now)),
+        )
+        .orderBy(asc(userItem.craftingFinishedAt))
+        .limit(1),
+      ctx.drizzle
+        .select({
+          imbuedName: imbuedItem.name,
+          targetName: item.name,
+          craftingFinishedAt: userItemImbuement.craftingFinishedAt,
+        })
+        .from(userItemImbuement)
+        .innerJoin(userItem, eq(userItemImbuement.userItemId, userItem.id))
+        .innerJoin(item, eq(userItem.itemId, item.id))
+        .innerJoin(imbuedItem, eq(userItemImbuement.imbuementItemId, imbuedItem.id))
+        .where(
+          and(
+            eq(userItem.userId, ctx.userId),
+            gt(userItemImbuement.craftingFinishedAt, now),
+          ),
+        )
+        .orderBy(asc(userItemImbuement.craftingFinishedAt))
+        .limit(1),
+    ]);
+
+    const jutsuTraining = jutsuTrainingRows[0];
+    const crafting = craftingRows[0];
+
+    return {
+      jutsuTraining: jutsuTraining?.finishTraining
+        ? { ...jutsuTraining, finishTraining: jutsuTraining.finishTraining }
+        : null,
+      crafting: crafting?.craftingFinishedAt
+        ? { ...crafting, craftingFinishedAt: crafting.craftingFinishedAt }
+        : null,
+      imbuement: imbuementRows[0] ?? null,
+    };
+  }),
   // Update battle description setting
   updateBattleDescription: protectedProcedure
     .meta({

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -72,6 +72,7 @@ import {
   insertAiSchema,
   item,
   jutsu,
+  jutsuReskin,
   mpvpBattleQueue,
   notification,
   poll,
@@ -207,12 +208,13 @@ export const profileRouter = createTRPCRouter({
     const [jutsuTrainingRows, craftingRows, imbuementRows] = await Promise.all([
       ctx.drizzle
         .select({
-          name: jutsu.name,
+          name: sql<string>`COALESCE(${jutsuReskin.name}, ${jutsu.name})`,
           level: userJutsu.level,
           finishTraining: userJutsu.finishTraining,
         })
         .from(userJutsu)
         .innerJoin(jutsu, eq(userJutsu.jutsuId, jutsu.id))
+        .leftJoin(jutsuReskin, eq(userJutsu.reskinId, jutsuReskin.id))
         .where(and(eq(userJutsu.userId, ctx.userId), gt(userJutsu.finishTraining, now)))
         .orderBy(asc(userJutsu.finishTraining))
         .limit(1),


### PR DESCRIPTION
## Summary

- replace the app-wide full jutsu and inventory reads with `profile.getSidebarTimers`
- select only the fields required for the jutsu-training, crafting, and imbuement countdowns
- preserve active jutsu reskin names without restoring the wide payload
- refresh the narrow cache when timers start, stop, finish, or are completed immediately
- keep the existing collection endpoints and stale merge-claim recovery unchanged

## Benchmark impact

- tRPC procedures per hard load: 2 -> 1 (50% fewer)
- DB work: 2 wide collection queries -> 3 parallel, index-served queries returning at most one narrow row each
- median payload: about 15 KB of jutsu data alone, plus inventory -> under 1 KB (at least about 93% smaller)
- heavy accounts: about 500-522 KB of jutsu JSON alone -> under 1 KB (>99.8% smaller)
- worst observed jutsu materialization: 340 wide joined rows plus inventory -> at most 3 narrow rows
- live local response with an active crafting timer: 164 bytes

The change targets database result materialization, wire payload, and SuperJSON/main-thread deserialization. It does not claim a production millisecond latency delta without an A/B timing deployment.

## Validation

- `bun run typecheck`
- targeted Biome check for all changed files (one pre-existing warning in `profile.ts`)
- live `profile.getSidebarTimers` call as a provisioned user
- browser: started jutsu training and observed the sidebar countdown without reload
- browser: started a craft and observed the sidebar countdown without reload
- CI build, lint, typecheck, CodeQL, Bugbot, CodeRabbit, and both Vercel previews passed

## Breaking changes

None. Existing collection procedures and consumers remain unchanged.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
