### PR TITLE
fix(ui): skip ActionTimer setState when the countdown view is unchanged

### DIFF
--- a/app/src/layout/ActionTimer.tsx
+++ b/app/src/layout/ActionTimer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Progress } from "@/components/ui/progress";
 import { availableUserActions, calcActiveUser } from "@/libs/combat/actions";
 import type { CombatAction, ReturnedBattle } from "@/libs/combat/types";
@@ -31,6 +31,8 @@ const ActionTimer: React.FC<ActionTimerProps> = (props) => {
     canAct: false,
     waiting: false,
   });
+  const stateRef = useRef(state);
+  stateRef.current = state;
 
   // Derived values
   const stunReduction = calcApReduction(battle, user.userId);
@@ -74,13 +76,16 @@ const ActionTimer: React.FC<ActionTimerProps> = (props) => {
 
     const updateState = () => {
       const next = nextTimerState();
-      setState((prev) =>
+      const prev = stateRef.current;
+      if (
         prev.label === next.label &&
         prev.canAct === next.canAct &&
         prev.waiting === next.waiting
-          ? prev
-          : next,
-      );
+      ) {
+        return;
+      }
+      stateRef.current = next;
+      setState(next);
     };
 
     updateState();

--- a/app/src/layout/ActionTimer.tsx
+++ b/app/src/layout/ActionTimer.tsx
@@ -50,19 +50,10 @@ const ActionTimer: React.FC<ActionTimerProps> = (props) => {
 
   // Active updating of this component
   useEffect(() => {
-    const interval = setInterval(() => {
-      // If not in focus, nothing
+    const nextTimerState = () => {
       if (!document.hasFocus() && process.env.NODE_ENV !== "development") {
-        // Keep the previous object, or an unfocused tab re-renders ten times a second
-        // to say the same thing
-        setState((prev) =>
-          prev.label === "Not in Focus" && !prev.canAct && !prev.waiting
-            ? prev
-            : { label: `Not in Focus`, canAct: false, waiting: false },
-        );
-        return;
+        return { label: "Not in Focus", canAct: false, waiting: false };
       }
-      // Set label
       const {
         actor,
         mseconds,
@@ -71,19 +62,29 @@ const ActionTimer: React.FC<ActionTimerProps> = (props) => {
         precomputedUserId: user.userId,
         precomputedActions,
       });
-      // Is it the user in question
       const canAct = actor.userId === user.userId;
       const waiting = user.userId !== actor.userId;
-      // Update state
       if (mseconds >= 0) {
-        const inform = !waiting ? "You" : `Opponent`;
+        const inform = !waiting ? "You" : "Opponent";
         const info = left > 0 ? `${inform}: ${left.toFixed(1)}s` : "Finished!";
-        setState({ label: info, canAct, waiting });
-      } else {
-        setState({ label: `Lobby`, canAct, waiting });
+        return { label: info, canAct, waiting };
       }
-      // Set action points
-    }, 100);
+      return { label: "Lobby", canAct, waiting };
+    };
+
+    const updateState = () => {
+      const next = nextTimerState();
+      setState((prev) =>
+        prev.label === next.label &&
+        prev.canAct === next.canAct &&
+        prev.waiting === next.waiting
+          ? prev
+          : next,
+      );
+    };
+
+    updateState();
+    const interval = setInterval(updateState, 100);
     return () => clearInterval(interval);
   }, [isPending, battle, user, timeDiff, precomputedActions]);
 

--- a/app/src/layout/ActionTimer.tsx
+++ b/app/src/layout/ActionTimer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Progress } from "@/components/ui/progress";
 import { availableUserActions, calcActiveUser } from "@/libs/combat/actions";
 import type { CombatAction, ReturnedBattle } from "@/libs/combat/types";
@@ -51,7 +51,7 @@ const ActionTimer: React.FC<ActionTimerProps> = (props) => {
   }, [battle?.version, user.userId]);
 
   // Active updating of this component
-  useEffect(() => {
+  useLayoutEffect(() => {
     const nextTimerState = () => {
       if (!document.hasFocus() && process.env.NODE_ENV !== "development") {
         return { label: "Not in Focus", canAct: false, waiting: false };
@@ -109,7 +109,11 @@ const ActionTimer: React.FC<ActionTimerProps> = (props) => {
                   <span
                     className={`h-2 w-2 rounded-full ${state.waiting ? "bg-amber-300" : "bg-emerald-300"}`}
                   />
-                  <span className="font-semibold">{state.label || "..."}</span>
+                  <span
+                    className={`font-semibold ${state.label ? "" : "invisible"}`}
+                  >
+                    {state.label || "..."}
+                  </span>
                 </div>
               </div>
             </div>

--- a/app/tests/layout/action-timer.test.tsx
+++ b/app/tests/layout/action-timer.test.tsx
@@ -11,31 +11,39 @@ import {
 
 ensureDom();
 
-const lobbyBattle = () => {
-  const now = Date.now();
-  return makeCompleteBattle({
-    usersState: [
-      makeBattleUser("p1", { curHealth: 100 }),
-      makeBattleUser("p2", { curHealth: 100 }),
-    ],
-    activeUserId: "p1",
-    roundStartAt: new Date(now + 60_000),
-    version: 1,
-  });
+vi.mock("@/utils/UserContext", () => ({
+  useUserData: () => ({ timeDiff: 0 }),
+}));
+
+const FROZEN_NOW = Date.UTC(2026, 0, 1, 12, 0, 0);
+let nowMs = FROZEN_NOW;
+
+const advanceTimers = (ms: number) => {
+  nowMs += ms;
+  vi.advanceTimersByTime(ms);
 };
 
-const countdownBattle = () => {
-  const now = Date.now();
-  return makeCompleteBattle({
+const lobbyBattle = () =>
+  makeCompleteBattle({
     usersState: [
       makeBattleUser("p1", { curHealth: 100 }),
       makeBattleUser("p2", { curHealth: 100 }),
     ],
     activeUserId: "p1",
-    roundStartAt: new Date(now - 1000),
+    roundStartAt: new Date(FROZEN_NOW + 60_000),
     version: 1,
   });
-};
+
+const countdownBattle = () =>
+  makeCompleteBattle({
+    usersState: [
+      makeBattleUser("p1", { curHealth: 100 }),
+      makeBattleUser("p2", { curHealth: 100 }),
+    ],
+    activeUserId: "p1",
+    roundStartAt: new Date(FROZEN_NOW - 1000),
+    version: 1,
+  });
 
 const renderTimer = (battle: ReturnType<typeof makeCompleteBattle>) => {
   let commits = 0;
@@ -54,7 +62,16 @@ const renderTimer = (battle: ReturnType<typeof makeCompleteBattle>) => {
   return { commits: () => commits, getByText: view.getByText };
 };
 
+const flushMount = () => {
+  act(() => {
+    vi.advanceTimersByTime(0);
+  });
+};
+
 beforeEach(() => {
+  nowMs = FROZEN_NOW;
+  vi.useFakeTimers();
+  vi.spyOn(Date, "now").mockImplementation(() => nowMs);
   vi.spyOn(document, "hasFocus").mockReturnValue(true);
 });
 
@@ -66,28 +83,42 @@ afterEach(() => {
 
 describe("ActionTimer interval commits", () => {
   it("does not re-commit when the timer label and flags stay the same", () => {
-    vi.useFakeTimers();
     const { commits, getByText } = renderTimer(lobbyBattle());
+    flushMount();
     expect(getByText("Lobby")).toBeTruthy();
     const afterMount = commits();
 
     act(() => {
-      vi.advanceTimersByTime(2000);
+      advanceTimers(2000);
     });
 
-    // 20 interval ticks. A stray child rAF/layout commit is fine; a commit per tick is not.
-    expect(commits() - afterMount).toBeLessThan(5);
+    expect(commits() - afterMount).toBe(0);
     expect(getByText("Lobby")).toBeTruthy();
   });
 
+  it("does not re-commit while the tab is unfocused", () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    const { commits, getByText } = renderTimer(lobbyBattle());
+    flushMount();
+    expect(getByText("Not in Focus")).toBeTruthy();
+    const afterMount = commits();
+
+    act(() => {
+      advanceTimers(2000);
+    });
+
+    expect(commits() - afterMount).toBe(0);
+    expect(getByText("Not in Focus")).toBeTruthy();
+  });
+
   it("re-commits when the displayed tenth-second label changes", () => {
-    vi.useFakeTimers();
     const { commits, getByText } = renderTimer(countdownBattle());
+    flushMount();
     expect(getByText(`You: ${(COMBAT_SECONDS - 1).toFixed(1)}s`)).toBeTruthy();
     const afterMount = commits();
 
     act(() => {
-      vi.advanceTimersByTime(100);
+      advanceTimers(100);
     });
 
     expect(commits()).toBeGreaterThan(afterMount);

--- a/app/tests/layout/action-timer.test.tsx
+++ b/app/tests/layout/action-timer.test.tsx
@@ -59,7 +59,11 @@ const renderTimer = (battle: ReturnType<typeof makeCompleteBattle>) => {
       />
     </Profiler>,
   );
-  return { commits: () => commits, getByText: view.getByText };
+  return {
+    commits: () => commits,
+    getByText: view.getByText,
+    queryByText: view.queryByText,
+  };
 };
 
 const flushMount = () => {
@@ -82,6 +86,12 @@ afterEach(() => {
 });
 
 describe("ActionTimer interval commits", () => {
+  it("does not paint the ellipsis fallback after the first timer state", () => {
+    const { queryByText, getByText } = renderTimer(lobbyBattle());
+    expect(queryByText("...")).toBeNull();
+    expect(getByText("Lobby")).toBeTruthy();
+  });
+
   it("does not re-commit when the timer label and flags stay the same", () => {
     const { commits, getByText } = renderTimer(lobbyBattle());
     flushMount();

--- a/app/tests/layout/action-timer.test.tsx
+++ b/app/tests/layout/action-timer.test.tsx
@@ -1,0 +1,96 @@
+import { ensureDom } from "../setup-dom.mjs";
+import { act, cleanup, render } from "@testing-library/react";
+import { Profiler, type ProfilerOnRenderCallback } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ActionTimer from "@/layout/ActionTimer";
+import { COMBAT_SECONDS } from "@/libs/combat/constants";
+import {
+  makeBattleUser,
+  makeCompleteBattle,
+} from "../libs/combat/helpers/battleScenario";
+
+ensureDom();
+
+const lobbyBattle = () => {
+  const now = Date.now();
+  return makeCompleteBattle({
+    usersState: [
+      makeBattleUser("p1", { curHealth: 100 }),
+      makeBattleUser("p2", { curHealth: 100 }),
+    ],
+    activeUserId: "p1",
+    roundStartAt: new Date(now + 60_000),
+    version: 1,
+  });
+};
+
+const countdownBattle = () => {
+  const now = Date.now();
+  return makeCompleteBattle({
+    usersState: [
+      makeBattleUser("p1", { curHealth: 100 }),
+      makeBattleUser("p2", { curHealth: 100 }),
+    ],
+    activeUserId: "p1",
+    roundStartAt: new Date(now - 1000),
+    version: 1,
+  });
+};
+
+const renderTimer = (battle: ReturnType<typeof makeCompleteBattle>) => {
+  let commits = 0;
+  const onRender: ProfilerOnRenderCallback = () => {
+    commits += 1;
+  };
+  const view = render(
+    <Profiler id="action-timer" onRender={onRender}>
+      <ActionTimer
+        user={{ userId: "p1", actionPoints: 100 }}
+        battle={battle}
+        isPending={false}
+      />
+    </Profiler>,
+  );
+  return { commits: () => commits, getByText: view.getByText };
+};
+
+beforeEach(() => {
+  vi.spyOn(document, "hasFocus").mockReturnValue(true);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("ActionTimer interval commits", () => {
+  it("does not re-commit when the timer label and flags stay the same", () => {
+    vi.useFakeTimers();
+    const { commits, getByText } = renderTimer(lobbyBattle());
+    expect(getByText("Lobby")).toBeTruthy();
+    const afterMount = commits();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    // 20 interval ticks. A stray child rAF/layout commit is fine; a commit per tick is not.
+    expect(commits() - afterMount).toBeLessThan(5);
+    expect(getByText("Lobby")).toBeTruthy();
+  });
+
+  it("re-commits when the displayed tenth-second label changes", () => {
+    vi.useFakeTimers();
+    const { commits, getByText } = renderTimer(countdownBattle());
+    expect(getByText(`You: ${(COMBAT_SECONDS - 1).toFixed(1)}s`)).toBeTruthy();
+    const afterMount = commits();
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(commits()).toBeGreaterThan(afterMount);
+    expect(getByText(`You: ${(COMBAT_SECONDS - 1.1).toFixed(1)}s`)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Finding #12 (P2): `ActionTimer` polled every 100ms and called `setState` on every focused tick, which is a real 10 React commits/s on the combat page.

**Change:** mirror `StatusBar` — keep the 100ms interval, but use a functional updater that returns the previous state unless `label`, `canAct`, or `waiting` changed. Also run the update immediately on mount/dependency change so the first label is not a 100ms `"..."` flash.

**Left alone (on purpose):**
- StatusBar’s 250ms × 3–4 profile bars already skip unchanged values. A shared tick would be a larger, easier-to-regress change for regen display.
- CSS-driven countdown would drop commits further during an active turn, but the visible label is still `toFixed(1)` tenths, so that is a higher-risk rewrite. During a live countdown the tenth still changes ~10 times/s; the win here is stable states (`Lobby`, `Finished!`, `Not in Focus`, same tenth) plus returning the same object so React bails out.
- Combat rules / `calcActiveUser` are untouched.

**Tests:** `app/tests/layout/action-timer.test.tsx` — lobby stays put across 20 ticks; a tenth-second change still commits.

Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-749cfd60-3910-42a9-8f3b-7e6e7f345cd6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-749cfd60-3910-42a9-8f3b-7e6e7f345cd6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timer updates to avoid unnecessary refreshes when displayed information has not changed.
  * Preserved timer layout when no label is available by keeping its placeholder space without displaying text.
  * Ensured timer focus behavior and countdown updates remain accurate, including when the app is not focused.

* **Tests**
  * Added coverage for stable timer labels, unfocused-tab behavior, placeholder handling, and tenth-second countdown updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->