### PR TITLE
fix(cleaner): bound the last three range deletes so a backlog cannot wedge them

### DIFF
--- a/app/src/app/api/cleaner/route.ts
+++ b/app/src/app/api/cleaner/route.ts
@@ -343,12 +343,18 @@ export async function GET() {
 
     // Step 22: Clear training log entries
     await drizzleDB.execute(
-      sql`DELETE FROM ${trainingLog} WHERE trainingFinishedAt < CURRENT_TIMESTAMP(3) - INTERVAL 7 DAY`,
+      sql`DELETE FROM ${trainingLog}
+          WHERE trainingFinishedAt < CURRENT_TIMESTAMP(3) - INTERVAL 7 DAY
+          ORDER BY trainingFinishedAt
+          LIMIT ${rangeCleanupBatchSize}`,
     );
 
     // Step 23: Clear mpvp battle queue entries
     await drizzleDB.execute(
-      sql`DELETE FROM ${mpvpBattleQueue} WHERE createdAt < CURRENT_TIMESTAMP(3) - INTERVAL 7 DAY`,
+      sql`DELETE FROM ${mpvpBattleQueue}
+          WHERE createdAt < CURRENT_TIMESTAMP(3) - INTERVAL 7 DAY
+          ORDER BY createdAt
+          LIMIT ${rangeCleanupBatchSize}`,
     );
 
     // Step 24: Clear mpvp battle user entries
@@ -384,7 +390,10 @@ export async function GET() {
 
     // Step 27: Clear old captcha checks
     await drizzleDB.execute(
-      sql`DELETE FROM ${captcha} WHERE createdAt < CURRENT_TIMESTAMP(3) - INTERVAL 30 DAY`,
+      sql`DELETE FROM ${captcha}
+          WHERE createdAt < CURRENT_TIMESTAMP(3) - INTERVAL 30 DAY
+          ORDER BY createdAt
+          LIMIT ${rangeCleanupBatchSize}`,
     );
 
     // Step 28: Clear old challenges:


### PR DESCRIPTION
## What is wrong

`/api/cleaner` has been returning 500 at step 22 for months:

```
DELETE FROM `TrainingLog` WHERE trainingFinishedAt < CURRENT_TIMESTAMP(3) - INTERVAL 7 DAY
→ row count exceeded 100000
```

Vitess caps a single DML statement at 100,000 rows. This delete has no `LIMIT`, so once the backlog crossed that line the statement could never complete — and because it never completed, the backlog kept growing. Production is at **154,712** stale rows, accumulating ~600/day back through January.

It is self-perpetuating: it cannot recover on its own.

## What else it takes down

The handler throws at step 22, so nothing after it runs. That includes:

- step 23, the mpvp battle queue sweep
- step 27, the captcha sweep
- **step 33, `reconcileFederalStatuses`** — the hourly re-derivation of `federalStatus` from PayPal and store receipts, which has therefore never run in production

## The fix

The file already states the rule in its own comment:

> Range deletes use indexed ordering and a bounded batch so one large backlog cannot consume the entire route execution window.

Most of its deletes follow it; three did not. Each now orders by the column its predicate filters on — keeping the delete on the index — and takes `rangeCleanupBatchSize` (10,000) per run. At hourly runs the current backlog drains in about sixteen passes; no manual cleanup needed.

## Scope

| statement | pending rows | why touched |
|---|---|---|
| `TrainingLog` (step 22) | **154,712 — over the cap** | the actual failure |
| `MpvpBattleQueue` (step 23) | 78 | same shape, same trap |
| `Captcha` (step 27) | 6,271 | same shape, same trap |

Deliberately **not** touched: the account purges at steps 17–18 and the join-based orphan sweeps. Those run every hour, sit at ~5,000 rows, and batching account deletion is a throughput change that deserves its own decision.

## Verification

Row counts read from `main-1`. `make typecheck`, `make lint` and the full suite (1828 pass / 0 fail) are clean.

This was found while checking production after #1477 deployed — that PR added a `UserLiveActivity` delete at step 21, which failed on its own until the schema was corrected and, once fixed, let the route reach step 22 and surface a failure that predates it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production data retention on high-volume tables; bounded deletes reduce outage risk but hourly cleanup behavior changes until backlogs clear.
> 
> **Overview**
> The hourly `/api/cleaner` job was failing at **step 22** because unbounded `DELETE`s on `TrainingLog` hit Vitess’s **100k row DML cap** (~155k stale rows), so the route never reached later steps (mpvp queue cleanup, captcha purge, **`reconcileFederalStatuses`**, etc.).
> 
> This change applies the same **indexed `ORDER BY` + `LIMIT ${rangeCleanupBatchSize}` (10k)** pattern already used elsewhere in the file to three range deletes: **training log** (7-day), **mpvp battle queue** (7-day), and **captcha** (30-day). Each hourly run trims a bounded batch so backlogs drain over multiple passes instead of wedging the cleaner permanently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8326b43ec33f97583f00347a65301b806a75c191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background cleanup reliability by processing old training logs, battle-queue entries, and captcha records in bounded batches.
  * Reduced the risk of slow or resource-intensive cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->