### PR TITLE
perf(raids): slim getAvailableRaids and joinRaidQueue user fetches

### DIFF
--- a/app/src/libs/raids.ts
+++ b/app/src/libs/raids.ts
@@ -17,7 +17,12 @@ export const isRaidChatConversationId = (conversationId: string) =>
  * Raid type is implicit from the objective task (open_raid or exclusive_raid).
  * Both raid types have sector for map location.
  */
-export const getRaidObjectiveData = (questData: { content: Quest["content"] }) => {
+/** Listing/join helpers only read objectives; they do not need a full QuestContentType. */
+type RaidObjectiveSource = {
+  content?: { objectives?: { task?: string }[] | null } | null;
+};
+
+export const getRaidObjectiveData = (questData: RaidObjectiveSource) => {
   const objective = questData.content?.objectives?.[0];
   if (!objective) return null;
 
@@ -76,11 +81,10 @@ export const validateRaidIsActive = (
  * precomputed owned/attacker sector sets are required — not a full user row.
  */
 export const isRaidListedForVillage = (
-  raid: {
+  raid: RaidObjectiveSource & {
     raidEndsAt: Date | null;
     raidCaptureDeadline: Date | null;
     raidGracePeriodEnd: Date | null;
-    content: Quest["content"];
   },
   villageId: string | null,
   ownedSectorNumbers: Set<number>,

--- a/app/src/libs/raids.ts
+++ b/app/src/libs/raids.ts
@@ -17,12 +17,7 @@ export const isRaidChatConversationId = (conversationId: string) =>
  * Raid type is implicit from the objective task (open_raid or exclusive_raid).
  * Both raid types have sector for map location.
  */
-/** Listing/join helpers only read objectives; they do not need a full QuestContentType. */
-type RaidObjectiveSource = {
-  content?: { objectives?: { task?: string }[] | null } | null;
-};
-
-export const getRaidObjectiveData = (questData: RaidObjectiveSource) => {
+export const getRaidObjectiveData = (questData: { content: Quest["content"] }) => {
   const objective = questData.content?.objectives?.[0];
   if (!objective) return null;
 
@@ -81,7 +76,8 @@ export const validateRaidIsActive = (
  * precomputed owned/attacker sector sets are required — not a full user row.
  */
 export const isRaidListedForVillage = (
-  raid: RaidObjectiveSource & {
+  raid: {
+    content: Quest["content"];
     raidEndsAt: Date | null;
     raidCaptureDeadline: Date | null;
     raidGracePeriodEnd: Date | null;

--- a/app/src/libs/raids.ts
+++ b/app/src/libs/raids.ts
@@ -17,7 +17,7 @@ export const isRaidChatConversationId = (conversationId: string) =>
  * Raid type is implicit from the objective task (open_raid or exclusive_raid).
  * Both raid types have sector for map location.
  */
-export const getRaidObjectiveData = (questData: Quest) => {
+export const getRaidObjectiveData = (questData: { content: Quest["content"] }) => {
   const objective = questData.content?.objectives?.[0];
   if (!objective) return null;
 
@@ -69,6 +69,56 @@ export const validateRaidIsActive = (
     return { isValid: false, error: "The raid boss has been defeated" };
   }
   return { isValid: true };
+};
+
+/**
+ * Exclusive/open listing rules for getAvailableRaids. Only villageId plus
+ * precomputed owned/attacker sector sets are required — not a full user row.
+ */
+export const isRaidListedForVillage = (
+  raid: {
+    raidEndsAt: Date | null;
+    raidCaptureDeadline: Date | null;
+    raidGracePeriodEnd: Date | null;
+    content: Quest["content"];
+  },
+  villageId: string | null,
+  ownedSectorNumbers: Set<number>,
+  attackerDefeatedShrineSectors: Set<number>,
+  now: Date,
+): boolean => {
+  if (raid.raidEndsAt && raid.raidEndsAt < now) {
+    return false;
+  }
+
+  const raidData = getRaidObjectiveData(raid);
+  if (!raidData) return false;
+
+  if (raidData.isOpen) {
+    return true;
+  }
+  if (raidData.isExclusive) {
+    if (!villageId || raidData.sector === null) {
+      return false;
+    }
+    const ownsCurrentSector = ownedSectorNumbers.has(raidData.sector);
+    const isAttackerWithDefeatedShrine = attackerDefeatedShrineSectors.has(
+      raidData.sector,
+    );
+
+    if (raid.raidCaptureDeadline && raid.raidCaptureDeadline < now) {
+      if (!raid.raidGracePeriodEnd) {
+        return false;
+      }
+      if (raid.raidGracePeriodEnd >= now) {
+        return ownsCurrentSector || isAttackerWithDefeatedShrine;
+      }
+      return false;
+    }
+
+    return ownsCurrentSector || isAttackerWithDefeatedShrine;
+  }
+  return false;
 };
 
 /**

--- a/app/src/server/api/routers/raids.ts
+++ b/app/src/server/api/routers/raids.ts
@@ -44,6 +44,7 @@ import { postProcessRewards } from "@/libs/quest";
 import {
   getRaidChatConversationId,
   getRaidObjectiveData,
+  isRaidListedForVillage,
   validateRaidIsActive,
 } from "@/libs/raids";
 import { fetchActiveUserMpvpBattles } from "@/routers/clan";
@@ -55,6 +56,7 @@ import {
   purgeAllRaidChatMembershipsForUser,
   purgeRaidChatMembership,
 } from "@/server/utils/raidChat";
+import { fetchRaidJoinUser, fetchRaidListUser } from "@/server/utils/raidUser";
 import { canChangeContent } from "@/utils/permissions";
 import { secondsFromDate } from "@/utils/time";
 import { AllTags } from "@/validators/combat";
@@ -141,17 +143,9 @@ export const raidsRouter = createTRPCRouter({
     })
     .input(z.object({ sector: z.number().optional() }).nullish())
     .query(async ({ ctx, input }) => {
-      // Query
-      const { user } = await fetchUpdatedUser({
-        client: ctx.drizzle,
-        userId: ctx.userId,
-      });
-
-      // Guard
-      if (!user) return { raids: [] };
-
-      // Query - parallel fetch for cleanup, raids, sectors, and active sector wars
-      const [, raids, userVillageSectors, activeSectorWars] = await Promise.all([
+      // Query - slim user + cleanup, raids, and shrine-down sector wars in one hop
+      const [user, , raids, activeSectorWars] = await Promise.all([
+        fetchRaidListUser(ctx.drizzle, ctx.userId),
         cleanupExpiredExclusiveRaids(ctx.drizzle),
         ctx.drizzle.query.quest.findMany({
           where: and(
@@ -167,35 +161,32 @@ export const raidsRouter = createTRPCRouter({
           },
           orderBy: desc(quest.createdAt),
         }),
-        user.villageId
-          ? ctx.drizzle.query.sector.findMany({
-              where: eq(sector.villageId, user.villageId),
-              columns: { sector: true },
-            })
-          : Promise.resolve([]),
-        // Fetch active sector wars where shrine is defeated (for given sector if provided)
-        // This allows attackers to see exclusive raids before war is finalized
-        user.villageId
-          ? ctx.drizzle.query.war.findMany({
-              where: and(
-                eq(war.type, "SECTOR_WAR"),
-                isNull(war.endedAt),
-                lte(war.defenderShrineHp, 0),
-                input?.sector !== undefined ? eq(war.sector, input.sector) : undefined,
-              ),
-              columns: { id: true, sector: true, attackerVillageId: true },
-              with: {
-                warAllies: {
-                  columns: { villageId: true, supportVillageId: true },
-                },
-              },
-            })
-          : Promise.resolve([]),
+        // Always fetched so this stays in the same round-trip as the user row.
+        // Users without a village never match the attacker/ally filter below.
+        ctx.drizzle.query.war.findMany({
+          where: and(
+            eq(war.type, "SECTOR_WAR"),
+            isNull(war.endedAt),
+            lte(war.defenderShrineHp, 0),
+            input?.sector !== undefined ? eq(war.sector, input.sector) : undefined,
+          ),
+          columns: { id: true, sector: true, attackerVillageId: true },
+          with: {
+            warAllies: {
+              columns: { villageId: true, supportVillageId: true },
+            },
+          },
+        }),
       ]);
+
+      // Guard
+      if (!user) return { raids: [] };
 
       // Derived
       const now = new Date();
-      const ownedSectorNumbers = new Set(userVillageSectors.map((s) => s.sector));
+      const ownedSectorNumbers = new Set(
+        user.village?.sectors?.map((s) => s.sector) ?? [],
+      );
       // Sectors where user's village is attacker (or ally of attacker) and shrine is defeated
       const attackerDefeatedShrineSectors = new Set(
         activeSectorWars
@@ -212,51 +203,15 @@ export const raidsRouter = createTRPCRouter({
           .map((w) => w.sector),
       );
 
-      const filteredRaids = raids.filter((raid) => {
-        // Check if raid has ended
-        if (raid.raidEndsAt && raid.raidEndsAt < now) {
-          return false;
-        }
-
-        // Get raid type from objective
-        const raidData = getRaidObjectiveData(raid);
-        if (!raidData) return false;
-
-        if (raidData.isOpen) {
-          return true;
-        }
-        if (raidData.isExclusive) {
-          // Check if user's village owns the sector
-          if (!user.villageId || raidData.sector === null) {
-            return false;
-          }
-          const ownsCurrentSector = ownedSectorNumbers.has(raidData.sector);
-          // Also allow attackers who have defeated the shrine but war not yet finalized
-          const isAttackerWithDefeatedShrine = attackerDefeatedShrineSectors.has(
-            raidData.sector,
-          );
-
-          // Check capture deadline and grace period logic
-          if (raid.raidCaptureDeadline && raid.raidCaptureDeadline < now) {
-            // Capture deadline has passed
-            if (!raid.raidGracePeriodEnd) {
-              // No grace period configured - raid is no longer accessible after deadline
-              return false;
-            }
-            if (raid.raidGracePeriodEnd >= now) {
-              // Still in grace period - only villages that owned at deadline can access
-              // Since we can't track historical ownership, we allow current owners during grace
-              return ownsCurrentSector || isAttackerWithDefeatedShrine;
-            } else if (raid.raidGracePeriodEnd < now) {
-              // Grace period has ended - raid is no longer accessible
-              return false;
-            }
-          }
-
-          return ownsCurrentSector || isAttackerWithDefeatedShrine;
-        }
-        return false;
-      });
+      const filteredRaids = raids.filter((raid) =>
+        isRaidListedForVillage(
+          raid,
+          user.villageId,
+          ownedSectorNumbers,
+          attackerDefeatedShrineSectors,
+          now,
+        ),
+      );
 
       // Filter by sector if provided
       const sectorFilteredRaids =
@@ -898,8 +853,8 @@ export const raidsRouter = createTRPCRouter({
     .output(baseServerResponse.extend({ teamId: z.string().optional() }))
     .mutation(async ({ ctx, input }) => {
       // Query - parallel fetch all required data upfront
-      const [{ user }, raid, teamData, existingQueueEntries] = await Promise.all([
-        fetchUpdatedUser({ client: ctx.drizzle, userId: ctx.userId }),
+      const [user, raid, teamData, existingQueueEntries] = await Promise.all([
+        fetchRaidJoinUser(ctx.drizzle, ctx.userId),
         ctx.drizzle.query.quest.findFirst({
           where: and(eq(quest.id, input.questId), eq(quest.questType, "raid")),
         }),

--- a/app/src/server/utils/raidUser.ts
+++ b/app/src/server/utils/raidUser.ts
@@ -1,0 +1,38 @@
+import { eq } from "drizzle-orm";
+import { userData } from "@/drizzle/schema";
+import type { DrizzleClient } from "@/server/db";
+
+/**
+ * Village membership for raid list filtering, plus owned sectors so exclusive
+ * raids can be gated without a second hop. Avoids fetchUpdatedUser's fat row,
+ * relations, regen writes, and quest bootstrap.
+ */
+export const fetchRaidListUser = async (client: DrizzleClient, userId: string) => {
+  return client.query.userData.findFirst({
+    where: eq(userData.userId, userId),
+    columns: { villageId: true },
+    with: {
+      village: {
+        columns: { id: true },
+        with: { sectors: { columns: { sector: true } } },
+      },
+    },
+  });
+};
+
+/**
+ * Fields required by joinRaidQueue guards (ban, AWAKE status, current sector,
+ * village). Does not persist regen or rewrite quests — the later status CAS
+ * and rollback pairing remain the source of truth for queue transitions.
+ */
+export const fetchRaidJoinUser = async (client: DrizzleClient, userId: string) => {
+  return client.query.userData.findFirst({
+    where: eq(userData.userId, userId),
+    columns: {
+      villageId: true,
+      sector: true,
+      status: true,
+      isBanned: true,
+    },
+  });
+};

--- a/app/tests/server/api/raids.slimUser.test.ts
+++ b/app/tests/server/api/raids.slimUser.test.ts
@@ -1,12 +1,21 @@
 // @vitest-environment node
 
 import { describe, expect, it, vi } from "vitest";
+import type { Quest } from "@/drizzle/schema";
 import { isRaidListedForVillage } from "@/libs/raids";
 import { fetchRaidJoinUser, fetchRaidListUser } from "@/server/utils/raidUser";
-import { RaidObjective } from "@/validators/objectives";
+import { RaidObjective, type QuestContentType } from "@/validators/objectives";
+import { ObjectiveReward } from "@/validators/rewards";
 
 const villageId = "village-1";
 const now = new Date("2026-06-01T00:00:00.000Z");
+
+type RaidListingInput = {
+  content: Quest["content"];
+  raidEndsAt: Date | null;
+  raidCaptureDeadline: Date | null;
+  raidGracePeriodEnd: Date | null;
+};
 
 const raid = (
   task: "open_raid" | "exclusive_raid",
@@ -16,7 +25,7 @@ const raid = (
     raidCaptureDeadline?: Date | null;
     raidGracePeriodEnd?: Date | null;
   } = {},
-) => ({
+): RaidListingInput => ({
   raidEndsAt: extras.raidEndsAt ?? new Date("2026-12-01T00:00:00.000Z"),
   raidCaptureDeadline: extras.raidCaptureDeadline ?? null,
   raidGracePeriodEnd: extras.raidGracePeriodEnd ?? null,
@@ -29,7 +38,10 @@ const raid = (
         opponentAIs: [{ ids: ["ai-1"], number: 100, quantity: 1 }],
       }),
     ],
-  },
+    reward: ObjectiveReward.parse({}),
+    sceneBackground: "",
+    sceneCharacters: [],
+  } satisfies QuestContentType,
 });
 
 describe("raid list/join slim user fetches", () => {

--- a/app/tests/server/api/raids.slimUser.test.ts
+++ b/app/tests/server/api/raids.slimUser.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+import { isRaidListedForVillage } from "@/libs/raids";
+import { fetchRaidJoinUser, fetchRaidListUser } from "@/server/utils/raidUser";
+import { RaidObjective } from "@/validators/objectives";
+
+const villageId = "village-1";
+const now = new Date("2026-06-01T00:00:00.000Z");
+
+const raid = (
+  task: "open_raid" | "exclusive_raid",
+  sector: number,
+  extras: {
+    raidEndsAt?: Date | null;
+    raidCaptureDeadline?: Date | null;
+    raidGracePeriodEnd?: Date | null;
+  } = {},
+) => ({
+  raidEndsAt: extras.raidEndsAt ?? new Date("2026-12-01T00:00:00.000Z"),
+  raidCaptureDeadline: extras.raidCaptureDeadline ?? null,
+  raidGracePeriodEnd: extras.raidGracePeriodEnd ?? null,
+  content: {
+    objectives: [
+      RaidObjective.parse({
+        id: `${task}-${sector}`,
+        task,
+        sector,
+        opponentAIs: [{ ids: ["ai-1"], number: 100, quantity: 1 }],
+      }),
+    ],
+  },
+});
+
+describe("raid list/join slim user fetches", () => {
+  it("loads only villageId and owned sectors for the list", async () => {
+    const findFirst = vi.fn().mockResolvedValue(null);
+    await fetchRaidListUser({ query: { userData: { findFirst } } } as never, "user-1");
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        columns: { villageId: true },
+        with: {
+          village: {
+            columns: { id: true },
+            with: { sectors: { columns: { sector: true } } },
+          },
+        },
+      }),
+    );
+  });
+
+  it("loads only ban, status, sector, and villageId for join guards", async () => {
+    const findFirst = vi.fn().mockResolvedValue(null);
+    await fetchRaidJoinUser({ query: { userData: { findFirst } } } as never, "user-1");
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        columns: {
+          villageId: true,
+          sector: true,
+          status: true,
+          isBanned: true,
+        },
+      }),
+    );
+    const columns = findFirst.mock.calls[0]?.[0]?.columns as Record<string, boolean>;
+    expect(Object.keys(columns).sort()).toEqual(
+      ["isBanned", "sector", "status", "villageId"].sort(),
+    );
+  });
+});
+
+describe("isRaidListedForVillage", () => {
+  const owned = new Set([7]);
+  const attacker = new Set([12]);
+
+  it("hides ended raids", () => {
+    expect(
+      isRaidListedForVillage(
+        raid("open_raid", 3, { raidEndsAt: new Date("2020-01-01T00:00:00.000Z") }),
+        villageId,
+        owned,
+        attacker,
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("lists open raids without village membership", () => {
+    expect(isRaidListedForVillage(raid("open_raid", 3), null, new Set(), new Set(), now)).toBe(
+      true,
+    );
+  });
+
+  it("lists exclusive raids the village owns", () => {
+    expect(isRaidListedForVillage(raid("exclusive_raid", 7), villageId, owned, attacker, now)).toBe(
+      true,
+    );
+    expect(isRaidListedForVillage(raid("exclusive_raid", 9), villageId, owned, attacker, now)).toBe(
+      false,
+    );
+  });
+
+  it("lists exclusive raids for attackers after the shrine falls", () => {
+    expect(
+      isRaidListedForVillage(raid("exclusive_raid", 12), villageId, new Set(), attacker, now),
+    ).toBe(true);
+  });
+
+  it("hides exclusive raids with no villageId", () => {
+    expect(isRaidListedForVillage(raid("exclusive_raid", 7), null, owned, attacker, now)).toBe(
+      false,
+    );
+  });
+
+  it("hides exclusive raids after the capture deadline when there is no grace period", () => {
+    expect(
+      isRaidListedForVillage(
+        raid("exclusive_raid", 7, {
+          raidCaptureDeadline: new Date("2020-01-01T00:00:00.000Z"),
+          raidGracePeriodEnd: null,
+        }),
+        villageId,
+        owned,
+        attacker,
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps exclusive raids visible during grace for current owners", () => {
+    expect(
+      isRaidListedForVillage(
+        raid("exclusive_raid", 7, {
+          raidCaptureDeadline: new Date("2020-01-01T00:00:00.000Z"),
+          raidGracePeriodEnd: new Date("2099-01-01T00:00:00.000Z"),
+        }),
+        villageId,
+        owned,
+        attacker,
+        now,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Finding #7: `raids.getAvailableRaids` opened with `fetchUpdatedUser` (fat row + regen/quest side-writes + relations) and then ran another parallel batch. Timed ~646 ms for `{ raids: [] }` in the original report. `joinRaidQueue` used the same opening fetch even though its guards only need ban / AWAKE / sector / villageId.

Validated on current `origin/main` (`41aec92fa`): both endpoints still start with `fetchUpdatedUser`. Low complexity — slimming is safe without dropping eligibility checks.

**These changes are not breaking.** Request/response shapes and join eligibility are unchanged.

### `getAvailableRaids`
- Replaced `fetchUpdatedUser` with `fetchRaidListUser`: `villageId` plus `village.sectors`.
- Folded that read into the existing cleanup / raid / war `Promise.all` (one hop).
- Sector ownership now comes from the village relation instead of a second `sector.findMany`.
- Active shrine-down sector wars are always queried in that same hop; users without a village still fail the attacker/ally JS filter.
- Listing rules live in `isRaidListedForVillage` (open / exclusive / deadline / grace / owner / attacker). Same branches as before.

### `joinRaidQueue`
- Opening fetch is now `fetchRaidJoinUser`: `isBanned`, `status`, `sector`, `villageId`.
- Every guard still has its fields (ban, AWAKE, raid sector, exclusive village + sector ownership / shrine-war).
- **Did not flatten** the later team insert → status CAS (`AWAKE` → `QUEUED`) → optional re-fetch → rollback pairing. That chain is unchanged.

Left `leaveRaidQueue`, `startRaidBattle`, and `claimDamageReward` on `fetchUpdatedUser` (out of scope; claim needs the fat user for `updateRewards`).

### Side effects no longer run on these two paths
`fetchUpdatedUser` also persists regen, bootstraps quests, and can kick a player with negative prestige to outlaw. Listing/joining a raid should not do that bookkeeping. `readyToQueue` already uses `fetchUser`. Travel auto-complete inside `fetchUpdatedUser` is nested under `AWAKE`/`ASLEEP` and never ran for `TRAVEL`.

## Tests
`app/tests/server/api/raids.slimUser.test.ts` locks the column sets and exclusive/open/deadline/grace/attacker listing rules.

Could not broker-time `raids.getAvailableRaids` in this environment (no Docker / Clerk `.env`). Re-time on a worktree with `make start` if you want a wall-clock delta.

## Do not merge
Ready for review. I will not merge.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e61fe81-7235-4c34-abda-398bdbd67cd8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e61fe81-7235-4c34-abda-398bdbd67cd8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved raid availability listings based on expiration times, village sector ownership, defeated shrine sectors, capture deadlines, and grace periods.
  - Ensured open and exclusive raids appear only to eligible villages.
  - Improved raid joining validation, including handling for users without village membership.
- **Tests**
  - Added coverage for raid visibility, eligibility rules, capture deadlines, grace periods, and raid joining scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->