### PR TITLE
Replace render-time form.watch() with useWatch

### DIFF
--- a/app/src/app/manual/staff/page.tsx
+++ b/app/src/app/manual/staff/page.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FileUser, Info, List } from "lucide-react";
 import Link from "next/link";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { api } from "@/app/_trpc/client";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -50,6 +50,8 @@ export default function Staff() {
     resolver: zodResolver(createApplicationSchema),
     defaultValues: { targetRole: "CONTENT", motivation: "" },
   });
+  const targetRole = useWatch({ control: form.control, name: "targetRole" });
+  const motivation = useWatch({ control: form.control, name: "motivation" }) ?? "";
   const createApp = api.applications.create.useMutation({
     onSuccess: async (res) => {
       showMutationToast(res);
@@ -103,7 +105,7 @@ export default function Staff() {
                           shouldValidate: true,
                         })
                       }
-                      value={form.watch("targetRole")}
+                      value={targetRole}
                     >
                       <SelectTrigger>
                         <SelectValue placeholder="Select role" />
@@ -123,7 +125,7 @@ export default function Staff() {
                     </div>
                     <Textarea
                       placeholder="Tell us why you want to join the staff..."
-                      value={form.watch("motivation")}
+                      value={motivation}
                       onChange={(e) =>
                         form.setValue("motivation", e.target.value, {
                           shouldValidate: true,
@@ -137,12 +139,12 @@ export default function Staff() {
                       </span>
                       <span
                         className={
-                          form.watch("motivation").length < 10
+                          motivation.length < 10
                             ? "text-muted-foreground"
                             : "text-green-600"
                         }
                       >
-                        {form.watch("motivation").length}/10 min
+                        {motivation.length}/10 min
                       </span>
                     </div>
                   </div>

--- a/app/src/hooks/skillTree.ts
+++ b/app/src/hooks/skillTree.ts
@@ -91,10 +91,15 @@ export const useSkillTreeEditForm = (data: SkillTree, refetch: () => void) => {
     name: "image",
   });
 
+  const watchedTier = useWatch({
+    control: form.control,
+    name: "tier",
+  });
+
   // Get available prerequisite skills (lower tier than current)
   const allSkillsFlat = allSkills?.pages.flatMap((p) => p.data) ?? [];
   const availablePrereqSkills = allSkillsFlat.filter(
-    (s) => s.id !== skillTree.id && s.tier < (form.watch("tier") as number),
+    (s) => s.id !== skillTree.id && s.tier < (watchedTier as number),
   );
 
   // Object for form values

--- a/app/src/layout/SeasonForm.tsx
+++ b/app/src/layout/SeasonForm.tsx
@@ -4,7 +4,7 @@ import { format } from "date-fns";
 import { Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import type { UseFormReturn } from "react-hook-form";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { api } from "@/app/_trpc/client";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -87,6 +87,8 @@ export default function SeasonForm({
       paused: false,
     },
   });
+
+  const watchedRewards = useWatch({ control: form.control, name: "rewards" }) ?? [];
 
   const createSeason = api.pvpRank.createSeason.useMutation({
     onSuccess: (data) => {
@@ -317,7 +319,7 @@ export default function SeasonForm({
             </Button>
           </div>
 
-          {form.watch("rewards").map((division, divisionIndex) => (
+          {watchedRewards.map((division, divisionIndex) => (
             <Card key={`division-${division.division}-${divisionIndex}`}>
               <CardHeader>
                 <CardTitle className="flex items-center justify-between">
@@ -411,7 +413,10 @@ const RewardDialog: React.FC<RewardDialogProps> = ({
   parentForm,
   buildRewardFormData,
 }) => {
-  const parentReward = parentForm.watch(`rewards.${divisionIndex}.rewards`);
+  const parentReward = useWatch({
+    control: parentForm.control,
+    name: `rewards.${divisionIndex}.rewards`,
+  });
   const rewardForm = useForm<RankedSeasonRewardInput, unknown, RankedSeasonReward>({
     resolver: zodResolver(rewardSchema),
     values: parentReward ?? rewardSchema.parse({}),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Replace render-time `form.watch()` with `useWatch` at the four confirmed finding #17f sites so these forms stay compatible with the React Compiler.

Sites:

- `app/src/layout/SeasonForm.tsx` — division rewards list and reward-dialog parent values
- `app/src/app/manual/staff/page.tsx` — staff application role and motivation fields
- `app/src/hooks/skillTree.ts` — prerequisite filter by current tier

## Why

Project rule: use `useWatch`, not `watch`, because of the React Compiler. Calling `form.watch()` during render is also easy to misuse inside loops; these sites can all subscribe at the top of the component or hook.

Hook rules:

- `SeasonForm` watches `rewards` at the parent top level (not inside `.map`)
- `RewardDialog` already is a child, so nested `rewards.${divisionIndex}.rewards` is watched there
- Staff application watches `targetRole` / `motivation` at the top of `Staff` (including when the apply dialog is closed)
- `useSkillTreeEditForm` already is a hook, so watching `tier` there is valid

Left `userSearchMethods.watch((value, { name }) => …)` in `manual/polls/page.tsx` alone — that is a subscription callback, not a render-time watch.

## Breaking

No. Behavior is the same: these fields still re-render when the watched values change.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1705fb14-8884-4226-b059-92e956d43251?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1705fb14-8884-4226-b059-92e956d43251&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved form value tracking across staff applications, skill prerequisites, and season rewards.
  * Updated reward dialogs and form controls to respond more consistently to changes in watched fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->