### PR TITLE
perf(combat): skip highlightTiles rebuild when hover and action are unchanged

### DIFF
--- a/app/src/libs/threejs/combat.ts
+++ b/app/src/libs/threejs/combat.ts
@@ -1480,6 +1480,30 @@ const resetEdgePool = (pool: HighlightEdgePool) => {
 };
 
 /**
+ * Cache key for skipping highlightTiles rebuilds. Hover tile and canUseTile
+ * must be included: action/version/position alone would freeze hover selection
+ * and leave range highlights up after the local turn expires.
+ */
+export const getHighlightTilesCacheKey = (info: {
+  actionId: string | undefined;
+  battleVersion: number;
+  userId: string;
+  longitude: number;
+  latitude: number;
+  canUseTile: boolean;
+  hoverTileName: string;
+}) =>
+  [
+    info.actionId ?? "",
+    info.battleVersion,
+    info.userId,
+    info.longitude,
+    info.latitude,
+    info.canUseTile ? "1" : "0",
+    info.hoverTileName,
+  ].join("|");
+
+/**
  * Highlight possible squares based on action
  * Uses cached intersections to avoid redundant raycasting
  * Performance optimized: Uses geometry caching and object pooling
@@ -1511,6 +1535,7 @@ export const highlightTiles = (info: {
   } = info;
   const battleTileIntersects = info.cachedIntersections.battleTiles;
   const hit = battleTileIntersects.length > 0 && battleTileIntersects[0];
+  const hoverTileName = hit ? (hit.object as HexagonalFaceMesh).name : "";
 
   // Get or create the edge mesh pool (stored on group userData for persistence)
   let pool = group_highlight_edges.userData.edgePool as HighlightEdgePool | undefined;
@@ -1518,13 +1543,6 @@ export const highlightTiles = (info: {
     pool = { meshes: [], activeCount: 0 };
     group_highlight_edges.userData.edgePool = pool;
   }
-
-  // Reset pool - hide all previously active meshes
-  resetEdgePool(pool);
-
-  // Get user's origin and possible tiles for highlighting
-  const origin = user && grid.getHex({ col: user.longitude, row: user.latitude });
-  const highlights = getPossibleActionTiles(action, origin, grid);
 
   // Check if user can use tiles (actor check + action points). `user` is the
   // actor the human controls (self, or piloted summon on its turn — Combat.tsx
@@ -1536,6 +1554,27 @@ export const highlightTiles = (info: {
   });
   const { canAct } = actionPointsAfterAction(user, battle, action);
   const canUseTile = actor.userId === user.userId && canAct;
+
+  const cacheKey = getHighlightTilesCacheKey({
+    actionId: action?.id,
+    battleVersion: battle.version,
+    userId: user.userId,
+    longitude: user.longitude,
+    latitude: user.latitude,
+    canUseTile,
+    hoverTileName,
+  });
+  if (group_highlight_edges.userData.highlightTilesKey === cacheKey) {
+    endMark();
+    return currentHighlights;
+  }
+
+  // Reset pool - hide all previously active meshes
+  resetEdgePool(pool);
+
+  // Get user's origin and possible tiles for highlighting
+  const origin = user && grid.getHex({ col: user.longitude, row: user.latitude });
+  const highlights = getPossibleActionTiles(action, origin, grid);
 
   // Highlight fields on the map where action can be applied
   const newHighlights = new Set<string>();
@@ -1696,8 +1735,10 @@ export const highlightTiles = (info: {
     }
   });
 
+  const result = new Set([...newHighlights, ...newSelection]);
+  group_highlight_edges.userData.highlightTilesKey = cacheKey;
   endMark();
-  return new Set([...newHighlights, ...newSelection]);
+  return result;
 };
 
 /**

--- a/app/src/libs/threejs/combat.ts
+++ b/app/src/libs/threejs/combat.ts
@@ -90,7 +90,11 @@ import { playPreloadedAudio } from "@/utils/audio";
 import type { BarrierTagType } from "@/validators/combat";
 import type { HexagonalFaceMesh, TerrainHex } from "../hexgrid";
 import { findHex, getPossibleActionTiles, PathCalculator } from "../hexgrid";
-import { getHighlightTilesCacheKey } from "./highlightTilesCache";
+import {
+  type CombatHoverCursor,
+  getHighlightTilesCacheKey,
+  nextCombatHoverCursor,
+} from "./highlightTilesCache";
 
 // Queue for non-movement SFX that should play after movement completes
 type PendingSfx = { url: string; volume: number };
@@ -1542,6 +1546,15 @@ export const highlightTiles = (info: {
     hoverTileName,
   });
   if (group_highlight_edges.userData.highlightTilesKey === cacheKey) {
+    const nextCursor = nextCombatHoverCursor(
+      group_highlight_edges.userData.highlightTilesCursor as
+        | CombatHoverCursor
+        | undefined,
+      document.body.style.cursor,
+    );
+    if (nextCursor !== document.body.style.cursor) {
+      document.body.style.cursor = nextCursor;
+    }
     endMark();
     return currentHighlights;
   }
@@ -1583,6 +1596,7 @@ export const highlightTiles = (info: {
 
   // Highlight intersected tile using shared validation
   const newSelection = new Set<string>();
+  let desiredCursor: CombatHoverCursor = "default";
   if (hit && action && canUseTile) {
     const intersected = hit.object as HexagonalFaceMesh;
     const targetTile = intersected.userData.tile as TerrainHex;
@@ -1665,19 +1679,8 @@ export const highlightTiles = (info: {
           newSelection.add(name);
         }
       });
-      // Set cursor type on highlight
-      if (
-        (document.body.style.cursor === "default" ||
-          document.body.style.cursor === "") &&
-        green.size > 0 &&
-        isValid
-      ) {
-        document.body.style.cursor = "pointer";
-      } else if (
-        document.body.style.cursor === "pointer" &&
-        (green.size === 0 || !isValid)
-      ) {
-        document.body.style.cursor = "default";
+      if (green.size > 0 && isValid) {
+        desiredCursor = "pointer";
       }
     }
   }
@@ -1714,6 +1717,11 @@ export const highlightTiles = (info: {
 
   const result = new Set([...newHighlights, ...newSelection]);
   group_highlight_edges.userData.highlightTilesKey = cacheKey;
+  group_highlight_edges.userData.highlightTilesCursor = desiredCursor;
+  const nextCursor = nextCombatHoverCursor(desiredCursor, document.body.style.cursor);
+  if (nextCursor !== document.body.style.cursor) {
+    document.body.style.cursor = nextCursor;
+  }
   endMark();
   return result;
 };

--- a/app/src/libs/threejs/combat.ts
+++ b/app/src/libs/threejs/combat.ts
@@ -1686,8 +1686,9 @@ export const highlightTiles = (info: {
   }
 
   // Apply colors to all tiles based on their state
-  // Process all tiles that were previously highlighted or selected
-  currentHighlights.forEach((name) => {
+  // Finish new range colors in this pass: cache hits skip subsequent frames.
+  // Include previous highlights so tiles leaving the range are reset as well.
+  new Set([...currentHighlights, ...newHighlights]).forEach((name) => {
     const isHighlighted = newHighlights.has(name);
     const isSelected = newSelection.has(name);
     const mesh = group_tiles.getObjectByName(name) as HexagonalFaceMesh;

--- a/app/src/libs/threejs/combat.ts
+++ b/app/src/libs/threejs/combat.ts
@@ -90,6 +90,7 @@ import { playPreloadedAudio } from "@/utils/audio";
 import type { BarrierTagType } from "@/validators/combat";
 import type { HexagonalFaceMesh, TerrainHex } from "../hexgrid";
 import { findHex, getPossibleActionTiles, PathCalculator } from "../hexgrid";
+import { getHighlightTilesCacheKey } from "./highlightTilesCache";
 
 // Queue for non-movement SFX that should play after movement completes
 type PendingSfx = { url: string; volume: number };
@@ -1478,30 +1479,6 @@ const resetEdgePool = (pool: HighlightEdgePool) => {
   }
   pool.activeCount = 0;
 };
-
-/**
- * Cache key for skipping highlightTiles rebuilds. Hover tile and canUseTile
- * must be included: action/version/position alone would freeze hover selection
- * and leave range highlights up after the local turn expires.
- */
-export const getHighlightTilesCacheKey = (info: {
-  actionId: string | undefined;
-  battleVersion: number;
-  userId: string;
-  longitude: number;
-  latitude: number;
-  canUseTile: boolean;
-  hoverTileName: string;
-}) =>
-  [
-    info.actionId ?? "",
-    info.battleVersion,
-    info.userId,
-    info.longitude,
-    info.latitude,
-    info.canUseTile ? "1" : "0",
-    info.hoverTileName,
-  ].join("|");
 
 /**
  * Highlight possible squares based on action

--- a/app/src/libs/threejs/highlightTilesCache.ts
+++ b/app/src/libs/threejs/highlightTilesCache.ts
@@ -20,7 +20,9 @@ export const getHighlightTilesCacheKey = (info: {
     info.latitude,
     info.canUseTile ? "1" : "0",
     info.hoverTileName,
-  ].join("|");
+  ]
+    .map((value) => JSON.stringify(value))
+    .join("|");
 
 export type CombatHoverCursor = "pointer" | "default";
 

--- a/app/src/libs/threejs/highlightTilesCache.ts
+++ b/app/src/libs/threejs/highlightTilesCache.ts
@@ -1,0 +1,23 @@
+/**
+ * Cache key for skipping highlightTiles rebuilds. Hover tile and canUseTile
+ * must be included: action/version/position alone would freeze hover selection
+ * and leave range highlights up after the local turn expires.
+ */
+export const getHighlightTilesCacheKey = (info: {
+  actionId: string | undefined;
+  battleVersion: number;
+  userId: string;
+  longitude: number;
+  latitude: number;
+  canUseTile: boolean;
+  hoverTileName: string;
+}) =>
+  [
+    info.actionId ?? "",
+    info.battleVersion,
+    info.userId,
+    info.longitude,
+    info.latitude,
+    info.canUseTile ? "1" : "0",
+    info.hoverTileName,
+  ].join("|");

--- a/app/src/libs/threejs/highlightTilesCache.ts
+++ b/app/src/libs/threejs/highlightTilesCache.ts
@@ -21,3 +21,23 @@ export const getHighlightTilesCacheKey = (info: {
     info.canUseTile ? "1" : "0",
     info.hoverTileName,
   ].join("|");
+
+export type CombatHoverCursor = "pointer" | "default";
+
+/**
+ * Next body cursor after a highlight pass. Never overrides an in-flight "wait"
+ * (set while a mutation is pending); restores pointer after settle-to-default.
+ */
+export const nextCombatHoverCursor = (
+  desired: CombatHoverCursor | undefined,
+  current: string,
+): string => {
+  if (current === "wait") return current;
+  if (desired === "pointer" && (current === "default" || current === "")) {
+    return "pointer";
+  }
+  if (desired === "default" && current === "pointer") {
+    return "default";
+  }
+  return current;
+};

--- a/app/tests/libs/threejs.highlightTiles.test.ts
+++ b/app/tests/libs/threejs.highlightTiles.test.ts
@@ -1,0 +1,164 @@
+import { Grid, rectangle } from "honeycomb-grid";
+import { Color, Group, Mesh, MeshBasicMaterial, PlaneGeometry, Vector3 } from "three";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { defineHex } from "@/libs/hexgrid";
+import { highlightTiles } from "@/libs/threejs/combat";
+
+// Bun has no DOM; the renderer only needs the body cursor in these tests.
+const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+beforeEach(() => {
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { body: { style: { cursor: "default" } } },
+  });
+});
+afterEach(() => {
+  if (originalDocument) {
+    Object.defineProperty(globalThis, "document", originalDocument);
+  } else {
+    Reflect.deleteProperty(globalThis, "document");
+  }
+});
+
+type HighlightInfo = Parameters<typeof highlightTiles>[0];
+
+const createScene = () => {
+  const grid = new Grid(defineHex(), rectangle({ width: 3, height: 3 }));
+  const group_tiles = new Group();
+  const meshes = Array.from(grid, (tile) => {
+    const mesh = new Mesh(
+      new PlaneGeometry(1, 1),
+      new MeshBasicMaterial({ color: "white" }),
+    );
+    mesh.name = `${tile.row},${tile.col}`;
+    mesh.userData = {
+      tile,
+      originalColor: mesh.material.color.clone(),
+      highlight: false,
+      selected: false,
+      canClick: false,
+    };
+    group_tiles.add(mesh);
+    return mesh;
+  });
+  const user = {
+    userId: "user-1",
+    longitude: 0,
+    latitude: 0,
+    curHealth: 100,
+    maxHealth: 100,
+    actionPoints: 100,
+    fledBattle: false,
+  } as HighlightInfo["user"];
+  const action: NonNullable<HighlightInfo["action"]> = {
+    id: "wide-range",
+    name: "Wide range",
+    image: "",
+    battleDescription: "",
+    type: "basic",
+    target: "GROUND",
+    method: "SINGLE",
+    range: 10,
+    healthCost: 0,
+    chakraCost: 0,
+    staminaCost: 0,
+    actionCostPerc: 10,
+    updatedAt: 0,
+    cooldown: 0,
+    originalCooldown: 0,
+    effects: [],
+  };
+  const info: HighlightInfo = {
+    group_tiles,
+    group_highlight_edges: new Group(),
+    grid,
+    user,
+    battle: {
+      version: 1,
+      activeUserId: user.userId,
+      round: 1,
+      roundStartAt: new Date(),
+      usersState: [user],
+      usersEffects: [],
+      groundEffects: [],
+    } as unknown as HighlightInfo["battle"],
+    action,
+    precomputedActions: [action],
+    timeDiff: 0,
+    cachedIntersections: { battleTiles: [], tiles: [], ground: [] },
+    currentHighlights: new Set<string>(),
+  };
+  const render = () => {
+    info.currentHighlights = highlightTiles(info);
+    return info.currentHighlights;
+  };
+  return { info, meshes, render };
+};
+
+const rangeColor = new Color("white").lerp(new Color("rgb(80, 80, 80)"), 0.7);
+
+const expectRangeColors = (meshes: Mesh<PlaneGeometry, MeshBasicMaterial>[]) => {
+  for (const mesh of meshes) {
+    expect(mesh.userData.highlight).toBe(true);
+    expect(mesh.material.color.equals(rangeColor)).toBe(true);
+  }
+};
+
+describe("highlightTiles range colors", () => {
+  it("colors newly highlighted tiles before caching the first frame", () => {
+    const { meshes, render } = createScene();
+    const highlights = render();
+    expectRangeColors(meshes);
+
+    // The next frame reuses the completed colors and highlight set.
+    expect(render()).toBe(highlights);
+    expectRangeColors(meshes);
+  });
+
+  it("colors newly added tiles immediately when switching to a wider action", () => {
+    const { info, meshes, render } = createScene();
+    const wideAction = info.action;
+    info.action = {
+      ...wideAction,
+      id: "origin-only",
+      method: "SINGLE",
+      range: 0,
+    } as HighlightInfo["action"];
+    expect(render().size).toBe(1);
+
+    info.action = wideAction;
+    expect(render().size).toBe(meshes.length);
+    expectRangeColors(meshes);
+  });
+
+  it("preserves selected colors above range tint on the first frame", () => {
+    const { info, meshes, render } = createScene();
+    const selected = meshes[0]!;
+    info.cachedIntersections.battleTiles = [
+      { object: selected, distance: 0, point: new Vector3() },
+    ];
+    render();
+    const selectedColor = new Color("white").lerp(new Color("rgb(0, 255, 100)"), 0.8);
+    expect(selected.material.color.equals(selectedColor)).toBe(true);
+    expect(selected.userData.canClick).toBe(true);
+    expectRangeColors(meshes.slice(1));
+
+    info.cachedIntersections.battleTiles = [];
+    render();
+    expectRangeColors(meshes);
+    expect(selected.userData.selected).toBe(false);
+    expect(selected.userData.canClick).toBe(false);
+  });
+
+  it("restores original colors and hides edges when the action is deselected", () => {
+    const { info, meshes, render } = createScene();
+    render();
+    info.action = undefined;
+    expect(render().size).toBe(0);
+    for (const mesh of meshes) {
+      expect(mesh.userData.highlight).toBe(false);
+      expect(mesh.material.color.equals(mesh.userData.originalColor)).toBe(true);
+    }
+    expect(info.group_highlight_edges.children.every((edge) => !edge.visible)).toBe(true);
+  });
+});

--- a/app/tests/libs/threejs.highlightTilesCache.test.ts
+++ b/app/tests/libs/threejs.highlightTilesCache.test.ts
@@ -41,6 +41,14 @@ describe("getHighlightTilesCacheKey", () => {
     expect(key).not.toEqual(getHighlightTilesCacheKey({ ...base, userId: "user-2" }));
   });
 
+  it("does not collide when a field contains the key delimiter", () => {
+    expect(
+      getHighlightTilesCacheKey({ ...base, actionId: "a|3", battleVersion: 4 }),
+    ).not.toEqual(
+      getHighlightTilesCacheKey({ ...base, actionId: "a", battleVersion: 3, userId: "4|user-1" }),
+    );
+  });
+
   it("treats a missing action id as empty", () => {
     expect(getHighlightTilesCacheKey({ ...base, actionId: undefined })).toEqual(
       getHighlightTilesCacheKey({ ...base, actionId: undefined }),

--- a/app/tests/libs/threejs.highlightTilesCache.test.ts
+++ b/app/tests/libs/threejs.highlightTilesCache.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { getHighlightTilesCacheKey } from "@/libs/threejs/highlightTilesCache";
+import {
+  getHighlightTilesCacheKey,
+  nextCombatHoverCursor,
+} from "@/libs/threejs/highlightTilesCache";
 
 const base = {
   actionId: "move",
@@ -45,5 +48,21 @@ describe("getHighlightTilesCacheKey", () => {
     expect(getHighlightTilesCacheKey({ ...base, actionId: undefined })).not.toEqual(
       getHighlightTilesCacheKey(base),
     );
+  });
+});
+
+describe("nextCombatHoverCursor", () => {
+  it("restores pointer after a mutation settles back to default", () => {
+    expect(nextCombatHoverCursor("pointer", "default")).toBe("pointer");
+    expect(nextCombatHoverCursor("pointer", "")).toBe("pointer");
+  });
+
+  it("does not override an in-flight wait cursor", () => {
+    expect(nextCombatHoverCursor("pointer", "wait")).toBe("wait");
+    expect(nextCombatHoverCursor("default", "wait")).toBe("wait");
+  });
+
+  it("clears pointer when the hover is no longer a valid target", () => {
+    expect(nextCombatHoverCursor("default", "pointer")).toBe("default");
   });
 });

--- a/app/tests/libs/threejs.highlightTilesCache.test.ts
+++ b/app/tests/libs/threejs.highlightTilesCache.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { getHighlightTilesCacheKey } from "@/libs/threejs/combat";
+import { getHighlightTilesCacheKey } from "@/libs/threejs/highlightTilesCache";
 
 const base = {
   actionId: "move",

--- a/app/tests/libs/threejs.highlightTilesCache.test.ts
+++ b/app/tests/libs/threejs.highlightTilesCache.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { getHighlightTilesCacheKey } from "@/libs/threejs/combat";
+
+const base = {
+  actionId: "move",
+  battleVersion: 3,
+  userId: "user-1",
+  longitude: 4,
+  latitude: 5,
+  canUseTile: true,
+  hoverTileName: "5,6",
+};
+
+describe("getHighlightTilesCacheKey", () => {
+  it("is stable for identical highlight inputs", () => {
+    expect(getHighlightTilesCacheKey(base)).toEqual(getHighlightTilesCacheKey(base));
+  });
+
+  it("changes when the hovered tile changes, so hover selection can update", () => {
+    expect(getHighlightTilesCacheKey(base)).not.toEqual(
+      getHighlightTilesCacheKey({ ...base, hoverTileName: "5,7" }),
+    );
+  });
+
+  it("changes when the local actor can no longer act", () => {
+    expect(getHighlightTilesCacheKey(base)).not.toEqual(
+      getHighlightTilesCacheKey({ ...base, canUseTile: false }),
+    );
+  });
+
+  it("changes when action, version, or position change", () => {
+    const key = getHighlightTilesCacheKey(base);
+    expect(key).not.toEqual(getHighlightTilesCacheKey({ ...base, actionId: "attack" }));
+    expect(key).not.toEqual(getHighlightTilesCacheKey({ ...base, battleVersion: 4 }));
+    expect(key).not.toEqual(getHighlightTilesCacheKey({ ...base, longitude: 5 }));
+    expect(key).not.toEqual(getHighlightTilesCacheKey({ ...base, latitude: 6 }));
+    expect(key).not.toEqual(getHighlightTilesCacheKey({ ...base, userId: "user-2" }));
+  });
+
+  it("treats a missing action id as empty", () => {
+    expect(getHighlightTilesCacheKey({ ...base, actionId: undefined })).toEqual(
+      getHighlightTilesCacheKey({ ...base, actionId: undefined }),
+    );
+    expect(getHighlightTilesCacheKey({ ...base, actionId: undefined })).not.toEqual(
+      getHighlightTilesCacheKey(base),
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Finding #8: combat RAF still calls `highlightTiles` every frame, which rebuilt possible-action tiles and reset the edge pool even when nothing about the highlight had changed.

## What changed

`highlightTiles` now returns the previous highlight set when this cache key is unchanged:

- selected `action.id`
- `battle.version`
- controlled actor id + tile position
- `canUseTile` (active actor + action points)
- hovered hex name

Mesh/edge caches were already in place. This only skips the per-frame `getPossibleActionTiles` + edge-pool reset + hover recolor when those inputs are stable.

Hover tile and `canUseTile` are required. A key of just action/version/position would freeze hover selection and leave range highlights up after the local turn expires (`calcActiveUser` is time-based and can flip without a version bump).

## What this does not do

- No combat renderer rewrite
- No RAF pause on `document.hidden`. Production `requestAnimationFrame` is already throttled by the browser; a naive pause risks a `Clock.getDelta()` spike (sprite mixer) and a burst of appear/move SFX on resume because movement is frame-stepped. Dev unbounded `setTimeout(0)` is a separate issue.
- No changes to `drawCombatUsers` / `drawCombatEffects` / raycast

## Test plan

- [x] Unit tests for cache-key stability and the hover / canUseTile / action / version / position invalidations
- [ ] Arena battle: select move, hover tiles (range + green/red update), leave the hex (selection clears), wait out a turn (highlights drop), perform a move (rebuilds after version/position change)

Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85c0b65f-48e6-46b4-821c-a6e42475fcc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85c0b65f-48e6-46b4-821c-a6e42475fcc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved combat tile highlighting by reusing results when relevant battle and hover conditions remain unchanged.
* **User Experience**
  * Improved combat hover-cursor behavior, including preserving in-progress wait states and accurately switching between available and unavailable tile indicators.
* **Tests**
  * Added coverage for highlight consistency, state changes, and hover-cursor transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->