### PR TITLE
Pause listed tRPC polls in the background; cache inbox list 30s

### DIFF
--- a/app/src/app/_trpc/client.ts
+++ b/app/src/app/_trpc/client.ts
@@ -11,7 +11,10 @@ import { toast } from "@/components/ui/use-toast";
 
 /** A set of type-safe react-query hooks for your tRPC API. */
 export const api = createTRPCReact<AppRouter>({
-  // Abort on onmount, see: https://trpc.io/docs/client/react/aborting-procedure-calls
+  // Queries only (TanStack Query does not abort mutations). Left false so an in-flight
+  // query can still fill the Infinity staleTime cache after navigation — e.g. sector
+  // data started on /travel and read on the sector map. See:
+  // https://trpc.io/docs/client/react/aborting-procedure-calls
   abortOnUnmount: false,
 });
 

--- a/app/src/app/auctionhouse/page.tsx
+++ b/app/src/app/auctionhouse/page.tsx
@@ -263,6 +263,7 @@ const AuctionListing: React.FC<AuctionListingProps> = ({ selectedStatus }) => {
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,
       refetchInterval: 10000,
+      refetchIntervalInBackground: false,
     },
   );
 

--- a/app/src/app/colosseum/page.tsx
+++ b/app/src/app/colosseum/page.tsx
@@ -40,7 +40,7 @@ export default function ColosseumPage() {
   const [selectedType, setSelectedType] = useState<BattleType>("RANKED_PVP");
   const { data: battles, isLoading } = api.combat.listOngoingBattles.useQuery(
     { battleType: selectedType },
-    { refetchInterval: 5000 },
+    { refetchInterval: 5000, refetchIntervalInBackground: false },
   );
 
   const tableData =

--- a/app/src/app/hospital/page.tsx
+++ b/app/src/app/hospital/page.tsx
@@ -189,6 +189,7 @@ const HealOthersComponent: React.FC<HealOthersComponentProps> = (props) => {
   // Queries
   const { data: hospitalized } = api.hospital.getHospitalizedUsers.useQuery(undefined, {
     refetchInterval: 5000,
+    refetchIntervalInBackground: false,
     enabled: !!userData,
   });
 

--- a/app/src/app/inbox/page.tsx
+++ b/app/src/app/inbox/page.tsx
@@ -124,14 +124,16 @@ const ShowConversations: React.FC<ShowConversationsProps> = (props) => {
   const [pendingConvoId, setPendingConvoId] = useState<string | null>(null);
   const [isExitConfirmOpen, setIsExitConfirmOpen] = useState(false);
 
-  // Fetch conversations. Note we pass the selected convo to automatically re-fetch when it changes
+  // Fetch conversations. selectedConvo is part of the key so opening a thread still
+  // refetches. The open thread itself updates over Pusher; the list does not need
+  // to be immediately stale on every window focus.
   const {
     data: allConversations,
     refetch,
     isPending,
   } = api.comments.getUserConversations.useQuery(
     { selectedConvo: selectedConvo },
-    { enabled: !!userData, staleTime: 0 },
+    { enabled: !!userData, staleTime: 30_000 },
   );
 
   // Mutations

--- a/app/src/layout/Clan.tsx
+++ b/app/src/layout/Clan.tsx
@@ -477,7 +477,7 @@ export const ClanBattles: React.FC<ClanBattlesProps> = (props) => {
   // Query
   const { data } = api.clan.getClanBattles.useQuery(
     { clanId: clanId },
-    { refetchInterval: 10000 },
+    { refetchInterval: 10000, refetchIntervalInBackground: false },
   );
 
   // Clan search

--- a/app/src/layout/PvpRank.tsx
+++ b/app/src/layout/PvpRank.tsx
@@ -46,6 +46,7 @@ export const RankedArenaMain: React.FC = () => {
   const { data: queueData } = api.pvpRank.getRankedPvpQueue.useQuery(undefined, {
     enabled: !!userData,
     refetchInterval: 5000, // Refetch queue status every 5 seconds
+    refetchIntervalInBackground: false,
   });
 
   // Get current season

--- a/app/src/layout/RaidBrowser.tsx
+++ b/app/src/layout/RaidBrowser.tsx
@@ -90,7 +90,11 @@ const RaidBrowser: React.FC<RaidBrowserProps> = (props) => {
 
   const { data: leaderboardData } = api.raids.getRaidLeaderboard.useQuery(
     { questId: selectedRaidId ?? "", limit: 10 },
-    { enabled: !!selectedRaidId, refetchInterval: 10000 },
+    {
+      enabled: !!selectedRaidId,
+      refetchInterval: 10000,
+      refetchIntervalInBackground: false,
+    },
   );
 
   const { data: activeTeamsData } = api.raids.getActiveRaidTeams.useQuery(

--- a/app/src/layout/Sector.tsx
+++ b/app/src/layout/Sector.tsx
@@ -409,8 +409,10 @@ const Sector: React.FC<SectorProps> = (props) => {
       enabled: sector !== undefined,
       placeholderData: (previous) => previous,
       // Presence and fights change while the tab is open; pusher events can be
-      // missed, so poll the sector snapshot on a short interval.
+      // missed, so poll the sector snapshot on a short interval. Pause that
+      // interval while the tab is in the background.
       refetchInterval: 10_000,
+      refetchIntervalInBackground: false,
     },
   );
   const villageData = data?.village;

--- a/app/src/layout/ShrineBattleLobby.tsx
+++ b/app/src/layout/ShrineBattleLobby.tsx
@@ -48,7 +48,7 @@ export const ShrineBattleLobby: React.FC<ShrineBattleLobbyProps> = ({
   // Query for shrine battles
   const { data: shrineBattles, isLoading } = api.shrine.getShrineBattles.useQuery(
     { sectorNumber },
-    { refetchInterval: 5000 },
+    { refetchInterval: 5000, refetchIntervalInBackground: false },
   );
 
   // Mutations


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Finding #15 (P2): background polling / inbox `staleTime: 0` / global `abortOnUnmount`.

## What changed

- Left `abortOnUnmount: false` on the tRPC React client. tRPC/TanStack Query only abort **queries** on unmount (not mutations), so `PUBLIC_MUTATIONS` (`misc.trackVisitor`, `push.unregisterDevice`, etc.) are not the risk. The real one is in-flight **queries** that later pages still read under the Provider’s `staleTime: Infinity` — e.g. sector data started on `/travel` and consumed on the sector map. Flipping the global flag would cancel those cache fills.
- Set `refetchIntervalInBackground: false` on the listed polls: hospital (5s), ranked queue (5s), colosseum (5s), shrine lobby (5s), auction / clan battles / raid leaderboard (10s), sector snapshot (10s).
- Raised inbox `getUserConversations` `staleTime` from `0` to `30s`. The open thread already updates over Pusher. This query also writes `inboxNews: 0` on every fetch, so it was not invalidated from the `newInbox` Pusher handler (that would clear the unread badge while the user is still off `/inbox`).

## Why

Background tabs were a stated cost for these short-interval polls. Inbox was refetching on every focus/remount despite live thread updates.

TanStack Query v5 already defaults `refetchIntervalInBackground` to `false`, so the poll flags are explicit / defensive (same runtime behavior today). The inbox `staleTime` change is the actual request-volume cut.

## Out of scope

- Did not flip global `abortOnUnmount`.
- Did not touch other polls (UserContext 5m, shrine page sector 10s, ShrineHall, Logbook, ConceptImage, farm).
- No merge.

## Testing

- CI: `test_linting`, `test_typecheck`, `test_build` passed on this revision.
- Vercel `tnr` preview served `/hospital`, `/colosseum`, `/inbox`, `/auctionhouse`, `/shrine`, `/travel`, `/battlearena`, `/clanhall` as 200 (Clerk login wall; this agent has no bun/docker/`app/.env`, so no signed-in browser pass).
- Query-option behavior (background interval paused, inbox cache 30s) is not observable from those unauthenticated HTML responses.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c749d617-d898-4f48-a922-ea4a396f0e07?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c749d617-d898-4f48-a922-ea4a396f0e07&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

