### PR TITLE
fix(bank): slim post-CAS balance reads on deposit and withdraw

### DIFF
--- a/app/src/server/api/routers/bank.ts
+++ b/app/src/server/api/routers/bank.ts
@@ -4,11 +4,13 @@ import { z } from "zod";
 import { RYO_CAP } from "@/drizzle/constants";
 import { bankTransfers, dailyBankInterest, userData } from "@/drizzle/schema";
 import { fetchUser } from "@/routers/profile";
+import type { DrizzleClient } from "@/server/db";
 import {
   baseServerResponse,
   createTRPCRouter,
   errorResponse,
   protectedProcedure,
+  serverError,
 } from "../trpc";
 
 export const bankRouter = createTRPCRouter({
@@ -44,8 +46,7 @@ export const bankRouter = createTRPCRouter({
       if (result.rowsAffected === 0) {
         return { success: false, message: "Not enough money in pocket" };
       }
-      // Re-fetch user to get accurate balances after concurrent updates
-      const updatedUser = await fetchUser(ctx.drizzle, ctx.userId);
+      const updatedUser = await fetchUserBalances(ctx.drizzle, ctx.userId);
       return {
         success: true,
         message: `Successfully deposited ${value} ryo`,
@@ -84,8 +85,7 @@ export const bankRouter = createTRPCRouter({
       if (result.rowsAffected === 0) {
         return { success: false, message: "Not enough money in bank" };
       }
-      // Re-fetch user to get accurate balances after concurrent updates
-      const updatedUser = await fetchUser(ctx.drizzle, ctx.userId);
+      const updatedUser = await fetchUserBalances(ctx.drizzle, ctx.userId);
       return {
         success: true,
         message: `Successfully withdrew ${value} ryo`,
@@ -316,3 +316,22 @@ export const bankRouter = createTRPCRouter({
       };
     }),
 });
+
+/**
+ * Post-CAS pocket/bank read. Concurrent grants can change either column after
+ * the increment, so callers cannot derive balances from the pre-update snapshot.
+ * Only these two columns are returned to the UI.
+ */
+export const fetchUserBalances = async (client: DrizzleClient, userId: string) => {
+  const user = await client.query.userData.findFirst({
+    where: eq(userData.userId, userId),
+    columns: { money: true, bank: true },
+  });
+  if (!user) {
+    throw serverError(
+      "NOT_FOUND",
+      `User not found: ${userId}. Please complete registration.`,
+    );
+  }
+  return user;
+};

--- a/app/tests/server/api/bank.balances.test.ts
+++ b/app/tests/server/api/bank.balances.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { userData } from "@/drizzle/schema";
+import { bankRouter, fetchUserBalances } from "@/server/api/routers/bank";
+import { insertUsers } from "../../setup/factories";
+import {
+  callerFor,
+  describeWithDatabase,
+  getTestDatabase,
+  resetTables,
+} from "../../setup/testDatabase";
+
+describe("fetchUserBalances", () => {
+  it("selects only money and bank", async () => {
+    const findFirst = vi.fn().mockResolvedValue({ money: 900, bank: 1100 });
+    const client = { query: { userData: { findFirst } } };
+    await expect(fetchUserBalances(client as never, "user-1")).resolves.toEqual({
+      money: 900,
+      bank: 1100,
+    });
+    expect(findFirst).toHaveBeenCalledTimes(1);
+    expect(findFirst.mock.calls[0]?.[0]).toMatchObject({
+      columns: { money: true, bank: true },
+    });
+  });
+
+  it("throws when the user row is missing", async () => {
+    const client = {
+      query: { userData: { findFirst: vi.fn().mockResolvedValue(undefined) } },
+    };
+    await expect(fetchUserBalances(client as never, "missing")).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+});
+
+const caller = (userId: string) => callerFor(bankRouter, userId);
+
+const seedUser = async (patch: Record<string, unknown> = {}) => {
+  await insertUsers([
+    {
+      userId: "bank-user",
+      username: "BankUser",
+      money: 1000,
+      bank: 2000,
+      ...patch,
+    } as never,
+  ]);
+};
+
+describeWithDatabase("bank toBank/toPocket return committed balances", () => {
+  beforeEach(async () => {
+    await resetTables(userData);
+  });
+
+  it("deposits pocket ryo and returns the committed balances", async () => {
+    await seedUser();
+    const result = await (await caller("bank-user")).toBank({ amount: 250 });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ money: 750, bank: 2250 });
+
+    const database = await getTestDatabase();
+    const [row] = await database
+      .select({ money: userData.money, bank: userData.bank })
+      .from(userData)
+      .where(eq(userData.userId, "bank-user"));
+    expect(row).toEqual({ money: 750, bank: 2250 });
+  });
+
+  it("withdraws bank ryo and returns the committed balances", async () => {
+    await seedUser();
+    const result = await (await caller("bank-user")).toPocket({ amount: 400 });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ money: 1400, bank: 1600 });
+
+    const database = await getTestDatabase();
+    const [row] = await database
+      .select({ money: userData.money, bank: userData.bank })
+      .from(userData)
+      .where(eq(userData.userId, "bank-user"));
+    expect(row).toEqual({ money: 1400, bank: 1600 });
+  });
+
+  it("rejects a deposit when pocket funds are insufficient", async () => {
+    await seedUser({ money: 10, bank: 2000 });
+    const result = await (await caller("bank-user")).toBank({ amount: 50 });
+    expect(result.success).toBe(false);
+    expect(result.data).toBeUndefined();
+
+    const database = await getTestDatabase();
+    const [row] = await database
+      .select({ money: userData.money, bank: userData.bank })
+      .from(userData)
+      .where(eq(userData.userId, "bank-user"));
+    expect(row).toEqual({ money: 10, bank: 2000 });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`bank.toBank` and `bank.toPocket` still re-read committed balances after the CAS increment so the UI can show exact pocket/bank values after concurrent grants. They no longer call `fetchUser` for that post-read.

After `rowsAffected === 1`, both mutations now select only `money` and `bank` via `fetchUserBalances`. Computing `money - value` from the pre-update snapshot is still wrong: other grants can interleave with the SQL increment.

## Why

`UserData` is a wide row (`questData`, `effects`, and a large set of scalar columns). Warm `toBank` was spending a full-row fetch just to return two numbers. The post-read stays because the bank page writes `data.money` / `data.bank` into client state.

## Out of scope

`transfer` and `claimInterest` still do a full `fetchUser` after their writes. This PR only changes the two endpoints in the finding.

## Tests

- Unit: `fetchUserBalances` requests only `money` and `bank`, and throws `NOT_FOUND` when the row is missing.
- Throwaway MySQL (when configured): deposit/withdraw return committed balances that match the row; insufficient pocket is rejected without a write.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8b6dd27-43e1-4f55-8df4-3ed3f9f01bc1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8b6dd27-43e1-4f55-8df4-3ed3f9f01bc1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

