### PR TITLE
fix(combat): keep pending/result current without remounting WebGL

### DIFF
--- a/app/src/app/battlelog/[battleid]/page.tsx
+++ b/app/src/app/battlelog/[battleid]/page.tsx
@@ -67,7 +67,7 @@ export default function BattleLog(props: { params: Promise<{ battleid: string }>
         />
       )
     );
-  }, [versionId, userId, config.showGridNumbers]);
+  }, [battleState, userId, config.showGridNumbers]);
 
   // Render functions for layout components
   const renderTimer = useCallback(() => {

--- a/app/src/app/combat/page.tsx
+++ b/app/src/app/combat/page.tsx
@@ -147,6 +147,9 @@ export default function CombatPage() {
 
   // Battle scene. Pass the CONTROLLED actor (self, or the piloted summon on its
   // turn) so Combat does not have to re-derive it from the same battle object.
+  // Depend on battleState so isPending / result reach Combat; do not depend on
+  // the whole config object — Combat only reads showGridNumbers, and the WebGL
+  // scene is set up on [battleId, gameAssets, sfxOn], not on this element.
   const combat = useMemo(() => {
     return (
       battleState &&
@@ -160,14 +163,7 @@ export default function CombatPage() {
         />
       )
     );
-  }, [
-    versionId,
-    actionId,
-    controlledActorId,
-    results,
-    config.showGridNumbers,
-    actions,
-  ]);
+  }, [battleState, actionId, controlledActorId, config.showGridNumbers, actions]);
 
   // Handle key-presses
   useEffect(() => {

--- a/app/src/hooks/combat.ts
+++ b/app/src/hooks/combat.ts
@@ -1,63 +1,24 @@
 import { useCallback, useMemo } from "react";
 import { api } from "@/app/_trpc/client";
 import { useLocalStorage } from "@/hooks/localstorage";
-import type { GroundEffect, ReturnedBattle, UserEffect } from "@/libs/combat/types";
-import { isEffectActive } from "@/libs/combat/util";
+import { type BattleMaps, computeBattleMaps } from "@/libs/combat/battleMaps";
+import type { ReturnedBattle } from "@/libs/combat/types";
 import { showMutationToast } from "@/libs/toast";
 import { useUserData } from "@/utils/UserContext";
 
-/**
- * Precomputed maps for efficient combat tile lookups
- */
-export interface BattleMaps {
-  groundEffectsByTile: Map<string, GroundEffect[]>;
-  userEffectsByUserId: Map<string, UserEffect[]>;
-  usersByTile: Map<string, string>;
-}
-
-const EMPTY_BATTLE_MAPS: BattleMaps = {
-  groundEffectsByTile: new Map<string, GroundEffect[]>(),
-  userEffectsByUserId: new Map<string, UserEffect[]>(),
-  usersByTile: new Map<string, string>(),
-};
+export type { BattleMaps } from "@/libs/combat/battleMaps";
+export {
+  computeBattleMaps,
+  shouldInvalidateEndedBattleCaches,
+} from "@/libs/combat/battleMaps";
 
 /**
- * Hook to precompute maps for ground effects, user effects, and user positions
- * Only recomputes when battle version changes
+ * Hook to precompute maps for ground effects, user effects, and user positions.
+ * Only recomputes when battle id or version changes — a new battle object with
+ * the same snapshot must not rebuild the maps (isPending toggles do this).
  */
 export const useBattleMaps = (battle: ReturnedBattle | null): BattleMaps => {
-  return useMemo(() => {
-    if (!battle) return EMPTY_BATTLE_MAPS;
-
-    const groundEffectsByTile = new Map<string, GroundEffect[]>();
-    const userEffectsByUserId = new Map<string, UserEffect[]>();
-    const usersByTile = new Map<string, string>();
-
-    // Populate ground effects
-    battle.groundEffects.forEach((effect) => {
-      const key = `${effect.longitude},${effect.latitude}`;
-      const existing = groundEffectsByTile.get(key) || [];
-      existing.push(effect);
-      groundEffectsByTile.set(key, existing);
-    });
-
-    // Populate user effects
-    battle.usersEffects.forEach((effect) => {
-      if (!isEffectActive(effect)) return;
-      const existing = userEffectsByUserId.get(effect.targetId) || [];
-      existing.push(effect);
-      userEffectsByUserId.set(effect.targetId, existing);
-    });
-
-    // Populate user positions
-    battle.usersState.forEach((user) => {
-      if (user.curHealth > 0 && !user.fledBattle) {
-        usersByTile.set(`${user.longitude},${user.latitude}`, user.userId);
-      }
-    });
-
-    return { groundEffectsByTile, userEffectsByUserId, usersByTile };
-  }, [battle]);
+  return useMemo(() => computeBattleMaps(battle), [battle?.id, battle?.version]);
 };
 
 /**
@@ -137,29 +98,54 @@ export const useCombatPreferences = () => {
     [setLayoutOrder],
   );
 
-  return {
-    showGridNumbers,
-    setShowGridNumbers,
-    toggleGridNumbers,
-    useSmallActions,
-    setUseSmallActions,
-    toggleSmallActions,
-    showBattleLog,
-    setShowBattleLog,
-    toggleBattleLog,
-    showTimeline,
-    setShowTimeline,
-    toggleTimeline,
-    showBasicActions,
-    setShowBasicActions,
-    toggleBasicActions,
-    layoutOrder,
-    setLayoutOrder,
-    useTabs,
-    setUseTabs,
-    toggleUseTabs,
-    resetLayoutOrder,
-  };
+  return useMemo(
+    () => ({
+      showGridNumbers,
+      setShowGridNumbers,
+      toggleGridNumbers,
+      useSmallActions,
+      setUseSmallActions,
+      toggleSmallActions,
+      showBattleLog,
+      setShowBattleLog,
+      toggleBattleLog,
+      showTimeline,
+      setShowTimeline,
+      toggleTimeline,
+      showBasicActions,
+      setShowBasicActions,
+      toggleBasicActions,
+      layoutOrder,
+      setLayoutOrder,
+      useTabs,
+      setUseTabs,
+      toggleUseTabs,
+      resetLayoutOrder,
+    }),
+    [
+      showGridNumbers,
+      setShowGridNumbers,
+      toggleGridNumbers,
+      useSmallActions,
+      setUseSmallActions,
+      toggleSmallActions,
+      showBattleLog,
+      setShowBattleLog,
+      toggleBattleLog,
+      showTimeline,
+      setShowTimeline,
+      toggleTimeline,
+      showBasicActions,
+      setShowBasicActions,
+      toggleBasicActions,
+      layoutOrder,
+      setLayoutOrder,
+      useTabs,
+      setUseTabs,
+      toggleUseTabs,
+      resetLayoutOrder,
+    ],
+  );
 };
 
 export type CombatPreferences = ReturnType<typeof useCombatPreferences>;

--- a/app/src/layout/Combat.tsx
+++ b/app/src/layout/Combat.tsx
@@ -14,8 +14,12 @@ import {
   IMG_INITIATIVE_D20,
   PvpBattleTypes,
 } from "@/drizzle/constants";
-import type { CombatPreferences } from "@/hooks/combat";
-import { useAutoCombatSetting, useBattleMaps } from "@/hooks/combat";
+import {
+  type CombatPreferences,
+  shouldInvalidateEndedBattleCaches,
+  useAutoCombatSetting,
+  useBattleMaps,
+} from "@/hooks/combat";
 import { safeLocalStorageGetItem, useLocalStorage } from "@/hooks/localstorage";
 import { usePerformanceMonitor } from "@/hooks/performance-monitor";
 import { useTutorialStep } from "@/hooks/tutorial";
@@ -129,6 +133,9 @@ const Combat: React.FC<CombatProps> = (props) => {
 
   // Track if component is mounted to prevent stale render callbacks
   const isMountedRef = useRef<boolean>(false);
+  // getUser / travel / raid invalidation after a result must run once per
+  // ended battle, not on every later props identity change while result is set.
+  const endedBattleInvalidationRef = useRef<string | null>(null);
 
   // Tutorial step
   const { currentStep, handleNextStepAsync } = useTutorialStep();
@@ -571,21 +578,38 @@ const Combat: React.FC<CombatProps> = (props) => {
     // the ref following a piloted summon on its turn.
     userIdRef.current = props.userId;
     battleRef.current = props.battleState.battle;
-    if (props.battleState.result) {
-      void Promise.all([
-        utils.profile.getUser.invalidate(),
-        utils.travel.getSectorData.invalidate(),
-        // Invalidate raid queries when a RAID battle ends so boss HP is refreshed
-        ...(props.battleState.battle?.battleType === "RAID"
-          ? [
-              utils.raids.getRaidDetails.invalidate(),
-              utils.raids.getAvailableRaids.invalidate(),
-              utils.raids.getRaidLeaderboard.invalidate(),
-            ]
-          : []),
-      ]);
+  }, [props.action, props.userId, props.battleState.battle]);
+
+  useEffect(() => {
+    const endedBattleId = props.battleState.battle?.id;
+    const hasResult = !!props.battleState.result;
+    if (!hasResult) {
+      endedBattleInvalidationRef.current = null;
+      return;
     }
-  }, [props]);
+    if (
+      !shouldInvalidateEndedBattleCaches(
+        endedBattleInvalidationRef.current,
+        endedBattleId,
+        hasResult,
+      )
+    ) {
+      return;
+    }
+    endedBattleInvalidationRef.current = endedBattleId ?? null;
+    void Promise.all([
+      utils.profile.getUser.invalidate(),
+      utils.travel.getSectorData.invalidate(),
+      // Invalidate raid queries when a RAID battle ends so boss HP is refreshed
+      ...(props.battleState.battle?.battleType === "RAID"
+        ? [
+            utils.raids.getRaidDetails.invalidate(),
+            utils.raids.getAvailableRaids.invalidate(),
+            utils.raids.getRaidLeaderboard.invalidate(),
+          ]
+        : []),
+    ]);
+  }, [props.battleState.result, props.battleState.battle?.id]);
 
   useEffect(() => {
     if (battleId && pusher) {
@@ -616,6 +640,8 @@ const Combat: React.FC<CombatProps> = (props) => {
     }
   }, [battleRef.current?.version, timeDiff, isInLobby]);
 
+  // WebGL scene. Keep this list narrow: Combat re-renders when battleState
+  // isPending / result change, and those updates must not tear the renderer down.
   useEffect(() => {
     // Reference to the mount
     const sceneRef = mountRef.current;

--- a/app/src/libs/combat/battleMaps.ts
+++ b/app/src/libs/combat/battleMaps.ts
@@ -1,0 +1,61 @@
+import type { GroundEffect, ReturnedBattle, UserEffect } from "@/libs/combat/types";
+import { isEffectActive } from "@/libs/combat/util";
+
+/**
+ * Precomputed maps for efficient combat tile lookups
+ */
+export interface BattleMaps {
+  groundEffectsByTile: Map<string, GroundEffect[]>;
+  userEffectsByUserId: Map<string, UserEffect[]>;
+  usersByTile: Map<string, string>;
+}
+
+const EMPTY_BATTLE_MAPS: BattleMaps = {
+  groundEffectsByTile: new Map<string, GroundEffect[]>(),
+  userEffectsByUserId: new Map<string, UserEffect[]>(),
+  usersByTile: new Map<string, string>(),
+};
+
+/**
+ * Precompute maps for ground effects, user effects, and user positions.
+ * useBattleMaps only recomputes this when battle id or version changes.
+ */
+export const computeBattleMaps = (battle: ReturnedBattle | null): BattleMaps => {
+  if (!battle) return EMPTY_BATTLE_MAPS;
+
+  const groundEffectsByTile = new Map<string, GroundEffect[]>();
+  const userEffectsByUserId = new Map<string, UserEffect[]>();
+  const usersByTile = new Map<string, string>();
+
+  battle.groundEffects.forEach((effect) => {
+    const key = `${effect.longitude},${effect.latitude}`;
+    const existing = groundEffectsByTile.get(key) || [];
+    existing.push(effect);
+    groundEffectsByTile.set(key, existing);
+  });
+
+  battle.usersEffects.forEach((effect) => {
+    if (!isEffectActive(effect)) return;
+    const existing = userEffectsByUserId.get(effect.targetId) || [];
+    existing.push(effect);
+    userEffectsByUserId.set(effect.targetId, existing);
+  });
+
+  battle.usersState.forEach((user) => {
+    if (user.curHealth > 0 && !user.fledBattle) {
+      usersByTile.set(`${user.longitude},${user.latitude}`, user.userId);
+    }
+  });
+
+  return { groundEffectsByTile, userEffectsByUserId, usersByTile };
+};
+
+/**
+ * Post-battle getUser / travel / raid invalidation should run once per ended
+ * battle, not on every later props identity change while result stays set.
+ */
+export const shouldInvalidateEndedBattleCaches = (
+  lastInvalidatedBattleId: string | null,
+  battleId: string | undefined,
+  hasResult: boolean,
+): boolean => Boolean(hasResult && battleId && lastInvalidatedBattleId !== battleId);

--- a/app/tests/libs/combat/battleMaps.test.ts
+++ b/app/tests/libs/combat/battleMaps.test.ts
@@ -17,13 +17,14 @@ const battleUser = (overrides: {
   latitude?: number;
   curHealth?: number;
   fledBattle?: boolean;
-}) => ({
-  longitude: 0,
-  latitude: 0,
-  curHealth: 10,
-  fledBattle: false,
-  ...overrides,
-});
+}): ReturnedBattle["usersState"][number] =>
+  ({
+    longitude: 0,
+    latitude: 0,
+    curHealth: 10,
+    fledBattle: false,
+    ...overrides,
+  }) as ReturnedBattle["usersState"][number];
 
 const battle = (overrides: Partial<ReturnedBattle> = {}): ReturnedBattle =>
   ({

--- a/app/tests/libs/combat/battleMaps.test.ts
+++ b/app/tests/libs/combat/battleMaps.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeBattleMaps,
+  shouldInvalidateEndedBattleCaches,
+} from "@/libs/combat/battleMaps";
+import type { GroundEffect, ReturnedBattle, UserEffect } from "@/libs/combat/types";
+
+const groundEffect = (longitude: number, latitude: number): GroundEffect =>
+  ({ longitude, latitude }) as GroundEffect;
+
+const userEffect = (targetId: string, rounds?: number): UserEffect =>
+  ({ targetId, rounds }) as UserEffect;
+
+const battleUser = (overrides: {
+  userId: string;
+  longitude?: number;
+  latitude?: number;
+  curHealth?: number;
+  fledBattle?: boolean;
+}) => ({
+  longitude: 0,
+  latitude: 0,
+  curHealth: 10,
+  fledBattle: false,
+  ...overrides,
+});
+
+const battle = (overrides: Partial<ReturnedBattle> = {}): ReturnedBattle =>
+  ({
+    id: "battle-1",
+    version: 1,
+    groundEffects: [],
+    usersEffects: [],
+    usersState: [],
+    ...overrides,
+  }) as ReturnedBattle;
+
+describe("computeBattleMaps", () => {
+  it("indexes ground effects, active user effects, and living users", () => {
+    const maps = computeBattleMaps(
+      battle({
+        groundEffects: [groundEffect(2, 3)],
+        usersEffects: [userEffect("hero", 2), userEffect("hero", 0)],
+        usersState: [
+          battleUser({ userId: "hero", longitude: 1, latitude: 4 }),
+          battleUser({ userId: "dead", curHealth: 0, longitude: 5, latitude: 5 }),
+          battleUser({ userId: "fled", fledBattle: true, longitude: 6, latitude: 6 }),
+        ],
+      }),
+    );
+
+    expect(maps.groundEffectsByTile.get("2,3")).toHaveLength(1);
+    expect(maps.userEffectsByUserId.get("hero")).toHaveLength(1);
+    expect(maps.usersByTile.get("1,4")).toBe("hero");
+    expect(maps.usersByTile.size).toBe(1);
+  });
+
+  it("returns the shared empty maps when there is no battle", () => {
+    expect(computeBattleMaps(null)).toBe(computeBattleMaps(null));
+  });
+});
+
+describe("shouldInvalidateEndedBattleCaches", () => {
+  it("runs once per ended battle and again only for a new battle id", () => {
+    expect(shouldInvalidateEndedBattleCaches(null, "battle-1", false)).toBe(false);
+    expect(shouldInvalidateEndedBattleCaches(null, undefined, true)).toBe(false);
+    expect(shouldInvalidateEndedBattleCaches(null, "battle-1", true)).toBe(true);
+    expect(shouldInvalidateEndedBattleCaches("battle-1", "battle-1", true)).toBe(false);
+    expect(shouldInvalidateEndedBattleCaches("battle-1", "battle-2", true)).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Finding #13: combat `useMemo` / effect deps were stale relative to their comments, so `isPending` / `result` could fail to reach `<Combat>` while `getUser` was invalidated on every later props identity change.

- `useBattleMaps` now recomputes only when `battle.id` or `battle.version` changes (a new object with the same snapshot, e.g. an `isPending` toggle, no longer rebuilds the maps).
- `useCombatPreferences` returns a stable object until a preference actually changes.
- `/combat` and `/battlelog/[battleid]` include `battleState` in the `<Combat>` element memo so `isPending` and `result` update, without depending on the whole config object (Combat only reads `showGridNumbers`).
- Post-battle `getUser` / travel / raid invalidation is gated by a per-battle ref and runs once per ended battle.

## Why this does not remount the Three.js scene

The WebGL `setupScene` effect in `layout/Combat.tsx` still depends only on `[battleId, gameAssets, userData?.sfxOn]`. Adding `battleState` to the parent memo creates a new React element with the same type and no `key`, so React updates props in place. Unrelated pref toggles are not in that memo list.

Pending/result still update because `battleState` is now a memo dep, and Combat syncs `battleRef` from `props.battleState.battle` on that object’s identity.

## Tests

`app/tests/libs/combat/battleMaps.test.ts` covers map indexing and the once-per-battle invalidation predicate.

## Breaking

No.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6705d078-3b8e-4bb0-a581-09a6f9226bf0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6705d078-3b8e-4bb0-a581-09a6f9226bf0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

