### PR TITLE
perf(farming): prefetch yield items off the mutation tail

### DIFF
--- a/app/src/server/api/routers/farming.ts
+++ b/app/src/server/api/routers/farming.ts
@@ -1667,10 +1667,7 @@ export const buildFarmState = async (
   const shopEntriesPromise = buildShopEntries(client, user);
   const collectionLogPromise = getFarmCollectionState(client, userId);
 
-  const [plotsRaw, userItems] = await Promise.all([
-    plotsPromise,
-    userItemsPromise,
-  ]);
+  const [plotsRaw, userItems] = await Promise.all([plotsPromise, userItemsPromise]);
   const yieldIds = [
     ...new Set(
       [

--- a/app/src/server/api/routers/farming.ts
+++ b/app/src/server/api/routers/farming.ts
@@ -82,14 +82,24 @@ export const farmingRouter = createTRPCRouter({
     .input(z.object({ plotId: z.string(), seedItemId: z.string() }))
     .output(farmMutationResponseSchema)
     .mutation(async ({ ctx, input }) => {
-      const [user, userItems, plot, seedItem, questState] = await Promise.all([
+      const seedItemQuery = ctx.drizzle.query.item.findFirst({
+        where: eq(item.id, input.seedItemId),
+      });
+      const [user, userItems, plot, seedItem, questState, yieldItem] = await Promise.all([
         fetchUser(ctx.drizzle, ctx.userId),
         fetchUserItems(ctx.drizzle, ctx.userId),
         ctx.drizzle.query.farmPlot.findFirst({
           where: and(eq(farmPlot.id, input.plotId), eq(farmPlot.userId, ctx.userId)),
         }),
-        ctx.drizzle.query.item.findFirst({ where: eq(item.id, input.seedItemId) }),
+        seedItemQuery,
         fetchFarmingQuestState(ctx.drizzle, ctx.userId),
+        seedItemQuery.then((loadedSeed) =>
+          loadedSeed?.farmYieldItemId
+            ? ctx.drizzle.query.item.findFirst({
+                where: eq(item.id, loadedSeed.farmYieldItemId),
+              })
+            : null,
+        ),
       ]);
 
       const guard = guardFarmingMutation(user);
@@ -214,9 +224,7 @@ export const farmingRouter = createTRPCRouter({
             lastWateredAt: null,
             fertilizerApplied: false,
             seedItem,
-            yieldItem: await ctx.drizzle.query.item.findFirst({
-              where: eq(item.id, seedItem.farmYieldItemId),
-            }),
+            yieldItem,
           },
           now,
         ),
@@ -1651,21 +1659,30 @@ export const buildFarmState = async (
   ]);
   const totalPlots = getTotalFarmPlots(user.farmPlotsPurchased);
 
-  const [plotsRaw, userItems, shopEntries, collectionLog] = await Promise.all([
-    ensureFarmPlots(client, userId, totalPlots),
-    fetchUserItems(client, userId),
-    buildShopEntries(client, user),
-    getFarmCollectionState(client, userId),
-  ]);
+  const plotsPromise = ensureFarmPlots(client, userId, totalPlots);
+  const userItemsPromise = fetchUserItems(client, userId);
+  const shopEntriesPromise = buildShopEntries(client, user);
+  const collectionLogPromise = getFarmCollectionState(client, userId);
 
+  const [plotsRaw, userItems] = await Promise.all([
+    plotsPromise,
+    userItemsPromise,
+  ]);
   const yieldIds = [
-    ...plotsRaw.map((plot) => plot.seedItem?.farmYieldItemId),
-    ...userItems.map((userItem) => userItem.item.farmYieldItemId),
-  ].filter(Boolean) as string[];
-  const yieldItems =
+    ...new Set(
+      [
+        ...plotsRaw.map((plot) => plot.seedItem?.farmYieldItemId),
+        ...userItems.map((owned) => owned.item.farmYieldItemId),
+      ].filter((itemId): itemId is string => !!itemId),
+    ),
+  ];
+  const [shopEntries, collectionLog, yieldItems] = await Promise.all([
+    shopEntriesPromise,
+    collectionLogPromise,
     yieldIds.length > 0
-      ? await client.query.item.findMany({ where: inArray(item.id, yieldIds) })
-      : [];
+      ? client.query.item.findMany({ where: inArray(item.id, yieldIds) })
+      : Promise.resolve([]),
+  ]);
 
   const yieldItemsById = new Map(
     yieldItems.map((yieldItem) => [yieldItem.id, yieldItem]),

--- a/app/src/server/api/routers/farming.ts
+++ b/app/src/server/api/routers/farming.ts
@@ -82,25 +82,16 @@ export const farmingRouter = createTRPCRouter({
     .input(z.object({ plotId: z.string(), seedItemId: z.string() }))
     .output(farmMutationResponseSchema)
     .mutation(async ({ ctx, input }) => {
-      const seedItemQuery = ctx.drizzle.query.item.findFirst({
-        where: eq(item.id, input.seedItemId),
-      });
-      const [user, userItems, plot, seedItem, questState, yieldItem] = await Promise.all([
-        fetchUser(ctx.drizzle, ctx.userId),
-        fetchUserItems(ctx.drizzle, ctx.userId),
-        ctx.drizzle.query.farmPlot.findFirst({
-          where: and(eq(farmPlot.id, input.plotId), eq(farmPlot.userId, ctx.userId)),
-        }),
-        seedItemQuery,
-        fetchFarmingQuestState(ctx.drizzle, ctx.userId),
-        seedItemQuery.then((loadedSeed) =>
-          loadedSeed?.farmYieldItemId
-            ? ctx.drizzle.query.item.findFirst({
-                where: eq(item.id, loadedSeed.farmYieldItemId),
-              })
-            : null,
-        ),
-      ]);
+      const [user, userItems, plot, { seedItem, yieldItem }, questState] =
+        await Promise.all([
+          fetchUser(ctx.drizzle, ctx.userId),
+          fetchUserItems(ctx.drizzle, ctx.userId),
+          ctx.drizzle.query.farmPlot.findFirst({
+            where: and(eq(farmPlot.id, input.plotId), eq(farmPlot.userId, ctx.userId)),
+          }),
+          fetchFarmSeedAndYield(ctx.drizzle, input.seedItemId),
+          fetchFarmingQuestState(ctx.drizzle, ctx.userId),
+        ]);
 
       const guard = guardFarmingMutation(user);
       if (guard) return guard;
@@ -1317,6 +1308,18 @@ const guardFarmingMutation = (user: Awaited<ReturnType<typeof fetchUser>>) => {
     return errorResponse("Cannot farm on Wake Island");
   }
   return null;
+};
+
+const fetchFarmSeedAndYield = async (client: DrizzleClient, seedItemId: string) => {
+  const seedItem = await client.query.item.findFirst({
+    where: eq(item.id, seedItemId),
+  });
+  const yieldItem = seedItem?.farmYieldItemId
+    ? await client.query.item.findFirst({
+        where: eq(item.id, seedItem.farmYieldItemId),
+      })
+    : null;
+  return { seedItem, yieldItem };
 };
 
 const fetchFarmPlotWithItems = async (

--- a/app/tests/server/api/farming.router.test.ts
+++ b/app/tests/server/api/farming.router.test.ts
@@ -159,6 +159,52 @@ describeWithDatabase("farming router guards against a real MySQL", () => {
     expect(stack?.quantity).toBe(2);
   });
 
+  it("plants a seed and returns the prefetched yield on the updated plot", async () => {
+    await farmer();
+    await giveItem("ui-seed", "seed-1", 2);
+    const database = await getTestDatabase();
+    await database.insert(farmPlot).values({
+      id: "plot-plant",
+      userId: "farm-user",
+      slotIndex: 0,
+    } as never);
+    const api = await caller("farm-user");
+    const result = await api.plantSeed({ plotId: "plot-plant", seedItemId: "seed-1" });
+    expect(result.success).toBe(true);
+    expect(result.updatedPlot?.cropName).toBe("Test Crop");
+    expect(result.updatedPlot?.cropImage).toBe("/crop.png");
+    expect(result.updatedPlot?.harvestExperience).toBe(10);
+    expect(result.updatedPlot?.seedItemId).toBe("seed-1");
+    const [stack] = await database.select().from(userItem).where(eq(userItem.id, "ui-seed"));
+    expect(stack?.quantity).toBe(1);
+    const [plot] = await database.select().from(farmPlot).where(eq(farmPlot.id, "plot-plant"));
+    expect(plot?.seedItemId).toBe("seed-1");
+    expect(plot?.finishAt).toBeTruthy();
+  });
+
+  it("resolves planted crop names from the overlapped yield catalog", async () => {
+    await farmer();
+    await giveItem("ui-seed", "seed-1", 1);
+    const database = await getTestDatabase();
+    await database.insert(farmPlot).values({
+      id: "plot-state",
+      userId: "farm-user",
+      slotIndex: 0,
+      seedItemId: "seed-1",
+      plantedAt: new Date(),
+      finishAt: new Date(Date.now() + 60_000),
+    } as never);
+    const api = await caller("farm-user");
+    const state = await api.getFarmState();
+    if ("success" in state && state.success === false) {
+      throw new Error(state.message);
+    }
+    expect(state.plots.find((plot) => plot.id === "plot-state")?.cropName).toBe("Test Crop");
+    expect(state.availableSeeds.find((seed) => seed.itemId === "seed-1")?.yieldName).toBe(
+      "Test Crop",
+    );
+  });
+
   it("grants every distinct crop exactly once when a mixed harvest is settled together", async () => {
     await farmer();
     const database = await getTestDatabase();

--- a/app/tests/server/api/farming.router.test.ts
+++ b/app/tests/server/api/farming.router.test.ts
@@ -196,8 +196,8 @@ describeWithDatabase("farming router guards against a real MySQL", () => {
     } as never);
     const api = await caller("farm-user");
     const state = await api.getFarmState();
-    if ("success" in state && state.success === false) {
-      throw new Error(state.message);
+    if (!("plots" in state)) {
+      throw new Error("message" in state ? state.message : "getFarmState failed");
     }
     expect(state.plots.find((plot) => plot.id === "plot-state")?.cropName).toBe("Test Crop");
     expect(state.availableSeeds.find((seed) => seed.itemId === "seed-1")?.yieldName).toBe(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Prefetch the known `farmYieldItemId` crop during `plantSeed`’s opening reads, and overlap `getFarmState`’s yield catalog with shop/collection instead of a third sequential phase.

## Why

On current `main`, `farming.plantSeed` still `await`s `item.findFirst` for `seedItem.farmYieldItemId` after the claim → plot → consume → award CAS chain, even though that id is known from the seed row. `buildFarmState` then waits for plots, inventory, shop, and collection before loading yields.

Water / fertilize / harvest keep their existing guarded write order. This PR does not `Promise.all` consume with plot updates.

## Changes

- `plantSeed`: share the seed `findFirst` and prefetch the yield item in the opening `Promise.all`. `updatedPlot` uses that row instead of a post-mutation lookup.
- `buildFarmState`: start yield `findMany` as soon as plots + inventory resolve, in parallel with shop and collection (still already in flight).
- Router tests: planting returns the yield crop name/image/harvest XP; `getFarmState` still resolves planted crop names from that catalog.

## Validation

Finding re-read on `origin/main` (`41aec92fa`): confirmed. CAS chains were not flattened.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5bf7d17-0a52-43e2-a250-a3e8810b95df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5bf7d17-0a52-43e2-a250-a3e8810b95df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

