### PR TITLE
fix(user): memoize UserContext value to avoid signed-in tree rerenders

### DIFF
--- a/app/src/utils/UserContext.tsx
+++ b/app/src/utils/UserContext.tsx
@@ -6,7 +6,14 @@ import { atom } from "jotai";
 import { useRouter } from "next/navigation";
 import type Pusher from "pusher-js";
 import type React from "react";
-import { createContext, useContext, useEffect, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import type { AchievementProgress, UserWithRelations } from "@/api/routers/profile";
 import { api } from "@/app/_trpc/client";
 import type { StructureRoute } from "@/drizzle/constants";
@@ -39,7 +46,7 @@ export const blockingPopupOpenAtom = atom<boolean>(false);
 /**
  * Context for managing user data and state.
  */
-export const UserContext = createContext<{
+type UserContextValue = {
   data: UserWithRelations;
   /**
    * Achievement progress, carried beside `data` rather than inside `data.userQuests`: the
@@ -60,7 +67,9 @@ export const UserContext = createContext<{
   updateNotifications: (
     notifications: NavBarDropdownLink[] | undefined,
   ) => Promise<void>;
-}>({
+};
+
+export const UserContext = createContext<UserContextValue>({
   data: undefined,
   achievementProgress: undefined,
   notifications: undefined,
@@ -115,22 +124,26 @@ export function UserContextProvider(props: {
   const pusher = usePusherHandler(userId, data?.userData);
 
   // Optimistic user info update function
-  const updateUser = async (updatedData: Partial<UserWithRelations>) => {
-    await utils.profile.getUser.cancel();
-    utils.profile.getUser.setData(undefined, (old) => {
-      return { ...old, userData: { ...old?.userData, ...updatedData } } as typeof old;
-    });
-  };
+  const updateUser = useCallback(
+    async (updatedData: Partial<UserWithRelations>) => {
+      await utils.profile.getUser.cancel();
+      utils.profile.getUser.setData(undefined, (old) => {
+        return { ...old, userData: { ...old?.userData, ...updatedData } } as typeof old;
+      });
+    },
+    [utils],
+  );
 
   // Optimistic notification update function
-  const updateNotifications = async (
-    notifications: NavBarDropdownLink[] | undefined,
-  ) => {
-    await utils.profile.getUser.cancel();
-    utils.profile.getUser.setData(undefined, (old) => {
-      return { ...old, notifications } as typeof old;
-    });
-  };
+  const updateNotifications = useCallback(
+    async (notifications: NavBarDropdownLink[] | undefined) => {
+      await utils.profile.getUser.cancel();
+      utils.profile.getUser.setData(undefined, (old) => {
+        return { ...old, notifications } as typeof old;
+      });
+    },
+    [utils],
+  );
 
   // Time diff setting
   useEffect(() => {
@@ -178,26 +191,41 @@ export function UserContextProvider(props: {
     }
   }, [data?.userData, user?.primaryEmailAddress?.emailAddress]);
 
-  return (
-    <UserContext
-      value={{
-        data: data?.userData,
-        achievementProgress: data?.achievementProgress,
-        notifications: data?.notifications,
-        userAgent: data?.userAgent,
-        pusher: pusher,
-        status: userStatus,
-        timeDiff: timeDiff,
-        userId: userId,
-        isClerkLoaded: isLoaded,
-        isSignedIn: effectiveIsSignedIn,
-        updateUser: updateUser,
-        updateNotifications: updateNotifications,
-      }}
-    >
-      {props.children}
-    </UserContext>
+  // Keep this object identity stable so useUserData consumers do not re-render
+  // when the provider re-renders without user/auth changes (parent updates,
+  // getUser background refetch with structural sharing, etc.).
+  const value = useMemo<UserContextValue>(
+    () => ({
+      data: data?.userData,
+      achievementProgress: data?.achievementProgress,
+      notifications: data?.notifications,
+      userAgent: data?.userAgent,
+      pusher: pusher,
+      status: userStatus,
+      timeDiff: timeDiff,
+      userId: userId,
+      isClerkLoaded: isLoaded,
+      isSignedIn: effectiveIsSignedIn,
+      updateUser: updateUser,
+      updateNotifications: updateNotifications,
+    }),
+    [
+      data?.userData,
+      data?.achievementProgress,
+      data?.notifications,
+      data?.userAgent,
+      pusher,
+      userStatus,
+      timeDiff,
+      userId,
+      isLoaded,
+      effectiveIsSignedIn,
+      updateUser,
+      updateNotifications,
+    ],
   );
+
+  return <UserContext value={value}>{props.children}</UserContext>;
 }
 
 // Easy hook for getting the current user data


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`UserContextProvider` was allocating a fresh context object (and fresh `updateUser` / `updateNotifications` functions) on every render. Every `useUserData` consumer then rerendered even when `profile.getUser` data had not changed.

This memoizes the context value and stabilizes the two updater callbacks. It does **not** change the `getUser` server payload, rewrite the ~44 `profile.getUser.invalidate()` call sites, or split the context into atoms.

## Why

Validated on current `main`: the provider still passed an inline object into `<UserContext value={...}>` with no `useMemo`, and the updaters were recreated each render. Combined with a fat `getUser` query and widespread `useUserData` usage, that made small client updates and provider-parent rerenders (Clerk, tRPC observers, layout) recrawl the signed-in tree.

## Downstream

- Consumers still rerender when any published field changes (`userData`, notifications, pusher, `timeDiff`, auth flags, etc.).
- `updateUser` / `updateNotifications` keep a stable identity, so child effects/callbacks that list them as deps no longer fire every provider render.
- A completed `getUser` refetch that changes `serverTime` still updates `timeDiff` and therefore still publishes a new context value. That is existing clock-sync behavior, not something this slice tries to split out.
- React Compiler is enabled, but this provider talks to Clerk/tRPC and mutates query data in an effect, so explicit memoization is the reliable guarantee.

## Breaking

No. Same context shape and the same updater semantics.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e4bc763-b134-46bc-8f4c-be625934b195?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e4bc763-b134-46bc-8f4c-be625934b195&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

