### PR TITLE
fix(perf): skip activity-streak popup query when it cannot open

### DIFF
--- a/app/src/layout/ActivityStreakPopup.tsx
+++ b/app/src/layout/ActivityStreakPopup.tsx
@@ -19,6 +19,7 @@ import {
   isActivityStreakPopupBlocking,
   resolveActivityStreakDateLatches,
   resolveActivityStreakPopupOpen,
+  shouldFetchActivityStreaksForPopup,
 } from "@/libs/activityStreak";
 import { cn } from "@/libs/shadui";
 import { isTutorialActive } from "@/libs/tutorial";
@@ -54,11 +55,20 @@ const ActivityStreakPopup: React.FC = () => {
   // the very first render, with no window where both can be on screen.
   const tutorialActive = isTutorialActive(userData);
 
-  // Always query streaks if we have a user (we check dismissedToday separately)
+  // Only fetch while the dialog is still allowed to open. Tutorial / dismissed-today /
+  // session-close already forbid it; querying then is 13KB on every signed-in page
+  // for a popup that cannot appear. Re-enables when those latches clear (tutorial
+  // finished, date rollover) so an unclaimed reward is not dropped.
+  const shouldFetchStreaks = shouldFetchActivityStreaksForPopup({
+    hasUser: !!userData,
+    tutorialActive,
+    dismissedToday,
+    userClosed,
+  });
   const { data: userStreaks, isLoading } = api.activityStreak.getUserStreaks.useQuery(
     undefined,
     {
-      enabled: !!userData,
+      enabled: shouldFetchStreaks,
       staleTime: 1000 * 60 * 5, // 5 minutes
     },
   );

--- a/app/src/libs/activityStreak.ts
+++ b/app/src/libs/activityStreak.ts
@@ -61,3 +61,25 @@ export const isActivityStreakPopupBlocking = (
   !state.dismissedToday &&
   !state.userClosed &&
   (state.isLoading || state.shouldShowPopup || state.isOpen);
+
+/**
+ * True when the root-layout popup is still allowed to open, so `getUserStreaks`
+ * is worth sending. There is no claim-eligibility field on `userData`; the
+ * suppressions below are the ones that already forbid the dialog, and skipping
+ * the query for them cannot drop an unclaimed-reward popup.
+ *
+ * Do not defer this query behind first paint: `isActivityStreakPopupBlocking`
+ * treats a not-yet-started fetch as non-blocking, which lets the overworld
+ * arrival prompt win the login race.
+ */
+export const shouldFetchActivityStreaksForPopup = ({
+  hasUser,
+  tutorialActive,
+  dismissedToday,
+  userClosed,
+}: {
+  hasUser: boolean;
+  tutorialActive: boolean;
+  dismissedToday: boolean;
+  userClosed: boolean;
+}): boolean => hasUser && !tutorialActive && !dismissedToday && !userClosed;

--- a/app/tests/libs/activityStreak.test.ts
+++ b/app/tests/libs/activityStreak.test.ts
@@ -3,6 +3,7 @@ import {
   isActivityStreakPopupBlocking,
   resolveActivityStreakDateLatches,
   resolveActivityStreakPopupOpen,
+  shouldFetchActivityStreaksForPopup,
   type ActivityStreakPopupState,
 } from "@/libs/activityStreak";
 
@@ -115,5 +116,93 @@ describe("activity streak popup compatibility", () => {
         state({ shouldShowPopup: true, tutorialActive: false }),
       ),
     ).toBe(true);
+  });
+});
+
+describe("shouldFetchActivityStreaksForPopup", () => {
+  it("fetches for a signed-in user who can still see the popup", () => {
+    expect(
+      shouldFetchActivityStreaksForPopup({
+        hasUser: true,
+        tutorialActive: false,
+        dismissedToday: false,
+        userClosed: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("skips the query when the popup cannot open", () => {
+    expect(
+      shouldFetchActivityStreaksForPopup({
+        hasUser: false,
+        tutorialActive: false,
+        dismissedToday: false,
+        userClosed: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldFetchActivityStreaksForPopup({
+        hasUser: true,
+        tutorialActive: true,
+        dismissedToday: false,
+        userClosed: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldFetchActivityStreaksForPopup({
+        hasUser: true,
+        tutorialActive: false,
+        dismissedToday: true,
+        userClosed: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldFetchActivityStreaksForPopup({
+        hasUser: true,
+        tutorialActive: false,
+        dismissedToday: false,
+        userClosed: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("resumes fetching after the tutorial ends so an unclaimed reward is not dropped", () => {
+    expect(
+      shouldFetchActivityStreaksForPopup({
+        hasUser: true,
+        tutorialActive: true,
+        dismissedToday: false,
+        userClosed: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldFetchActivityStreaksForPopup({
+        hasUser: true,
+        tutorialActive: false,
+        dismissedToday: false,
+        userClosed: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not hold competing popups when the streaks query is gated off", () => {
+    expect(
+      isActivityStreakPopupBlocking(
+        true,
+        state({ isLoading: false, tutorialActive: true }),
+      ),
+    ).toBe(false);
+    expect(
+      isActivityStreakPopupBlocking(
+        true,
+        state({ isLoading: false, dismissedToday: true }),
+      ),
+    ).toBe(false);
+    expect(
+      isActivityStreakPopupBlocking(
+        true,
+        state({ isLoading: false, userClosed: true }),
+      ),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`ActivityStreakPopup` lives in the root layout and was calling `activityStreak.getUserStreaks` whenever `userData` existed (~300ms / 13KB on every signed-in page). There is no claim-eligibility field on `userData`, so this gates the query on the same suppressions that already forbid the dialog:

- no signed-in user
- tutorial active
- dismissed for today
- closed for this session

The query re-enables when those latches clear (tutorial finished, date rollover), so an unclaimed reward is not dropped.

## Why not lazy-mount / first-paint deferral

`isActivityStreakPopupBlocking` treats a not-yet-started fetch as non-blocking. Deferring the query behind first paint would let the overworld arrival prompt win the login race and hide the claim popup. Gating more tightly (this PR) avoids that.

ParticleProvider is out of scope and untouched.

## Compatibility

- Claiming still uses `ActivityStreakPanel`’s own query once the dialog is open
- Tutorial suppression still wins and no longer pays for a fetch that cannot surface
- “Dismiss for today” still uses the existing localStorage date key
- Close-for-session still reopens on refresh (session latch resets; query runs again)

## Testing

- Unit tests for `shouldFetchActivityStreaksForPopup` plus existing open / block / tutorial / dismiss latches (13 passing locally; `test_build` green)
- `test_linting`, `test_typecheck`, and `test_build` all passed
- No local `app/.env` or Docker in this agent environment, so the tnr-dev-server claim/dismiss path was not exercised in a browser

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d39b3567-b1b5-4343-a8cb-76470cdd08f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d39b3567-b1b5-4343-a8cb-76470cdd08f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Activity streak information is now loaded only when the streak popup is eligible to appear.
  - Streak checks are suppressed during tutorials and after the popup has been dismissed or closed for the day.
  - Streak loading resumes when eligibility returns and no longer interferes with other popups.
- **Tests**
  - Added coverage for signed-in, signed-out, tutorial, dismissal, closure, and eligibility-reset scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->