### PR TITLE
ci: deploy Vercel previews only via /tnr-create-preview

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,10 @@
 
 **Please fill: what was implemented, why, possibly include screenshots, are any of the changes breaking, etc.**
 
+## Vercel preview
+
+Pull requests do **not** get a Vercel preview automatically. A collaborator with write access can comment `/tnr-create-preview` on this PR to deploy one of the current head commit. Later pushes do not refresh it — run the command again if you need an updated URL.
+
 ## License
 
 By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.

--- a/.github/scripts/check-preview-ready.mjs
+++ b/.github/scripts/check-preview-ready.mjs
@@ -1,12 +1,14 @@
 /**
  * Checks whether a Vercel preview deployment is ready for a given PR.
  *
- * Queries the GitHub Checks API for the PR's head SHA, finds Vercel check runs
- * matching a configurable name pattern, and extracts the preview URL from the
- * most recent successful check's output summary.
+ * Looks for a preview in this order:
+ *   1. Successful Vercel check runs on the PR head SHA (legacy auto-deploys)
+ *   2. A reusable "Preview – tnr" GitHub deployment of the PR head SHA
+ *   3. A snapshot commit on `tnr-preview/pr-{N}` whose parent is the PR head
  *
  * Env vars consumed:
- *   GITHUB_TOKEN, PR_NUMBER, VERCEL_CHECK_NAME_PATTERN
+ *   GITHUB_TOKEN, PR_NUMBER, VERCEL_CHECK_NAME_PATTERN,
+ *   PREVIEW_BRANCH (optional), PREVIEW_ENVIRONMENT_PATTERN
  *
  * Outputs (via GITHUB_OUTPUT):
  *   is_ready    — "true" | "false"
@@ -15,11 +17,17 @@
  *   check_name, details_url, head_sha, pr_url — supplementary metadata
  */
 import { setOutput, createGithubClient, toTrustedPreviewUrl } from "./ci-helpers.mjs";
+import {
+  createPreviewDeploymentClient,
+  withRetry,
+} from "./preview-deployments.mjs";
 
 const githubToken = process.env.GITHUB_TOKEN;
 const repository = process.env.GITHUB_REPOSITORY;
 const prNumber = Number(process.env.PR_NUMBER);
 const checkNamePatternRaw = process.env.VERCEL_CHECK_NAME_PATTERN ?? "vercel";
+const environmentPatternRaw =
+  process.env.PREVIEW_ENVIRONMENT_PATTERN || "^Preview\\s+[–-]\\s+tnr$";
 
 if (!githubToken) {
   throw new Error("Missing GITHUB_TOKEN");
@@ -33,12 +41,21 @@ if (!Number.isInteger(prNumber) || prNumber <= 0) {
   throw new Error(`Invalid PR_NUMBER: ${process.env.PR_NUMBER ?? "undefined"}`);
 }
 
+const previewBranch =
+  process.env.PREVIEW_BRANCH || `tnr-preview/pr-${prNumber}`;
+
 const [owner, repo] = repository.split("/");
 if (!owner || !repo) {
   throw new Error(`Invalid GITHUB_REPOSITORY: ${repository}`);
 }
 
 const githubRequest = createGithubClient(githubToken);
+const preview = createPreviewDeploymentClient({
+  githubRequest,
+  owner,
+  repo,
+  environmentRegex: new RegExp(environmentPatternRaw, "i"),
+});
 
 /** Parse the deployment URL out of a Vercel check run's output summary. */
 const extractPreviewUrl = (checkRun) => {
@@ -63,73 +80,145 @@ const extractPreviewUrl = (checkRun) => {
   return "";
 };
 
-const main = async () => {
+const notReady = (reason, extras = {}) => {
+  setOutput("is_ready", "false");
+  setOutput("reason", reason);
+  setOutput("preview_url", extras.preview_url ?? "");
+  setOutput("check_name", extras.check_name ?? "");
+  setOutput("details_url", extras.details_url ?? "");
+  setOutput("head_sha", extras.head_sha ?? "");
+  setOutput("pr_url", extras.pr_url ?? "");
+};
+
+const ready = ({ previewUrl, checkName, detailsUrl, headSha, prUrl }) => {
+  setOutput("is_ready", "true");
+  setOutput("reason", "");
+  setOutput("preview_url", previewUrl);
+  setOutput("check_name", checkName ?? "");
+  setOutput("details_url", detailsUrl ?? "");
+  setOutput("head_sha", headSha);
+  setOutput("pr_url", prUrl ?? "");
+};
+
+const findSuccessfulCheck = async (headSha) => {
   const regex = new RegExp(checkNamePatternRaw, "i");
-
-  // Need the PR's head SHA to query the Checks API
-  const pullRequest = await githubRequest(`/repos/${owner}/${repo}/pulls/${prNumber}`);
-  const headSha = pullRequest?.head?.sha;
-  const prUrl = pullRequest?.html_url ?? "";
-
-  if (!headSha) {
-    setOutput("is_ready", "false");
-    setOutput("reason", `Missing head SHA for PR #${prNumber}`);
-    return;
-  }
-
-  // Fetch all check runs for the head commit and filter to Vercel ones
   const checksResponse = await githubRequest(
     `/repos/${owner}/${repo}/commits/${headSha}/check-runs?per_page=100`,
   );
 
-  const checks = Array.isArray(checksResponse?.check_runs) ? checksResponse.check_runs : [];
-  const matchingChecks = checks.filter((checkRun) => regex.test(checkRun?.name ?? ""));
+  const checks = Array.isArray(checksResponse?.check_runs)
+    ? checksResponse.check_runs
+    : [];
+  const matchingChecks = checks.filter((checkRun) =>
+    regex.test(checkRun?.name ?? ""),
+  );
   const successfulChecks = matchingChecks.filter(
-    (checkRun) => checkRun?.status === "completed" && checkRun?.conclusion === "success",
+    (checkRun) =>
+      checkRun?.status === "completed" && checkRun?.conclusion === "success",
   );
 
-  // Pick the most recently completed successful check (in case of re-deploys)
   const latestSuccessfulCheck = successfulChecks.sort((a, b) => {
     const aCompleted = Date.parse(a?.completed_at ?? "");
     const bCompleted = Date.parse(b?.completed_at ?? "");
     return bCompleted - aCompleted;
   })[0];
 
-  if (!latestSuccessfulCheck) {
-    // Give a diagnostic message distinguishing "no matches" from "matches but pending"
-    const availableCheckNames = checks.map((checkRun) => checkRun?.name).filter(Boolean);
-    const reason = matchingChecks.length
-      ? `Found Vercel checks but none are successful yet for pattern ${checkNamePatternRaw}.`
-      : `No checks matched Vercel pattern ${checkNamePatternRaw}. Available checks: ${availableCheckNames.join(", ")}`;
-    setOutput("is_ready", "false");
-    setOutput("reason", reason);
-    setOutput("head_sha", headSha);
-    setOutput("pr_url", prUrl);
+  return { checks, matchingChecks, latestSuccessfulCheck };
+};
+
+const createPreviewHint =
+  "A collaborator with write access can comment `/tnr-create-preview` to deploy one.";
+
+const main = async () => {
+  const pullRequest = await githubRequest(
+    `/repos/${owner}/${repo}/pulls/${prNumber}`,
+  );
+  const headSha = pullRequest?.head?.sha;
+  const prUrl = pullRequest?.html_url ?? "";
+
+  if (!headSha) {
+    notReady(`Missing head SHA for PR #${prNumber}`);
     return;
   }
 
-  const previewUrl = extractPreviewUrl(latestSuccessfulCheck);
+  const { matchingChecks, latestSuccessfulCheck } =
+    await findSuccessfulCheck(headSha);
+  if (latestSuccessfulCheck) {
+    const previewUrl = extractPreviewUrl(latestSuccessfulCheck);
+    if (previewUrl) {
+      ready({
+        previewUrl,
+        checkName: latestSuccessfulCheck?.name ?? "",
+        detailsUrl: latestSuccessfulCheck?.details_url ?? "",
+        headSha,
+        prUrl,
+      });
+      return;
+    }
+  }
 
-  if (!previewUrl) {
-    setOutput("is_ready", "false");
-    setOutput("reason", "Vercel check succeeded but could not extract a preview URL");
+  const headDeployment = await withRetry(() => preview.inspectPreview(headSha));
+  if (headDeployment.successful) {
+    ready({
+      previewUrl: headDeployment.successful.url,
+      checkName: headDeployment.successful.environment,
+      detailsUrl: headDeployment.successful.detailsUrl,
+      headSha,
+      prUrl,
+    });
     return;
   }
 
-  setOutput("is_ready", "true");
-  setOutput("reason", "");
-  setOutput("preview_url", previewUrl);
-  setOutput("check_name", latestSuccessfulCheck?.name ?? "");
-  setOutput("details_url", latestSuccessfulCheck?.details_url ?? "");
-  setOutput("head_sha", headSha);
-  setOutput("pr_url", prUrl);
+  const snapshotSha = await preview.readBranchSha(previewBranch);
+  if (snapshotSha) {
+    const snapshotOfHead = await preview.isSnapshotOf(snapshotSha, headSha);
+    if (snapshotOfHead) {
+      const snapshotPreview = await withRetry(() =>
+        preview.inspectPreview(snapshotSha),
+      );
+      if (snapshotPreview.successful) {
+        ready({
+          previewUrl: snapshotPreview.successful.url,
+          checkName: snapshotPreview.successful.environment,
+          detailsUrl: snapshotPreview.successful.detailsUrl,
+          headSha,
+          prUrl,
+        });
+        return;
+      }
+      if (snapshotPreview.inProgress) {
+        notReady(
+          `A preview of this PR head is still building on ${previewBranch}. Wait for it to finish, or comment \`/tnr-create-preview\` again.`,
+          { head_sha: headSha, pr_url: prUrl },
+        );
+        return;
+      }
+      if (snapshotPreview.allTerminal) {
+        notReady(
+          `The last preview build for this PR head failed. ${createPreviewHint}`,
+          { head_sha: headSha, pr_url: prUrl },
+        );
+        return;
+      }
+    } else {
+      notReady(
+        `The existing preview on ${previewBranch} is for an older commit. ${createPreviewHint}`,
+        { head_sha: headSha, pr_url: prUrl },
+      );
+      return;
+    }
+  }
+
+  const reason = matchingChecks.length
+    ? `Found Vercel checks but none are successful yet for pattern ${checkNamePatternRaw}. ${createPreviewHint}`
+    : `No Vercel preview is deployed for this PR. ${createPreviewHint}`;
+  notReady(reason, { head_sha: headSha, pr_url: prUrl });
 };
 
 // Catch-all: surface the error as a "not ready" output rather than crashing
 // the workflow step, so the "Post blocked reason" step can still run
 main().catch((error) => {
   const message = error instanceof Error ? error.message : String(error);
-  setOutput("is_ready", "false");
-  setOutput("reason", message);
+  notReady(message);
   console.error(message);
 });

--- a/.github/scripts/create-pr-preview.mjs
+++ b/.github/scripts/create-pr-preview.mjs
@@ -1,0 +1,198 @@
+/**
+ * Create (or reuse) an on-demand Vercel preview for a pull request.
+ *
+ * Regular PR branches no longer auto-deploy. This script snapshots the PR
+ * head onto `tnr-preview/pr-{N}` so Vercel's GitHub integration builds a
+ * preview of that exact tree, then waits until the deployment is ready.
+ *
+ * Env vars consumed:
+ *   GITHUB_TOKEN, GITHUB_REPOSITORY, PUSH_TOKEN (PAT, contents:write),
+ *   PR_NUMBER, PREVIEW_BRANCH (optional), PREVIEW_ENVIRONMENT_PATTERN,
+ *   POLL_INTERVAL_MS, POLL_TIMEOUT_MS
+ *
+ * Outputs (via GITHUB_OUTPUT):
+ *   is_ready, preview_url, reason, check_name, details_url, head_sha
+ */
+import { setOutput, createGithubClient } from "./ci-helpers.mjs";
+import {
+  createPreviewDeploymentClient,
+  requirePreview,
+  withRetry,
+} from "./preview-deployments.mjs";
+
+const githubToken = process.env.GITHUB_TOKEN;
+const pushToken = process.env.PUSH_TOKEN || "";
+const repository = process.env.GITHUB_REPOSITORY;
+const prNumber = Number(process.env.PR_NUMBER);
+const environmentPatternRaw =
+  process.env.PREVIEW_ENVIRONMENT_PATTERN || "^Preview\\s+[–-]\\s+tnr$";
+const pollIntervalMs = Number(process.env.POLL_INTERVAL_MS ?? 15_000);
+const pollTimeoutMs = Number(process.env.POLL_TIMEOUT_MS ?? 25 * 60 * 1000);
+const waitBudgetDeadline = Date.now() + pollTimeoutMs;
+
+if (!githubToken) {
+  throw new Error("Missing GITHUB_TOKEN");
+}
+
+if (!repository) {
+  throw new Error("Missing GITHUB_REPOSITORY");
+}
+
+if (!Number.isInteger(prNumber) || prNumber <= 0) {
+  throw new Error(`Invalid PR_NUMBER: ${process.env.PR_NUMBER ?? "undefined"}`);
+}
+
+const previewBranch =
+  process.env.PREVIEW_BRANCH || `tnr-preview/pr-${prNumber}`;
+
+const [owner, repo] = repository.split("/");
+if (!owner || !repo) {
+  throw new Error(`Invalid GITHUB_REPOSITORY: ${repository}`);
+}
+
+const githubRequest = createGithubClient(githubToken);
+const pushRequest = pushToken ? createGithubClient(pushToken) : null;
+const preview = createPreviewDeploymentClient({
+  githubRequest,
+  pushRequest,
+  owner,
+  repo,
+  environmentRegex: new RegExp(environmentPatternRaw, "i"),
+});
+
+const waitOptions = { pollIntervalMs, deadline: waitBudgetDeadline };
+
+const notReady = (reason, extras = {}) => {
+  setOutput("is_ready", "false");
+  setOutput("reason", reason);
+  setOutput("preview_url", extras.preview_url ?? "");
+  setOutput("check_name", extras.check_name ?? "");
+  setOutput("details_url", extras.details_url ?? "");
+  setOutput("head_sha", extras.head_sha ?? "");
+};
+
+const ready = ({ previewUrl, reason, checkName, detailsUrl, headSha }) => {
+  setOutput("is_ready", "true");
+  setOutput("reason", reason ?? "");
+  setOutput("preview_url", previewUrl);
+  setOutput("check_name", checkName ?? "");
+  setOutput("details_url", detailsUrl ?? "");
+  setOutput("head_sha", headSha ?? "");
+};
+
+const fetchPullRequestHead = async () => {
+  const pullRequest = await githubRequest(
+    `/repos/${owner}/${repo}/pulls/${prNumber}`,
+  );
+  const headSha = pullRequest?.head?.sha;
+  if (!headSha) {
+    throw new Error(`Missing head SHA for PR #${prNumber}`);
+  }
+  if (pullRequest?.state !== "open") {
+    throw new Error(`PR #${prNumber} is not open`);
+  }
+  return headSha;
+};
+
+const main = async () => {
+  const headSha = await fetchPullRequestHead();
+
+  const existing = await withRetry(() => preview.inspectPreview(headSha));
+  if (existing.successful) {
+    ready({
+      previewUrl: existing.successful.url,
+      reason: `Reusing existing ${existing.successful.environment} of the PR head`,
+      checkName: existing.successful.environment,
+      detailsUrl: existing.successful.detailsUrl,
+      headSha,
+    });
+    return;
+  }
+
+  if (existing.inProgress) {
+    console.log(
+      `Preview already in progress (${existing.inProgress.state}); waiting`,
+    );
+    const waited = await preview.waitForPreview(headSha, waitOptions);
+    if (waited.successful) {
+      ready({
+        previewUrl: waited.successful.url,
+        reason: `Waited for in-progress ${waited.successful.environment} of the PR head`,
+        checkName: waited.successful.environment,
+        detailsUrl: waited.successful.detailsUrl,
+        headSha,
+      });
+      return;
+    }
+    if (!waited.failed) requirePreview(waited, headSha);
+    console.log(
+      `In-progress preview of the PR head failed (${waited.failed}); falling back to a snapshot build`,
+    );
+  }
+
+  const currentBranchSha = await preview.readBranchSha(previewBranch);
+  if (currentBranchSha && currentBranchSha !== headSha) {
+    const snapshotOfHead = await preview.isSnapshotOf(currentBranchSha, headSha);
+    if (snapshotOfHead) {
+      const snapshotPreview = await withRetry(() =>
+        preview.inspectPreview(currentBranchSha),
+      );
+      if (snapshotPreview.successful) {
+        ready({
+          previewUrl: snapshotPreview.successful.url,
+          reason: `Reusing snapshot preview of PR #${prNumber} on ${previewBranch}`,
+          checkName: snapshotPreview.successful.environment,
+          detailsUrl: snapshotPreview.successful.detailsUrl,
+          headSha,
+        });
+        return;
+      }
+      if (snapshotPreview.inProgress) {
+        const waited = await preview.waitForPreview(
+          currentBranchSha,
+          waitOptions,
+        );
+        if (waited.successful) {
+          ready({
+            previewUrl: waited.successful.url,
+            reason: `Waited for in-progress snapshot preview of PR #${prNumber}`,
+            checkName: waited.successful.environment,
+            detailsUrl: waited.successful.detailsUrl,
+            headSha,
+          });
+          return;
+        }
+        if (!waited.failed) requirePreview(waited, currentBranchSha);
+        console.log(
+          `Snapshot preview build failed (${waited.failed}); creating a fresh snapshot`,
+        );
+      }
+    }
+  }
+
+  const snapshotSha = await preview.createSnapshotCommit(
+    headSha,
+    `tnr-preview: snapshot of PR #${prNumber} ${headSha.slice(0, 7)}`,
+  );
+  await preview.pointBranchAtSha(previewBranch, snapshotSha);
+  console.log(
+    `Created snapshot ${snapshotSha.slice(0, 7)} of PR #${prNumber} ${headSha.slice(0, 7)} on ${previewBranch}`,
+  );
+  const successful = requirePreview(
+    await preview.waitForPreview(snapshotSha, waitOptions),
+    snapshotSha,
+  );
+  ready({
+    previewUrl: successful.url,
+    reason: `Created Preview – tnr snapshot of PR #${prNumber} via ${previewBranch}`,
+    checkName: successful.environment,
+    detailsUrl: successful.detailsUrl,
+    headSha,
+  });
+};
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  notReady(message);
+  console.error(message);
+});

--- a/.github/scripts/preview-deployments.mjs
+++ b/.github/scripts/preview-deployments.mjs
@@ -108,7 +108,7 @@ export const createPreviewDeploymentClient = ({
     const reader = pushRequest || githubRequest;
     try {
       const ref = await withRetry(() =>
-        reader(`/repos/${owner}/${repo}/git/refs/heads/${encodeHeadsRef(branch)}`),
+        reader(`/repos/${owner}/${repo}/git/ref/heads/${encodeHeadsRef(branch)}`),
       );
       return ref?.object?.sha ?? "";
     } catch (error) {

--- a/.github/scripts/preview-deployments.mjs
+++ b/.github/scripts/preview-deployments.mjs
@@ -1,0 +1,263 @@
+/**
+ * Shared GitHub Deployment helpers for TNR Vercel preview snapshots.
+ *
+ * Vercel previews for this repo are discovered via GitHub Deployments whose
+ * environment matches `Preview – tnr`. On-demand previews are created by
+ * pointing a `tnr-preview/*` branch at an empty snapshot commit (same tree as
+ * the source SHA) so the GitHub integration builds a unique preview SHA.
+ */
+import { toTrustedPreviewUrl } from "./ci-helpers.mjs";
+
+export const REUSABLE_STATES = ["success", "inactive"];
+export const TERMINAL_STATES = ["failure", "error", "inactive"];
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Retry a GitHub API call across transient failures (rate limits, 5xx).
+ * 404 is a real answer, not a transient failure, so it is rethrown immediately.
+ */
+export const withRetry = async (fn, { attempts = 3, delayMs = 5_000 } = {}) => {
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (error?.status === 404) throw error;
+      lastError = error;
+      if (attempt < attempts) {
+        console.log(
+          `Transient GitHub API error (attempt ${attempt}/${attempts}): ${error.message}`,
+        );
+        await sleep(delayMs);
+      }
+    }
+  }
+  throw lastError;
+};
+
+export const encodeHeadsRef = (branch) =>
+  branch.split("/").map(encodeURIComponent).join("/");
+
+/**
+ * @param {object} options
+ * @param {(path: string, options?: RequestInit) => Promise<any>} options.githubRequest
+ * @param {((path: string, options?: RequestInit) => Promise<any>) | null} [options.pushRequest]
+ * @param {string} options.owner
+ * @param {string} options.repo
+ * @param {RegExp} options.environmentRegex
+ */
+export const createPreviewDeploymentClient = ({
+  githubRequest,
+  pushRequest = null,
+  owner,
+  repo,
+  environmentRegex,
+}) => {
+  const listDeploymentsForSha = async (sha) => {
+    const deployments = await githubRequest(
+      `/repos/${owner}/${repo}/deployments?sha=${encodeURIComponent(sha)}&per_page=30`,
+    );
+    return Array.isArray(deployments) ? deployments : [];
+  };
+
+  const getLatestStatus = async (deploymentId) => {
+    const statuses = await githubRequest(
+      `/repos/${owner}/${repo}/deployments/${deploymentId}/statuses?per_page=10`,
+    );
+    return Array.isArray(statuses) ? statuses[0] : null;
+  };
+
+  const matchingDeployments = (deployments) =>
+    deployments.filter((deployment) =>
+      environmentRegex.test(deployment?.environment ?? ""),
+    );
+
+  const inspectPreview = async (sha) => {
+    const matching = matchingDeployments(await listDeploymentsForSha(sha));
+    const statuses = await Promise.all(
+      matching.map((deployment) => getLatestStatus(deployment.id)),
+    );
+    const inspected = matching.map((deployment, index) => {
+      const status = statuses[index];
+      return {
+        id: deployment.id,
+        environment: deployment.environment ?? "",
+        state: status?.state ?? "unknown",
+        url: toTrustedPreviewUrl(
+          status?.environment_url || status?.target_url || "",
+        ),
+        detailsUrl: status?.target_url ?? "",
+      };
+    });
+    const successful = inspected.find(
+      (item) => REUSABLE_STATES.includes(item.state) && item.url,
+    );
+    const inProgress = inspected.find((item) =>
+      ["pending", "queued", "in_progress"].includes(item.state),
+    );
+    const allTerminal =
+      inspected.length > 0 &&
+      !successful &&
+      !inProgress &&
+      inspected.every((item) => TERMINAL_STATES.includes(item.state));
+    return { successful, inProgress, inspected, allTerminal };
+  };
+
+  const readBranchSha = async (branch) => {
+    const reader = pushRequest || githubRequest;
+    try {
+      const ref = await withRetry(() =>
+        reader(`/repos/${owner}/${repo}/git/refs/heads/${encodeHeadsRef(branch)}`),
+      );
+      return ref?.object?.sha ?? "";
+    } catch (error) {
+      if (error?.status === 404) return "";
+      throw error;
+    }
+  };
+
+  const pointBranchAtSha = async (branch, sha) => {
+    if (!pushRequest) {
+      throw new Error(
+        `PUSH_TOKEN is required to update ${branch} so Vercel can build a preview`,
+      );
+    }
+
+    const currentSha = await readBranchSha(branch);
+    if (currentSha === sha) {
+      return { changed: false };
+    }
+
+    if (currentSha) {
+      await pushRequest(
+        `/repos/${owner}/${repo}/git/refs/heads/${encodeHeadsRef(branch)}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({ sha, force: true }),
+        },
+      );
+      return { changed: true, action: "updated" };
+    }
+
+    await pushRequest(`/repos/${owner}/${repo}/git/refs`, {
+      method: "POST",
+      body: JSON.stringify({
+        ref: `refs/heads/${branch}`,
+        sha,
+      }),
+    });
+    return { changed: true, action: "created" };
+  };
+
+  const waitForPreview = async (
+    sha,
+    { pollIntervalMs, deadline, timeoutMs } = {},
+  ) => {
+    const interval = pollIntervalMs ?? 15_000;
+    const waitDeadline =
+      deadline ?? (timeoutMs ? Date.now() + timeoutMs : Date.now() + 25 * 60 * 1000);
+    const maxConsecutiveErrors = 5;
+    let lastNote = "waiting for Vercel to create a Preview – tnr deployment";
+    let consecutiveErrors = 0;
+
+    while (Date.now() < waitDeadline) {
+      let inspection;
+      try {
+        inspection = await inspectPreview(sha);
+      } catch (error) {
+        consecutiveErrors += 1;
+        if (consecutiveErrors >= maxConsecutiveErrors) {
+          throw new Error(
+            `GitHub API kept failing while polling for the preview: ${error.message}`,
+          );
+        }
+        console.log(
+          `Transient GitHub API error while polling (${consecutiveErrors}/${maxConsecutiveErrors}): ${error.message}`,
+        );
+        await sleep(interval);
+        continue;
+      }
+      consecutiveErrors = 0;
+
+      const { successful, inProgress, inspected, allTerminal } = inspection;
+      if (successful) {
+        return { successful };
+      }
+      if (allTerminal) {
+        const failed = inspected
+          .map((item) => `${item.environment}=${item.state}`)
+          .join(", ");
+        console.log(`Preview build reached a terminal state: ${failed}`);
+        return { successful: null, failed };
+      }
+      lastNote = inProgress
+        ? `Vercel preview is ${inProgress.state} (${inProgress.environment})`
+        : inspected.length
+          ? `Preview deployments exist but none are successful yet: ${inspected
+              .map((item) => `${item.environment}=${item.state}`)
+              .join(", ")}`
+          : "No Preview – tnr deployment yet for this SHA";
+      console.log(lastNote);
+      await sleep(interval);
+    }
+
+    return { successful: null, lastNote };
+  };
+
+  const createSnapshotCommit = async (baseSha, message) => {
+    if (!pushRequest) {
+      throw new Error(
+        "PUSH_TOKEN is required to create a unique preview snapshot commit",
+      );
+    }
+    const baseCommit = await withRetry(() =>
+      pushRequest(`/repos/${owner}/${repo}/git/commits/${baseSha}`),
+    );
+    const snapshot = await pushRequest(`/repos/${owner}/${repo}/git/commits`, {
+      method: "POST",
+      body: JSON.stringify({
+        message,
+        tree: baseCommit.tree.sha,
+        parents: [baseSha],
+      }),
+    });
+    if (!snapshot?.sha) {
+      throw new Error("Failed to create tnr-preview snapshot commit");
+    }
+    return snapshot.sha;
+  };
+
+  const isSnapshotOf = async (candidateSha, parentSha) => {
+    try {
+      const commit = await withRetry(() =>
+        githubRequest(`/repos/${owner}/${repo}/git/commits/${candidateSha}`),
+      );
+      return (commit?.parents ?? []).some((parent) => parent.sha === parentSha);
+    } catch (error) {
+      if (error?.status === 404) return false;
+      throw error;
+    }
+  };
+
+  return {
+    inspectPreview,
+    waitForPreview,
+    readBranchSha,
+    pointBranchAtSha,
+    createSnapshotCommit,
+    isSnapshotOf,
+  };
+};
+
+export const requirePreview = (result, sha) => {
+  if (result.successful) return result.successful;
+  if (result.failed) {
+    throw new Error(
+      `Vercel preview build failed for ${sha.slice(0, 7)}: ${result.failed}`,
+    );
+  }
+  throw new Error(
+    `Timed out waiting for a Preview – tnr deployment of ${sha.slice(0, 7)}. Last status: ${result.lastNote}`,
+  );
+};

--- a/.github/scripts/resolve-main-preview.mjs
+++ b/.github/scripts/resolve-main-preview.mjs
@@ -27,11 +27,12 @@
  * Outputs (via GITHUB_OUTPUT):
  *   is_ready, preview_url, reason, check_name, details_url, head_sha
  */
+import { setOutput, createGithubClient, toTrustedPreviewUrl } from "./ci-helpers.mjs";
 import {
-  setOutput,
-  createGithubClient,
-  toTrustedPreviewUrl,
-} from "./ci-helpers.mjs";
+  createPreviewDeploymentClient,
+  requirePreview,
+  withRetry,
+} from "./preview-deployments.mjs";
 
 const githubToken = process.env.GITHUB_TOKEN;
 const pushToken = process.env.PUSH_TOKEN || "";
@@ -63,40 +64,15 @@ if (!owner || !repo) {
 const githubRequest = createGithubClient(githubToken);
 const pushRequest = pushToken ? createGithubClient(pushToken) : null;
 const environmentRegex = new RegExp(environmentPatternRaw, "i");
+const preview = createPreviewDeploymentClient({
+  githubRequest,
+  pushRequest,
+  owner,
+  repo,
+  environmentRegex,
+});
 
-// An `inactive` deployment was built and then superseded or skipped; its
-// environment_url (when present) still serves an immutable preview of exactly
-// this SHA, so it is reusable. Without a URL it is as dead as a failed build.
-// Vercel's integration runs with auto_inactive off, so neither case has been
-// observed here — both are handled defensively.
-const REUSABLE_STATES = ["success", "inactive"];
-const TERMINAL_STATES = ["failure", "error", "inactive"];
-
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-/**
- * Retry a read-only GitHub API call across transient failures (rate limits,
- * 5xx). 404 is a real answer, not a transient failure, so it is rethrown
- * immediately for callers that branch on it.
- */
-const withRetry = async (fn, { attempts = 3, delayMs = 5_000 } = {}) => {
-  let lastError;
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    try {
-      return await fn();
-    } catch (error) {
-      if (error?.status === 404) throw error;
-      lastError = error;
-      if (attempt < attempts) {
-        console.log(
-          `Transient GitHub API error (attempt ${attempt}/${attempts}): ${error.message}`,
-        );
-        await sleep(delayMs);
-      }
-    }
-  }
-  throw lastError;
-};
+const waitOptions = { pollIntervalMs, deadline: waitBudgetDeadline };
 
 const notReady = (reason, extras = {}) => {
   setOutput("is_ready", "false");
@@ -133,214 +109,6 @@ const fetchDefaultBranchSha = async () => {
   return { defaultBranch, sha };
 };
 
-const listDeploymentsForSha = async (sha) => {
-  const deployments = await githubRequest(
-    `/repos/${owner}/${repo}/deployments?sha=${encodeURIComponent(sha)}&per_page=30`,
-  );
-  return Array.isArray(deployments) ? deployments : [];
-};
-
-const getLatestStatus = async (deploymentId) => {
-  const statuses = await githubRequest(
-    `/repos/${owner}/${repo}/deployments/${deploymentId}/statuses?per_page=10`,
-  );
-  return Array.isArray(statuses) ? statuses[0] : null;
-};
-
-const matchingDeployments = (deployments) =>
-  deployments.filter((deployment) =>
-    environmentRegex.test(deployment?.environment ?? ""),
-  );
-
-const inspectPreview = async (sha) => {
-  const matching = matchingDeployments(await listDeploymentsForSha(sha));
-  const statuses = await Promise.all(
-    matching.map((deployment) => getLatestStatus(deployment.id)),
-  );
-  const inspected = matching.map((deployment, index) => {
-    const status = statuses[index];
-    return {
-      id: deployment.id,
-      environment: deployment.environment ?? "",
-      state: status?.state ?? "unknown",
-      url: toTrustedPreviewUrl(
-        status?.environment_url || status?.target_url || "",
-      ),
-      detailsUrl: status?.target_url ?? "",
-    };
-  });
-  const successful = inspected.find(
-    (item) => REUSABLE_STATES.includes(item.state) && item.url,
-  );
-  const inProgress = inspected.find((item) =>
-    ["pending", "queued", "in_progress"].includes(item.state),
-  );
-  // Every matching deployment is dead — waiting longer cannot help.
-  const allTerminal =
-    inspected.length > 0 &&
-    !successful &&
-    !inProgress &&
-    inspected.every((item) => TERMINAL_STATES.includes(item.state));
-  return { successful, inProgress, inspected, allTerminal };
-};
-
-const encodeHeadsRef = (branch) =>
-  branch.split("/").map(encodeURIComponent).join("/");
-
-const readPreviewBranchSha = async () => {
-  if (!pushRequest) return "";
-  try {
-    const ref = await withRetry(() =>
-      pushRequest(
-        `/repos/${owner}/${repo}/git/refs/heads/${encodeHeadsRef(previewBranch)}`,
-      ),
-    );
-    return ref?.object?.sha ?? "";
-  } catch (error) {
-    if (error?.status === 404) return "";
-    throw error;
-  }
-};
-
-const pointPreviewBranchAtSha = async (sha) => {
-  if (!pushRequest) {
-    throw new Error(
-      "PUSH_TOKEN is required to update the tnr-preview/main ref so Vercel can build a preview of main",
-    );
-  }
-
-  const currentSha = await readPreviewBranchSha();
-  if (currentSha === sha) {
-    return { changed: false };
-  }
-
-  if (currentSha) {
-    await pushRequest(
-      `/repos/${owner}/${repo}/git/refs/heads/${encodeHeadsRef(previewBranch)}`,
-      {
-        method: "PATCH",
-        body: JSON.stringify({ sha, force: true }),
-      },
-    );
-    return { changed: true, action: "updated" };
-  }
-
-  await pushRequest(`/repos/${owner}/${repo}/git/refs`, {
-    method: "POST",
-    body: JSON.stringify({
-      ref: `refs/heads/${previewBranch}`,
-      sha,
-    }),
-  });
-  return { changed: true, action: "created" };
-};
-
-/**
- * Poll until the preview for `sha` succeeds, dies, or the timeout expires.
- * Returns { successful } on success, { failed } when every matching
- * deployment reached a terminal state, and { lastNote } alone on timeout.
- * Transient API errors are tolerated; only a persistent streak aborts.
- */
-const waitForPreview = async (sha, timeoutMs = pollTimeoutMs) => {
-  const deadline = Math.min(Date.now() + timeoutMs, waitBudgetDeadline);
-  const maxConsecutiveErrors = 5;
-  let lastNote = "waiting for Vercel to create a Preview – tnr deployment";
-  let consecutiveErrors = 0;
-
-  while (Date.now() < deadline) {
-    let inspection;
-    try {
-      inspection = await inspectPreview(sha);
-    } catch (error) {
-      consecutiveErrors += 1;
-      if (consecutiveErrors >= maxConsecutiveErrors) {
-        throw new Error(
-          `GitHub API kept failing while polling for the preview: ${error.message}`,
-        );
-      }
-      console.log(
-        `Transient GitHub API error while polling (${consecutiveErrors}/${maxConsecutiveErrors}): ${error.message}`,
-      );
-      await sleep(pollIntervalMs);
-      continue;
-    }
-    consecutiveErrors = 0;
-
-    const { successful, inProgress, inspected, allTerminal } = inspection;
-    if (successful) {
-      return { successful };
-    }
-    if (allTerminal) {
-      const failed = inspected
-        .map((item) => `${item.environment}=${item.state}`)
-        .join(", ");
-      console.log(`Preview build reached a terminal state: ${failed}`);
-      return { successful: null, failed };
-    }
-    lastNote = inProgress
-      ? `Vercel preview is ${inProgress.state} (${inProgress.environment})`
-      : inspected.length
-        ? `Preview deployments exist but none are successful yet: ${inspected
-            .map((item) => `${item.environment}=${item.state}`)
-            .join(", ")}`
-        : "No Preview – tnr deployment yet for this SHA";
-    console.log(lastNote);
-    await sleep(pollIntervalMs);
-  }
-
-  return { successful: null, lastNote };
-};
-
-const requirePreview = (result, sha) => {
-  if (result.successful) return result.successful;
-  if (result.failed) {
-    throw new Error(
-      `Vercel preview build failed for ${sha.slice(0, 7)}: ${result.failed}`,
-    );
-  }
-  throw new Error(
-    `Timed out waiting for a Preview – tnr deployment of ${sha.slice(0, 7)}. Last status: ${result.lastNote}`,
-  );
-};
-
-/** Empty commit on top of main so Vercel sees a unique non-production SHA. */
-const createMainSnapshotSha = async (baseSha) => {
-  if (!pushRequest) {
-    throw new Error(
-      "PUSH_TOKEN is required to create a unique preview snapshot of main",
-    );
-  }
-  const baseCommit = await withRetry(() =>
-    pushRequest(`/repos/${owner}/${repo}/git/commits/${baseSha}`),
-  );
-  const snapshot = await pushRequest(`/repos/${owner}/${repo}/git/commits`, {
-    method: "POST",
-    body: JSON.stringify({
-      message: `tnr-preview: snapshot of ${baseSha.slice(0, 7)}`,
-      tree: baseCommit.tree.sha,
-      parents: [baseSha],
-    }),
-  });
-  if (!snapshot?.sha) {
-    throw new Error("Failed to create tnr-preview snapshot commit");
-  }
-  return snapshot.sha;
-};
-
-const isSnapshotOf = async (candidateSha, parentSha) => {
-  try {
-    const commit = await withRetry(() =>
-      githubRequest(`/repos/${owner}/${repo}/git/commits/${candidateSha}`),
-    );
-    return (commit?.parents ?? []).some((parent) => parent.sha === parentSha);
-  } catch (error) {
-    // A missing commit genuinely isn't a snapshot; anything else (rate limit,
-    // 5xx) must propagate rather than silently forcing a redundant rebuild.
-    if (error?.status === 404) return false;
-    throw error;
-  }
-};
-
 const main = async () => {
   const { sha: resolvedSha } = process.env.MAIN_SHA
     ? { sha: process.env.MAIN_SHA }
@@ -368,7 +136,7 @@ const main = async () => {
     return;
   }
 
-  const existing = await withRetry(() => inspectPreview(resolvedSha));
+  const existing = await withRetry(() => preview.inspectPreview(resolvedSha));
   if (existing.successful) {
     ready({
       previewUrl: existing.successful.url,
@@ -384,7 +152,7 @@ const main = async () => {
     console.log(
       `Preview already in progress (${existing.inProgress.state}); waiting`,
     );
-    const waited = await waitForPreview(resolvedSha);
+    const waited = await preview.waitForPreview(resolvedSha, waitOptions);
     if (waited.successful) {
       ready({
         previewUrl: waited.successful.url,
@@ -402,12 +170,15 @@ const main = async () => {
   }
 
   // A previous run may already have a unique snapshot commit of this main SHA.
-  const currentBranchSha = await readPreviewBranchSha();
+  const currentBranchSha = await preview.readBranchSha(previewBranch);
   if (currentBranchSha && currentBranchSha !== resolvedSha) {
-    const snapshotOfMain = await isSnapshotOf(currentBranchSha, resolvedSha);
+    const snapshotOfMain = await preview.isSnapshotOf(
+      currentBranchSha,
+      resolvedSha,
+    );
     if (snapshotOfMain) {
       const snapshotPreview = await withRetry(() =>
-        inspectPreview(currentBranchSha),
+        preview.inspectPreview(currentBranchSha),
       );
       if (snapshotPreview.successful) {
         ready({
@@ -420,7 +191,10 @@ const main = async () => {
         return;
       }
       if (snapshotPreview.inProgress) {
-        const waited = await waitForPreview(currentBranchSha);
+        const waited = await preview.waitForPreview(
+          currentBranchSha,
+          waitOptions,
+        );
         if (waited.successful) {
           ready({
             previewUrl: waited.successful.url,
@@ -442,13 +216,16 @@ const main = async () => {
   // No reusable preview: build one from a fresh snapshot commit. The unique
   // SHA guarantees Vercel treats it as new work, even though the tree is
   // identical to main.
-  const snapshotSha = await createMainSnapshotSha(resolvedSha);
-  await pointPreviewBranchAtSha(snapshotSha);
+  const snapshotSha = await preview.createSnapshotCommit(
+    resolvedSha,
+    `tnr-preview: snapshot of ${resolvedSha.slice(0, 7)}`,
+  );
+  await preview.pointBranchAtSha(previewBranch, snapshotSha);
   console.log(
     `Created snapshot ${snapshotSha.slice(0, 7)} of main ${resolvedSha.slice(0, 7)} on ${previewBranch}`,
   );
   const successful = requirePreview(
-    await waitForPreview(snapshotSha),
+    await preview.waitForPreview(snapshotSha, waitOptions),
     snapshotSha,
   );
   ready({

--- a/.github/workflows/tnr-create-preview.yml
+++ b/.github/workflows/tnr-create-preview.yml
@@ -1,0 +1,333 @@
+# On-demand Vercel previews for pull requests.
+#
+# Triggers:
+#   • `/tnr-create-preview` as the first line of a PR comment
+#   • Manual workflow_dispatch with a PR number
+#   • New PRs get an instructions comment (no deploy)
+#   • Closed PRs delete the `tnr-preview/pr-{N}` snapshot branch
+#
+# Regular PR branches do not auto-deploy (see app/vercel.json
+# git.deploymentEnabled). This workflow snapshots the PR head onto
+# `tnr-preview/pr-{N}` so Vercel's GitHub integration builds one preview.
+name: TNR Create Preview
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to deploy a preview for"
+        required: true
+        type: number
+
+jobs:
+  welcome:
+    if: github.event_name == 'pull_request_target' && github.event.action == 'opened'
+    runs-on: ${{ vars.TNR_REVIEWER_RUNNER_LABEL || 'blacksmith-2vcpu-ubuntu-2404' }}
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Post preview instructions
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const marker = '<!-- tnr-preview-instructions -->';
+            const prNumber = context.payload.pull_request.number;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 30,
+            });
+            if (comments.some((comment) => (comment.body ?? '').includes(marker))) {
+              core.info('Preview instructions already posted.');
+              return;
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: [
+                marker,
+                '## Vercel preview',
+                '',
+                'This repository does **not** deploy a Vercel preview for every pull request.',
+                '',
+                'To deploy a preview of the current PR head, a collaborator with write access can comment:',
+                '',
+                '```',
+                '/tnr-create-preview',
+                '```',
+                '',
+                'That builds one preview of the current head commit. Later pushes do not refresh it — run the command again if you need an updated URL.',
+                '',
+                'Once the preview is ready, `/tnr-review-now` can review against it.',
+              ].join('\n'),
+            });
+
+  cleanup:
+    if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
+    runs-on: ${{ vars.TNR_REVIEWER_RUNNER_LABEL || 'blacksmith-2vcpu-ubuntu-2404' }}
+    permissions:
+      contents: write
+    steps:
+      - name: Delete PR preview snapshot branch
+        continue-on-error: true
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const branch = `tnr-preview/pr-${prNumber}`;
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${branch}`,
+              });
+              core.info(`Deleted ${branch}`);
+            } catch (error) {
+              if (error.status === 404) {
+                core.info(`${branch} did not exist`);
+                return;
+              }
+              throw error;
+            }
+
+  command_gate:
+    if: >-
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, '/tnr-create-preview')) ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ${{ vars.TNR_REVIEWER_RUNNER_LABEL || 'blacksmith-2vcpu-ubuntu-2404' }}
+    permissions:
+      issues: write
+      pull-requests: write
+    outputs:
+      should_run: ${{ steps.parse.outputs.should_run }}
+      pr_number: ${{ steps.parse.outputs.pr_number }}
+      comment_id: ${{ steps.initial_comment.outputs.comment_id }}
+      head_sha: ${{ steps.parse.outputs.head_sha }}
+    steps:
+      - name: Parse command and validate actor
+        id: parse
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const isWorkflowDispatch = context.eventName === 'workflow_dispatch';
+            const actor = isWorkflowDispatch
+              ? context.actor
+              : context.payload.comment.user.login;
+            const teamPermissions = new Set(['admin', 'maintain', 'write']);
+            const commandExact = /^\/tnr-create-preview\s*$/i;
+
+            let prNumber = 0;
+            if (isWorkflowDispatch) {
+              prNumber = Number(context.payload.inputs?.pr_number);
+            } else {
+              const firstLine = (context.payload.comment.body ?? '')
+                .split(/\r?\n/, 1)[0]
+                .trim();
+              if (!commandExact.test(firstLine)) {
+                core.setOutput('should_run', 'false');
+                return;
+              }
+              prNumber = context.issue.number;
+            }
+
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              if (isWorkflowDispatch) {
+                core.setFailed('Provide a valid pr_number.');
+              }
+              core.setOutput('should_run', 'false');
+              return;
+            }
+
+            if (!isWorkflowDispatch) {
+              let permission = '';
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username: actor,
+                });
+                permission = data.permission ?? '';
+              } catch {
+                permission = '';
+              }
+              if (!teamPermissions.has(permission)) {
+                core.setOutput('should_run', 'false');
+                return;
+              }
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            if (pr.state !== 'open') {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: `PR #${prNumber} is not open, so a preview was not created.`,
+              });
+              core.setOutput('should_run', 'false');
+              return;
+            }
+
+            core.setOutput('should_run', 'true');
+            core.setOutput('pr_number', String(pr.number));
+            core.setOutput('head_sha', pr.head.sha);
+
+      - name: Post initial comment
+        if: steps.parse.outputs.should_run == 'true'
+        id: initial_comment
+        continue-on-error: true
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const prNumber = Number('${{ steps.parse.outputs.pr_number }}');
+            const headSha = '${{ steps.parse.outputs.head_sha }}';
+            const { data: comment } = await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: [
+                '## Vercel preview started',
+                '',
+                `Building a preview of \`${headSha.slice(0, 7)}\`. Later pushes will not update this URL unless you run \`/tnr-create-preview\` again.`,
+                `Run: [View workflow run](${runUrl})`,
+                '',
+                '> This comment will be updated when the preview is ready.',
+              ].join('\n'),
+            });
+            core.setOutput('comment_id', String(comment.id));
+
+  create_preview:
+    needs: command_gate
+    if: needs.command_gate.outputs.should_run == 'true'
+    runs-on: ${{ vars.TNR_REVIEWER_RUNNER_LABEL || 'blacksmith-2vcpu-ubuntu-2404' }}
+    timeout-minutes: 35
+    concurrency:
+      group: tnr-create-preview-${{ needs.command_gate.outputs.pr_number }}
+      cancel-in-progress: false
+    permissions:
+      checks: read
+      pull-requests: write
+      issues: write
+      contents: read
+      deployments: read
+    outputs:
+      is_ready: ${{ steps.create.outputs.is_ready }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Create or reuse Vercel preview
+        id: create
+        run: node .github/scripts/create-pr-preview.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PUSH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          PR_NUMBER: ${{ needs.command_gate.outputs.pr_number }}
+          PREVIEW_BRANCH: tnr-preview/pr-${{ needs.command_gate.outputs.pr_number }}
+          PREVIEW_ENVIRONMENT_PATTERN: ${{ vars.TNR_MAIN_PREVIEW_ENV_PATTERN || '' }}
+
+      - name: Post preview result
+        uses: actions/github-script@v9
+        env:
+          IS_READY: ${{ steps.create.outputs.is_ready }}
+          PREVIEW_URL: ${{ steps.create.outputs.preview_url }}
+          REASON: ${{ steps.create.outputs.reason }}
+          HEAD_SHA: ${{ steps.create.outputs.head_sha }}
+          COMMENT_ID: ${{ needs.command_gate.outputs.comment_id }}
+          PR_NUMBER: ${{ needs.command_gate.outputs.pr_number }}
+        with:
+          script: |
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const isReady = process.env.IS_READY === 'true';
+            const previewUrl = process.env.PREVIEW_URL || '';
+            const reason = process.env.REASON || '';
+            const headSha = (process.env.HEAD_SHA || '').slice(0, 7);
+            const prNumber = Number(process.env.PR_NUMBER);
+            const commentId = Number(process.env.COMMENT_ID);
+            const body = isReady
+              ? [
+                  '## Vercel preview ready',
+                  '',
+                  `Preview of \`${headSha}\`: ${previewUrl}`,
+                  '',
+                  'Later pushes do not refresh this URL. Comment `/tnr-create-preview` again if you need an updated deploy.',
+                  `Run: [View workflow run](${runUrl})`,
+                ].join('\n')
+              : [
+                  '## Vercel preview failed',
+                  '',
+                  reason ? `Reason: ${reason}` : 'Reason: unknown',
+                  `Run: [View workflow run](${runUrl})`,
+                ].join('\n');
+
+            if (Number.isInteger(commentId) && commentId > 0) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: commentId,
+                body,
+              });
+              return;
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+
+  report_interrupted:
+    needs: [command_gate, create_preview]
+    if: always() && needs.command_gate.outputs.should_run == 'true' && (needs.create_preview.result == 'cancelled' || needs.create_preview.result == 'failure')
+    runs-on: ${{ vars.TNR_REVIEWER_RUNNER_LABEL || 'blacksmith-2vcpu-ubuntu-2404' }}
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Mark run as interrupted
+        uses: actions/github-script@v9
+        env:
+          COMMENT_ID: ${{ needs.command_gate.outputs.comment_id }}
+          PR_NUMBER: ${{ needs.command_gate.outputs.pr_number }}
+        with:
+          script: |
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const commentId = Number(process.env.COMMENT_ID);
+            const prNumber = Number(process.env.PR_NUMBER);
+            const body = [
+              '## Vercel preview interrupted',
+              '',
+              'This run was interrupted before the preview was ready — either a newer run took its concurrency slot or the preview wait hit the job timeout. Comment `/tnr-create-preview` again if it is still needed.',
+              `Run: [View workflow run](${runUrl})`,
+            ].join('\n');
+            if (Number.isInteger(commentId) && commentId > 0) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: commentId,
+                body,
+              });
+              return;
+            }
+            if (Number.isInteger(prNumber) && prNumber > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/tnr-reviewer.yml
+++ b/.github/workflows/tnr-reviewer.yml
@@ -17,7 +17,8 @@
 #
 # Pipeline: command_gate → preview_check → run_tnr_reviewer
 #   1. command_gate: validates the trigger, checks actor permissions, fetches metadata
-#   2. preview_check: PR → existing Vercel check URL; issue → resolve/create main preview
+#   2. preview_check: PR → existing Vercel check/deployment or tnr-preview/pr-{N}
+#      snapshot (created by `/tnr-create-preview`); issue → resolve/create main preview
 #   3. run_tnr_reviewer: checks out the target SHA, builds a prompt, runs Codex, posts results
 name: TNR Reviewer
 
@@ -337,6 +338,7 @@ jobs:
           if [ "$MODE" = "issue-repro" ]; then
             node .github/scripts/resolve-main-preview.mjs
           else
+            export PREVIEW_BRANCH="tnr-preview/pr-${PR_NUMBER}"
             node .github/scripts/check-preview-ready.mjs
           fi
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@
   subsequent commits to that branch will be added to the open pull request
   automatically.
 - When the PR is approved it will be merged into main and automatically deployed onto [www.theninja-rpg.com](www.theninja-rpg.com)
+- Pull requests do not get a Vercel preview by default (to avoid paying for every open PR). A collaborator with write access can comment `/tnr-create-preview` on the PR to deploy one of the current head commit. Later pushes do not refresh that URL; run the command again if you need an updated preview.
 
 ## Code Conventions
 

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -1,4 +1,13 @@
 {
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "tnr-preview/*": true,
+      "tnr-preview/**": true,
+      "*": false,
+      "**": false
+    }
+  },
   "crons": [
     {
       "path": "/api/subscriptions",


### PR DESCRIPTION
## Summary

- Stop automatic Vercel preview deploys on every PR branch. `app/vercel.json` now auto-deploys only `main` and `tnr-preview/*`, so ordinary PR pushes no longer consume Fluid compute or build minutes.
- A collaborator with write access can comment `/tnr-create-preview` to snapshot the current PR head onto `tnr-preview/pr-{N}` and wait for that one preview. Later pushes do not refresh it.
- New PRs get an automatic instructions comment (also added to the PR template and CONTRIBUTING). `/tnr-review-now` resolves on-demand snapshots; `/tnr-repro-now` still uses `tnr-preview/main`. Closed PRs delete the snapshot branch.

## Test plan

- [ ] After merge to `main`, confirm the next production deploy still runs
- [ ] Open a new PR and confirm the instructions comment is posted and Vercel does **not** start a preview for the PR branch
- [ ] As a write collaborator, comment `/tnr-create-preview` and confirm a preview URL is posted
- [ ] Push another commit and confirm the preview URL stays on the old SHA until the command is run again
- [ ] Run `/tnr-review-now` after a preview exists and confirm it finds the snapshot URL
- [ ] Close the PR and confirm `tnr-preview/pr-{N}` is deleted
- [ ] Confirm an unauthorized commenter cannot trigger a preview

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added on-demand Vercel preview deployments for pull requests using the `/tnr-create-preview` command.
  - Existing previews can be reused, while new previews provide readiness status and preview links.
  - Pull requests receive updates for successful, in-progress, failed, or unavailable previews.
  - Preview branches are cleaned up automatically when pull requests close.
  - Preview deployments are supported for approved preview branch patterns.

- **Documentation**
  - Added instructions for creating and refreshing pull request previews.
  - Updated contributor and pull request guidance with preview workflow details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->