### PR TITLE
Fix duplicate social login buttons in native apps

### DIFF
--- a/app/src/app/login/[[...rest]]/page.tsx
+++ b/app/src/app/login/[[...rest]]/page.tsx
@@ -39,10 +39,13 @@ export default function LoginUser() {
             elements: {
               rootBox: "!w-full [color-scheme:light]",
               cardBox: "!w-full",
-              // Clerk's social buttons open in the WebView, which Google rejects and
-              // Apple will not accept. NativeSignIn replaces them in the shell.
+              // Use Clerk style overrides: its generated display rules can override
+              // Tailwind utilities and expose duplicate WebView OAuth buttons.
               ...(isNativeShell
-                ? { socialButtons: "hidden", dividerRow: "hidden" }
+                ? {
+                    socialButtons: { display: "none" },
+                    dividerRow: { display: "none" },
+                  }
                 : {}),
             },
           }}

--- a/app/src/app/signup/[[...rest]]/page.tsx
+++ b/app/src/app/signup/[[...rest]]/page.tsx
@@ -57,10 +57,13 @@ export default function SignupUser() {
             elements: {
               rootBox: "!w-full [color-scheme:light]",
               cardBox: "!w-full",
-              // Clerk's social buttons open in the WebView, which Google rejects and
-              // Apple will not accept. NativeSignIn replaces them in the shell.
+              // Use Clerk style overrides: its generated display rules can override
+              // Tailwind utilities and expose duplicate WebView OAuth buttons.
               ...(isNativeShell
-                ? { socialButtons: "hidden", dividerRow: "hidden" }
+                ? {
+                    socialButtons: { display: "none" },
+                    dividerRow: { display: "none" },
+                  }
                 : {}),
             },
           }}


### PR DESCRIPTION
Native login and signup showed Clerk's embedded social buttons beneath the native provider buttons because Clerk's generated display rules overrode the Tailwind `hidden` utility. Use Clerk style overrides to hide the duplicate buttons and divider in native shells while preserving web authentication and email forms.

Validation: `make typecheck` and scoped Biome checks passed. Refreshed both pages in the iPhone simulator against the local server and verified a single provider list; signup retains its email field. Production email sign-in and Android rendering still need verification after deployment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI-only change on login/signup when running in the native shell; web auth paths are untouched.
> 
> **Overview**
> Fixes **duplicate social login buttons** on native app login and signup by hiding Clerk’s OAuth UI with **Clerk `appearance.elements` style overrides** (`display: "none"`) instead of Tailwind `hidden` class strings.
> 
> When `isNativeShell` is true, **`socialButtons`** and **`dividerRow`** are hidden this way on both **`SignIn`** and **`SignUp`**, so only **`NativeSignIn`** provider buttons show while email/password flows stay visible. Web behavior is unchanged when not in the native shell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c566993833e95ed1a66b42ed19fd4f473069dbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the native-shell login and signup experience by correctly hiding social sign-in options and divider elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->