### PR TITLE
Keep inventory mounted during background refetches

### DIFF
--- a/app/src/app/items/page.tsx
+++ b/app/src/app/items/page.tsx
@@ -84,12 +84,13 @@ export default function MyItems() {
   const utils = api.useUtils();
 
   // Data from DB
-  const { data: userItems, isFetching } = api.item.getUserItemsWithVariants.useQuery(
-    undefined,
-    {
-      enabled: !!userData,
-    },
-  );
+  const {
+    data: userItems,
+    isPending: isLoadingItems,
+    isFetching,
+  } = api.item.getUserItemsWithVariants.useQuery(undefined, {
+    enabled: !!userData,
+  });
 
   // Mutations
   const { mutate: buyItemSlot, isPending } = api.blackmarket.buyItemSlot.useMutation({
@@ -203,7 +204,7 @@ export default function MyItems() {
 
   // Loaders
   if (!userData) return <Loader explanation="Loading userdata" />;
-  if (isFetching) return <Loader explanation="Loading items" />;
+  if (isLoadingItems) return <Loader explanation="Loading items" />;
 
   // Can afford removing
   const canAfford =
@@ -279,6 +280,7 @@ export default function MyItems() {
           </div>
         }
       >
+        {isFetching && <Loader explanation="Refreshing items" />}
         <div className="flex flex-col">
           <div className="flex flex-col sm:flex-row">
             <div className="w-full basis-1/2 p-3">
@@ -801,6 +803,8 @@ const Backpack: React.FC<BackpackProps> = (props) => {
         showMutationToast(data);
         if (data.success) {
           setIsRepairModalOpen(false);
+          setIsOpen(false);
+          setUserItem(undefined);
           await Promise.all([
             utils.item.getUserItemsWithVariants.invalidate(),
             utils.profile.getUser.invalidate(),
@@ -1343,6 +1347,8 @@ const Character: React.FC<CharacterProps> = (props) => {
         showMutationToast(data);
         if (data.success) {
           setIsRepairModalOpen(false);
+          setShowItemDetails(false);
+          setUserItem(undefined);
           await Promise.all([
             utils.item.getUserItemsWithVariants.invalidate(),
             utils.profile.getUser.invalidate(),
@@ -1639,6 +1645,8 @@ const ItemVariantModal: React.FC<ItemVariantModalProps> = ({
     onSuccess: async (result) => {
       showMutationToast(result);
       if (result.success) {
+        setIsOpen(false);
+        onClose();
         await Promise.all([
           utils.item.getUserUnlockedVariants.invalidate({ itemId: userItem.item.id }),
           utils.item.getUserItemsWithVariants.invalidate(),


### PR DESCRIPTION
## Summary

- distinguish the initial inventory query load from background refetches
- keep the equipment and backpack trees mounted while refreshed data is fetched
- show an inline Refreshing items indicator during invalidation-driven refetches
- explicitly close repair and variant-token dialogs that previously closed only because the page unmounted

## Why

Inventory mutations invalidate getUserItemsWithVariants. The page used isFetching for its full-page loading guard, so every successful mutation replaced the entire inventory with a spinner for the duration of the refetch and destroyed local UI state.

## Validation

- bunx biome check src/app/items/page.tsx
- bun run typecheck
- browser: provisioned a disposable player, bought an equippable item, and ran a real mutation with 800 ms network latency. Refreshing items appeared while Item Management, Equipped, and Backpack all remained visible; Loading items did not appear. The refresh completed normally with no console errors.
- bun run test --run: 1,059 tests passed and 7 skipped; 66 suites failed to collect because NEXT_PUBLIC_PUSHER_APP_KEY, NEXT_PUBLIC_PUSHER_APP_CLUSTER, and NEXT_PUBLIC_BASE_URL are missing in the Vitest environment.
- bun run check: the changed file and TypeScript pass, but the repository-wide Biome stage reports pre-existing formatting/import diagnostics in unrelated files.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only loading and modal lifecycle changes on the items page; no auth, payments, or server logic touched.
> 
> **Overview**
> Fixes inventory **Item Management** so mutation-driven refetches no longer swap the whole page for a full-screen spinner.
> 
> The page now uses **`isPending`** (`isLoadingItems`) only for the first load (“Loading items”), while **`isFetching`** drives a lightweight **“Refreshing items”** loader over the existing Equipped / Backpack UI. That keeps local modal and tab state alive during invalidation refetches.
> 
> Because the tree stays mounted, repair-kit success handlers in **Backpack** and **Character** explicitly close item-detail / repair modals and clear selected item state. **Variant token** consumption likewise closes the variant modal via `setIsOpen(false)` and `onClose()` instead of relying on unmount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffd4787307d4923c853fd74359825a369f28c173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->