### PR TITLE
perf(combat): drop unused raid participant scan after CAS claim

### DIFF
--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -1049,9 +1049,9 @@ export const updateVillageAnbuClan = async (
  *
  * Protection against duplicate processing:
  * 1. Each user deducts only their share of damage (totalDamage / numAttackers)
- * 2. battleCount is used as an optimistic lock - the upsert only succeeds if
- *    battleCount matches the value stored at battle start
- * 3. rowsAffected === 0 indicates a duplicate call - skip HP deduction
+ * 2. battleCount is the optimistic lock: first battle inserts, later battles
+ *    UPDATE only while battleCount still equals the start-of-battle value
+ * 3. A duplicate reports 0 changed rows and skips HP deduction and inbox writes
  * 4. This ensures each user's damage is only counted once, regardless of how
  *    many times their endpoint is called
  */
@@ -1100,30 +1100,45 @@ export const updateRaidProgress = async (
   // Get the battleCount at the start of this battle (0 if user hasn't participated before)
   const startBattleCount = curBattle.extraState.raidStartBattleCount?.[userId] ?? 0;
 
-  // Claim this battle's damage for this user. battleCount is the optimistic lock:
-  // a retry sees the same startBattleCount and the IF clauses write the existing
-  // values, so rowsAffected is 0 and we stop before touching HP or the inbox.
-  const upsertResult = await client
-    .insert(raidParticipation)
-    .values({
-      id: nanoid(),
-      questId: raidQuestId,
-      userId: userId,
-      damageDealt: userDamage,
-      battleCount: 1,
-      rewardsClaimed: [],
-    })
-    .onDuplicateKeyUpdate({
-      set: {
-        damageDealt: sql`IF(${raidParticipation.battleCount} = ${startBattleCount}, ${raidParticipation.damageDealt} + ${userDamage}, ${raidParticipation.damageDealt})`,
-        battleCount: sql`IF(${raidParticipation.battleCount} = ${startBattleCount}, ${raidParticipation.battleCount} + 1, ${raidParticipation.battleCount})`,
-        updatedAt: sql`IF(${raidParticipation.battleCount} = ${startBattleCount}, NOW(), ${raidParticipation.updatedAt})`,
-      },
-    });
+  // Claim this battle's damage for this user. `battleCount` is the optimistic
+  // lock. An IF() upsert that writes the existing values still reports
+  // rowsAffected > 0 on MySQL, so a retry would decrement shared HP and notify
+  // again. First participation inserts; later ones update only while
+  // battleCount still equals the value captured at battle start. A no-op
+  // `id = id` duplicate insert reports 0 changed rows.
+  let claimed = false;
+  if (startBattleCount === 0) {
+    const insertResult = await client
+      .insert(raidParticipation)
+      .values({
+        id: nanoid(),
+        questId: raidQuestId,
+        userId: userId,
+        damageDealt: userDamage,
+        battleCount: 1,
+        rewardsClaimed: [],
+      })
+      .onDuplicateKeyUpdate({ set: { id: sql`id` } });
+    claimed = insertResult.rowsAffected === 1;
+  } else {
+    const updateResult = await client
+      .update(raidParticipation)
+      .set({
+        damageDealt: sql`${raidParticipation.damageDealt} + ${userDamage}`,
+        battleCount: sql`${raidParticipation.battleCount} + 1`,
+        updatedAt: sql`NOW()`,
+      })
+      .where(
+        and(
+          eq(raidParticipation.questId, raidQuestId),
+          eq(raidParticipation.userId, userId),
+          eq(raidParticipation.battleCount, startBattleCount),
+        ),
+      );
+    claimed = updateResult.rowsAffected === 1;
+  }
 
-  // rowsAffected = 1 (insert) or 2 (update that changed) → this call owns the claim
-  // rowsAffected = 0 (battleCount already advanced) → duplicate, skip
-  if (upsertResult.rowsAffected === 0) {
+  if (!claimed) {
     return;
   }
 

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -1100,9 +1100,9 @@ export const updateRaidProgress = async (
   // Get the battleCount at the start of this battle (0 if user hasn't participated before)
   const startBattleCount = curBattle.extraState.raidStartBattleCount?.[userId] ?? 0;
 
-  // Step 1: Try to upsert participation record with battleCount guard
-  // The IF conditions ensure the update only happens if battleCount matches startBattleCount
-  // If battleCount has changed (another call already processed), values stay the same
+  // Claim this battle's damage for this user. battleCount is the optimistic lock:
+  // a retry sees the same startBattleCount and the IF clauses write the existing
+  // values, so rowsAffected is 0 and we stop before touching HP or the inbox.
   const upsertResult = await client
     .insert(raidParticipation)
     .values({
@@ -1121,14 +1121,14 @@ export const updateRaidProgress = async (
       },
     });
 
-  // Step 2: Check rowsAffected to see if the upsert actually changed data
-  // rowsAffected = 1 (new insert) or 2 (update with changes) → proceed
-  // rowsAffected = 0 (no changes because battleCount didn't match) → skip
+  // rowsAffected = 1 (insert) or 2 (update that changed) → this call owns the claim
+  // rowsAffected = 0 (battleCount already advanced) → duplicate, skip
   if (upsertResult.rowsAffected === 0) {
     return;
   }
 
-  // Step 3: Deduct this user's share of damage from boss HP
+  // Shared raid HP is not itself idempotent, so it runs only after the claim.
+  // Parallelizing this with the upsert would double-decrement on a duplicate call.
   await client
     .update(quest)
     .set({
@@ -1136,27 +1136,22 @@ export const updateRaidProgress = async (
     })
     .where(and(eq(quest.id, raidQuestId), eq(quest.questType, "raid")));
 
-  // Step 4: Fetch updated quest and participants in PARALLEL
-  const [updatedQuest, participants] = await Promise.all([
-    client.query.quest.findFirst({
-      where: eq(quest.id, raidQuestId),
-      columns: { raidBossCurrentHealth: true, name: true },
-    }),
-    client.query.raidParticipation.findMany({
-      where: eq(raidParticipation.questId, raidQuestId),
-      columns: { userId: true },
-    }),
-  ]);
+  // Read committed global HP. A successful claim already means this user is a
+  // participant, so we do not scan RaidParticipation.
+  const updatedQuest = await client.query.quest.findFirst({
+    where: eq(quest.id, raidQuestId),
+    columns: { raidBossCurrentHealth: true, name: true },
+  });
 
   const bossDefeated = (updatedQuest?.raidBossCurrentHealth ?? 0) <= 0;
-  if (!bossDefeated || participants.length === 0) {
+  if (!bossDefeated) {
     return;
   }
 
-  // Step 5: Send notifications in PARALLEL
+  // Notify only after the post-decrement read, and only this acting user.
+  // Doing this beside the HP write would announce a kill from a stale HP
+  // snapshot, or insert a second inbox row if the claim gate were skipped.
   const raidName = updatedQuest?.name ?? "the raid";
-
-  // Only update the user this is being called for
   await Promise.all([
     client.insert(notification).values([
       {

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -63,6 +63,7 @@ import { extendWarParticipantSql, findWarsWithUser } from "@/libs/war";
 import type { UserWithRelations } from "@/routers/profile";
 import type { DrizzleClient } from "@/server/db";
 import { reduceActiveFarmPlotTimers } from "@/server/utils/farming";
+import { isMysqlDuplicateKeyError } from "@/server/utils/mysqlErrors";
 import { purgeRaidChatMembership } from "@/server/utils/raidChat";
 
 type DataBattleAction = {
@@ -1051,7 +1052,7 @@ export const updateVillageAnbuClan = async (
  * 1. Each user deducts only their share of damage (totalDamage / numAttackers)
  * 2. battleCount is the optimistic lock: first battle inserts, later battles
  *    UPDATE only while battleCount still equals the start-of-battle value
- * 3. A duplicate reports 0 changed rows and skips HP deduction and inbox writes
+ * 3. A duplicate unique key or a missed battleCount UPDATE skips HP and inbox writes
  * 4. This ensures each user's damage is only counted once, regardless of how
  *    many times their endpoint is called
  */
@@ -1101,25 +1102,26 @@ export const updateRaidProgress = async (
   const startBattleCount = curBattle.extraState.raidStartBattleCount?.[userId] ?? 0;
 
   // Claim this battle's damage for this user. `battleCount` is the optimistic
-  // lock. An IF() upsert that writes the existing values still reports
-  // rowsAffected > 0 on MySQL, so a retry would decrement shared HP and notify
-  // again. First participation inserts; later ones update only while
-  // battleCount still equals the value captured at battle start. A no-op
-  // `id = id` duplicate insert reports 0 changed rows.
+  // lock. ON DUPLICATE KEY UPDATE (IF() or `id = id`) still reports
+  // rowsAffected > 0 on MySQL when the row is only found, so a retry would
+  // decrement shared HP and notify again. First participation is a plain
+  // insert: a duplicate unique key is a lost claim. Later battles UPDATE
+  // only while battleCount still equals the start-of-battle value.
   let claimed = false;
   if (startBattleCount === 0) {
-    const insertResult = await client
-      .insert(raidParticipation)
-      .values({
+    try {
+      await client.insert(raidParticipation).values({
         id: nanoid(),
         questId: raidQuestId,
         userId: userId,
         damageDealt: userDamage,
         battleCount: 1,
         rewardsClaimed: [],
-      })
-      .onDuplicateKeyUpdate({ set: { id: sql`id` } });
-    claimed = insertResult.rowsAffected === 1;
+      });
+      claimed = true;
+    } catch (error) {
+      if (!isMysqlDuplicateKeyError(error)) throw error;
+    }
   } else {
     const updateResult = await client
       .update(raidParticipation)
@@ -1143,7 +1145,7 @@ export const updateRaidProgress = async (
   }
 
   // Shared raid HP is not itself idempotent, so it runs only after the claim.
-  // Parallelizing this with the upsert would double-decrement on a duplicate call.
+  // Parallelizing this with the claim would double-decrement on a duplicate call.
   await client
     .update(quest)
     .set({

--- a/app/src/server/utils/mysqlErrors.ts
+++ b/app/src/server/utils/mysqlErrors.ts
@@ -2,11 +2,23 @@
  * MySQL / Vitess duplicate-key detection for catch blocks around INSERTs guarded by UNIQUE.
  * Driver and layer (Drizzle, mysql2, vttablet) vary in error message text; this covers common shapes.
  */
-export const isMysqlDuplicateKeyError = (error: unknown): boolean =>
-  error instanceof Error &&
-  (error.message.includes("Duplicate entry") ||
-    error.message.includes("ER_DUP_ENTRY") ||
-    error.message.includes("UNIQUE constraint"));
+const hasDuplicateKeyText = (text: string) =>
+  text.includes("Duplicate entry") ||
+  text.includes("ER_DUP_ENTRY") ||
+  text.includes("UNIQUE constraint");
+
+export const isMysqlDuplicateKeyError = (error: unknown): boolean => {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current instanceof Error; depth++) {
+    if (hasDuplicateKeyText(current.message)) return true;
+    const sqlMessage = (current as { sqlMessage?: unknown }).sqlMessage;
+    if (typeof sqlMessage === "string" && hasDuplicateKeyText(sqlMessage)) {
+      return true;
+    }
+    current = current.cause;
+  }
+  return false;
+};
 
 /**
  * MySQL / Vitess deadlock detection (errno 1213). Drizzle rethrows driver errors as

--- a/app/tests/libs/combat/raid_progress.test.ts
+++ b/app/tests/libs/combat/raid_progress.test.ts
@@ -76,7 +76,11 @@ const createRaidProgressClient = ({
   const participationValues = vi.fn(async () => {
     calls.push("insertClaim");
     if (!insertSucceeds) {
-      throw new Error("Duplicate entry 'raid-quest-1-raid-user' for key 'RaidParticipation_questId_userId'");
+      throw new Error("Failed query: insert into `RaidParticipation`", {
+        cause: new Error(
+          "Duplicate entry 'raid-quest-1-raid-user' for key 'RaidParticipation_questId_userId'",
+        ),
+      });
     }
     return { rowsAffected: 1 };
   });

--- a/app/tests/libs/combat/raid_progress.test.ts
+++ b/app/tests/libs/combat/raid_progress.test.ts
@@ -1,0 +1,299 @@
+// @vitest-environment node
+
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  notification,
+  quest,
+  raidParticipation,
+  userData,
+} from "@/drizzle/schema";
+import { updateRaidProgress } from "@/libs/combat/database";
+import type { CompleteBattle } from "@/libs/combat/types";
+import { insertQuests, insertUsers } from "../../setup/factories";
+import {
+  describeWithDatabase,
+  getTestDatabase,
+  resetTables,
+} from "../../setup/testDatabase";
+import { makeBattleUser, makeCompleteBattle } from "./helpers/battleScenario";
+
+const USER_ID = "raid-user";
+const QUEST_ID = "raid-quest-1";
+
+const raidBattle = (
+  overrides: {
+    battleType?: CompleteBattle["battleType"];
+    raidQuestId?: string;
+    raidInitialBossHp?: number;
+    raidStartBattleCount?: Record<string, number>;
+    bossHealth?: number;
+    extraUsers?: ReturnType<typeof makeBattleUser>[];
+  } = {},
+): CompleteBattle =>
+  makeCompleteBattle({
+    battleType: overrides.battleType ?? "RAID",
+    extraState: {
+      raidQuestId: overrides.raidQuestId ?? QUEST_ID,
+      raidInitialBossHp: overrides.raidInitialBossHp ?? 1000,
+      raidStartBattleCount: overrides.raidStartBattleCount ?? { [USER_ID]: 0 },
+    },
+    usersState: [
+      makeBattleUser(USER_ID, { isAi: false, isSummon: false }),
+      makeBattleUser("raid-boss", {
+        isAi: true,
+        isSummon: false,
+        curHealth: overrides.bossHealth ?? 0,
+      }),
+      ...(overrides.extraUsers ?? []),
+    ],
+  });
+
+type RaidProgressClientOptions = {
+  upsertRowsAffected: number;
+  bossHpAfterDecrement: number;
+};
+
+const createRaidProgressClient = ({
+  upsertRowsAffected,
+  bossHpAfterDecrement,
+}: RaidProgressClientOptions) => {
+  const calls: string[] = [];
+  const findMany = vi.fn(async () => {
+    calls.push("fetchParticipants");
+    return [{ userId: USER_ID }];
+  });
+  const findFirst = vi.fn(async () => {
+    calls.push("fetchHp");
+    return { raidBossCurrentHealth: bossHpAfterDecrement, name: "Test Raid" };
+  });
+  const notificationValues = vi.fn(async () => {
+    calls.push("notify");
+    return { rowsAffected: 1 };
+  });
+  const onDuplicateKeyUpdate = vi.fn(async () => {
+    calls.push("upsert");
+    return { rowsAffected: upsertRowsAffected };
+  });
+  const participationValues = vi.fn().mockReturnValue({ onDuplicateKeyUpdate });
+  const questWhere = vi.fn(async () => {
+    calls.push("hp");
+    return { rowsAffected: 1 };
+  });
+  const unreadWhere = vi.fn(async () => {
+    calls.push("unread");
+    return { rowsAffected: 1 };
+  });
+
+  const client = {
+    insert: vi.fn((table: unknown) => {
+      if (table === raidParticipation) {
+        return {
+          values: participationValues,
+        };
+      }
+      if (table === notification) {
+        return { values: notificationValues };
+      }
+      throw new Error("unexpected insert");
+    }),
+    update: vi.fn((table: unknown) => {
+      if (table === quest) {
+        return { set: vi.fn().mockReturnValue({ where: questWhere }) };
+      }
+      if (table === userData) {
+        return { set: vi.fn().mockReturnValue({ where: unreadWhere }) };
+      }
+      throw new Error("unexpected update");
+    }),
+    query: {
+      quest: { findFirst },
+      raidParticipation: { findMany },
+    },
+  };
+
+  return {
+    client: client as never,
+    calls,
+    findMany,
+    findFirst,
+    notificationValues,
+    participationValues,
+  };
+};
+
+describe("updateRaidProgress", () => {
+  it("does not write when the battle is not a raid", async () => {
+    const { client, calls } = createRaidProgressClient({
+      upsertRowsAffected: 1,
+      bossHpAfterDecrement: 0,
+    });
+
+    await updateRaidProgress(client, raidBattle({ battleType: "COMBAT" }), USER_ID);
+
+    expect(calls).toEqual([]);
+  });
+
+  it("does not write when the boss took no damage", async () => {
+    const { client, calls } = createRaidProgressClient({
+      upsertRowsAffected: 1,
+      bossHpAfterDecrement: 0,
+    });
+
+    await updateRaidProgress(
+      client,
+      raidBattle({ raidInitialBossHp: 1000, bossHealth: 1000 }),
+      USER_ID,
+    );
+
+    expect(calls).toEqual([]);
+  });
+
+  it("stops after a lost battleCount claim and does not decrement HP or notify", async () => {
+    const { client, calls, findMany } = createRaidProgressClient({
+      upsertRowsAffected: 0,
+      bossHpAfterDecrement: 0,
+    });
+
+    await updateRaidProgress(client, raidBattle(), USER_ID);
+
+    expect(calls).toEqual(["upsert"]);
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it("decrements HP after a successful claim and skips notify while the boss lives", async () => {
+    const { client, calls, findMany } = createRaidProgressClient({
+      upsertRowsAffected: 1,
+      bossHpAfterDecrement: 400,
+    });
+
+    await updateRaidProgress(client, raidBattle({ bossHealth: 400 }), USER_ID);
+
+    expect(calls).toEqual(["upsert", "hp", "fetchHp"]);
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it("notifies only after the post-decrement HP read, without scanning participants", async () => {
+    const { client, calls, findMany, notificationValues } = createRaidProgressClient({
+      upsertRowsAffected: 2,
+      bossHpAfterDecrement: 0,
+    });
+
+    await updateRaidProgress(client, raidBattle(), USER_ID);
+
+    expect(calls.slice(0, 3)).toEqual(["upsert", "hp", "fetchHp"]);
+    expect([...calls.slice(3)].sort()).toEqual(["notify", "unread"]);
+    expect(findMany).not.toHaveBeenCalled();
+    expect(notificationValues).toHaveBeenCalledWith([
+      {
+        userId: USER_ID,
+        content:
+          "The boss in Test Raid has been defeated! Check if you've earned any rewards.",
+      },
+    ]);
+  });
+
+  it("splits battle damage evenly across human attackers and ignores summons", async () => {
+    const { client, participationValues } = createRaidProgressClient({
+      upsertRowsAffected: 1,
+      bossHpAfterDecrement: 500,
+    });
+
+    await updateRaidProgress(
+      client,
+      raidBattle({
+        extraUsers: [
+          makeBattleUser("teammate", { isAi: false, isSummon: false }),
+          makeBattleUser("pet", { isAi: true, isSummon: true }),
+        ],
+      }),
+      USER_ID,
+    );
+
+    expect(participationValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        questId: QUEST_ID,
+        userId: USER_ID,
+        damageDealt: 500,
+        battleCount: 1,
+      }),
+    );
+  });
+});
+
+describeWithDatabase("updateRaidProgress against MySQL", () => {
+  beforeEach(async () => {
+    await resetTables(notification, raidParticipation, quest, userData);
+  });
+
+  const seedRaid = async (bossHp: number) => {
+    await insertUsers([
+      { userId: USER_ID, username: "RaidUser", unreadNotifications: 0 },
+    ]);
+    await insertQuests([
+      {
+        id: QUEST_ID,
+        name: "Test Raid",
+        questType: "raid",
+        raidBossMaxHealth: 1000,
+        raidBossCurrentHealth: bossHp,
+      },
+    ]);
+    return getTestDatabase();
+  };
+
+  const readRaid = async () => {
+    const database = await getTestDatabase();
+    const [raid] = await database
+      .select({
+        raidBossCurrentHealth: quest.raidBossCurrentHealth,
+      })
+      .from(quest)
+      .where(eq(quest.id, QUEST_ID));
+    const participants = await database
+      .select()
+      .from(raidParticipation)
+      .where(eq(raidParticipation.questId, QUEST_ID));
+    const notices = await database
+      .select()
+      .from(notification)
+      .where(eq(notification.userId, USER_ID));
+    const [user] = await database
+      .select({ unreadNotifications: userData.unreadNotifications })
+      .from(userData)
+      .where(eq(userData.userId, USER_ID));
+    return { raid, participants, notices, user };
+  };
+
+  it("applies damage once and notifies once when a retry reuses the same battleCount", async () => {
+    const database = await seedRaid(1000);
+    const battle = raidBattle({ bossHealth: 0 });
+
+    await updateRaidProgress(database, battle, USER_ID);
+    await updateRaidProgress(database, battle, USER_ID);
+
+    const { raid, participants, notices, user } = await readRaid();
+    expect(raid?.raidBossCurrentHealth).toBe(0);
+    expect(participants).toHaveLength(1);
+    expect(participants[0]?.damageDealt).toBe(1000);
+    expect(participants[0]?.battleCount).toBe(1);
+    expect(notices).toHaveLength(1);
+    expect(notices[0]?.content).toMatch(/Test Raid/);
+    expect(user?.unreadNotifications).toBe(1);
+  });
+
+  it("does not notify when the shared boss HP is still above zero", async () => {
+    const database = await seedRaid(1000);
+    await updateRaidProgress(
+      database,
+      raidBattle({ raidInitialBossHp: 1000, bossHealth: 600 }),
+      USER_ID,
+    );
+
+    const { raid, participants, notices, user } = await readRaid();
+    expect(raid?.raidBossCurrentHealth).toBe(600);
+    expect(participants[0]?.damageDealt).toBe(400);
+    expect(notices).toHaveLength(0);
+    expect(user?.unreadNotifications).toBe(0);
+  });
+});

--- a/app/tests/libs/combat/raid_progress.test.ts
+++ b/app/tests/libs/combat/raid_progress.test.ts
@@ -50,13 +50,13 @@ const raidBattle = (
   });
 
 type RaidProgressClientOptions = {
-  insertRowsAffected: number;
+  insertSucceeds?: boolean;
   claimUpdateRowsAffected?: number;
   bossHpAfterDecrement: number;
 };
 
 const createRaidProgressClient = ({
-  insertRowsAffected,
+  insertSucceeds = true,
   claimUpdateRowsAffected = 0,
   bossHpAfterDecrement,
 }: RaidProgressClientOptions) => {
@@ -73,11 +73,13 @@ const createRaidProgressClient = ({
     calls.push("notify");
     return { rowsAffected: 1 };
   });
-  const onDuplicateKeyUpdate = vi.fn(async () => {
+  const participationValues = vi.fn(async () => {
     calls.push("insertClaim");
-    return { rowsAffected: insertRowsAffected };
+    if (!insertSucceeds) {
+      throw new Error("Duplicate entry 'raid-quest-1-raid-user' for key 'RaidParticipation_questId_userId'");
+    }
+    return { rowsAffected: 1 };
   });
-  const participationValues = vi.fn().mockReturnValue({ onDuplicateKeyUpdate });
   const claimUpdateWhere = vi.fn(async () => {
     calls.push("updateClaim");
     return { rowsAffected: claimUpdateRowsAffected };
@@ -134,7 +136,6 @@ const createRaidProgressClient = ({
 describe("updateRaidProgress", () => {
   it("does not write when the battle is not a raid", async () => {
     const { client, calls } = createRaidProgressClient({
-      insertRowsAffected: 1,
       bossHpAfterDecrement: 0,
     });
 
@@ -145,7 +146,6 @@ describe("updateRaidProgress", () => {
 
   it("does not write when the boss took no damage", async () => {
     const { client, calls } = createRaidProgressClient({
-      insertRowsAffected: 1,
       bossHpAfterDecrement: 0,
     });
 
@@ -160,7 +160,7 @@ describe("updateRaidProgress", () => {
 
   it("stops after a lost battleCount claim and does not decrement HP or notify", async () => {
     const { client, calls, findMany } = createRaidProgressClient({
-      insertRowsAffected: 0,
+      insertSucceeds: false,
       bossHpAfterDecrement: 0,
     });
 
@@ -172,7 +172,6 @@ describe("updateRaidProgress", () => {
 
   it("does not decrement HP when a later battle's battleCount guard misses", async () => {
     const { client, calls, findMany } = createRaidProgressClient({
-      insertRowsAffected: 1,
       claimUpdateRowsAffected: 0,
       bossHpAfterDecrement: 0,
     });
@@ -189,7 +188,6 @@ describe("updateRaidProgress", () => {
 
   it("decrements HP after a successful claim and skips notify while the boss lives", async () => {
     const { client, calls, findMany } = createRaidProgressClient({
-      insertRowsAffected: 1,
       bossHpAfterDecrement: 400,
     });
 
@@ -201,7 +199,6 @@ describe("updateRaidProgress", () => {
 
   it("notifies only after the post-decrement HP read, without scanning participants", async () => {
     const { client, calls, findMany, notificationValues } = createRaidProgressClient({
-      insertRowsAffected: 1,
       bossHpAfterDecrement: 0,
     });
 
@@ -221,7 +218,6 @@ describe("updateRaidProgress", () => {
 
   it("splits battle damage evenly across human attackers and ignores summons", async () => {
     const { client, participationValues } = createRaidProgressClient({
-      insertRowsAffected: 1,
       bossHpAfterDecrement: 500,
     });
 

--- a/app/tests/libs/combat/raid_progress.test.ts
+++ b/app/tests/libs/combat/raid_progress.test.ts
@@ -50,12 +50,14 @@ const raidBattle = (
   });
 
 type RaidProgressClientOptions = {
-  upsertRowsAffected: number;
+  insertRowsAffected: number;
+  claimUpdateRowsAffected?: number;
   bossHpAfterDecrement: number;
 };
 
 const createRaidProgressClient = ({
-  upsertRowsAffected,
+  insertRowsAffected,
+  claimUpdateRowsAffected = 0,
   bossHpAfterDecrement,
 }: RaidProgressClientOptions) => {
   const calls: string[] = [];
@@ -72,10 +74,14 @@ const createRaidProgressClient = ({
     return { rowsAffected: 1 };
   });
   const onDuplicateKeyUpdate = vi.fn(async () => {
-    calls.push("upsert");
-    return { rowsAffected: upsertRowsAffected };
+    calls.push("insertClaim");
+    return { rowsAffected: insertRowsAffected };
   });
   const participationValues = vi.fn().mockReturnValue({ onDuplicateKeyUpdate });
+  const claimUpdateWhere = vi.fn(async () => {
+    calls.push("updateClaim");
+    return { rowsAffected: claimUpdateRowsAffected };
+  });
   const questWhere = vi.fn(async () => {
     calls.push("hp");
     return { rowsAffected: 1 };
@@ -98,6 +104,9 @@ const createRaidProgressClient = ({
       throw new Error("unexpected insert");
     }),
     update: vi.fn((table: unknown) => {
+      if (table === raidParticipation) {
+        return { set: vi.fn().mockReturnValue({ where: claimUpdateWhere }) };
+      }
       if (table === quest) {
         return { set: vi.fn().mockReturnValue({ where: questWhere }) };
       }
@@ -125,7 +134,7 @@ const createRaidProgressClient = ({
 describe("updateRaidProgress", () => {
   it("does not write when the battle is not a raid", async () => {
     const { client, calls } = createRaidProgressClient({
-      upsertRowsAffected: 1,
+      insertRowsAffected: 1,
       bossHpAfterDecrement: 0,
     });
 
@@ -136,7 +145,7 @@ describe("updateRaidProgress", () => {
 
   it("does not write when the boss took no damage", async () => {
     const { client, calls } = createRaidProgressClient({
-      upsertRowsAffected: 1,
+      insertRowsAffected: 1,
       bossHpAfterDecrement: 0,
     });
 
@@ -151,37 +160,54 @@ describe("updateRaidProgress", () => {
 
   it("stops after a lost battleCount claim and does not decrement HP or notify", async () => {
     const { client, calls, findMany } = createRaidProgressClient({
-      upsertRowsAffected: 0,
+      insertRowsAffected: 0,
       bossHpAfterDecrement: 0,
     });
 
     await updateRaidProgress(client, raidBattle(), USER_ID);
 
-    expect(calls).toEqual(["upsert"]);
+    expect(calls).toEqual(["insertClaim"]);
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it("does not decrement HP when a later battle's battleCount guard misses", async () => {
+    const { client, calls, findMany } = createRaidProgressClient({
+      insertRowsAffected: 1,
+      claimUpdateRowsAffected: 0,
+      bossHpAfterDecrement: 0,
+    });
+
+    await updateRaidProgress(
+      client,
+      raidBattle({ raidStartBattleCount: { [USER_ID]: 2 } }),
+      USER_ID,
+    );
+
+    expect(calls).toEqual(["updateClaim"]);
     expect(findMany).not.toHaveBeenCalled();
   });
 
   it("decrements HP after a successful claim and skips notify while the boss lives", async () => {
     const { client, calls, findMany } = createRaidProgressClient({
-      upsertRowsAffected: 1,
+      insertRowsAffected: 1,
       bossHpAfterDecrement: 400,
     });
 
     await updateRaidProgress(client, raidBattle({ bossHealth: 400 }), USER_ID);
 
-    expect(calls).toEqual(["upsert", "hp", "fetchHp"]);
+    expect(calls).toEqual(["insertClaim", "hp", "fetchHp"]);
     expect(findMany).not.toHaveBeenCalled();
   });
 
   it("notifies only after the post-decrement HP read, without scanning participants", async () => {
     const { client, calls, findMany, notificationValues } = createRaidProgressClient({
-      upsertRowsAffected: 2,
+      insertRowsAffected: 1,
       bossHpAfterDecrement: 0,
     });
 
     await updateRaidProgress(client, raidBattle(), USER_ID);
 
-    expect(calls.slice(0, 3)).toEqual(["upsert", "hp", "fetchHp"]);
+    expect(calls.slice(0, 3)).toEqual(["insertClaim", "hp", "fetchHp"]);
     expect([...calls.slice(3)].sort()).toEqual(["notify", "unread"]);
     expect(findMany).not.toHaveBeenCalled();
     expect(notificationValues).toHaveBeenCalledWith([
@@ -195,7 +221,7 @@ describe("updateRaidProgress", () => {
 
   it("splits battle damage evenly across human attackers and ignores summons", async () => {
     const { client, participationValues } = createRaidProgressClient({
-      upsertRowsAffected: 1,
+      insertRowsAffected: 1,
       bossHpAfterDecrement: 500,
     });
 
@@ -295,5 +321,47 @@ describeWithDatabase("updateRaidProgress against MySQL", () => {
     expect(participants[0]?.damageDealt).toBe(400);
     expect(notices).toHaveLength(0);
     expect(user?.unreadNotifications).toBe(0);
+  });
+
+  it("does not decrement shared HP again when the same battleCount is retried", async () => {
+    const database = await seedRaid(1000);
+    const battle = raidBattle({ raidInitialBossHp: 1000, bossHealth: 600 });
+
+    await updateRaidProgress(database, battle, USER_ID);
+    await updateRaidProgress(database, battle, USER_ID);
+
+    const { raid, participants, notices } = await readRaid();
+    expect(raid?.raidBossCurrentHealth).toBe(600);
+    expect(participants[0]?.damageDealt).toBe(400);
+    expect(participants[0]?.battleCount).toBe(1);
+    expect(notices).toHaveLength(0);
+  });
+
+  it("claims a later battle with an UPDATE guard and ignores a stale retry", async () => {
+    const database = await seedRaid(800);
+    await database.insert(raidParticipation).values({
+      id: "existing-participation",
+      questId: QUEST_ID,
+      userId: USER_ID,
+      damageDealt: 200,
+      battleCount: 1,
+      rewardsClaimed: [],
+    });
+
+    const laterBattle = raidBattle({
+      raidInitialBossHp: 800,
+      bossHealth: 300,
+      raidStartBattleCount: { [USER_ID]: 1 },
+    });
+
+    await updateRaidProgress(database, laterBattle, USER_ID);
+    await updateRaidProgress(database, laterBattle, USER_ID);
+
+    const { raid, participants, notices } = await readRaid();
+    expect(raid?.raidBossCurrentHealth).toBe(300);
+    expect(participants).toHaveLength(1);
+    expect(participants[0]?.damageDealt).toBe(700);
+    expect(participants[0]?.battleCount).toBe(2);
+    expect(notices).toHaveLength(0);
   });
 });

--- a/app/tests/server/utils/mysqlErrors.test.ts
+++ b/app/tests/server/utils/mysqlErrors.test.ts
@@ -42,6 +42,22 @@ describe("isMysqlDuplicateKeyError", () => {
     );
   });
 
+  it("returns true when Drizzle wraps the driver error as Failed query", () => {
+    const driver = new Error(
+      "Duplicate entry 'raid-quest-1-raid-user' for key 'RaidParticipation.RaidParticipation_questId_userId'",
+    );
+    (driver as { sqlMessage?: string }).sqlMessage =
+      "Duplicate entry 'raid-quest-1-raid-user' for key 'RaidParticipation.RaidParticipation_questId_userId'";
+    expect(
+      isMysqlDuplicateKeyError(
+        new Error(
+          "Failed query: insert into `RaidParticipation` (`id`, `questId`, `userId`) values (?, ?, ?)",
+          { cause: driver },
+        ),
+      ),
+    ).toBe(true);
+  });
+
   it("returns false for unrelated errors and non-errors", () => {
     expect(isMysqlDuplicateKeyError(new Error("connection timeout"))).toBe(false);
     expect(isMysqlDuplicateKeyError(null)).toBe(false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Finding #17c: `updateRaidProgress` still does sequential writes after a RAID `performAction` result: claim participation, decrement shared boss HP, read committed HP, maybe notify.

This PR does **not** collapse those steps. Shared HP and inbox writes are not idempotent.

Two safe changes:

1. **Drop the dead `RaidParticipation` scan.** A successful claim already means this user participated, and notify only targets the acting `userId`.
2. **Make the `battleCount` claim actually exclusive.** The old `IF(battleCount = start, …)` upsert — and even `ON DUPLICATE KEY UPDATE id = id` — left `rowsAffected > 0` on a no-op retry. CI MySQL reproduced two defeat notifications and a living boss going 1000 → 600 → 200. First participation is now a plain insert; a unique-key error is a lost claim. Later battles `UPDATE … WHERE battleCount = start`. Lost claims skip HP and inbox writes.

Drizzle wraps the driver error as `Failed query: …`, with `Duplicate entry` on `cause` / `sqlMessage`. `isMysqlDuplicateKeyError` now walks that chain (same pattern as deadlock detection).

Remaining order: claim → HP decrement → committed HP read → maybe notify.

## Why this is safe

- Duplicate `performAction` now dies on a duplicate-key error or a missed `battleCount` UPDATE before HP or inbox writes.
- HP still uses `GREATEST(0, raidBossCurrentHealth - userDamage)` only after the claim.
- Defeat notify still waits for the post-decrement global HP read (local `boss.curHealth` is a per-battle snapshot and cannot decide a multi-team kill).
- Combat reward grants are unchanged; this function does not pay raid rewards.

## Out of scope

- Folding the HP write into the claim (different tables; no transaction).
- `INSERT … SELECT` notify-if-dead (replaces a cheap HP read with two conditional writes on the common non-kill path).
- Changing who gets notified (still the acting user only).

## Tests

- Unit: lost insert (Drizzle-wrapped duplicate key) / missed UPDATE skip HP and notify; live boss skips notify; kill path notifies after the HP read and never scans participants; summons are not attackers.
- Throwaway MySQL: the same `battleCount` retry decrements HP once and inserts one notification; a later battle uses the UPDATE guard.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc1a0b34-9534-4a2e-a7a7-ba31fd3a9cd1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc1a0b34-9534-4a2e-a7a7-ba31fd3a9cd1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

