### PR TITLE
Restore default prefetch on primary News/Info/Forum/Bugs/Art nav

### DIFF
--- a/app/src/components/layout/core4_beta.tsx
+++ b/app/src/components/layout/core4_beta.tsx
@@ -155,7 +155,6 @@ const BetaGameLayout: React.FC<GameLayoutRenderProps> = ({
                         await link.onClick();
                       }
                     }}
-                    prefetch={false}
                   >
                     {link.icon}
                     {link.name}
@@ -177,7 +176,6 @@ const BetaGameLayout: React.FC<GameLayoutRenderProps> = ({
                   onClick={async () => {
                     if (link.onClick) await link.onClick();
                   }}
-                  prefetch={false}
                 >
                   {link.icon}
                   {link.name}

--- a/app/src/components/layout/core4_pixel.tsx
+++ b/app/src/components/layout/core4_pixel.tsx
@@ -120,7 +120,6 @@ const PixelGameLayout: React.FC<GameLayoutRenderProps> = ({
                       onClick={async () => {
                         if (link.onClick) await link.onClick();
                       }}
-                      prefetch={false}
                     >
                       <span className="relative flex min-w-0 items-center gap-1">
                         {link.icon}

--- a/app/src/layout/PixelPublicMenuDropdown.tsx
+++ b/app/src/layout/PixelPublicMenuDropdown.tsx
@@ -41,7 +41,7 @@ const PixelPublicMenuDropdown: React.FC<{ className?: string }> = ({ className }
                 }}
                 className="tnr-ink-menu-item"
               >
-                <Link href={item.href} prefetch={false}>
+                <Link href={item.href}>
                   {item.icon}
                   <span>{item.name}</span>
                   {count > 0 && (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Restore Next.js default `Link` prefetch on the five `getMainNavbarLinks` destinations (News, Info, Forum, Bugs, Art). Those links are the signed-in desktop top nav in both beta and pixel layouts, and the same list is used by the pixel public menu dropdown.

## Validation on current `main`

- Confirmed: **0** `loading.tsx` files across 141 `page.tsx` routes.
- Confirmed: `prefetch={false}` on beta top nav (`core4_beta.tsx`), pixel signed-in top nav (`core4_pixel.tsx`), and `PixelPublicMenuDropdown`.
- Those five hrefs (`/news`, `/manual`, `/forum`, `/help`, `/conceptart`) are **not** auth-gated. Their layouts are metadata-only passthroughs. They are also the signed-in chrome, not anonymous-only.
- The leftover “Participate” GitHub/Discord flash in `LayoutSidebars.tsx` is Clerk-loaded-before-`getUser`. Soft client nav already keeps `getUser` cached (`staleTime: Infinity`). **Out of scope** — this PR does not change auth/layout architecture.

## Change

Drop `prefetch={false}` so these links match `LayoutMainMenu` (already default) and Next.js 16 defaults:

- Static destinations can prefetch in production when in viewport.
- Dynamic destinations without `loading.tsx` are **not** fully prefetched (Next 16: dynamic routes skip unless they have a loading boundary, unless `prefetch={true}`).

Did **not** set `prefetch={true}`. `/news` is `force-dynamic` and clears `unreadNews` during RSC render (`readNews`). Full prefetch would run that mutation (and `currentUser()`) without a real visit. Concept art is also a large client page.

Did **not** add `loading.tsx` skeletons. They would only fill the page slot during RSC fetch and do not fix waiting on `getUser`. Optional per the finding; skipped to keep the slice smallest.

## Downstream

- **Bundle:** default prefetch may download static RSC/JS for `/help` (cheap) and any statically prerenderable client pages. No extra combat/travel/village chunks. Mobile game nav already uses `prefetch={true}` on heavier routes.
- **Auth / Clerk:** destinations are public; no auth-gated prefetch, no Clerk layout rewrite.
- **Notifications:** avoiding `prefetch={true}` keeps `/news` from being rendered just because the top nav is visible.

## Test plan

- Click News / Info / Forum / Bugs / Art from signed-in beta and pixel top nav; links still client-navigate.
- Pixel public menu dropdown still opens those same routes.
- Production-only prefetch is not observable on `next dev`.

Do not merge from this agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ae90bc1-d299-44c4-97b2-a0771b3f916d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ae90bc1-d299-44c4-97b2-a0771b3f916d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Navigation links across beta and pixel layouts now use the platform’s default preloading behavior.
  - Page transitions may feel faster because destinations can be prepared before links are selected.
  - Navigation targets and click behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->