### PR TITLE
perf(combat): parallelize raid availability broadcasts after war SQL

### DIFF
--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -966,9 +966,9 @@ export const updateWars = async (
   await Promise.all([...otherPromises, ...shrineUpdatePromises]);
 
   // Broadcast pusher notifications after mutations complete
-  for (const sector of sectorsToNotify) {
-    await broadcastRaidAvailability(pusher, sector);
-  }
+  await Promise.all(
+    sectorsToNotify.map((sector) => broadcastRaidAvailability(pusher, sector)),
+  );
 };
 
 export const updateTournament = async (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Finding #17b: after shrine/raid SQL in `updateWars`, raid-availability pusher notifies ran **one sector at a time**.

```ts
await Promise.all([...otherPromises, ...shrineUpdatePromises]);
await Promise.all(
  sectorsToNotify.map((sector) => broadcastRaidAvailability(pusher, sector)),
);
```

Notify-after-mutate is unchanged. Only the per-sector loop is parallel.

## Why this is safe

`broadcastRaidAvailability` → `pusher.trigger` is a **stateless HTTP POST** (signed fetch to Soketi). Each call builds its own timestamp, body, MD5, and HMAC. The client stores only `app_id` / `key` / `secret`. There is **no shared session, queue, mutex, or client-side rate limiter** that would require serial `await`.

Sectors are independent channels (`sector.toString()`). Typical cardinality is 0–1; when several shrine sectors activate in one battle, fan-out removes unnecessary latency on the combat write path.

## Out of scope

- Not merging the notify step into the SQL `Promise.all` (clients must see committed raid state).
- No behavior change to raid activation mutations.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99441e6d-70cd-4bdb-a8f9-f9c31b6976db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99441e6d-70cd-4bdb-a8f9-f9c31b6976db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Raid availability notifications are now broadcast concurrently across affected sectors, improving notification delivery speed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->