### PR TITLE
fix(combat): do not block performAction on Sentry.flush

### DIFF
--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -17,6 +17,7 @@ import {
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/mysql-core";
 import { nanoid } from "nanoid";
+import { after } from "next/server";
 import { z } from "zod";
 import {
   baseServerResponse,
@@ -844,9 +845,10 @@ export const combatRouter = createTRPCRouter({
               }
             }
 
-            // Stop profiling
+            // Stop profiling. Flush after the response so the client is not
+            // blocked; after() keeps the Vercel lambda alive via waitUntil.
             Sentry.profiler.stopProfiler();
-            await Sentry.flush(15000);
+            after(() => Sentry.flush(15000));
 
             // Return the new battle + result state if applicable
             // Note: battleUpdate excludes extraState - frontend merges with existing


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`combat.performAction` started the Sentry profiler at the top of the mutation and, after a successful persist, **awaited** `Sentry.flush(15000)` before returning to the client.

That flush is a timeout ceiling, not a fixed 15s wait (live waits were ~1–1.3s), but it still sat on the success path after battle writes. Early exits already skipped flush. The tRPC route-level flush in `app/src/app/api/trpc/[trpc]/route.ts` is error-only (`shouldFlush`) and is unrelated.

## Why not `void Sentry.flush(...)`

On Vercel the lambda can freeze as soon as the response is sent. The route helper already documents this (`flushSafe`). Fire-and-forget flush would drop profiler events. This PR does **not** do that.

## Change

- Keep `startProfiler` / `stopProfiler` on the success path (stop stays synchronous so the profile is queued before return).
- Schedule `Sentry.flush(15000)` with Next.js `after()`, matching `staff.throwTrpcError`. `after()` uses `waitUntil` on Vercel, so the lambda stays alive long enough to deliver the profile without blocking the client.
- No combat game-logic changes. `updateBattle` CAS is still awaited before reward writes. `getBattle` idle settlement is untouched.

## Validation

- Confirmed on current `main`: await flush is only on the persist success path in `combat.ts`.
- Local arena via the broker was not run here: this environment has no `app/.env` and no Docker, so the tnr-dev-server stack could not boot.
- CI on this branch is the runtime check (lint and typecheck already green).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6779442f-d549-4cc3-b93c-7d82dfc29ece?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6779442f-d549-4cc3-b93c-7d82dfc29ece&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Combat actions now complete responses without waiting for diagnostic data to finish uploading, improving response times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->