### PR TITLE
Refetch inbox conversation list when returning from a thread

### DIFF
--- a/app/src/app/inbox/page.tsx
+++ b/app/src/app/inbox/page.tsx
@@ -124,16 +124,17 @@ const ShowConversations: React.FC<ShowConversationsProps> = (props) => {
   const [pendingConvoId, setPendingConvoId] = useState<string | null>(null);
   const [isExitConfirmOpen, setIsExitConfirmOpen] = useState(false);
 
-  // Fetch conversations. selectedConvo is part of the key so opening a thread still
-  // refetches. The open thread itself updates over Pusher; the list does not need
-  // to be immediately stale on every window focus.
+  // This list unmounts while a thread is open, so selectedConvo is always null here
+  // and cannot bust the cache. Refetch on remount so going back after reading or
+  // creating a conversation picks up lastReadAt and new threads. staleTime still
+  // skips window-focus refetches while the list stays mounted.
   const {
     data: allConversations,
     refetch,
     isPending,
   } = api.comments.getUserConversations.useQuery(
     { selectedConvo: selectedConvo },
-    { enabled: !!userData, staleTime: 30_000 },
+    { enabled: !!userData, staleTime: 30_000, refetchOnMount: "always" },
   );
 
   // Mutations
@@ -320,6 +321,7 @@ export interface NewConversationPromptProps {
 
 export const NewConversationPrompt: React.FC<NewConversationPromptProps> = (props) => {
   const { data: userData } = useRequiredUserData();
+  const utils = api.useUtils();
   const maxUsers = 5;
 
   const create = useForm<CreateConversationSchema>({
@@ -374,6 +376,7 @@ export const NewConversationPrompt: React.FC<NewConversationPromptProps> = (prop
       showMutationToast(data);
       if (data.success) {
         create.reset();
+        void utils.comments.getUserConversations.invalidate();
         if (data.conversationId) props.setSelectedConvo?.(data.conversationId);
       }
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #1515 (Bugbot: inbox list stays stale after reading).

## What changed

`ShowConversations` only mounts when no thread is selected, so `selectedConvo` is always `null` and cannot bust the 30s `getUserConversations` cache. Going back after reading or creating a conversation reused stale rows: unread bells lingered (`lastReadAt` is written when comments load) and new threads could be missing.

- Set `refetchOnMount: "always"` on that list query. Window-focus refetches while the list stays mounted still respect `staleTime: 30s`.
- Invalidate `getUserConversations` after a successful `createConversation` (including the prompt used from profiles).

## Why

#1515 raised inbox `staleTime` from 0 to 30s to cut focus/remount spam. The comment there assumed opening a thread changed the query key; that path never runs because the list unmounts first.

## Testing

Lint, typecheck, and build passed on this revision (an earlier `test_build` failure was an unrelated flaky tavern-color race). No merge.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c749d617-d898-4f48-a922-ea4a396f0e07?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c749d617-d898-4f48-a922-ea4a396f0e07&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Conversation lists now refresh whenever the inbox is reopened.
  - Newly created conversations appear in the conversation list immediately.
  - Opening a newly created conversation remains supported after the list refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->