### PR TITLE
perf(shop): page catalogs and mount one black-market shop

### DIFF
--- a/app/src/app/blackmarket/page.tsx
+++ b/app/src/app/blackmarket/page.tsx
@@ -107,50 +107,65 @@ export default function BlackMarket() {
       </ContentBox>
       {tab === "Bloodline" && <Bloodline userData={userData} />}
       {tab === "Ryo" && <RyoShop userData={userData} />}
-      {tab === "Item" && (
-        <>
-          <Shop
-            userData={userData}
-            defaultType="CONSUMABLE"
-            initialBreak={true}
-            minRepsCost={1}
-            title="Reputation Shop"
-            subtitle="Browse categories, search the catalog, then open a card to buy."
-            catalog={{
-              silverLabel: "silver",
-              heroTitle: "Reputation catalog",
-              heroDescription:
-                "Spend reputation on rare stock. Category tabs and search match the village shop; filters refine rarity, slot, and effects.",
-              heroBadge: "Reputation pricing",
-              searchId: "blackmarket-rep-catalog-search",
-              listId: false,
-              filterTriggerId: "blackmarket-rep-filter",
-            }}
-          />
-          <Shop
-            userData={userData}
-            defaultType="CONSUMABLE"
-            initialBreak={true}
-            minSeichiSilverCost={1}
-            title="Silver Shop"
-            subtitle="Browse categories, search the catalog, then open a card to buy."
-            catalog={{
-              silverLabel: "silver",
-              heroTitle: "Silver catalog",
-              heroDescription:
-                "Spend silver on exclusive goods. Use tabs and search, then tap a card to review and purchase.",
-              heroBadge: "Silver pricing",
-              searchId: "blackmarket-seichi-catalog-search",
-              listId: false,
-              filterTriggerId: "blackmarket-seichi-filter",
-            }}
-          />
-          {PITY_SYSTEM_ENABLED && <PityBloodlineRoll userData={userData} />}
-        </>
-      )}
+      {tab === "Item" && <BlackMarketItemCatalog userData={userData} />}
     </>
   );
 }
+
+const itemCurrencyTabs = ["Reputation", "Silver"] as const;
+
+/**
+ * Reputation and silver catalogs share Shop, but only one is mounted so we do
+ * not fire two item.getAll infinite queries or render two card grids at once.
+ */
+const BlackMarketItemCatalog: React.FC<{
+  userData: NonNullable<UserWithRelations>;
+}> = ({ userData }) => {
+  const [itemCurrency, setItemCurrency] = useLocalStorage<
+    (typeof itemCurrencyTabs)[number]
+  >("blackmarketItemCurrency", "Reputation");
+  const isSilver = itemCurrency === "Silver";
+  const currencyNav = (
+    <NavTabs
+      id="blackmarket-item-currency"
+      current={itemCurrency}
+      options={itemCurrencyTabs}
+      setValue={setItemCurrency}
+    />
+  );
+
+  return (
+    <>
+      <Shop
+        key={itemCurrency}
+        userData={userData}
+        defaultType="CONSUMABLE"
+        initialBreak={true}
+        minRepsCost={isSilver ? undefined : 1}
+        minSeichiSilverCost={isSilver ? 1 : undefined}
+        title={isSilver ? "Silver Shop" : "Reputation Shop"}
+        subtitle="Browse categories, search the catalog, then open a card to buy."
+        catalog={{
+          silverLabel: "silver",
+          heroTitle: isSilver ? "Silver catalog" : "Reputation catalog",
+          heroDescription: isSilver
+            ? "Spend silver on exclusive goods. Use tabs and search, then tap a card to review and purchase."
+            : "Spend reputation on rare stock. Category tabs and search match the village shop; filters refine rarity, slot, and effects.",
+          heroBadge: isSilver ? "Silver pricing" : "Reputation pricing",
+          searchId: isSilver
+            ? "blackmarket-seichi-catalog-search"
+            : "blackmarket-rep-catalog-search",
+          listId: false,
+          filterTriggerId: isSilver
+            ? "blackmarket-seichi-filter"
+            : "blackmarket-rep-filter",
+          headerExtra: currencyNav,
+        }}
+      />
+      {PITY_SYSTEM_ENABLED && <PityBloodlineRoll userData={userData} />}
+    </>
+  );
+};
 
 /**
  * For every 150 failed rolls, let the user get a free bloodline of the given rank

--- a/app/src/layout/Shop.tsx
+++ b/app/src/layout/Shop.tsx
@@ -259,7 +259,7 @@ const Shop: React.FC<ShopProps> = (props) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [item, setItem] = useState<Item | undefined>(undefined);
   const [stacksize, setStacksize] = useState<number>(1);
-  const [lastElement, setLastElement] = useState<HTMLLIElement | null>(null);
+  const [lastElement, setLastElement] = useState<HTMLDivElement | null>(null);
   const filteringState = useShopFiltering(defaultType);
   const isAwake = useAwake(userData);
   const itemTypeTabOptions = useMemo(
@@ -655,9 +655,12 @@ const Shop: React.FC<ShopProps> = (props) => {
               </div>
 
               <div className="px-1.5 py-2 sm:px-3 sm:py-3 md:p-5" id={catalogListDomId}>
-                {isFetching && !catalogItems.length ? (
-                  <div className="flex min-h-[40vh] items-center justify-center">
+                {!catalogItems.length && (isFetching || hasNextPage) ? (
+                  <div className="flex min-h-[40vh] flex-col items-center justify-center">
                     <Loader explanation="Loading catalog…" />
+                    {hasNextPage ? (
+                      <div ref={setLastElement} className="h-px w-full" aria-hidden />
+                    ) : null}
                   </div>
                 ) : !catalogItems.length ? (
                   <div className="flex min-h-[36vh] flex-col items-center justify-center rounded-2xl border border-dashed bg-muted/20 px-6 py-16 text-center">
@@ -672,7 +675,7 @@ const Shop: React.FC<ShopProps> = (props) => {
                 ) : (
                   <>
                     <ul className="mx-auto grid max-w-7xl list-none grid-cols-3 gap-1 sm:gap-2 md:grid-cols-4 md:gap-3 lg:grid-cols-6">
-                      {catalogItems.map((row, index) => {
+                      {catalogItems.map((row) => {
                         const rowFactor = shopItemDiscountFactor(
                           row,
                           sDiscount,
@@ -689,11 +692,6 @@ const Shop: React.FC<ShopProps> = (props) => {
                         return (
                           <li
                             key={row.id}
-                            ref={
-                              index === catalogItems.length - 1
-                                ? setLastElement
-                                : undefined
-                            }
                             id={
                               row.id === TUTORIAL_ITEM_ID && !isOpen
                                 ? "tutorial-itemshop-item"
@@ -723,6 +721,9 @@ const Shop: React.FC<ShopProps> = (props) => {
                         );
                       })}
                     </ul>
+                    {hasNextPage ? (
+                      <div ref={setLastElement} className="h-px w-full" aria-hidden />
+                    ) : null}
                     {isFetching && catalogItems.length > 0 && (
                       <div className="flex justify-center py-8">
                         <Loader explanation="Updating catalog…" />

--- a/app/src/layout/Shop.tsx
+++ b/app/src/layout/Shop.tsx
@@ -17,7 +17,13 @@ import {
   Ticket,
 } from "lucide-react";
 import { usePathname } from "next/navigation";
-import { type Dispatch, type SetStateAction, useMemo, useState } from "react";
+import {
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  useMemo,
+  useState,
+} from "react";
 import { api } from "@/app/_trpc/client";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -42,6 +48,7 @@ import ItemWithEffects from "@/layout/ItemWithEffects";
 import Loader from "@/layout/Loader";
 import Modal2 from "@/layout/Modal2";
 import { UncontrolledSliderField } from "@/layout/SliderField";
+import { useInfinitePagination } from "@/libs/pagination";
 import { cn } from "@/libs/shadui";
 import { getMaxItemShopPurchaseQuantity } from "@/libs/shop";
 import { showMutationToast } from "@/libs/toast";
@@ -50,7 +57,10 @@ import type { UserWithRelations } from "@/routers/profile";
 import { useAwake } from "@/utils/routing";
 import { getStrucBoost } from "@/utils/village";
 
-/** Optional overrides for the catalog UI (e.g. black market uses several at once). */
+/** First-page catalog size; further rows load through the existing infinite-query cursor. */
+const SHOP_CATALOG_PAGE_SIZE = 30;
+
+/** Optional overrides for the catalog UI (e.g. black-market reputation vs silver). */
 export interface ShopCatalogOverrides {
   heroTitle?: string;
   heroDescription?: string;
@@ -61,6 +71,8 @@ export interface ShopCatalogOverrides {
   filterTriggerId?: string;
   /** User-facing Seichi silver wording (`silver` on black market; default village: seichi). */
   silverLabel?: "silver" | "seichi";
+  /** Extra controls next to the filter button (e.g. black-market currency tabs). */
+  headerExtra?: ReactNode;
 }
 
 interface ShopProps {
@@ -247,6 +259,7 @@ const Shop: React.FC<ShopProps> = (props) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [item, setItem] = useState<Item | undefined>(undefined);
   const [stacksize, setStacksize] = useState<number>(1);
+  const [lastElement, setLastElement] = useState<HTMLLIElement | null>(null);
   const filteringState = useShopFiltering(defaultType);
   const isAwake = useAwake(userData);
   const itemTypeTabOptions = useMemo(
@@ -256,25 +269,27 @@ const Shop: React.FC<ShopProps> = (props) => {
 
   const utils = api.useUtils();
 
-  const { data: items, isFetching } = api.item.getAll.useInfiniteQuery(
-    {
-      minCost,
-      minRepsCost,
-      minSeichiSilverCost,
-      eventItems: props.eventItems,
-      limit: 500,
-      ...getShopFilter(filteringState),
-      onlyInShop: true,
-      hidden: false,
-      maxLevel: userData.level,
-    },
-    {
-      enabled: userData !== undefined,
-      staleTime: Infinity,
-      getNextPageParam: (lastPage) => lastPage.nextCursor,
-      placeholderData: (previousData) => previousData,
-    },
-  );
+  const { data: items, isFetching, fetchNextPage, hasNextPage } =
+    api.item.getAll.useInfiniteQuery(
+      {
+        minCost,
+        minRepsCost,
+        minSeichiSilverCost,
+        eventItems: props.eventItems,
+        ...getShopFilter(filteringState),
+        onlyInShop: true,
+        limit: SHOP_CATALOG_PAGE_SIZE,
+        hidden: false,
+        maxLevel: userData.level,
+      },
+      {
+        enabled: userData !== undefined,
+        staleTime: Infinity,
+        getNextPageParam: (lastPage) => lastPage.nextCursor,
+        placeholderData: (previousData) => previousData,
+      },
+    );
+  useInfinitePagination({ fetchNextPage, hasNextPage, lastElement });
   const allItems = items?.pages
     .flatMap((page) => page.data)
     .filter(
@@ -514,6 +529,7 @@ const Shop: React.FC<ShopProps> = (props) => {
           padding={false}
           topRightContent={
             <div className="flex flex-row flex-wrap items-center justify-end gap-2">
+              {catalog?.headerExtra}
               <ItemShopFiltering
                 state={filteringState}
                 defaultType={defaultType}
@@ -657,7 +673,7 @@ const Shop: React.FC<ShopProps> = (props) => {
                 ) : (
                   <>
                     <ul className="mx-auto grid max-w-7xl list-none grid-cols-3 gap-1 sm:gap-2 md:grid-cols-4 md:gap-3 lg:grid-cols-6">
-                      {catalogItems.map((row) => {
+                      {catalogItems.map((row, index) => {
                         const rowFactor = shopItemDiscountFactor(
                           row,
                           sDiscount,
@@ -674,6 +690,11 @@ const Shop: React.FC<ShopProps> = (props) => {
                         return (
                           <li
                             key={row.id}
+                            ref={
+                              index === catalogItems.length - 1
+                                ? setLastElement
+                                : undefined
+                            }
                             id={
                               row.id === TUTORIAL_ITEM_ID && !isOpen
                                 ? "tutorial-itemshop-item"

--- a/app/src/layout/Shop.tsx
+++ b/app/src/layout/Shop.tsx
@@ -50,7 +50,7 @@ import Modal2 from "@/layout/Modal2";
 import { UncontrolledSliderField } from "@/layout/SliderField";
 import { useInfinitePagination } from "@/libs/pagination";
 import { cn } from "@/libs/shadui";
-import { getMaxItemShopPurchaseQuantity } from "@/libs/shop";
+import { getMaxItemShopPurchaseQuantity, isItemAvailableInStore } from "@/libs/shop";
 import { showMutationToast } from "@/libs/toast";
 import { isTutorialItemBuyStep, isTutorialPageMatch } from "@/libs/tutorial";
 import type { UserWithRelations } from "@/routers/profile";
@@ -278,6 +278,7 @@ const Shop: React.FC<ShopProps> = (props) => {
         eventItems: props.eventItems,
         ...getShopFilter(filteringState),
         onlyInShop: true,
+        excludeExpiredFromStore: true,
         limit: SHOP_CATALOG_PAGE_SIZE,
         hidden: false,
         maxLevel: userData.level,
@@ -292,9 +293,7 @@ const Shop: React.FC<ShopProps> = (props) => {
   useInfinitePagination({ fetchNextPage, hasNextPage, lastElement });
   const allItems = items?.pages
     .flatMap((page) => page.data)
-    .filter(
-      (row) => !row.expireFromStoreAt || new Date(row.expireFromStoreAt) > new Date(),
-    );
+    .filter((row) => isItemAvailableInStore(row.expireFromStoreAt));
 
   const pathname = usePathname();
   const { currentStep, handleNextStep } = useTutorialStep();

--- a/app/src/libs/shop.ts
+++ b/app/src/libs/shop.ts
@@ -2,3 +2,8 @@ import { MAX_ITEM_SHOP_PURCHASE_QUANTITY } from "@/drizzle/constants";
 
 export const getMaxItemShopPurchaseQuantity = (stackSize: number) =>
   Math.min(stackSize, MAX_ITEM_SHOP_PURCHASE_QUANTITY);
+
+export const isItemAvailableInStore = (
+  expireFromStoreAt: string | Date | null | undefined,
+  now: Date = new Date(),
+) => !expireFromStoreAt || new Date(expireFromStoreAt) > now;

--- a/app/src/server/api/routers/item.ts
+++ b/app/src/server/api/routers/item.ts
@@ -3416,6 +3416,17 @@ export const itemDatabaseFilter = (
     // Shop filter
     ...(input?.onlyInShop !== undefined ? [eq(item.inShop, input.onlyInShop)] : []),
 
+    // Timed store listings: match Shop's client hide so paged catalogs do not
+    // fill a page with expired rows and stall the infinite-scroll sentinel.
+    ...(input?.excludeExpiredFromStore
+      ? [
+          or(
+            isNull(item.expireFromStoreAt),
+            gt(item.expireFromStoreAt, new Date().toISOString().slice(0, 10)),
+          ),
+        ]
+      : []),
+
     // Hidden filter (default to false if not specified)
     ...(input?.hidden !== undefined
       ? [eq(item.hidden, input.hidden)]

--- a/app/src/validators/item.ts
+++ b/app/src/validators/item.ts
@@ -50,6 +50,8 @@ export const itemFilteringSchema = z.object({
   minSeichiSilverCost: z.number().prefault(0),
   maxSeichiSilverCost: z.number().optional(),
   onlyInShop: z.boolean().optional(),
+  /** Drop rows whose store listing date has passed. Shop catalogs page on this. */
+  excludeExpiredFromStore: z.boolean().optional(),
   eventItems: z.boolean().optional(),
   slot: z.enum(ItemSlotTypes).optional(),
   target: z.enum(AttackTargets).optional(),

--- a/app/tests/libs/shop.test.ts
+++ b/app/tests/libs/shop.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { MAX_ITEM_SHOP_PURCHASE_QUANTITY } from "@/drizzle/constants";
-import { getMaxItemShopPurchaseQuantity } from "@/libs/shop";
+import { getMaxItemShopPurchaseQuantity, isItemAvailableInStore } from "@/libs/shop";
 
 describe("getMaxItemShopPurchaseQuantity", () => {
   it("uses the item's smaller stack size", () => {
@@ -9,5 +9,22 @@ describe("getMaxItemShopPurchaseQuantity", () => {
 
   it("caps large item stacks at the server purchase limit", () => {
     expect(getMaxItemShopPurchaseQuantity(9_999)).toBe(MAX_ITEM_SHOP_PURCHASE_QUANTITY);
+  });
+});
+
+describe("isItemAvailableInStore", () => {
+  const now = new Date("2026-09-09T12:00:00.000Z");
+
+  it("keeps listings with no expiry", () => {
+    expect(isItemAvailableInStore(null, now)).toBe(true);
+    expect(isItemAvailableInStore(undefined, now)).toBe(true);
+  });
+
+  it("keeps listings that expire after now", () => {
+    expect(isItemAvailableInStore("2026-09-10", now)).toBe(true);
+  });
+
+  it("hides listings that have already expired", () => {
+    expect(isItemAvailableInStore("2026-09-08", now)).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Low-complexity slice for shop catalog cost on current `main` (Finding #14). No virtualizer library.

- **Shop** (`app/src/layout/Shop.tsx`): `item.getAll` page size `500` → `30`. The infinite query already had a cursor; it never fetched the next page. Wired `useInfinitePagination` (same intersection observer as manuals / bounty board / ryo ledger) so later rows still load.
- **Black market Item tab**: reputation and silver catalogs no longer mount two `Shop` instances at once. A Reputation / Silver toggle (localStorage) mounts one catalog. Copy, `minRepsCost` / `minSeichiSilverCost`, and buy path are unchanged.
- **Expired listings**: `item.getAll` can now drop `expireFromStoreAt` rows when `excludeExpiredFromStore` is set (shop catalogs only). This keeps paged results aligned with the existing client hide, so a page of expired rows cannot empty the grid or stall the scroll sentinel. The client check remains for cached pages (`staleTime: Infinity`).

## Why

On `main`, black market Item mounted two Shops, each requesting up to 500 shop rows and mapping every card. `item.getAll` was measured at ~94 rows / ~226 KB with 459–487 ms then ~5.5 s warm latency. No `react-virtuoso` / `react-window` / `useVirtualizer` in `app/src`; adding one would be a product/design change. This slice cuts the first-page payload and the duplicate mount.

## Out of scope

- Shop pricing, discounts, and eligibility filters (`onlyInShop`, `minCost` / `minRepsCost` / `minSeichiSilverCost`, `maxLevel`). Expired listings were already hidden in the UI and rejected at buy time.
- New virtualization dependency.

## Breaking

No. Users who scroll still reach the full in-stock catalog; black market items are one currency at a time instead of stacked.

## Validation

- Finding reconfirmed on `origin/main` (`Shop.tsx` `limit: 500`, no virtualizer under `app/src`, black market mounted two Shops).
- CI: lint, typecheck, and build passed on the first commit; re-running on the expired-listing follow-up.
- This cloud environment has no `app/.env`, Docker, or `node_modules`, so the local tnr-dev-server path was not available. Vercel preview is SSO-protected, so `item.getAll` payload could not be re-measured live here.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae79c649-9554-4194-a05e-26d5224937a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae79c649-9554-4194-a05e-26d5224937a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Reputation and Silver tabs to the Black Market, with the selected tab remembered between visits.
  - Only the selected shop is displayed, with updated titles, descriptions, pricing, search, and filtering.
  - Shop catalogs now load additional items as you browse and show only currently available stock.
- **Bug Fixes**
  - Expired listings are now excluded consistently from shop catalogs.
  - Items without an expiration date remain available.
- **Tests**
  - Added coverage for item availability based on expiration dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->