### PR TITLE
perf(travel): optimistic globe start and prefetch crossing maps

### DIFF
--- a/app/src/app/travel/page.tsx
+++ b/app/src/app/travel/page.tsx
@@ -499,8 +499,10 @@ export default function Travel() {
           status: userData.status,
           travelFinishAt: userData.travelFinishAt ?? null,
         };
+        // startGlobalMoveSchema coerces the sector, so the mutate input type is unknown.
+        const destinationSector = Number(variables.sector);
         const travelTime = globe
-          ? calcGlobalTravelTime(userData.sector, variables.sector, globe)
+          ? calcGlobalTravelTime(userData.sector, destinationSector, globe)
           : 0;
         await updateUser(optimisticGlobalTravelStart(travelTime));
         return previous;

--- a/app/src/app/travel/page.tsx
+++ b/app/src/app/travel/page.tsx
@@ -83,7 +83,11 @@ import { getStealthStatus } from "@/libs/stealth";
 import type { GlobalTile, SectorPoint } from "@/libs/threejs/types";
 import { showMutationToast, showRewardToast } from "@/libs/toast";
 import { hasRequiredRank } from "@/libs/train";
-import { calcGlobalTravelTime } from "@/libs/travel";
+import {
+  calcGlobalTravelTime,
+  optimisticGlobalTravelFinish,
+  optimisticGlobalTravelStart,
+} from "@/libs/travel";
 import { isTutorialActive } from "@/libs/tutorial";
 import { findVillageUserRelationship } from "@/utils/alliance";
 import { getReadableVillageHexColor } from "@/utils/color";
@@ -485,11 +489,36 @@ export default function Travel() {
   // Mutations
   const { mutate: startGlobalMove, isPending: isStartingTravel } =
     api.travel.startGlobalMove.useMutation({
-      onSuccess: async (result) => {
+      onMutate: async (variables) => {
+        // A pending local walk must not keep a target after we flip status;
+        // Sector writes arrival coordinates only from UserContext, and a
+        // leftover target could overwrite them once the start mutation lands.
+        setTargetPosition(null);
+        if (!userData) return;
+        const previous = {
+          status: userData.status,
+          travelFinishAt: userData.travelFinishAt ?? null,
+        };
+        const travelTime = globe
+          ? calcGlobalTravelTime(userData.sector, variables.sector, globe)
+          : 0;
+        await updateUser(optimisticGlobalTravelStart(travelTime));
+        return previous;
+      },
+      onError: async (_error, _variables, previous) => {
+        if (!previous) return;
+        await updateUser({
+          status: previous.status,
+          travelFinishAt: previous.travelFinishAt,
+        });
+      },
+      onSuccess: async (result, _variables, previous) => {
         showMutationToast(result);
         if (result.success && result.data) {
           // Clear any local-sector movement target before the destination
           // coordinates enter UserContext so it cannot overwrite the arrival.
+          // Do not write sector/coords until this payload arrives — they are
+          // server-chosen, and an in-flight sector walk must not land on them.
           setTargetPosition(null);
           setTargetSector(null);
           setShowModal(false);
@@ -501,6 +530,11 @@ export default function Travel() {
               setCurrentTile(tile);
             }
           }
+        } else if (previous) {
+          await updateUser({
+            status: previous.status,
+            travelFinishAt: previous.travelFinishAt,
+          });
         }
       },
     });
@@ -513,7 +547,7 @@ export default function Travel() {
           await handleNextStepAsync();
         }
         if (result.success) {
-          await updateUser({ status: "AWAKE", travelFinishAt: null });
+          await updateUser(optimisticGlobalTravelFinish());
           setActiveTab(sectorLink);
         }
       },
@@ -1071,14 +1105,16 @@ export default function Travel() {
         {userData?.travelFinishAt && (
           <div className="absolute top-0 right-0 bottom-0 left-0 z-20 m-auto flex flex-col justify-center bg-black opacity-90">
             <div className="m-auto text-center text-white">
-              <p className="p-5 text-3xl">Traveling to Sector {userData?.sector}</p>
+              <p className="p-5 text-3xl">
+                Traveling to Sector {targetSector ?? userData?.sector}
+              </p>
               <p className="text-5xl">
                 Time Left:{" "}
                 <Countdown
                   targetDate={userData?.travelFinishAt}
                   timeDiff={timeDiff}
                   onFinish={() => {
-                    if (!isFinishingTravel) finishGlobalMove();
+                    if (!isFinishingTravel && !isStartingTravel) finishGlobalMove();
                   }}
                 />
               </p>

--- a/app/src/libs/travel.ts
+++ b/app/src/libs/travel.ts
@@ -6,6 +6,7 @@ import {
 import type { NormalizedSectorMap } from "@/libs/sector-map/types";
 import { getSectorTile } from "@/libs/sector-map/validation";
 import type { GlobalMapData, GlobalTile, SectorPoint } from "@/libs/threejs/types";
+import { secondsFromNow } from "@/utils/time";
 
 /**
  * Gets the biome for a globe tile terrain type (0=ocean, 1=land, 2=desert, 3=ice)
@@ -109,6 +110,25 @@ export const calcGlobalTravelTime = (
   }
   return MAP_GLOBAL_TRAVEL_TIME_CAP_SECS;
 };
+
+/**
+ * Client cache patch when globe travel starts. Instant journeys (Wake Island
+ * is 0 seconds) omit travelFinishAt so the arrival countdown cannot call
+ * finishGlobalMove before startGlobalMove commits — that would no-op on the
+ * still-AWAKE row, after which start would leave the player stuck traveling.
+ */
+export const optimisticGlobalTravelStart = (travelTimeSeconds: number) => ({
+  status: "TRAVEL" as const,
+  ...(travelTimeSeconds > 0
+    ? { travelFinishAt: secondsFromNow(travelTimeSeconds) }
+    : {}),
+});
+
+/** Client cache patch when globe travel ends. */
+export const optimisticGlobalTravelFinish = () => ({
+  status: "AWAKE" as const,
+  travelFinishAt: null,
+});
 
 /**
  * Whether a position sits in a village zone. When a sector map is provided

--- a/app/src/server/api/routers/travel.ts
+++ b/app/src/server/api/routers/travel.ts
@@ -51,7 +51,9 @@ import { fetchSector, fetchSectorVillage } from "@/routers/village";
 import { isTransientDatabaseError } from "@/server/dbRetry";
 import {
   fetchPublishedSectorMap,
+  fetchPublishedSectorMaps,
   getSectorNeighborIds,
+  publishedMapsToPrefetchForMove,
   resolveSectorCrossing,
 } from "@/server/utils/sectorMap";
 import { findRelationship } from "@/utils/alliance";
@@ -702,9 +704,14 @@ export const travelRouter = createTRPCRouter({
       const userVillage = villageId ?? "syndicate";
       // Return a graceful response instead of a raw 500 if the sector has no
       // published map (mutations must return baseServerResponse per CLAUDE.md).
-      const sectorMap = await fetchPublishedSectorMap(ctx.drizzle, sector).catch(
-        () => null,
-      );
+      // When the destination looks like a default-sized border crossing, load
+      // that neighbour in the same query so the walk does not wait on a
+      // second sequential published-map read.
+      const maps = await fetchPublishedSectorMaps(
+        ctx.drizzle,
+        publishedMapsToPrefetchForMove(sector, { x: longitude, y: latitude }),
+      ).catch(() => null);
+      const sectorMap = maps?.get(sector);
       if (!sectorMap) return errorResponse("This sector has no published map yet");
       // If a republish blocked the tile the player is standing on, snap them to
       // the nearest walkable tile instead of locking them in place forever.
@@ -735,10 +742,9 @@ export const travelRouter = createTRPCRouter({
         if (targetSector < 0) {
           return errorResponse("The polar wastes block your path");
         }
-        const neighbourMap = await fetchPublishedSectorMap(
-          ctx.drizzle,
-          targetSector,
-        ).catch(() => null);
+        const neighbourMap =
+          maps?.get(targetSector) ??
+          (await fetchPublishedSectorMap(ctx.drizzle, targetSector).catch(() => null));
         if (!neighbourMap) {
           return errorResponse("The neighbouring sector has no published map yet");
         }

--- a/app/src/server/utils/sectorMap.ts
+++ b/app/src/server/utils/sectorMap.ts
@@ -1,6 +1,11 @@
 import { and, eq, inArray } from "drizzle-orm";
 import * as globalMapData from "@/data/hexasphere.json";
-import { MAP_SECTOR_ID_MAX, MAP_SECTOR_ID_MIN } from "@/drizzle/constants";
+import {
+  MAP_SECTOR_ID_MAX,
+  MAP_SECTOR_ID_MIN,
+  SECTOR_HEIGHT,
+  SECTOR_WIDTH,
+} from "@/drizzle/constants";
 import { sectorMap } from "@/drizzle/schema";
 import {
   type EdgeIndex,
@@ -127,6 +132,35 @@ export const getSectorNeighborIds = (
     south: neighbors[2]!,
     west: neighbors[3]!,
   };
+};
+
+/**
+ * Sectors whose published maps a moveInSector call should load together.
+ * When the destination is exactly one step past a default-sized (26×26)
+ * border, include that neighbour so the crossing does not wait on a second
+ * sequential query. Authored maps with a different size, diagonals, and
+ * polar gaps fall back to just the current sector; the router then loads
+ * the real neighbour after it sees the actual map dimensions.
+ */
+export const publishedMapsToPrefetchForMove = (
+  sector: number,
+  dest: { x: number; y: number },
+): number[] => {
+  const outWest = dest.x === -1;
+  const outEast = dest.x === SECTOR_WIDTH;
+  const outSouth = dest.y === -1;
+  const outNorth = dest.y === SECTOR_HEIGHT;
+  const outCount = [outWest, outEast, outNorth, outSouth].filter(Boolean).length;
+  if (outCount !== 1) return [sector];
+  const direction = outWest
+    ? "west"
+    : outEast
+      ? "east"
+      : outNorth
+        ? "north"
+        : "south";
+  const neighbor = getSectorNeighborIds(sector)[direction];
+  return neighbor >= 0 ? [sector, neighbor] : [sector];
 };
 
 /**

--- a/app/src/server/utils/sectorMap.ts
+++ b/app/src/server/utils/sectorMap.ts
@@ -152,13 +152,7 @@ export const publishedMapsToPrefetchForMove = (
   const outNorth = dest.y === SECTOR_HEIGHT;
   const outCount = [outWest, outEast, outNorth, outSouth].filter(Boolean).length;
   if (outCount !== 1) return [sector];
-  const direction = outWest
-    ? "west"
-    : outEast
-      ? "east"
-      : outNorth
-        ? "north"
-        : "south";
+  const direction = outWest ? "west" : outEast ? "east" : outNorth ? "north" : "south";
   const neighbor = getSectorNeighborIds(sector)[direction];
   return neighbor >= 0 ? [sector, neighbor] : [sector];
 };

--- a/app/tests/libs/sector-crossing-prefetch.test.ts
+++ b/app/tests/libs/sector-crossing-prefetch.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { SECTOR_HEIGHT, SECTOR_WIDTH } from "@/drizzle/constants";
+import { sectorIdAt } from "@/libs/sector-map/world-grid";
+import {
+  getSectorNeighborIds,
+  publishedMapsToPrefetchForMove,
+} from "@/server/utils/sectorMap";
+
+describe("publishedMapsToPrefetchForMove", () => {
+  const sector = 1631; // Shirohana: ordinary grid neighbors
+  const neighbors = getSectorNeighborIds(sector);
+
+  it("fetches only the current sector for an in-bounds step", () => {
+    expect(publishedMapsToPrefetchForMove(sector, { x: 5, y: 5 })).toEqual([sector]);
+  });
+
+  it("includes the west neighbour when dest is x=-1", () => {
+    expect(publishedMapsToPrefetchForMove(sector, { x: -1, y: 5 })).toEqual([
+      sector,
+      neighbors.west,
+    ]);
+  });
+
+  it("includes the south neighbour when dest is y=-1", () => {
+    expect(publishedMapsToPrefetchForMove(sector, { x: 5, y: -1 })).toEqual([
+      sector,
+      neighbors.south,
+    ]);
+  });
+
+  it("includes the east neighbour when dest is the default map width", () => {
+    expect(
+      publishedMapsToPrefetchForMove(sector, { x: SECTOR_WIDTH, y: 5 }),
+    ).toEqual([sector, neighbors.east]);
+  });
+
+  it("includes the north neighbour when dest is the default map height", () => {
+    expect(
+      publishedMapsToPrefetchForMove(sector, { x: 5, y: SECTOR_HEIGHT }),
+    ).toEqual([sector, neighbors.north]);
+  });
+
+  it("does not prefetch a diagonal step beyond two borders", () => {
+    expect(publishedMapsToPrefetchForMove(sector, { x: -1, y: -1 })).toEqual([sector]);
+  });
+
+  it("does not treat the last in-bounds default tile as a crossing", () => {
+    expect(
+      publishedMapsToPrefetchForMove(sector, {
+        x: SECTOR_WIDTH - 1,
+        y: SECTOR_HEIGHT - 1,
+      }),
+    ).toEqual([sector]);
+  });
+
+  it("leaves a non-default authored width to the sequential fallback", () => {
+    // A 20-wide map crosses at x=20, which is still in-bounds on the default size.
+    expect(publishedMapsToPrefetchForMove(sector, { x: 20, y: 5 })).toEqual([sector]);
+  });
+
+  it("does not prefetch a polar gap", () => {
+    const northPolar = sectorIdAt(10, 0);
+    expect(northPolar).toBeGreaterThanOrEqual(0);
+    expect(getSectorNeighborIds(northPolar).north).toBe(-1);
+    expect(
+      publishedMapsToPrefetchForMove(northPolar, { x: 5, y: SECTOR_HEIGHT }),
+    ).toEqual([northPolar]);
+  });
+});

--- a/app/tests/libs/travel.test.ts
+++ b/app/tests/libs/travel.test.ts
@@ -3,6 +3,8 @@ import type { NormalizedSectorTile } from "@/libs/sector-map/types";
 import {
   findGlobalTravelDestination,
   getBiomeAtSectorAnchor,
+  optimisticGlobalTravelFinish,
+  optimisticGlobalTravelStart,
 } from "@/libs/travel";
 
 const makeTile = (
@@ -84,5 +86,29 @@ describe("getBiomeAtSectorAnchor", () => {
     expect(getBiomeAtSectorAnchor(makeMap(3, 3), "shrine.default", 3)).toBe(
       "ice",
     );
+  });
+});
+
+describe("optimisticGlobalTravelStart", () => {
+  it("omits travelFinishAt for instant journeys so arrival cannot race start", () => {
+    expect(optimisticGlobalTravelStart(0)).toEqual({ status: "TRAVEL" });
+  });
+
+  it("sets a future travelFinishAt when the journey takes time", () => {
+    const before = Date.now();
+    const patch = optimisticGlobalTravelStart(12);
+    expect(patch.status).toBe("TRAVEL");
+    expect(patch.travelFinishAt).toBeInstanceOf(Date);
+    expect(patch.travelFinishAt?.getTime()).toBeGreaterThanOrEqual(before + 12_000);
+    expect(patch.travelFinishAt?.getTime()).toBeLessThanOrEqual(Date.now() + 12_000);
+  });
+});
+
+describe("optimisticGlobalTravelFinish", () => {
+  it("returns to AWAKE and clears the countdown", () => {
+    expect(optimisticGlobalTravelFinish()).toEqual({
+      status: "AWAKE",
+      travelFinishAt: null,
+    });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Low-complexity slice of FINDING #10 (P1). Validated on current `main` (`41aec92`).

## What this implements

1. **Optimistic globe travel start** (`travel/page.tsx`): `startGlobalMove` now patches `profile.getUser` with `status: "TRAVEL"` (and a client `travelFinishAt` when the journey is not instant) in `onMutate`, and rolls that patch back on transport error or `success: false`. Destination `sector` / `longitude` / `latitude` are still applied only in `onSuccess` from the server payload.
2. **Neighbour-map prefetch on sector crossing** (`moveInSector`): when the destination is exactly one step past a default-sized (26×26) border, the current and neighbour published maps load in one `fetchPublishedSectorMaps` query instead of two sequential `findFirst`s. Authored maps with a different size, diagonals, and polar gaps fall back to today’s sequential neighbour fetch after the current map is known.

## Race notes

- **Arrival overwrite:** `startGlobalMove` already writes destination coordinates on the server. A leftover local-sector `targetPosition` can still issue `moveInSector` after those coordinates enter UserContext. This change clears the local target in `onMutate` and **does not** optimistic-write sector or landing coordinates. `moveInSector` is also CAS-guarded on `status = AWAKE` and the origin sector, so once start commits, a late walk cannot overwrite the arrival.
- **Instant travel (Wake Island is 0s):** the optimistic patch omits `travelFinishAt` when travel time is 0, and the countdown will not call `finishGlobalMove` while `startGlobalMove` is still in flight. Finishing before start commits would no-op on the still-AWAKE row, after which start would leave the player stuck traveling.
- **Finish is not optimistic:** rolling `travelFinishAt` back on a failed finish remounts `Countdown`, which would fire `onFinish` again and loop. Finish still updates UserContext on success only.
- **Sector crossing:** prefetch is a hint from dest coordinates (`x === -1` / `y === -1` / default width/height). The real crossing is still decided by `resolveAdjacentCrossing` against the loaded map. A missed guess costs one extra sequential fetch (same as today). A false guess only warms an unused neighbour cache entry.

## Pushback (out of scope)

- **Do not split `Sector.tsx`.** It is ~3193 lines and owns the WebGL scene, walk animation, crossing re-anchor, quests, combat, and NPC dialogs. Extracting that is not a low-complexity slice.
- **Do not replace `getSectorData` 10s polling with Pusher-only.** Sector already subscribes to the sector channel for presence; the 10s poll is an explicit fallback because those events can be missed. Dropping the poll without another presence path is a product/reliability change.
- **Do not raise the poll interval** without a presence alternative — same reason.

## Tests

- `optimisticGlobalTravelStart` omits `travelFinishAt` for 0s journeys and sets a future date otherwise.
- `publishedMapsToPrefetchForMove` covers cardinal default-size crossings, in-bounds steps, diagonals, authored non-default widths, and polar gaps.

Does not merge.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30ec5564-9f5c-4b1c-9886-56a1f41af741?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30ec5564-9f5c-4b1c-9886-56a1f41af741&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

